### PR TITLE
Rebuild OSCAL to gain stable UUIDs

### DIFF
--- a/xml/ansible-tower-fedramp-High.xml
+++ b/xml/ansible-tower-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="66c36457-c179-415a-9bb9-a0277fc5a603">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="c21ffc8d-bf29-489c-a512-b440bd668125">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.22+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.43+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="2dd6d2b7-682f-4531-a466-2af8e5d1a212">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="6b6f4651-310d-47f8-971c-d90e4205aa59" control-id="ac-1">
+    <implemented-requirement uuid="25c4a27a-9fa7-4a09-a31d-3073e4efb8aa" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="3ca0b3b9-5a78-4dcd-a9ea-143bb35671ff">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="239a7e35-33f0-4413-96de-f44bdf941dd9">
+      <statement statement-id="ac-1_stmt.a" uuid="6903796e-b668-4d25-b438-a5a4c7cd70f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="e90e1a6f-d47a-4922-9f93-69b0eae0c116">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="280c83ce-7feb-40be-b729-57c1ef9f54c5">
+      <statement statement-id="ac-1_stmt.b" uuid="ef92194b-c5b9-4a06-8376-caffe5dec37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -503,10 +503,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0c620ab-fd96-4f71-8bfe-0c66c7a14793" control-id="ac-2">
+    <implemented-requirement uuid="ea88ac6e-45e3-4858-8bff-8ede745929b2" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="9fb70df7-c4be-4fed-a915-f16f2e07a491">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2372788b-0976-4379-ae7f-78acc0f908ac">
+      <statement statement-id="ac-2_stmt.a" uuid="874a51a8-9ea5-4545-8926-68508f7ef1f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ea0928-3a6c-427e-b3ba-11e8545aeb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower's Role-based Access Control (RBAC) implementation
 offers multiple types of information system accounts, each
@@ -540,16 +540,16 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/security.html#role-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="dd09f1d0-104c-4c8a-a0c7-5c39644f4a5e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="67dced07-df74-4952-8a6c-de4f109b0150">
+      <statement statement-id="ac-2_stmt.b" uuid="d7d82faa-dbe0-4a63-8aad-ce73e57aaae5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ae98e6-0009-4349-b613-feb56a7ff423">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning Ansible Tower account managers is an organizational
 process outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="d6a6506a-727d-4718-afd7-9e7832b715ac">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c561f12e-5915-480a-be9a-a43e4542bbe4">
+      <statement statement-id="ac-2_stmt.c" uuid="9cdad719-4e03-44a9-878b-cc7ea716515d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ddebf72-5bcb-4605-9f4f-0e9eac18c527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role membership is an
 organizational process outside the scope of Ansible Tower
@@ -557,8 +557,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="1c3777e7-b29c-4c48-8d0a-d1333f87dee9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3eac6d9e-5a94-46e7-bce3-c7c7f798622a">
+      <statement statement-id="ac-2_stmt.d" uuid="9c7781e4-f16b-4856-ad23-264539bd7579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b139daa8-ec36-49fc-b0f2-30d1d47c5caf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To specify authorized users of Ansible Tower, group and role
 membership, and access authorizations, refer to the
@@ -568,24 +568,24 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="22049b90-37f9-4303-becc-09b6f362b318">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="645c34bf-add9-4bb3-a8e5-16ed4d87cf9c">
+      <statement statement-id="ac-2_stmt.e" uuid="4c68b375-6f53-4efc-99b4-e6dfccf1532b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1068cd56-cf5d-4fe4-8d72-d8cb82f16c22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account creation requests
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="675da9a0-88a3-4225-adfd-2c3ce2af40aa">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="cae387fd-0dbd-4054-adb8-cafa379f0f4f">
+      <statement statement-id="ac-2_stmt.f" uuid="2a8b1715-0909-4400-b154-eb810db9533a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a07a8330-3554-46c6-a735-8bdd8e4f1894">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding administration of Ansible Tower
 accounts are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="467fc9ab-47bd-4ab5-bc67-657428ae825b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d7e258f9-054a-4e18-b99a-15de275df26f">
+      <statement statement-id="ac-2_stmt.g" uuid="a421ecf4-e4f8-417e-a6c2-8c388ba4219b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e7c0b80-832f-4f3b-b259-231d97e54f9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Ansible Tower logging subsystems can assist with monitoring the use of Ansible Tower
 accounts. Logging is a standalone feature introduced in Ansible Tower that provides
@@ -600,32 +600,32 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/logging.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="c03dfe62-9b74-4822-a89c-04805fa0981d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ebbca601-fd43-4b0d-a2d8-3bf3bc523158">
+      <statement statement-id="ac-2_stmt.h" uuid="d5de5f33-0b8f-4187-894c-fc85314d9d0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d063cd68-f8a3-47a9-8539-4988e90b2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account termination or need-to-know
 changes are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="b1dbb713-32c6-4e17-bc20-4fa612f4d48a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="58dcc0d8-7379-43c4-a127-a54c87998fa1">
+      <statement statement-id="ac-2_stmt.i" uuid="7a5a51d4-b432-4542-8557-18425d3ca131">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="01ed9398-b45a-4a48-991b-18af48d4fa2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding access authorization are outside
 the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="076585b4-fde6-4bbd-944d-98a6ee72499d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="60f614c5-ff18-4c2d-b138-48db4491bb71">
+      <statement statement-id="ac-2_stmt.j" uuid="bd3e33dc-cee1-4e02-b21a-c38dd5945ded">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7d2ca93-4412-4c9f-b131-baf0399a9064">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the review of account management policies
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="a5d2a637-eb75-4d6a-b7b7-f89798e84fb5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f6eb9f13-0863-4a24-88b2-2b2394f07e54">
+      <statement statement-id="ac-2_stmt.k" uuid="80c46447-3584-46b5-81d5-41e2e25e745d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9379ac56-1fc9-42db-9f34-40ee9871b77d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for reissuing shared/group account credentials
 are outside the scope of Ansible Tower configuration.
@@ -633,10 +633,10 @@ are outside the scope of Ansible Tower configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b756f1b1-6517-4e23-8b4b-84856dcf58cc" control-id="ac-2.1">
+    <implemented-requirement uuid="c8d7f4f4-6edc-4aaa-9e1a-9b17afb61b03" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="24a90f1b-6b5d-46d5-91b6-3cbdaaa300ad">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="da29b28f-b3c2-4e24-8101-deca0f8e5a35">
+      <statement statement-id="ac-2.1_stmt" uuid="d101db6d-de82-41a8-b858-e7eaef9a8bc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9167752-469c-49bc-9e4e-8dca520de107">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower offers supported integrations with many account management
 systems, such as Kerberos, Azure Active Directory, LDAP, RADIUS, SAML, TACACS+,
@@ -653,10 +653,10 @@ password complexity, an external account management system MUST be used!
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3aeef11c-5e59-4cea-b08a-ef138ad3844f" control-id="ac-2.2">
+    <implemented-requirement uuid="a2747b14-3629-4c1e-b392-69ed2c26f9c1" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="7e86901f-94a2-4039-8751-953dd614bdf1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="002b04cf-f068-4e4d-a684-194c92da3fc0">
+      <statement statement-id="ac-2.2_stmt" uuid="6509ce01-da80-41d9-b765-903dcedf7916">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da7a2079-d793-4be6-9f6d-53d8993fb9dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower does not natively have the capability to automatically
 remove or disable temporary and emergency accounts.
@@ -677,10 +677,10 @@ or disable the account.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da82e596-8247-4cde-8784-f9bf867ec2d1" control-id="ac-2.3">
+    <implemented-requirement uuid="ec3b2a88-118f-4f8b-8499-c9671216f60c" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="0b44b88a-0363-4f43-a4a4-442a68f226f4">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c9fe9203-166d-4152-a2aa-026d050842fc">
+      <statement statement-id="ac-2.3_stmt" uuid="497224a3-74f2-4dd3-978b-e6f27c28cd0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e7dd1e8-b694-4dbf-b6b3-488ff2301505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower does not natively have the capability to automatically
 disable inactive accounts after an organization-defined time period.
@@ -706,10 +706,10 @@ remove or disable the account.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f9f4470-49ab-41c4-8207-f06df7adac3e" control-id="ac-2.5">
+    <implemented-requirement uuid="a4c67b90-7062-40fb-bd4f-b84e52b59930" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="ff25b66f-1629-43a6-9267-a85ae28c848c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="05518a5a-0f27-4c02-ae28-d8195acbf70c">
+      <statement statement-id="ac-2.5_stmt" uuid="91206164-40bf-48ef-ad9f-f2217f128db6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29bff8c3-0ed3-4a85-8a98-78b06d2cf514">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Introduced in Ansible Tower 2.4 is a feature which adds an Auth-Token-Timeout
 to every response that includes a valid user-supplied token. This setting
@@ -728,10 +728,10 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/authentication
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa31a9f0-0ef7-4f39-916a-a53d77c8ca1f" control-id="ac-2.7">
+    <implemented-requirement uuid="bcd334fd-31cb-4dee-8928-8f8a5c0d1845" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="991121d8-3d99-422c-877f-7957dba62036">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="44bfc9c0-23c1-4c9b-8bfe-3ea142510353">
+      <statement statement-id="ac-2.7_stmt.a" uuid="ff82fdd0-bc1a-499d-a28a-142abd5a8f59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ea0928-3a6c-427e-b3ba-11e8545aeb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower's Role-based Access Control (RBAC) implementation
 offers multiple types of information system accounts, each
@@ -765,8 +765,8 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/security.html#role-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="2ccc601d-07f5-4727-b402-654ca8855af9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="533e260f-110e-4830-a782-f951b93eec34">
+      <statement statement-id="ac-2.7_stmt.b" uuid="55536e22-7c1a-4865-810e-42edd17e4eba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="880869fa-26a7-4b45-924d-cb65952fbe20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower automatically logs creation, modification,
 and removal of Role-based Access Control (RBAC) privileges.
@@ -774,8 +774,8 @@ This is non-configurable default behavior.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="da4edd34-c107-400c-9775-af3886ebffec">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="1291909d-53e5-4213-97f2-6aff5e53dc7c">
+      <statement statement-id="ac-2.7_stmt.c" uuid="287ae148-3681-429a-bee1-4f7ad3152e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6591f6b8-f784-43c3-a6c0-d573cc08f73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational process control
 outside the scope of Ansible Tower configuration.
@@ -783,10 +783,10 @@ outside the scope of Ansible Tower configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36595b80-a2df-4a5b-8b82-988058d7cfa7" control-id="ac-3">
+    <implemented-requirement uuid="80eaf071-6ce3-4d01-87f7-61bdf0ac7b11" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="a0d537ff-a731-4b00-aec2-3a68cd487e10">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="74ad0c01-c82e-4df3-8396-780d3463faee">
+      <statement statement-id="ac-3_stmt" uuid="f4ec59d1-9343-4ba5-b732-76a5ea36e80f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d876b570-2782-4580-a66e-c9baf5170c10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'There are three types of Tower users that can be assigned:
 
@@ -818,10 +818,10 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad0528b9-cc7b-4a10-872c-4252ede2dda3" control-id="ac-7">
+    <implemented-requirement uuid="3f996a42-c9b3-4f7d-8418-b6e041af0542" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="3498398b-b833-46dd-b588-8b6856a8ae33">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9af7d6c3-eaa0-4293-b11a-581a477874f5">
+      <statement statement-id="ac-7_stmt.a" uuid="9ed16087-8072-4f2d-bb7a-a7a2224e64c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2765dde1-c0ab-4bd1-9b16-72e35a55ae16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability to enforce limits
 on consecutive logon attempts.
@@ -832,8 +832,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="453cbb2d-cbe2-42dd-95a9-2bfbe1111587">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="59acfc5f-c9b7-4844-89bb-4030fa9f0218">
+      <statement statement-id="ac-7_stmt.b" uuid="aed9b374-52fb-4a05-82f9-37a045a64e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b22518c-16db-4dce-87a8-76fb4d93b4f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability automatically
 lock an account for an organizationally-defined time period, nor
@@ -856,10 +856,10 @@ finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a559f89-86ff-48d8-9576-e5b61172c022" control-id="ac-8">
+    <implemented-requirement uuid="355ed56d-434d-4e93-a07d-3ad038c1c908" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="abdab31b-1526-48e4-92aa-5b9264ccde44">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3c8741e7-2cc0-465f-a3c5-aa2a91cc1dd3">
+      <statement statement-id="ac-8_stmt.a" uuid="1f1f0f06-d21b-4832-acec-1740fc121d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0fdeb6-61ef-45dc-8c74-931d3748e6a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower supports configuration of custom system use
 notifications.
@@ -878,8 +878,8 @@ field. Note breaks must use "\n"'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="20539948-ab5d-40a4-b991-3949c327416e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="6cb09907-9da8-403f-9876-03b3cc6bb45a">
+      <statement statement-id="ac-8_stmt.b" uuid="1e940eca-2352-4ed1-9a2d-86faa54fd739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df7809ee-f81a-4997-add5-74b73dee367f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Custom system use notifications are displayed on the logon screen
 prior to the "login" button. This is default, non-configurable
@@ -887,8 +887,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="8089a51d-793c-4baf-b988-6d653d1c89b6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b6034543-ab58-4a77-b1d8-aa60a226df27">
+      <statement statement-id="ac-8_stmt.c" uuid="ef643b9e-123c-4c43-b1a4-7d4e67543e42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c92bcc5f-d5b3-4e83-9b16-5d0916817a4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not differentiate logon screens between private and
 publicly accessible instances. Custom system use notifications
@@ -898,10 +898,10 @@ procedures from AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5793c4da-456e-4adf-9e1e-1e094ab08b22" control-id="ac-14">
+    <implemented-requirement uuid="04df7290-eaa8-48ce-abba-b1cfd2d75875" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="a7bd255b-74d1-48bd-9dba-79afd50ff28d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="75603bb0-d0b2-4868-9d62-c59d33af8cf1">
+      <statement statement-id="ac-14_stmt" uuid="794730c0-822e-467e-bd9d-13e6447c0cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd876e51-4edc-4be9-a2a6-9483d7172b9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Ansible Tower
 console, unauthenticated users will only be shown the
@@ -914,63 +914,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6188695-cb06-418a-83ae-d837e2e59227" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="24d1c2eb-9299-4909-86ba-949b8b593897">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="17f37aad-fdde-4a36-a523-b3b7cd949eae">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bdd7c56-920c-4e47-b88c-549df64edcfb" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="698f4439-681a-4f0f-9bd4-55f5f5869ab9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="edc5a205-5fc6-48dd-b3c1-df3f7f06d241">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcbf522f-a0ab-4166-a692-1091afb22393" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="78ee6a38-86e1-420f-9ce8-a6c9455c8bee">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="bd9a12a5-df17-49dc-958a-14d01129ef64">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6a5218c-c418-44a1-9e87-def58e7c3bd8" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="39d512e3-ca2b-4032-9fb6-b414958fb608">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8e07205a-c4d9-4f1c-a423-c873efd9f72a">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e68024f-9347-4206-a7ed-4793818dda15" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="58b17856-6bbc-4df4-a232-5e02748bc0ba">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3d958a21-ffe2-4921-9ec6-9d3a165a3bbe">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4abfaa4f-55ad-4b70-8fee-008ad8fdfa9b" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="30ef85b0-41d8-4d6b-b442-44bb8a0ae33f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c0e92ac3-42ac-44fc-b930-cf09154284ed">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="2b0914a1-6ecc-4890-909b-0cf9c60575b5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="fc91cbc1-2c4f-4a92-bf3d-f8614315980c">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -978,26 +978,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bacfa9c5-d4b7-4f7d-a101-0dd224e9b774" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="2d0b54a5-c34e-40c9-ba9d-593bd02f7d60">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="952b67ad-7d40-4cf4-9bdb-eb950c55726a">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="2c8055d4-aae6-405d-ab85-072e2a7927d8">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2d2268a7-1e71-46e1-9542-98d72b3b4590">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="afd5369d-2d20-48d4-a1b2-7dae26fdac97">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="19831378-ded5-4139-b49a-077b775b476d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1005,10 +1005,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bc2a9ee-cde0-4b59-a28d-94af8d17e8dc" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="d33922cc-87f2-47f8-ba91-b6e8afff9daa">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3ccab991-8f61-40cb-a321-a35fadb27cfa">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1016,26 +1016,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c18c643d-b236-43cc-8649-be77d214fc61" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="942d3a44-e3f1-4cb8-b02a-404068693b0b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4012d337-b956-4b15-9b12-91136ed55e94">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="40d49d67-ef5a-43f6-ac2a-95cd97097abe">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="41dfb3a7-2e2b-4f56-ae57-16eefb1794c6">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="2728fad2-26cc-4cc9-96d1-23964ba08dec">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2a6ada66-8cea-481e-8e4f-71bcd082cdd3">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1043,10 +1043,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7c9b411-7bb8-4c24-817b-ba22302f362e" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="1508514e-b98e-4c35-b9fb-5b9b3d4632dd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="31feddd7-75e7-48ba-8f80-74015a4ca78b">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1054,10 +1054,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24da6757-b6be-4d3c-8147-8aee4d5024d1" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="15898695-0b5f-49e5-9df0-68971c66bd49">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="eac22561-a446-4812-aee2-2a546f66481b">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1065,18 +1065,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9770676-5678-46a8-a571-3185c73fdb03" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="d31ac4c2-4344-45ff-a369-c17f0511af01">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="da1f46b8-7ccc-4775-a3a4-96ebcff31803">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="5999f8ed-f2d0-4e1d-88e8-6f62441ae9f6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="200c0f61-f960-41fd-ac9e-91abdfe68db8">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1084,28 +1084,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7dc78ce-f7dd-4ff2-9921-cd18ffd94b5f" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="078c4a34-ba10-4f41-9efd-028508ae7568">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ec3da2f6-a2f8-44dc-961b-3c905df37f52">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d55de21f-2ab4-4539-b2a2-757fba029a48" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="59648ebc-c05e-47be-8793-38c3d85ec831">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="1d9e9280-786f-48d3-99b2-6ef910b37655">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe6d70ce-3e46-49be-a19e-1280a791ebf3" control-id="au-3">
+    <implemented-requirement uuid="0bc7b038-2291-47f1-b95e-f27718ba9dad" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="01802e5c-0e77-43ec-9c94-ed442b285d2f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="287a7327-feb9-4116-9895-a67e03029502">
+      <statement statement-id="au-3_stmt" uuid="bcbc1772-f72d-4ebf-940f-a87749be0356">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2243f0d-df11-4d3b-9feb-7843d573c755">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default Ansible Tower generates audit records containing
 information that establishes what type of event occurred,
@@ -1206,19 +1206,19 @@ https://docs.ansible.com/ansible-tower/latest/html/towerapi/activity_stream.html
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ccf8658-4f86-4d24-a16e-93b6cd37b5b3" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="ed95da6e-081c-49fd-8f88-ff4544491997">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="bb93166c-3fcc-465c-a6e2-34ec680d1b9b">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc1c6b1e-2ba3-401d-b8d5-65fff5f2a008" control-id="au-5">
+    <implemented-requirement uuid="4141f72e-f8c5-46b2-b788-ec3ad473ed39" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="9b47f38f-d201-4b65-b11e-be12e3d26d37">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ad21e98a-ac66-46a7-91d4-3b19c8b8a99a">
+      <statement statement-id="au-5_stmt.a" uuid="9d51e840-f6b9-4ab1-bbd6-f93358885e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1227,8 +1227,8 @@ Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="e06595cc-e6a5-4398-ba9a-b2c821f24c83">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c8090f0c-041e-41d8-ad8b-2ca057c43b58">
+      <statement statement-id="au-5_stmt.b" uuid="fdfb5480-4156-4e8a-b268-80d158fa7b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1238,19 +1238,19 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77dd4ad2-b3a4-47d1-a33a-eb32651e07c5" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="42545bc1-7473-46e5-b8c2-4e107bca7f6e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="88a7916c-d862-4379-89aa-4175a8293644">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cd007e9-12b0-44fa-a982-35f894c2fe0a" control-id="au-8">
+    <implemented-requirement uuid="becf8e32-f685-4e4a-bf9e-be88774fd26a" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="c07c00cd-95e1-453a-8f2b-61e7308e459c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="439acfae-f00e-4310-8427-b6b25522e8cf">
+      <statement statement-id="au-8_stmt.a" uuid="998c237c-d0c9-4e6e-a78c-76cb2bfefe12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd476bbf-c7b0-4ec0-9434-3419bd161f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower relies on the time services
 provided by the underlying operating system. Utilization of
@@ -1259,8 +1259,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="b338e404-a327-4731-877a-8abd98a724ae">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a837b68f-56ba-443d-8abf-bf89bd42f420">
+      <statement statement-id="au-8_stmt.b" uuid="9b88938b-72b8-4957-ae98-fa4158a1d301">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e5ac9f-1dad-4443-99a9-916e73faa646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the time zone settings of the underlying
 operating system. This is default, non-configurable behavior.'
@@ -1268,10 +1268,10 @@ operating system. This is default, non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70e25db7-4bfa-4e88-b418-d4115a4a592c" control-id="au-9">
+    <implemented-requirement uuid="3ec9f35f-418c-4efc-8f59-f18cc0171564" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="2570b132-cd17-42cf-93e5-14f95155aa00">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="44e1347c-ac7f-456c-8a50-fa9d6af4af30">
+      <statement statement-id="au-9_stmt" uuid="f4d285da-2c8e-40e5-a625-adf62450757c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0cf7e1a1-821e-42b9-bafe-1f376835c3e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower logfiles have been consolidated and can be easily
 accessed from two centralized locations:
@@ -1291,10 +1291,10 @@ to the accessing user).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="668fa0df-c842-4d7f-a5a7-8b410fc3acfc" control-id="au-11">
+    <implemented-requirement uuid="2ff74e9f-c91d-4851-9a09-bbf7fd625131" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="e51b59b5-0544-4dea-9536-1b95ac80a0e9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0123cbfa-c8e7-4140-aced-284ffa9bb7b9">
+      <statement statement-id="au-11_stmt" uuid="4b25af90-cc8e-4644-ab85-38b9090ec3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="657201e0-b861-4759-a353-a33f315df693">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'For locally retained logs, such as those recorded to
 /var/log/ansible, Ansible Tower utilizes the audit subsystems
@@ -1308,10 +1308,10 @@ outside the scope of configuring Ansible Tower.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95e9d690-c442-4504-a657-2c748ca1e4b1" control-id="au-12">
+    <implemented-requirement uuid="da920acf-393a-4df5-a211-a2b2b3c7eb8b" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="80ec13f4-4ae0-4a8a-b820-d042c879adb2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="47a61305-550e-4f1f-bb0b-401fc3d3f9ff">
+      <statement statement-id="au-12_stmt.a" uuid="c9d7357b-b9c4-4857-99d7-5259ff704990">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfa206b9-bd1e-49b8-bef9-243817f2292e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default, Ansible Tower audits the following events.
 Audit of these events is automatic and not user configurable.
@@ -1546,8 +1546,8 @@ being imported and "status" field indicates success or failure:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="27d1e984-5ae1-4d0d-a8d5-e7f7d76a9bcb">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5f098430-6901-4e90-b140-2d3a0bb553f3">
+      <statement statement-id="au-12_stmt.b" uuid="ff513e1f-4fff-41ac-aa19-fca0ea601659">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="250fa9aa-0867-42ec-a2ba-9b71bd3cf330">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to allow defined personnel or roles to select
 which auditable events are to be audited by specific components of the
@@ -1563,8 +1563,8 @@ https://github.com/ComplianceAsCode/redhat/issues/296'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="782793b9-34ea-4c41-93bd-13a3be60273e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7498a16f-fa42-472e-b0d1-ef7ea7005254">
+      <statement statement-id="au-12_stmt.c" uuid="8faaa7d8-0fc6-4270-8743-8328ee1220f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d475dd-7fd8-43ed-a837-5425e4438cfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -1579,109 +1579,109 @@ https://github.com/ComplianceAsCode/redhat/issues/297'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb5edc80-5e37-48b6-bf70-50d7fa8a6792" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="69c8d377-55cd-4c65-88bc-07ba2d768967">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b92a7b1e-0198-4759-87fd-bf8d6149f3fe">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9ea71f2-5319-4b95-870a-1c717542c369" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="22790cc0-9f71-4be1-87da-ef81d26c4323">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5ba829ad-033b-40f4-be70-44f135bc042d">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a9251a2-049d-4541-bc18-49df068d9993" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="897e9b7e-b083-4b86-9a92-02b1ac3e12fc">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9e8b883d-9ce9-44a0-b9f6-ffe73e2a2018">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cc36f9b-0f50-4770-9dff-521c3d0c4bee" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="4178553e-388c-4589-acfd-ae3fbf328d6f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d1dbe8f9-9283-4622-9f98-1bcaa7cff38a">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ad9c486-bd8e-4807-b429-e74cac384b40" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="96f9fa94-dd1c-42ef-9cf8-fab2e6ae869b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="70b69131-0427-4797-a705-3aeb395221bf">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="259fcde7-7d61-4404-9c61-482079c5ada2" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="e5dcdb9f-c090-42b5-ba4e-136ae1ad0c2e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4975c893-91aa-4466-baaf-faa5b03cd795">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53a4f93a-b8d9-48eb-ba26-ff0a724210d0" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="ec69776d-8466-48e3-baf6-14e65a440fd5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a6d2e84e-bb29-4d14-b0a4-0eaaeefb2dac">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="485b8453-07f1-4fd8-a709-e47aa0a7d591" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="e3a04328-f8c8-42a1-83a4-32652226f64b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f0f67c3a-c21e-4107-afe5-ffc698f39c06">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68ba7e3a-b807-4d9a-a8c3-fe955ca0d06f" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="252f2eb3-10a0-4cf5-8242-a170b1577b1e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0c793fa1-1189-4fb8-bd0c-78d32996957c">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23e61278-95b3-4438-95c3-7c935e02a86f" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="18f7984a-007a-43bd-8a14-ba5085370192">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="22656c5c-9a98-40ab-a5b1-ab526aac3ed2">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3862816-27ae-4823-9141-9a29206ddd3f" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="408c7b59-ad26-495d-84a9-ff3af6c09e5d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2fb8a942-9dcd-40a8-8c6a-74464550f377">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dde45bf6-2832-475b-aa11-12c1beab1472" control-id="cm-6">
+    <implemented-requirement uuid="fde226d7-7d67-4355-bbc8-71f20e317364" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="b5c21116-c520-4dad-bd39-b51280d43712">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9997f92c-de72-46ca-a2d4-1bc8aa15d1ea">
+      <statement statement-id="cm-6_stmt.a" uuid="4fa9858c-a284-4d75-b344-139e30e35aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e78a106a-eb43-4e69-af14-e7af054511d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower. Use of the NIST National Checklist
@@ -1690,8 +1690,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="c5976719-779e-4089-bb0b-2af8a6a0fb6b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="074be051-5b21-4563-8b92-04f42fba01cc">
+      <statement statement-id="cm-6_stmt.b" uuid="d81d0acf-4339-4280-96d7-48862c912509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb628c5-f152-43a0-97ad-a73c840900ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1705,16 +1705,16 @@ https://github.com/ComplianceAsCode/redhat/issues/299'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="9e19f08d-e6b4-483c-8b49-43bf07abf03b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c1b7cb11-2b26-42ff-93d6-420ca84590b6">
+      <statement statement-id="cm-6_stmt.c" uuid="56f21bb5-8370-4e48-8e9e-9e92d5708f6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="103b70b3-143c-4df8-8a73-762b9f8618b4">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8820892e-273d-49fe-80fc-6832f0d11712">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1726,10 +1726,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c23d430c-f963-4c78-98b2-e81fb463d3fb" control-id="cm-7">
+    <implemented-requirement uuid="342ffb57-0682-4fbc-abd3-c1a74e8296bd" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="ed7ad10b-f464-426f-ae86-643656101dd9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="30f0b5b6-09a8-463d-9949-da3a1a509916">
+      <statement statement-id="cm-7_stmt" uuid="8997ae8a-a31e-49c5-afc1-631aa0487d39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b29c60da-efb5-4a9a-ac22-72e78771ae9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ensuring Ansible Tower is deployed in a minimal configuration
 is being tracked through GitHub:
@@ -1739,37 +1739,37 @@ https://github.com/ComplianceAsCode/redhat/issues/300'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f501000-e0b1-4b8c-a52f-a000b0a706e2" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="48d3d299-388c-4a24-8db7-0cdbfd3d83e8">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b718f449-44d1-422a-ac0f-79fa805d6f00">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e05eb50d-b532-4293-a0f9-d73eb32fc09c" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="e0d3b9fd-f426-4e89-bf33-2fdb54e41fff">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="78ebbc64-51c7-40fd-b231-ecc6052b873a">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3be42ea8-086c-4d22-bad1-7dd3f30d951a" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="96ebe411-b643-4b44-8941-389ccd22b051">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e09ca9bf-64c6-4214-9b77-b73a70ff8119">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06c71c3f-fe77-40e2-a667-905f7ebe7ea9" control-id="cp-1">
+    <implemented-requirement uuid="817aa407-2d8e-45b6-98b9-3924740bfc4f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="fa5ce462-3730-4d45-a665-39c16124b7c8">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="80102cb3-8203-4d98-9dff-98d1f0fb35c3">
+      <statement statement-id="cp-1_stmt" uuid="e0de154f-41c2-4ba7-942e-6aa40461900e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1777,10 +1777,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4c5e421-5d8c-4f5b-8110-0a6c855b3af2" control-id="cp-2">
+    <implemented-requirement uuid="6128ae2d-fec8-4f37-adc4-72c9afd8be57" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="1b86580f-6aa9-4f51-a35b-e740926e3e9a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="babaa120-7007-4ac0-b82b-9ea8355d5103">
+      <statement statement-id="cp-2_stmt" uuid="05bc64ef-f544-4d5e-ad96-e8e21b035818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1788,10 +1788,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0576d6d3-d8a8-4070-a7ef-5f58f2ce0795" control-id="cp-2.1">
+    <implemented-requirement uuid="443c3d6c-5cf5-41c7-9f58-2ee399dc27a4" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="aadcc274-26c7-4613-a8d3-e364c0482e45">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0aeaed1b-fe81-4d5d-9641-ef5c125d9d89">
+      <statement statement-id="cp-2.1_stmt" uuid="396224c8-0b3b-4326-98af-1e98e29c4b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1799,10 +1799,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56c5c372-4416-402e-b3d3-9fdb28020fa2" control-id="cp-2.2">
+    <implemented-requirement uuid="9547f7f0-ac58-4bc7-94df-14f1eccd8f89" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="f5e15027-aa1e-49d3-b0a0-ab3a3a38341d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8a13c2a9-6a09-4880-9bf8-920d6600f351">
+      <statement statement-id="cp-2.2_stmt" uuid="7d014629-227c-477d-bc5d-f780163e5063">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09438de9-00bd-48e3-abfa-d4a39595c003">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Ansible Tower capacity system determines how many jobs can run on an instance
 given the amount of resources available to the instance and the size of the jobs that
@@ -1817,10 +1817,10 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/jobs.html#at-capaci
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="482cb3a7-34cd-4626-9759-7cb1ce2d3907" control-id="cp-2.3">
+    <implemented-requirement uuid="ca8a83a7-37b8-44a5-b8ef-6732e37b3171" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="680433cb-f325-4384-bb58-af03c33796a2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="94be0167-5e2e-46f1-be42-60b3de55e967">
+      <statement statement-id="cp-2.3_stmt" uuid="d02da8c3-8ff7-42ab-a62d-6ef628be873f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1828,10 +1828,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e368928b-b095-424b-8c0c-f3644b04bcae" control-id="cp-2.4">
+    <implemented-requirement uuid="d52be88b-6261-4d93-8c72-7abfe582f314" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="b3788500-c052-4712-86df-c40f721d7399">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c01e1455-6229-404d-94d9-6c8a57af8295">
+      <statement statement-id="cp-2.4_stmt" uuid="a5721303-2572-4ab0-b987-510526560955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1839,10 +1839,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69800057-29ea-4ca1-834d-3b1cdd9f5693" control-id="cp-2.5">
+    <implemented-requirement uuid="982ce472-28e2-4b7e-a7af-31b7a548365c" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="9eada8a5-b02d-45ba-a9bd-489f05c16967">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e210e93f-758c-448d-b033-70513b7fc75e">
+      <statement statement-id="cp-2.5_stmt" uuid="635e5845-e86d-49bc-bd94-356109e52d86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1850,10 +1850,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bdbc9ea-cad9-4bfe-925e-1425bbded0ff" control-id="cp-2.8">
+    <implemented-requirement uuid="2bfbfcef-7399-46bc-a1aa-3938f82620a6" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="1ade502a-4bc4-4f95-9478-57f2584741f1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="af366740-aa2d-4a58-9b95-976530a65d33">
+      <statement statement-id="cp-2.8_stmt" uuid="65eb1bd7-7e85-465f-81c6-c55d421e9711">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1861,10 +1861,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed9928e3-e856-434b-a993-9a2f1b6da235" control-id="cp-3">
+    <implemented-requirement uuid="8f336932-5f5d-482c-bb93-891f6558844a" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="ad0efd20-4afa-4755-86f2-f11003a34c03">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="dc58cd7b-43f4-468c-a80d-d56c5aa0b617">
+      <statement statement-id="cp-3_stmt" uuid="2a381acf-5960-4243-a8c4-1dd9e4a7cfb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1872,10 +1872,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab837179-5973-41ea-be6c-83ccfe50a1ac" control-id="cp-3.1">
+    <implemented-requirement uuid="cdf6c226-9826-4ed0-9ebc-2e1ee994a494" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="1ff99357-6270-48ac-a0df-4f1120aaed9b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4d6e60c5-d53c-47f5-b570-96d0daff7189">
+      <statement statement-id="cp-3.1_stmt" uuid="9a4a2503-c7ca-4d03-b106-f6bff8f88612">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1883,10 +1883,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2268d5c7-bb8e-4fd2-b516-19586bae2be7" control-id="cp-4">
+    <implemented-requirement uuid="fe89b6b9-4856-4bba-a265-d6de21bded58" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="8661092e-6fd3-4228-8b66-779f7773c486">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e6e5107b-6b2b-4914-9022-ee215f954b70">
+      <statement statement-id="cp-4_stmt" uuid="d8698da3-c318-4ad5-994a-2d1f3a9f40a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1894,10 +1894,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6695d01-2340-4d02-9b81-263043ad4227" control-id="cp-4.1">
+    <implemented-requirement uuid="35f68508-22b1-4606-8dab-7db1f48a167a" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="9e286711-ae1a-4c99-a8ea-f634826bda18">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="22f1d6d0-2119-420b-98e8-165400ebde42">
+      <statement statement-id="cp-4.1_stmt" uuid="149c9f21-1835-4e28-8e89-5a9ad40d5499">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1905,10 +1905,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edb4af0f-963f-47b5-a49e-87cc5bdbc33c" control-id="cp-4.2">
+    <implemented-requirement uuid="df22f0ae-4757-4bbc-9130-416450835bbf" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt" uuid="737896af-daeb-4b6d-8119-1c2374be7470">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7e0a6059-8855-4bab-ac09-e55f3220b806">
+      <statement statement-id="cp-4.2_stmt" uuid="9548a3b6-f518-445d-a0fa-ee05163a2d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1916,10 +1916,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72379f36-5a26-41b7-b8e9-ac7b63914bac" control-id="cp-6">
+    <implemented-requirement uuid="6702202d-608f-42df-bb89-96bac9195812" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="d839d845-857a-4ff8-b6da-6f3ce6e3570b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="660b7c62-84f4-4608-8202-503732ea06a3">
+      <statement statement-id="cp-6_stmt" uuid="41770b17-a878-47e6-b989-bf9f10e68977">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1927,10 +1927,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d663061-3775-4e7b-9fd7-f0dd8b8e46a8" control-id="cp-6.1">
+    <implemented-requirement uuid="ee7a4bd6-3de0-40b0-bd5a-b5e89d680878" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="738b1479-a261-4386-88e6-21c825753ba1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b31c4cca-2fdd-439d-804d-9f87abdb8c4b">
+      <statement statement-id="cp-6.1_stmt" uuid="85627f8a-9c40-4d75-b2e0-2bc6cd31d239">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1938,10 +1938,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f07ff19f-f701-44d0-b922-d6ca83f5e276" control-id="cp-6.2">
+    <implemented-requirement uuid="5847922c-041d-4c02-bc6c-49a1189e689e" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="8dcef94c-e47b-4651-9a33-9e507b3994b9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="702b60fe-e5e6-4408-8639-7f16c45185be">
+      <statement statement-id="cp-6.2_stmt" uuid="29b85cc4-7dae-46f6-9f8c-44ae97639bb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1949,10 +1949,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a905db92-984b-4ff6-8a23-52fe7f825da4" control-id="cp-6.3">
+    <implemented-requirement uuid="25e99e64-bb50-468d-ae5d-67a917bb0de7" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="aad98118-d971-4213-ab85-c0c2caea75cc">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="dbf5c211-f5e3-447f-949f-673e44f9ae66">
+      <statement statement-id="cp-6.3_stmt" uuid="53baf1c2-ef64-4151-a123-c86529b8ce83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1960,10 +1960,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4343da39-59e6-449e-b49f-97f009c609f9" control-id="cp-7">
+    <implemented-requirement uuid="35004d48-fc3d-42a8-9526-87ee35704be8" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="6458db54-77c7-4b2e-b8e1-3c1a81e8fec7">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d6f14913-972b-42f1-921f-9f97ec5f92d0">
+      <statement statement-id="cp-7_stmt" uuid="9f7f327b-4692-42e1-8880-f7aa1ba05f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1971,10 +1971,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfb82251-af07-4e41-b6c1-21005182940a" control-id="cp-7.1">
+    <implemented-requirement uuid="ac4b90cc-c415-41dd-a2ff-76adc602c1c2" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="58c02277-988d-4617-933e-472def13e8d5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="26bac355-1797-4768-a293-f66d610e1650">
+      <statement statement-id="cp-7.1_stmt" uuid="1c08d553-a02f-46eb-9089-eca7fa24ebe5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1982,10 +1982,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9eff419-c3a1-429d-a871-7a9acac197d7" control-id="cp-7.2">
+    <implemented-requirement uuid="36b050b9-4f9a-40e2-85d8-9d0a1b1f925d" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="343030c7-ed4f-4fef-a697-23edd79b4c9a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7680af98-355f-4159-976a-43337686f922">
+      <statement statement-id="cp-7.2_stmt" uuid="a144f534-b92f-4996-bf2c-b7885c142253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1993,10 +1993,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d79e4734-9d77-4036-a57a-09e9f43c41e8" control-id="cp-7.3">
+    <implemented-requirement uuid="5741fa2a-7c2a-4b29-bc92-d189a19bee72" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="a5602311-810a-46c9-8703-90bbd5702cd1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="070dd4a0-45ec-4829-a478-0a6f1a16c6ba">
+      <statement statement-id="cp-7.3_stmt" uuid="d4712154-9585-4d1f-8167-078622321a7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2004,10 +2004,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24774428-65a7-4b6e-92ae-c70c62400591" control-id="cp-7.4">
+    <implemented-requirement uuid="30ce408e-f055-4413-84cf-a09c451d5ee3" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="23bb2adb-6ae6-4c53-aed3-6cd7a619272a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0e400896-5dbc-44de-baed-129b77e88a91">
+      <statement statement-id="cp-7.4_stmt" uuid="66efee45-7dc5-4634-854f-2b8ff214d2df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2015,10 +2015,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a7a1a62-bc7c-45aa-ac3f-159b6351130a" control-id="cp-8">
+    <implemented-requirement uuid="3ab3d3b0-e75f-487e-9b21-f444df4b32cd" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="5c79ecea-83ea-4da0-a11e-3a35a966866f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="fb94e36a-09df-4d81-beb7-04b9cafb0ba2">
+      <statement statement-id="cp-8_stmt" uuid="6b87e6f6-fcaa-4665-ad57-411fe94efa02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2026,10 +2026,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20059330-9557-4719-b222-7d6a8e67808c" control-id="cp-8.1">
+    <implemented-requirement uuid="a97dbdc3-d355-4154-9e14-d4c4a029e00e" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="18531c7f-5514-4abf-8fee-e9bd126882df">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b0f4ca76-f232-4ed3-8ea5-6752f96782e1">
+      <statement statement-id="cp-8.1_stmt" uuid="749430d8-0b05-4517-a9ee-caaedce7e714">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2037,10 +2037,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="905e6227-5b26-40a3-a600-668a5b07a53e" control-id="cp-8.2">
+    <implemented-requirement uuid="58fe5cc5-6bbc-4525-80b7-1fa633e8fe7d" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="1cbe9ff0-dfcd-4dca-950c-4d5e8eb00d6b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f223f0e6-c216-4966-a88c-b9cea3e4bd84">
+      <statement statement-id="cp-8.2_stmt" uuid="04c3c8a1-5538-4ceb-95f6-edd9a626f200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2048,10 +2048,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c05043c-65ae-496f-8ccf-12be32910754" control-id="cp-8.3">
+    <implemented-requirement uuid="e9be2778-a36d-4117-939f-d81cda79baca" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="69e82f55-7338-4f5c-a4a0-edb47be8a471">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="346d9a95-05f1-47a7-a1cd-343c4cbb3aa2">
+      <statement statement-id="cp-8.3_stmt" uuid="d3dc47a3-b931-4b38-9e2b-7c875d4e11a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2059,10 +2059,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce1a469f-2c4e-470a-836c-dabb6743c152" control-id="cp-8.4">
+    <implemented-requirement uuid="340f54ab-3f5d-403f-a2f8-9e10f7497132" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt" uuid="6c115a3c-a0da-46f9-b69a-04628e5dc9db">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2ff83210-5c08-46e6-986c-908325448067">
+      <statement statement-id="cp-8.4_stmt" uuid="d3d5e16c-0dd3-4a0d-b2d2-15a938524e05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2070,10 +2070,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1e1fa40-6003-4f49-af1a-61a6085612ab" control-id="cp-9">
+    <implemented-requirement uuid="c42626c3-79e3-429c-bf12-9f7fe675e345" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="2ef12eec-3363-4b73-a844-f9e1b79bd519">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3255ca9d-da00-40aa-a777-b20775e86d61">
+      <statement statement-id="cp-9_stmt.a" uuid="dcf4f455-b4e7-46be-ac29-ee3f20c0809b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -2094,8 +2094,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="872f5549-b476-4f77-bfad-c3201f3e2c04">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ec8627d4-5fa6-468a-9e54-90ef3ffcaaba">
+      <statement statement-id="cp-9_stmt.b" uuid="1d0d882e-0d3f-4ea4-a5f7-1f0b4b8778cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -2116,8 +2116,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="9b432777-0240-41b4-bad8-704c6d11aa62">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="44a650b0-0d4e-40ea-b587-48866d4e6278">
+      <statement statement-id="cp-9_stmt.c" uuid="939b14aa-c91d-4b11-aeea-e90fb6c233a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -2138,8 +2138,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="0718e22a-68ff-4677-ab15-a1d64e175117">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b2b1c10b-2823-490c-9cad-77b80121f8fe">
+      <statement statement-id="cp-9_stmt.d" uuid="b7ef92c7-efb3-48bb-8a38-5d178485dca9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2147,10 +2147,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74fccb76-80c6-4da4-9b94-cccf2a126a27" control-id="cp-9.1">
+    <implemented-requirement uuid="e20b88e9-72cc-4223-9b8d-faedb2834c67" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="e98e2908-4fd6-4a2d-8444-0e2e7dcbf1b2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7a344978-6927-4cb3-94ac-cdb8ac200971">
+      <statement statement-id="cp-9.1_stmt" uuid="afe52a67-a2b5-442f-aa15-f8d979d86064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2158,10 +2158,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90d70ed9-33ef-4ed9-a330-de2a4fd0e66f" control-id="cp-9.2">
+    <implemented-requirement uuid="f687a0b7-9b3c-4442-a567-4b6d57acd71b" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="e52c6171-656b-4620-a70a-318a4a7b3808">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b45001fa-41e6-4b37-a2c3-ec1951b1bd98">
+      <statement statement-id="cp-9.2_stmt" uuid="cb95c52d-a8e1-4a79-894b-2cfb51f5cc78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1b394c9-57c1-4473-81b6-ef134c161a44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The ability to backup and restore Ansible Tower systems has been integrated into the
 Tower setup playbook.
@@ -2175,10 +2175,10 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c684b142-29c2-4f31-a6b1-c718e8c8f7a0" control-id="cp-9.3">
+    <implemented-requirement uuid="bcf315a6-84c2-4771-b6b7-e1637ca46ae8" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="c56d2342-6139-477f-98a0-9e6b54d69dcd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="79b083ad-3df0-460e-8461-c259feda8c13">
+      <statement statement-id="cp-9.3_stmt" uuid="206b1614-e40a-40c3-81ec-73cc84f951d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2186,10 +2186,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cd28cc0-816c-442b-a43a-6469131596ee" control-id="cp-9.5">
+    <implemented-requirement uuid="a4f1eea6-d3f5-4451-a1e1-b1e501329850" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="b7ef5cf3-0e55-4d07-b0e8-060ecfd006ee">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9ebdc88c-8f4f-4f9c-830e-ed33c0aa5f1e">
+      <statement statement-id="cp-9.5_stmt" uuid="6bb96cf5-d0e6-4b07-8f08-c8fa0486284a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2197,10 +2197,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd126169-5c37-4d15-8d84-149f65ea37a2" control-id="cp-10">
+    <implemented-requirement uuid="9ab3db9e-2973-4241-8a86-58a8392136ae" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="22757bf1-e4b4-4290-83d4-60ba58f82eb1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="cd8130c0-fa28-4160-8c89-f5ed3d167282">
+      <statement statement-id="cp-10_stmt" uuid="917e418a-a1ff-4431-9cd4-039411666940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac578ce4-9a5c-441b-82a3-ff8032c49bc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on establishing backup procedures can be found in the
 Ansible Tower Administration Guide:
@@ -2213,10 +2213,10 @@ reflects two distinct processes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a71f715d-2841-4eb7-9d2c-66813f0636a1" control-id="cp-10.2">
+    <implemented-requirement uuid="867698d4-e6e9-4a7b-9202-9e1d8e469630" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="38d19f1e-e5b1-47f6-aafc-7382665ac41d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c8198e7f-60b9-4254-906f-6782cd64e1b9">
+      <statement statement-id="cp-10.2_stmt" uuid="485fd960-7c56-44da-8ca9-377179edda96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2224,10 +2224,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa50cedc-d5ef-4767-ab1f-9817bc47dd96" control-id="cp-10.4">
+    <implemented-requirement uuid="d113dc7c-e223-4ee1-8068-6b7ebd2f1d4a" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="6f9a5b37-d367-4f03-978c-cbe20341efa6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5b1b3aa5-6a46-40e4-bceb-f180a946f3eb">
+      <statement statement-id="cp-10.4_stmt" uuid="9d7665d7-3aba-4618-bcb7-1dd4556f74b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1b394c9-57c1-4473-81b6-ef134c161a44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The ability to backup and restore Ansible Tower systems has been integrated into the
 Tower setup playbook.
@@ -2241,19 +2241,19 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4af3446-3888-4da7-9592-0690edf06f34" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="d5acc5b1-5120-4f5f-a707-02d5097dd848">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4e216e58-428e-44ff-9ca0-a88046403397">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e5dbd88-5ebb-46b4-8c9b-0ee43f3b2976" control-id="ia-2">
+    <implemented-requirement uuid="371b0174-b58a-4b53-bc2b-9918c5dfa56a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="08933d91-1395-4799-900b-d3273d7a2803">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="465f6033-68ed-4296-b357-2fdd9a9e178b">
+      <statement statement-id="ia-2_stmt" uuid="2a30572f-4271-483b-95ed-f5dd0570e737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef6b479e-1a5b-482d-ba86-9fadb9c2f3e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely identify and
 authenticate organizational users (or processes acting on
@@ -2266,10 +2266,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5985dea5-1b09-4ef1-a64e-bf455bf877be" control-id="ia-2.1">
+    <implemented-requirement uuid="8a1d4f6c-1288-496c-bd0c-da79beb23d8b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="92e18305-3dbb-4f33-8938-577913a72e92">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3f30d61b-dc73-4d2c-8284-172e9cd6eede">
+      <statement statement-id="ia-2.1_stmt" uuid="59b74a03-8f9b-4d5a-a8b9-6ace804461fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72479822-926a-428d-bc0d-04bb9d5c56be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2284,10 +2284,10 @@ https://github.com/ComplianceAsCode/redhat/issues/305'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3a854b9-4321-4c2d-a7e7-85e5124699c3" control-id="ia-2.12">
+    <implemented-requirement uuid="f53bb0e0-cd3d-44e8-b1e0-4321fe49103e" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="533a3485-17b5-4909-abeb-656bc64bd079">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3d28690e-1165-4b6a-aac7-1c3600542502">
+      <statement statement-id="ia-2.12_stmt" uuid="16bbb60a-cde0-46b5-9d80-9fcb59849304">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2965a46b-a7e9-4591-bde4-a0545660b690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2304,34 +2304,34 @@ https://github.com/ComplianceAsCode/redhat/issues/306'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b7dbb58-85a2-4edb-b70a-fce9474cddf2" control-id="ia-4">
+    <implemented-requirement uuid="2fb876e4-d80c-4efd-b6ea-4395761494f8" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="2fb26bcd-6f77-4c6c-8e94-cf5aa2ad9446">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="1ac66997-ad05-456f-b4c5-68adf07b5eff">
+      <statement statement-id="ia-4_stmt.a" uuid="9a1880b5-870f-4829-af6d-3595d3c46747">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="ebd59361-41fd-4bcb-8bc1-66d5b84437d5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ebd3f809-8446-434f-8152-dea9aa6a508b">
+      <statement statement-id="ia-4_stmt.b" uuid="a9e0b21f-f9f8-495e-b507-c8052d91b838">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="9a8e0b25-3e46-411a-81d7-58bf00d3c4d0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="699a3ec2-1f81-4dde-a569-8f1e56cde246">
+      <statement statement-id="ia-4_stmt.c" uuid="fce0656d-bbba-43fc-9331-c8a1ddcf462e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="932867f8-2ec7-4b94-a6bb-40698aa059ac">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="45d04356-5c9d-4fa2-8265-cd395dc4a911">
+      <statement statement-id="ia-4_stmt.d" uuid="c0c376b3-6f15-44cd-abcd-ca748e3f0f96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bd77aea-ff91-4d07-92c6-ae2974fbca31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to prevent the
 reuse of identifiers for an organizationally-defined time period.
@@ -2342,8 +2342,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="5db974cc-fbdf-4f49-ba3b-4f62f8512e13">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7baa67a7-dcea-476d-b611-c5810c896528">
+      <statement statement-id="ia-4_stmt.e" uuid="c6b12517-aecf-46a2-b41e-47db93a8551e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c0512e3-9b32-4049-a60d-e66256a64237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to disable an identifier
 after an organizationally-defined time period of inactivity.
@@ -2355,18 +2355,18 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cfc92c6-4a11-4a75-a54c-275b37eb5cfd" control-id="ia-5">
+    <implemented-requirement uuid="c9da835f-959d-42c5-83e3-133b0f133523" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="eaff1fbf-ffeb-4123-b671-fdcbfea9dfd3">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e94121fb-661c-4ad1-9965-987c9cdcfb09">
+      <statement statement-id="ia-5_stmt.a" uuid="c860bf89-2251-4267-b154-89892e906011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="f4a9460d-64ad-429c-88ba-0a52f2849147">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9206270c-2fbc-470c-bc91-867a25c35dd1">
+      <statement statement-id="ia-5_stmt.b" uuid="d780ccfa-5d17-4fb6-b5d8-002a1bb91196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fd24638-7acd-49f0-ad11-24e1cb66bc00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish initial
 authenticator content for authenticators defined by the organization
@@ -2378,8 +2378,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="95143463-953f-4197-825e-f39fd469e68e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="170f5d8a-a7a4-4c6e-a44a-edab7c4b23d0">
+      <statement statement-id="ia-5_stmt.c" uuid="bccd653c-dcc5-469f-a628-589d6b168d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fba1bcc-0376-45f4-93a1-685765ffb3f2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to ensure that
 authenticators have sufficient strength of mechanism for their
@@ -2391,16 +2391,16 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="9c22b4be-1327-4009-ae53-333d825f9862">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2da338c2-65ca-4611-8a19-f9af2d76f1bd">
+      <statement statement-id="ia-5_stmt.d" uuid="6ea5e500-9a54-4ce8-b0ca-284f84cb561b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="76a36e0f-939f-4b4d-a1a2-08996cf7e0f4">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="18f00d01-0f61-45ba-a37c-a21aa6a69728">
+      <statement statement-id="ia-5_stmt.e" uuid="5e21d34e-3528-4acc-9145-49a9fb4d7250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="584dac48-67cd-4f21-b513-00c8c14132ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have default account authenticators.
 Authenticators used during the installation of Ansible Tower,
@@ -2413,8 +2413,8 @@ configuration of Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="4afb58d2-a780-41c3-8dad-919b64131012">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b8c5fff3-edf4-4364-ae00-5fc95885732a">
+      <statement statement-id="ia-5_stmt.f" uuid="76c6d3cf-34a0-4f48-bdcc-2eca1ef06792">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48cdb5ef-17c2-4659-a791-c0a69df35fd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish
 minimum and maximum lifetime restrictions and reuse
@@ -2427,8 +2427,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="cd1f2f45-b039-42af-854e-8ff0edccf8bd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="288f04f2-2dc4-4e61-907f-72146293316e">
+      <statement statement-id="ia-5_stmt.g" uuid="1edb3597-9cef-4b18-99ee-16830cb78a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="772ffc08-0df1-40c0-bf07-d1bb23eb32d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to change/refresh
 authenticators after an organizationally-defined time period
@@ -2441,8 +2441,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="50e690e2-ffd1-475d-864f-c0ec579774f0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d03de3dd-7abe-49cb-900b-360bd6043c70">
+      <statement statement-id="ia-5_stmt.h" uuid="470a74c1-968f-4a85-b411-027724a32231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b8910fe-57c8-419a-92cd-fc087a6beccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower uses SSH to connect to remote hosts (or the Windows
 equivalent). In order to pass the key from Tower to SSH, the key must
@@ -2479,16 +2479,16 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="0df27b0e-1ea7-4511-a91e-17857b721a5a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c9156673-eb91-4e46-aaae-5b464396f1e8">
+      <statement statement-id="ia-5_stmt.i" uuid="848dec97-d87d-4035-afaf-95846dc67fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="ab774ee3-3ba8-4108-8e28-e9229c74078a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e0d6dcfd-ca3a-416b-b7fe-202d6df93f4f">
+      <statement statement-id="ia-5_stmt.j" uuid="c0603fd0-07ba-487f-9910-2c7a853f7d3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
@@ -2496,10 +2496,10 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fc4c0e2-d7bb-49db-b906-17e0e9f8a83e" control-id="ia-5.1">
+    <implemented-requirement uuid="442093fb-88df-4b5a-976d-7019c41f2bdb" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="4c86e74c-8155-48d3-b8c2-c06071316691">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4dd15bdb-fb31-4470-ad39-175dde634ad8">
+      <statement statement-id="ia-5.1_stmt.a" uuid="4829f5a1-5e72-46c5-a366-5c1f3caece88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f722e76-3170-4205-b13d-636506171fa2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce minimum
 password complexity requirements.
@@ -2510,8 +2510,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="450ce306-1bfc-4dc6-bcd8-bbb6e12e9de9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7cb4bbca-645f-40a2-b809-74d4af353be1">
+      <statement statement-id="ia-5.1_stmt.b" uuid="5a016e67-3d19-48f5-9a2e-7579d5dd44ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c75dfa4b-6b21-4f92-8cf0-7d02730b9aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce at least
 an organizationally-defined number of characters be changed
@@ -2523,8 +2523,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="3da5fc2c-f03a-45e8-a615-4250cb395a18">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b8a2cb68-c75e-4998-93a5-946752590e00">
+      <statement statement-id="ia-5.1_stmt.c" uuid="4df30f7d-deee-4627-810f-36e90bc683a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69890876-37d8-4a97-ac90-0433ffcd3eca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'If passwords are used, Ansible Tower handles those by responding
 directly to the password prompt and decrypting the password before
@@ -2556,8 +2556,8 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="5d13e3c0-f855-421c-b814-c948db272a98">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b30cc5a8-64f5-457e-ba2d-6f3e9b9cad72">
+      <statement statement-id="ia-5.1_stmt.d" uuid="324ee3c0-1524-4b50-81eb-e6ec751aa14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1b237a3-fc3f-4c15-b1d9-8a3f8791ec2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce password
 minimum and maximum lifetime restrictions.
@@ -2568,8 +2568,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="8e79210b-387e-40b7-abc7-96bdacc1a683">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5375ea87-2957-4d82-b6a3-5a541e8a74b6">
+      <statement statement-id="ia-5.1_stmt.e" uuid="1af302e0-ae92-4006-a576-8630677663d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="340ef716-a1d0-4147-a01c-8571db050ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability prohibit password
 reuse.
@@ -2580,8 +2580,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="cbaaea60-62f9-4e53-9278-19f70424c934">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e4b9ca8c-07b3-40f7-8efe-e914e7fdb04c">
+      <statement statement-id="ia-5.1_stmt.f" uuid="d538b56b-9681-4bba-be6e-475546134c1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b31d80ff-dbac-410b-8140-9b1d43464121">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability allow the use of a
 temporary password for system logons with an immediate change
@@ -2594,19 +2594,19 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b74b730f-1eb6-4539-a6a8-23ae3d5267af" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="d9947704-e9a7-4b03-ac1e-45a9dbf1013c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e9777121-fc6a-4087-970b-a709fc747a8d">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2442e3e-d52c-45df-9dc9-50d27bdf542e" control-id="ia-6">
+    <implemented-requirement uuid="52e63706-e780-4498-b229-df02905c4bae" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="6e6e88fb-6304-4c94-8bb8-33fdf5a02730">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="74a9527c-0929-4056-a237-fd68cef18615">
+      <statement statement-id="ia-6_stmt" uuid="b1427d3e-0f18-41ab-9fdf-1653e0f04669">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43ec1e2b-4874-4815-a27c-899f6b688ecb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower natively obscures such information.
 Ansible Tower cannot be configured to be out of
@@ -2615,10 +2615,10 @@ compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57bcf99c-03e0-4294-9e63-2fac869da18e" control-id="ia-7">
+    <implemented-requirement uuid="03d1bb60-c8f4-45b2-bb19-886634954cad" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="3effca5d-dd30-42ca-b790-da21091ddf59">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ea6ffd54-9ebc-4f5b-b7b0-e970a9b679f8">
+      <statement statement-id="ia-7_stmt" uuid="c50d587c-9459-4058-86c3-303a824b3e45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a04cba0e-544a-4b60-a086-c6b1018ef518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is currently not possible to configure Ansible Tower to use
 appropriate cryptographic modules. This is a permanent finding.'
@@ -2626,10 +2626,10 @@ appropriate cryptographic modules. This is a permanent finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c82ce679-7028-4950-8575-d775a25eb38e" control-id="ia-8">
+    <implemented-requirement uuid="6bfaf3f4-0c06-4104-a0c8-a1b8e38138c9" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="cb1b4a3e-7212-4197-b662-c023f8b1c32c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="38fe05b0-e03c-47c0-975d-0e4d469aaa5a">
+      <statement statement-id="ia-8_stmt" uuid="68db25d6-2d81-4938-9613-398b847608a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="50bfd45e-adc4-4859-a020-11f67e67db75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely
 identify and authenticate non-organizational users (or
@@ -2642,10 +2642,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0eb3b909-db0f-4d65-9d19-806311d24227" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="f55fce08-b6ae-49b4-a4d9-0b16435dbc1e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f86f8a3a-4e83-4f58-8a96-da53a89fe1e3">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2658,10 +2658,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a7ba04e-3a71-4ad1-b484-79c63d3221e3" control-id="ia-8.2">
+    <implemented-requirement uuid="22e661de-b033-4fb0-9d1e-23146e8f9eaa" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="14fcf8b0-8a69-48e4-be10-f3ab864091a7">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="13ca82da-fb9a-45c8-8445-ffbd1a487a04">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2675,10 +2675,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05254a6c-fdbb-410f-9353-6b938be0ac7f" control-id="ia-8.3">
+    <implemented-requirement uuid="d62f3488-6cc0-4bf1-8170-6510f1df9392" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="7dcbae3a-5aa6-4990-b793-76dbc03d91b9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c4d3ff0a-cd83-4067-8567-37fc01a52ab1">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2692,10 +2692,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a614cec3-244c-4bd8-a723-3404a48bde76" control-id="ia-8.4">
+    <implemented-requirement uuid="d8d58f64-4237-48c3-b94a-23b93f6aca24" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="5bdb4c00-9716-4285-af4d-f44933c34201">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="20674473-fb76-49ce-ac5d-14d0fca512ec">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2709,10 +2709,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="994b5b6e-9a78-4ae4-96ea-6d31d3d438c9" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="791c43d8-416a-4859-ad18-2baa167251a3">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ccb36022-317d-4d86-84ca-04ad0a3d2839">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2720,10 +2720,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e3479d9-4036-4cc1-8d41-95fe3b9d43f5" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="b93186a6-4d25-484b-9609-eba0fd47af53">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5e8b4a42-198d-48b9-b050-9a09bf2061d6">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2731,10 +2731,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec17fa34-e245-41f2-b078-1177a721535f" control-id="ir-2.1">
+    <implemented-requirement uuid="78d7845f-de00-4c63-bd97-4e0839f3f0a2" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="8392acc2-b9fd-4e46-99cf-a29a54b03e69">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="edb9fc6e-ce51-4b47-b491-9f252399962b">
+      <statement statement-id="ir-2.1_stmt" uuid="2a2123c8-220a-4661-8f26-18515e8eb566">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2742,10 +2742,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63863aef-95d2-4974-97b3-45cb2be0e555" control-id="ir-2.2">
+    <implemented-requirement uuid="246aa74d-9372-4467-ac4e-954bae434f90" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="61083dae-bbf6-4b4c-8de4-bd013fbb0365">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="640d20ab-e964-49c3-8207-ed1dd9ecca83">
+      <statement statement-id="ir-2.2_stmt" uuid="f3b8f0bb-f626-43e6-9afa-be7e82b405e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2753,10 +2753,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95a34552-d6aa-4257-bceb-88f696eccd77" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="09cdfde0-100c-4887-8569-03c4ed9ba1cf">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="65c4fbb6-15ca-4a83-9793-cfc92868edb9">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2764,10 +2764,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24b4fb80-07e3-4971-8b27-27a53699738a" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="5702f273-4380-4f9b-a8c7-ca6ceca8e34c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="817eb913-6fd3-4fe0-8f8d-37a8dc1f196d">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2775,10 +2775,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c0aac84-caa0-48de-9ae0-ff6c96f9cca6" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="2c3d81e3-9924-4ffb-a426-233a6845827a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c1944dfe-c4df-4744-84a1-2cbf7b88103c">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2786,10 +2786,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d651289b-8bb2-401a-9560-523a612bff96" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="73d00c5a-2a95-46b4-8046-1c69de37ea67">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="6b7099d4-02a4-4a3a-8be7-c0ba1c5e86c7">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2797,10 +2797,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ca9f0f2-7478-4205-9b0f-75843cb3edb2" control-id="ir-4.2">
+    <implemented-requirement uuid="7f0a3982-d079-4924-b580-f0dc1d216e85" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="248fc66b-fd33-42a1-a46b-5e8fdab9e9fa">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="021505f3-2adc-4d84-8232-5f1cc868c8f3">
+      <statement statement-id="ir-4.2_stmt" uuid="9c563bcc-5237-449c-a4ab-d3b700a97da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2808,10 +2808,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02c2f3e9-26d8-4d22-bccc-fb66e1884957" control-id="ir-4.3">
+    <implemented-requirement uuid="13b97b42-76d6-4061-b638-febe0cd90231" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="bfbe76c3-5ba7-4445-89e3-c407a8573ed5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0ea59543-9f0d-4755-b224-a29f477ffa2b">
+      <statement statement-id="ir-4.3_stmt" uuid="5e0e6990-1ff8-49bf-be0d-5d2737ce63e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2819,10 +2819,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3446e71c-d710-4eba-a4da-ebd90979505a" control-id="ir-4.4">
+    <implemented-requirement uuid="3f7d2d28-2608-42b5-be50-8da2df81d87f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="87d59a19-e026-48bc-b663-4372cd08adc9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3664f3cd-da41-4faa-8fdc-fbe5f87045df">
+      <statement statement-id="ir-4.4_stmt" uuid="ac63043c-31bb-4d93-b0da-40a829860d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2830,10 +2830,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40f84d8f-93e5-4bb8-bb5a-09c8fe2a6704" control-id="ir-4.6">
+    <implemented-requirement uuid="37e8a5cc-59e9-4a7c-9bdb-cbeee02214ca" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="7b279267-3075-46a9-bc4c-acddf7d7074b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="fc784039-5ddb-4ce9-a9c5-ac17fb1f7c19">
+      <statement statement-id="ir-4.6_stmt" uuid="7ef8f800-1279-4b68-9615-3565349db7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2841,10 +2841,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb3de33d-94c4-468a-8f2a-b669c94e0194" control-id="ir-4.8">
+    <implemented-requirement uuid="4e72b7dc-4243-419a-8f07-49afa8e6bb71" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="f0523fcf-89f1-489d-a08b-0c944fd118f7">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b8bf214f-5d75-44e3-977e-e8376a67a3c4">
+      <statement statement-id="ir-4.8_stmt" uuid="eeea2ede-129f-4055-8e4e-5f5514fae167">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2852,10 +2852,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04ceb5ea-3171-4861-bf67-310d6fd4f549" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="92976234-3f49-4f68-812f-7c572408d049">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="78cb5ab5-5e1d-424b-8a8b-72055be3acc4">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2863,10 +2863,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1edeebd6-f43e-4d3d-89c6-85fcac1f341a" control-id="ir-5.1">
+    <implemented-requirement uuid="6d97e9c2-2cde-4770-915c-0fb3374028bf" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="7b637dbb-f517-48c6-b1e8-e39454f0d8cd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9da6d4dc-2b77-4c70-bc9c-5fbdfcf90460">
+      <statement statement-id="ir-5.1_stmt" uuid="555bebe2-f2d2-489a-99b8-98b462646d4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2874,10 +2874,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef546e59-2361-46f8-8f4d-637b66b14b3e" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="58920ca9-b599-4707-aa3e-ad10ec42c09a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f9f591f2-f66e-44a5-836a-493177cd0dcc">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2885,10 +2885,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10f19935-04aa-4e48-8106-ada3c95d1ab5" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="8ddfd10a-6cc9-48c2-94c2-38412772f013">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="6f31bef2-d59d-4e43-ac90-f9fa2b715028">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2896,10 +2896,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a57e363-73e2-444b-8285-a7757cd5fd41" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="78e7e6b8-50df-4a16-8e96-d472158308aa">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="6cd370e6-ef10-4be6-9592-5a3ac703aaae">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2907,10 +2907,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72bf0833-1b3a-4262-9282-b5a05ea62647" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="47683ae0-dc86-4fa9-8bf4-147cad1a3715">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3065a997-3319-42f9-aa85-45c55a0bd205">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2918,10 +2918,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3142b723-2850-4b8c-b9e4-a3c1f15ae405" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="50817b41-8ef6-4e23-b244-da4e5c597441">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="78b064b0-16f1-4980-a8cf-a51e71edf6d7">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2929,10 +2929,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e608c4a-ce7d-4429-a790-ccbfb9fb64fa" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="ef1b29aa-1261-428a-849d-9ecaa5081d52">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="860d76c5-2ee7-4b2a-85e0-baddef443379">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2940,10 +2940,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb0eeb81-1451-463f-8d02-da945970fe0b" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="f989cbf0-c53e-4388-a5a0-3165dc551734">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ea06855c-a08d-40c0-b705-8b201f448b20">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2951,10 +2951,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dd52010-f2b0-4149-b66a-35121dcf454e" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="7878bb42-182d-4277-b0e3-59bd3184ca7b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="25b1be90-cd03-4a0c-bd51-f0f13a7a5865">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2962,10 +2962,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af27d3cb-7e9a-4e92-ad47-a225b88a9fb4" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="cb30f309-9734-4faa-8eaf-411356463e98">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e2243e1c-fc63-41b2-a6e7-179e0995d832">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2973,10 +2973,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7e79f17-0102-4fd8-8874-9c46b6226f72" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="f26f4c2e-2b85-4b37-bf5c-ecae7415908d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a4ec452b-47ff-4c0b-a12c-edf9cc2702cb">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2984,10 +2984,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7de7bdd-e35d-4d9a-aef3-bea621f4162d" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="83d5a578-c574-45dc-9e38-e38d881b38c0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="eea793ee-20dd-403b-a197-f4ba67dcc121">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2995,325 +2995,325 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a2bc24e-bf57-4c9a-b9b4-a932d40903b2" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="f5604430-5cbb-40f7-b080-3504069b0487">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="707a391a-d57b-480b-9d6a-992c10983d53">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dab6f72-410d-4b03-b374-40c8b8084e67" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="9b4d389e-2405-4c6b-b485-ebe410049070">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="73d0d101-1e45-42ee-98ad-e0cefee07e40">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c77cd53-68a6-478c-8a58-6033b334423b" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="4d2f703a-3737-4e42-9dc6-f904dc55d888">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0222af7a-38bf-4d01-baec-0c7621adcaec">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba0b9cb0-7344-422a-b33e-90d2c1a11da7" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="d3d06d15-dcd4-43d2-8d17-5484f1590531">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7db6ebdb-f8a6-4f06-b3e5-e5a58874818c">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebe701b5-f13f-4e13-af02-c1ab8cb5205c" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="95d5ea2a-6cdb-4709-a5d3-7928531ffd20">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8cf278b3-35b8-41a8-a126-a543fa7ab491">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57c846d2-f53a-49fd-8dce-9ad98ce1bd9d" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="9e76e766-235a-4edb-8e72-a3fdd1c23049">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2f835c4d-a120-4dbe-9a17-35e2f98222ca">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70404d35-328b-4a93-a48d-a1ea111c235d" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="9d1d892b-148d-4c84-9a25-bb06a8a603c4">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0f7d6c7a-a639-4616-9289-d6f111666316">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d15c449-5954-477f-ac76-4c6d27ae8125" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="1d30c92b-2b3f-4cb6-9ee7-d05e67cac6dd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2c75dda9-4e9e-446c-b65c-61545a65e87a">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b92d777-d890-4505-8387-18dee37b2de5" control-id="pe-1">
+    <implemented-requirement uuid="2f7f0c97-6293-4bcd-b72d-48d898a85c69" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="e34284a5-2ce4-42ec-88bb-ef85c22e83f2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a689b20a-e918-46ba-8b4d-7fc1b08be982">
+      <statement statement-id="pe-1_stmt" uuid="49128975-33cd-4a5b-b055-ec15d44fbd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ff8a59a-308c-46da-9707-a299bb833006" control-id="pe-2">
+    <implemented-requirement uuid="99e9769e-d92b-49e5-bb4d-8d0e0d0bfd5f" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="0c0221b5-d1af-4794-ab25-1b1efc606009">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="ed78b639-de75-4ba3-8749-86e3cf6db30e">
+      <statement statement-id="pe-2_stmt" uuid="4ac4c77c-6b19-45d0-b1cb-299060ae3873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14bba851-d125-4044-872d-d75722d3f157" control-id="pe-3">
+    <implemented-requirement uuid="46bcf589-84e3-4bd0-9c21-7f0f7a5c2682" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="814b960f-0a10-4281-95c6-baa241916739">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="36567cab-0677-43bd-a4c7-5613ca2b6b7e">
+      <statement statement-id="pe-3_stmt" uuid="7af14783-a56e-4e7e-b622-1ed3f5a2d534">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2afa1b4f-ebf4-4fca-882f-bb041c999853" control-id="pe-3.1">
+    <implemented-requirement uuid="8e5029a1-2659-4ebf-a2d5-46d17952d7b9" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="391f412a-3b3a-4346-96be-5040b9282c72">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="16ce5f4f-b9d9-4965-8a68-c2195c1df531">
+      <statement statement-id="pe-3.1_stmt" uuid="024726ff-7a46-46f1-a1f9-1f38daeef568">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88765691-25b2-43cb-8c83-fd1350800693" control-id="pe-4">
+    <implemented-requirement uuid="5398beb6-0bcf-4ecd-8411-c99d79fadd98" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="18cb03d1-7a0a-4346-969a-67c1d720d99c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d97f0e9f-4ad2-4e39-913b-1d138b159794">
+      <statement statement-id="pe-4_stmt" uuid="ce67f5f8-1825-4d71-9bd3-54fc406ce2ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d77da01-71a7-43ca-a804-883af4a193ab" control-id="pe-5">
+    <implemented-requirement uuid="adf6841e-cad0-4d46-adb2-29a6678fee44" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="fd2f4891-f718-4bd1-8479-97d0c2a67cd2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="5f36acc0-e4ea-4c92-8756-6538d4b658f6">
+      <statement statement-id="pe-5_stmt" uuid="0d04fd69-6ae8-41e5-ad6f-7b735659189b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df2b070c-4f28-4786-9c2a-60e569601a57" control-id="pe-6">
+    <implemented-requirement uuid="d29450a2-ccd0-4565-b5a1-136395ecfbb9" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="f8d8b5e7-a56c-4391-8db9-222e5a012b38">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="50d3595c-965c-432d-a9cc-ae6dc68f86a7">
+      <statement statement-id="pe-6_stmt" uuid="ec6c4c4b-033b-42e7-aacb-9009aac4e615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d20430f-f96c-4a2d-8c44-973faddffe02" control-id="pe-6.1">
+    <implemented-requirement uuid="3cb204b6-7e26-401b-a771-5587034add8a" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="5c0c998f-90e1-4ec4-a6ee-4b3c8da824a0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="512168d7-e342-468c-b443-a106eefbf8de">
+      <statement statement-id="pe-6.1_stmt" uuid="ebbb8901-f3a2-4844-acab-cad0db5c5b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09647ab3-fd51-4d74-b992-f6fdb50a5d61" control-id="pe-6.4">
+    <implemented-requirement uuid="08ab869a-e433-4f38-b6e9-5200e01b5ff1" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="bd5a0f0e-5a54-4699-94b9-c1c53e5bf419">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e004640c-1c77-4727-9c62-9fd34e954880">
+      <statement statement-id="pe-6.4_stmt" uuid="7a208c5a-20d2-4536-b9e3-bc839ac7a54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ed62f71-5095-4098-ab35-9d3f2735401f" control-id="pe-8">
+    <implemented-requirement uuid="fd1a7d09-ad45-4281-8eb8-60471713fa5e" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="29f57eef-0368-4cbc-bd08-5bfcecfcc879">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b596e4ae-f09b-4cb3-ac1c-c77e575e687f">
+      <statement statement-id="pe-8_stmt" uuid="cebb755c-5a3c-4b68-9470-31b5866508f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a0a9165-b216-4a82-b406-2fdabf1d37ce" control-id="pe-8.1">
+    <implemented-requirement uuid="748800ba-ef57-49af-b961-8957aeeb2136" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="10d110d1-3f73-463a-b37e-d8e8db1e6558">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8026dff5-751e-4c1c-839b-3ad87888943a">
+      <statement statement-id="pe-8.1_stmt" uuid="eccf68b9-3cbe-479b-8994-49994ee4b655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8cdc1b0-2279-480e-b9af-5dd547d3a1ca" control-id="pe-9">
+    <implemented-requirement uuid="0e606685-a2cc-4e48-952b-d1585845579d" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="51ee4936-4a58-4f68-b0fe-8b58b85097b1">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="57293799-1762-4d43-a2d6-e56c0d4bab53">
+      <statement statement-id="pe-9_stmt" uuid="a1aeba62-6ef7-4afe-9f7e-8a275f2c503b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf57afc9-f519-4fdc-aed6-adda78f8bc25" control-id="pe-10">
+    <implemented-requirement uuid="fc2b981b-a537-4c9b-ad52-2f1f766fd2af" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="c0a524b1-e220-42b9-930d-9f8bc7ba1ab9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c29a2083-5de6-403f-8764-d1c31dac8052">
+      <statement statement-id="pe-10_stmt" uuid="740f2b7f-3ad3-4bc3-86f9-243d75ecaa27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d33ec8f4-eea3-4894-8865-d7569c269d25" control-id="pe-11">
+    <implemented-requirement uuid="4e378dac-3cb2-4ef9-9715-df80215b71fc" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="36dcec26-9b58-4a83-afd6-8ab6d6901c55">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3f0c826d-8b68-4ebb-9f35-713182bb868e">
+      <statement statement-id="pe-11_stmt" uuid="2ce19ca8-7e5b-4029-bccb-fa0867337ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73fd55ed-36d6-4a0b-8b12-14f61ebf55b7" control-id="pe-11.1">
+    <implemented-requirement uuid="fd386ee2-2e38-4e22-a5a2-d5c90b2e5a68" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="b526f9c0-24b0-499f-894d-c956125d3c79">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="97c0b35d-76a2-4377-9b99-fc397461f387">
+      <statement statement-id="pe-11.1_stmt" uuid="e72c0704-ca06-49ab-a46e-344686acd4e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02cba514-c62a-467f-876d-643242d50f55" control-id="pe-12">
+    <implemented-requirement uuid="1bf66550-56c7-49f7-936c-83a279d81381" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="618b80c4-2d2d-4a7e-b5c7-badfef724e77">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="aee2b606-6367-4f1b-8252-dac07b85388d">
+      <statement statement-id="pe-12_stmt" uuid="e51bc885-c7a6-484d-a9bc-82fc55897514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f63401f0-3645-4285-8fd5-c1d85136b2bc" control-id="pe-13">
+    <implemented-requirement uuid="461125ab-9fa7-4af6-ad14-25b5d7674053" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="5c4640b6-0577-4017-b489-692d70f55154">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d3305483-aa3c-4c9f-9ccd-2210c58c79e2">
+      <statement statement-id="pe-13_stmt" uuid="272e29ab-c2fc-4613-945b-8dbd0fa31461">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ec2f02a-f5ec-42e3-b70c-ad3e5c8545e4" control-id="pe-13.1">
+    <implemented-requirement uuid="6836b92b-d5d8-4f87-935b-f590137d232f" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="7d4bc710-cd33-465b-9483-1a2b32376fea">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b45366e4-25a2-4dc6-ba12-59e1b92cdf43">
+      <statement statement-id="pe-13.1_stmt" uuid="05aa54ce-489a-497b-9617-08832a3d9d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66f0d420-649e-4785-bb32-ea635e4f2e8a" control-id="pe-13.2">
+    <implemented-requirement uuid="f45e7c31-6e6c-4b48-8672-84d1baeedb32" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="0210833b-c378-44e7-96a8-47669fe7d807">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c5450099-47f6-4208-9bef-2dbc6bb7d694">
+      <statement statement-id="pe-13.2_stmt" uuid="a30d566f-7c76-429a-8dae-bf11cfbbaac0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebaa41a9-e73c-4b59-8c03-5336d1b910ab" control-id="pe-13.3">
+    <implemented-requirement uuid="5e69a9e2-b3a2-4913-9e73-19b074b9d6f7" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="b95a80b2-40c6-47a3-a626-b533b8afeaed">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="edcaf545-e738-408e-9a6b-5dbcc89e5a30">
+      <statement statement-id="pe-13.3_stmt" uuid="6ed87f30-a2d0-4a72-ba7c-b4942e76f14f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48a6e4b8-a36c-4594-8596-a335b67765ec" control-id="pe-14">
+    <implemented-requirement uuid="0c2e6c1d-668e-44f3-bb50-b9b7c4d58788" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="07141983-a498-4b96-84ba-faaeb0d4e2a0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f8763c66-37ba-4922-8fa0-59cb9be904f0">
+      <statement statement-id="pe-14_stmt" uuid="71cfa9a2-51da-495e-b0e4-cd6ed446d5e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56678061-cbbe-48ed-bcfe-19300b165726" control-id="pe-14.2">
+    <implemented-requirement uuid="c1839e3d-ae60-46cf-88bd-d1d95591b36e" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="c25e0ff7-4fd4-4d70-959f-db5b630238ce">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8ccf74bb-3322-4be9-addb-a67d4c8bfc4e">
+      <statement statement-id="pe-14.2_stmt" uuid="643fe30e-156a-41c0-931b-3bd53d1bb318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58fddea5-0619-4244-b7f8-0af979a86d2a" control-id="pe-15">
+    <implemented-requirement uuid="fe4172ae-185d-42b8-a78f-c0f39067dc34" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="48e8c324-a1c8-4cfc-acaf-38058e8f1da6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="156a2405-32de-44b8-9415-f6c88982fc50">
+      <statement statement-id="pe-15_stmt" uuid="0d79a669-82f8-4de4-88e5-cfa1fa7e0ee4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fae32135-f920-4c9e-acef-45e6dc4b9955" control-id="pe-15.1">
+    <implemented-requirement uuid="8020bff8-61fc-4006-b7ef-2b26a5b1da61" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="4345441d-5374-4d75-9579-0f22f502edc2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f3d67b11-59c8-4eaf-b6c2-5b3f82aede5d">
+      <statement statement-id="pe-15.1_stmt" uuid="0d77f460-d019-4f79-b369-65a03e82c841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3e36867-84b2-4657-a4b4-fbd272778c67" control-id="pe-16">
+    <implemented-requirement uuid="71f12c3d-ab07-4ce0-b016-609d6f02e9e5" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="f68dcf06-6b3f-4fe7-930a-906caf7077ad">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4f124d0b-6c88-46e7-942c-6fe24158c5fa">
+      <statement statement-id="pe-16_stmt" uuid="bcd29e47-8369-492a-897d-e9fae6e0c867">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8437d5d7-6a36-4022-98e6-d6cad568c249" control-id="pe-17">
+    <implemented-requirement uuid="db25ef54-eba9-4543-97bd-402949471b78" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="c6f31d66-4a52-4e7e-a786-1847b79b9fc5">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3d995203-25fd-449e-b8b2-937b4718747f">
+      <statement statement-id="pe-17_stmt" uuid="09976af6-2514-4c59-a721-4cb5a4bda261">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d623f09-5f65-4b62-bdbc-3be986821ae7" control-id="pe-18">
+    <implemented-requirement uuid="f5e37eaa-8cd7-4c27-ad75-57c64481ae88" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="134f549b-3149-45d2-be4f-d7a1f5d6e92b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="8f151c05-3d42-41ff-91d1-aafcb2f79325">
+      <statement statement-id="pe-18_stmt" uuid="02cf66ea-8d54-40ef-8fc3-f9deac969e88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65c4bf7c-112f-49fe-ae57-28a67c4fc3c1" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="5c697790-eb6d-416f-9a7f-e3d0873f22f7">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a8f8e34b-9851-4cd8-8bb2-0d4e55d35d34">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3321,10 +3321,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0245e3a-90e5-4803-963c-9cf011636727" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="954fdda8-2953-42bb-89b3-dbef7c110133">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b4f36651-8fc5-4efb-a804-9c9ad55edf59">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3332,10 +3332,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20ea0c6a-e9c9-4b02-8fe7-a89ee52ae129" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="9a094379-2f5b-4fa7-8dbb-405f94666993">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="53893273-309c-43c4-a29c-ba114dc84f47">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3343,10 +3343,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3813b70-7d46-4113-87a9-426a317e5498" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="50a06f70-7c54-4066-a35f-2b779156cd0f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="89d40970-f428-4035-88d3-5967ea09efbd">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3354,10 +3354,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b903312-41d2-475f-a9e7-8ef470fbcaa0" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="aa85daf3-b275-4990-8e5b-49d286861412">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="530466e4-6a92-46ae-843f-0df303061d27">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3365,10 +3365,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ba95bca-c23b-4e58-83ae-371a3fd0e7db" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="bd34a881-5c12-4866-8db4-961968a80a93">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9b7294a9-bf39-4f3e-91f7-6b93374bffb1">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3376,118 +3376,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="400c2024-505f-4b33-8fda-d4af5447a898" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="e0cee903-51db-4b21-9531-4a4597022374">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b4b3bba3-4bc7-4004-8c3a-77795e421e8e">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="858105e9-185d-4867-8df4-e21f90bd41b2" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="0edc8f9d-4bdd-4df2-8139-6d1152cd754a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c6361e33-a745-4026-976f-71b141f2198a">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e514e532-df62-4556-b391-8b5424627383" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="525d014d-4c8b-4a5a-947e-e0350e6fbafb">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="c0340fe7-423b-4e3d-bc6a-98bedcc4057f">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0bbb80c-1385-4df5-99ae-c6f052fc90b5" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="2f3859ba-3070-4668-a7f6-0bdb4bfd94d6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="1634c71e-77bd-4395-946e-a410bdcc3dd9">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b783b4d-0606-4e66-b2f7-b4d967e31d50" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="090106f8-b77c-4f4c-9782-5e35f458f4ce">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7d5f18d3-695a-45cf-b884-4e48937ea81b">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7c5a239-d617-4cc6-943d-67513b68b638" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="9803c1cd-c696-47c9-832c-1d9004467702">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d1c3759a-6812-4b51-9666-5f96442a51e4">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46502bc8-47fd-4543-b38d-6bc4183d4198" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="0c3634a7-b250-4882-ba86-61dddeb82b0b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a53324cd-793f-41a6-895f-1e02be333c92">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4ef1fae-7e25-4ded-ad69-7fd9a31e71a1" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="2d442603-5f10-4e8a-9f78-dc27ad64c02c">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="dd8f78eb-6aaa-4f4b-861a-ecdef3625adb">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcf1b481-9823-4586-9a19-0a8aa049f40c" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="41400a31-0a51-4997-bbe4-38b9d2ec0d5b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3d7c056c-22bc-436b-b2a9-108141bd0dbd">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90dffa5e-7d84-4033-89ba-3819562b4952" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="f476f3da-a631-4170-bfa5-baa7b4cffa0f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="cca3d155-8fe9-4009-ab21-400d348c95c8">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3d96dc5-5c6d-47a7-9fca-7edd4fa558d1" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="20cf12d1-e440-4866-9ce6-7cbcf4be0ec9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="806aeb1f-8ed3-41de-b8f0-5fd7b189a431">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc8be174-0e47-4e01-b913-8714b7b3aacc" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="445e6768-7fe2-4027-b661-c4e0ef104285">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="31c8239b-7c06-4a7b-9f1b-0833a69d359a">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a07fcd7-d5db-4e7f-bda1-37f24ffbd445" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="c7db4620-2dd6-46c3-a6fe-0a2870c3463e">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="93370361-5c31-45d9-8607-3068d2f6af7e">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3495,10 +3495,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="380332b7-93c1-4efe-80ed-0516414240b0" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="2f6f5df7-c20d-4117-88df-9920d196f56d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e39cac5e-74c2-4d18-b7f0-64a34cea2c90">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3506,10 +3506,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5563f238-57a1-4fef-aba3-eb12e37cb3f1" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="c2940065-35c0-4e94-a6f9-f3f4b6785326">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="06c3c9f9-ca4f-4a55-a5ab-0ac4e5550398">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3517,10 +3517,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd1da3b8-5dc5-49a6-acfe-6d256d9c4214" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="0f38289f-586a-4cb8-9fff-31b3c7422e2f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a2d679ee-caf3-45fc-a734-9935e8aa533e">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3528,50 +3528,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b3fcb6b-74be-43ca-9516-441892df6228" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="84aa03b0-d5e6-4910-bf8e-13acddf4e934">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="43c0d926-fd1e-40ba-b9f1-b3632da00ed1">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbef193f-fbdf-4630-b7c5-70ae5569e21a" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="119147c7-b74a-4364-89f4-4a816e7eddf8">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="21b5bd4e-25f3-4015-8435-459e5a04bdaa">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a361e60b-85e3-445b-8f8a-2522b5b0132e" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="9160e371-77dd-49e8-b07b-6b6e992b5380">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="0b80c9db-21e8-4492-9175-48cecf4037bf">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9f591fb-af40-47f7-8f0f-b9db6295a1d0" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="bcc5513f-3980-4cae-8def-20d39151ab5b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="461bc27c-d459-4be2-af41-27b7d63fe643">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03df4bd0-eab9-4871-8d62-17059f8a8713" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="33a80146-29c6-41cb-a7c7-f25bda38aee0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f0b3f3fc-007e-4ce0-a6b2-419298fdf2f5">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3579,10 +3579,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="158ad9d0-e665-4112-99cd-159e33823b1a" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="a874419d-dafa-4887-bf84-95bb92eeed4b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="fd0e4c9a-4c46-4d24-a459-8687678728be">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3590,10 +3590,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24caa107-65ff-4b81-bb4f-6e102d342581" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="2ad5ef1b-74fb-4988-ad71-56b72825c06a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9dce9b2d-5ff3-4174-badc-0a5e5d8f3d2f">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3601,10 +3601,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70a1e477-3316-4584-b2e1-9041c9b7cc47" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="c316ace5-ff54-44a1-87f9-70711387fc90">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="47438b0e-592a-4b58-bc1a-6b7b5a1563aa">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3612,10 +3612,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e692048-c1f4-4276-82e8-e9c7e70a5f2b" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="113045e2-e727-4198-a2e9-5e1e9898ec2b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="781f7fe6-be96-4e3d-b52e-803c3676e0c9">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3623,10 +3623,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad325028-ec9a-4568-a29c-60650049b332" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="ef3e21c2-5e19-4afe-8173-c8ff184e31bf">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a83aa6e4-f096-4d43-8dc8-39faafec6c89">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3634,10 +3634,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="704f5a7d-6922-4b25-a9d0-1af0252accea" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="87a4fe70-73d6-47b7-9bb0-b06b5180c3a3">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="95dfc04a-4e69-4044-a2ff-4b7719c5c0a7">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3645,10 +3645,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="532a150a-5736-4d64-b144-4bb4fc7b6372" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="b0bce043-3dcc-4027-ac58-c3deefeb92c8">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="e6ab7bf7-05bb-4fe5-b885-d60611c0beab">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3656,67 +3656,67 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59484f0f-d875-4c73-afee-65974ede4b71" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="41d70087-d013-4fd7-8b8d-2d8b9b232461">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="7f310b81-d909-4a16-9cc5-9b120a8257d7">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="4c8c6a70-f668-4c81-a2bc-ebcc99e845fc">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="d22e6eed-7614-4d26-955f-9363c5f6a523">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="f6c5757a-18ad-414e-abb6-455372b61b4b">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f8f03b4f-bdc3-4994-8426-c8804910e52a">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="fd4d9b35-6c28-409c-bb39-e04b2e1f1da9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="1f2bf74c-541d-44f0-b786-9ea91ef99d87">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="b887fb37-2092-409e-bb2d-6dd3e3b40515">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="abaac8d3-73d8-4d72-a3a5-a2e634cc20f5">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6cf512e-111d-4d99-89fc-ee9379a3a918" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="9be63fc6-2a2b-46ce-a5f4-f4bad0d189e0">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="fce56506-cc7c-42e6-977e-60de9bad6e4a">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53addc5a-deb5-4bfc-8e21-f9ce08025029" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="4a8b3515-1fd5-4467-830c-30a7a8c9d0f2">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2d12c820-22de-4761-bbfa-edaf954c80ef">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="122f32ce-36c0-401d-b565-930e79bd6633" control-id="sc-5">
+    <implemented-requirement uuid="f289d3c1-ea77-4218-bee0-d26c22b792e6" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="e480091c-e65b-47c3-bcb8-a7762a2790eb">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="23b3b1d4-57ed-450b-936e-a9d0b7a000af">
+      <statement statement-id="sc-5_stmt" uuid="fd835df2-1964-4d23-93fe-320a0cce93c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eb04c3a-268c-4698-8ac3-07070531f142">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation of anti-denial of service capabilities is being
 tracked on GitHub:
@@ -3726,19 +3726,19 @@ https://github.com/ComplianceAsCode/redhat/issues/333'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5031cc96-adfc-4e7b-a62e-e707b622856b" control-id="sc-7">
+    <implemented-requirement uuid="d1537646-d09d-4b27-8168-e2f8ac841f65" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="c21f076c-6e57-499a-a79e-94059002a39d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2c5580f2-7961-43f6-bddd-76d876c83cd9">
+      <statement statement-id="sc-7_stmt" uuid="95e9e235-41e6-46bb-b0a1-a1f95cbf5047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="299751eb-a32f-4081-bbb4-2c33cfe217c6" control-id="sc-12">
+    <implemented-requirement uuid="4e57123c-f1fc-4c5c-8c0a-16efeec9b8c5" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="84635692-9db8-4404-bf29-e33e15901752">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="3398366b-4c45-4c7c-881e-17d0134c81c9">
+      <statement statement-id="sc-12_stmt" uuid="c1a01dc9-6661-4f29-a9e7-1dac5c37004b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd03d06b-099b-4167-b1e2-6d7241efc817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Ansible Tower generates,
 distributes, stores,
@@ -3750,10 +3750,10 @@ https://github.com/ComplianceAsCode/redhat/issues/334'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df6de72a-fa30-4a5e-9366-8d4dda46fce1" control-id="sc-13">
+    <implemented-requirement uuid="167053ac-c758-4dd5-b2b1-6d57f85cc334" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="bfaebd85-7a1c-4cd8-a76e-ddce75252cdf">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="2b7f6cb2-3ada-4a3d-8e59-ed90cb3fd26f">
+      <statement statement-id="sc-13_stmt" uuid="fe1447c7-c6b2-402c-a493-70740422465e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32e15b57-5493-4344-a7eb-3b14d3f36cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Ansible Tower's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -3764,50 +3764,50 @@ https://github.com/ComplianceAsCode/redhat/issues/335'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e8de9f3-851b-4e0e-a8cb-70e9ee2ac44d" control-id="sc-15">
+    <implemented-requirement uuid="24d21625-55df-47e0-9ebb-3da75db7b953" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="825252ab-d31c-4d3d-a6a3-03828abb5366">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="67cc46e3-97bd-42cd-9b97-e15976803a75">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a22848d6-8d3e-483e-8e31-f144fd736707" control-id="sc-20">
+    <implemented-requirement uuid="9f9b9f7b-d437-4e54-99fe-5c761fd83e92" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="00416168-7e65-4d31-8758-8615ab23a11d">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="695fb106-38da-43f8-817e-812492edb76a">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48c7b620-3e97-41b4-b4e9-acc844b3ca38" control-id="sc-21">
+    <implemented-requirement uuid="cbf58203-fee8-449f-8667-d09d9c8f3784" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="c454d9bb-a932-4015-93ea-aeced2a9dbe6">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="afccea72-f675-4670-a09f-1b417f55d8a6">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a7e43f0-7689-4a71-b501-4f22906f72f0" control-id="sc-22">
+    <implemented-requirement uuid="39cbd98f-3f6e-4f5f-8053-eaf39f064d4f" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="c9ca5c75-5ed0-478c-85d6-7505986cfd7f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b154caa3-f661-4111-a181-21aab25d1112">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b3563a7-712f-43cb-a2b4-663f46fc9654" control-id="sc-39">
+    <implemented-requirement uuid="90ba4ed9-360e-4d8f-a52a-b1d0d64800bb" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="d68871d6-a00c-4266-a9e0-c0acfa05e0c7">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4ec08809-6404-49d9-ab66-35121fa11599">
+      <statement statement-id="sc-39_stmt" uuid="ef2bb7a2-b7ce-404a-b753-529eee8a76e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fff56306-7970-47e1-b6db-ca93a60de8f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on ensuring this functionality is
 configured is forthcoming.
@@ -3818,55 +3818,55 @@ https://github.com/ComplianceAsCode/redhat/issues/336'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="369c8f24-3006-4d19-8041-4a710dcd6f66" control-id="si-1">
+    <implemented-requirement uuid="56c0e671-8df6-4a5b-b567-d12378a4b229" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="6982c8ce-9c75-4b3a-b161-b00f15257c94">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="184031f7-9229-4517-b255-1ed04d24e875">
+      <statement statement-id="si-1_stmt" uuid="54378bbd-dcab-4b82-bdbf-8f22ef3a30a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99b1b913-7402-401a-a66a-ba79d2cac671" control-id="si-2">
+    <implemented-requirement uuid="46ff5a8d-0def-4d98-ba00-a0ff062e0c27" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt" uuid="ec8e34d2-2234-47c8-af55-35dc1d25bbf4">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="9c3cf104-f9de-4ef4-aebf-6a7569308e36">
+      <statement statement-id="si-2_stmt" uuid="09658e39-0531-444c-9325-5486d6767155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c257ea33-f22d-49ca-9fe0-f91f993a9452" control-id="si-3">
+    <implemented-requirement uuid="64d97460-7849-415c-bbe7-17373c00cf8b" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt" uuid="436d1cab-53a5-4525-b403-0f7a67805473">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="a50de7a5-abb2-41f1-a6bb-a133226607cc">
+      <statement statement-id="si-3_stmt" uuid="b1fa2f97-e94a-4d05-ad23-5e71c3dd9737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3fc3977-aeb8-48eb-803f-d3911dc0209b" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="4a9bc639-8845-4651-b39a-983d01a605bd">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="49cc832a-dfbc-41f8-9d13-09fd6f8f3f7e">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="842b8985-a3b5-41e6-b76e-3c55ea057770" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="3377eacd-0d93-467c-85bd-b16d193a60b9">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="f04420ef-f69f-444c-b8e1-b44d752a44cf">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eaa4b5b4-5d9d-4b95-86be-59bba52eff8b" control-id="si-12">
+    <implemented-requirement uuid="855f5b80-f73b-43a8-b10f-5b09d6b60917" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="71e2134e-4a77-44cd-8736-80f8b3411b3f">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="b89f3fc0-3ff1-45eb-8064-9d8b902a656a">
+      <statement statement-id="si-12_stmt" uuid="6b9b1a40-b818-4bf6-946e-48c195a1638d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf0273e2-470f-47b7-a9ad-acbbd3c39bf3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Ansible Tower in
@@ -3887,10 +3887,10 @@ https://github.com/ComplianceAsCode/redhat/issues/337'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9156ba12-a2cd-4fed-b9c0-88603cfd531c" control-id="si-16">
+    <implemented-requirement uuid="9e95d7ca-edef-4c70-892a-1eb0933fec78" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="43868efd-7808-4aae-b697-72fe673b064a">
-        <by-component component-uuid="6e1c1ea4-f855-4e68-9ce3-2e79018a8c0e" uuid="4b0d5263-e02c-47e6-bb07-8e446add69cc">
+      <statement statement-id="si-16_stmt" uuid="69d22aaa-17b3-4d19-9a07-bb8ef6502c9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>

--- a/xml/ansible-tower-fedramp-Low.xml
+++ b/xml/ansible-tower-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="3a645af6-ef14-4052-9aac-4bf6fb371ff7">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2a88d7ab-2fd5-4d86-b82b-03a3a030a5f3">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.14+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.31+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="c9b731c2-8790-4a9e-bca4-cd88af97fb9f">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="45cf80e0-0549-455d-bac9-da47a242c581" control-id="ac-1">
+    <implemented-requirement uuid="25c4a27a-9fa7-4a09-a31d-3073e4efb8aa" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="f0bd47fa-1c45-415d-9b8b-c4860f944803">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="95b1c890-2011-433e-a8e6-1974a573b918">
+      <statement statement-id="ac-1_stmt.a" uuid="6903796e-b668-4d25-b438-a5a4c7cd70f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="2535499a-2858-4669-828e-a5fd1d5ad21d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="77a33bcc-9f98-4efb-8f77-3cb2a730715e">
+      <statement statement-id="ac-1_stmt.b" uuid="ef92194b-c5b9-4a06-8376-caffe5dec37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -503,10 +503,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16f53d87-7e18-48f7-9103-29320846b81f" control-id="ac-2">
+    <implemented-requirement uuid="ea88ac6e-45e3-4858-8bff-8ede745929b2" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="7ad81f60-93da-40a1-be82-df2d0fadd1a1">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="6d91ca5a-bb9d-4f1a-a17e-0099f8985d29">
+      <statement statement-id="ac-2_stmt.a" uuid="874a51a8-9ea5-4545-8926-68508f7ef1f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ea0928-3a6c-427e-b3ba-11e8545aeb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower's Role-based Access Control (RBAC) implementation
 offers multiple types of information system accounts, each
@@ -540,16 +540,16 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/security.html#role-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="95f782cc-7992-498d-9a62-27b971962d3f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2bb64dbc-08ee-46b5-a47d-5111e832b8de">
+      <statement statement-id="ac-2_stmt.b" uuid="d7d82faa-dbe0-4a63-8aad-ce73e57aaae5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ae98e6-0009-4349-b613-feb56a7ff423">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning Ansible Tower account managers is an organizational
 process outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="5379796f-0d2b-44c3-9627-1a1ad22f47ec">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5f8e1dbb-6f3e-45a6-bcd5-d9284edc1858">
+      <statement statement-id="ac-2_stmt.c" uuid="9cdad719-4e03-44a9-878b-cc7ea716515d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ddebf72-5bcb-4605-9f4f-0e9eac18c527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role membership is an
 organizational process outside the scope of Ansible Tower
@@ -557,8 +557,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="73e4981b-1271-4380-a3b4-2654d3cd0c1e">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a5fb3c35-2b8b-4c01-a2a6-afcd86fdfa57">
+      <statement statement-id="ac-2_stmt.d" uuid="9c7781e4-f16b-4856-ad23-264539bd7579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b139daa8-ec36-49fc-b0f2-30d1d47c5caf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To specify authorized users of Ansible Tower, group and role
 membership, and access authorizations, refer to the
@@ -568,24 +568,24 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="e812ebc9-83ff-4dde-a01b-5adf1f169fdf">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="f0dcb13b-54c4-4179-8edf-69ea6e7a0b34">
+      <statement statement-id="ac-2_stmt.e" uuid="4c68b375-6f53-4efc-99b4-e6dfccf1532b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1068cd56-cf5d-4fe4-8d72-d8cb82f16c22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account creation requests
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="732cbf52-3859-4838-8609-350cb26acc88">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5b0fc2e6-7468-4759-bf76-bf0374c3152f">
+      <statement statement-id="ac-2_stmt.f" uuid="2a8b1715-0909-4400-b154-eb810db9533a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a07a8330-3554-46c6-a735-8bdd8e4f1894">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding administration of Ansible Tower
 accounts are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="2e3394ba-55f9-477b-b903-d8a51de7c7c5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="12bada1d-b8a6-4cd5-a57e-5de99d6fa2c4">
+      <statement statement-id="ac-2_stmt.g" uuid="a421ecf4-e4f8-417e-a6c2-8c388ba4219b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e7c0b80-832f-4f3b-b259-231d97e54f9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Ansible Tower logging subsystems can assist with monitoring the use of Ansible Tower
 accounts. Logging is a standalone feature introduced in Ansible Tower that provides
@@ -600,32 +600,32 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/logging.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="0d43d7a2-5c44-4ee0-8f29-02f6e21a992b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="cca2f60d-2d2a-4649-b666-07195d7b07f6">
+      <statement statement-id="ac-2_stmt.h" uuid="d5de5f33-0b8f-4187-894c-fc85314d9d0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d063cd68-f8a3-47a9-8539-4988e90b2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account termination or need-to-know
 changes are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="85ac1c02-660d-4944-8c91-dc2b617dec34">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="c7686a2a-4eb0-4c27-a469-13c7b612eb0c">
+      <statement statement-id="ac-2_stmt.i" uuid="7a5a51d4-b432-4542-8557-18425d3ca131">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="01ed9398-b45a-4a48-991b-18af48d4fa2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding access authorization are outside
 the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="bd3f9632-a48f-41d0-b5a9-17302d640364">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b891aeba-fff1-4771-a11a-3b0540a5b8b4">
+      <statement statement-id="ac-2_stmt.j" uuid="bd3e33dc-cee1-4e02-b21a-c38dd5945ded">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7d2ca93-4412-4c9f-b131-baf0399a9064">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the review of account management policies
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="fa4ec4aa-b9d1-4509-a92d-48bce670c4f8">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="c75a7299-9fa2-47c2-91bb-5121ddaa55b3">
+      <statement statement-id="ac-2_stmt.k" uuid="80c46447-3584-46b5-81d5-41e2e25e745d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9379ac56-1fc9-42db-9f34-40ee9871b77d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for reissuing shared/group account credentials
 are outside the scope of Ansible Tower configuration.
@@ -633,10 +633,10 @@ are outside the scope of Ansible Tower configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbdad774-5272-481c-9341-050571bdff3a" control-id="ac-3">
+    <implemented-requirement uuid="80eaf071-6ce3-4d01-87f7-61bdf0ac7b11" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="91645970-762f-43f8-ae92-5f0083ebd381">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1fe78628-bc6e-49a8-bc06-2f238fffa000">
+      <statement statement-id="ac-3_stmt" uuid="f4ec59d1-9343-4ba5-b732-76a5ea36e80f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d876b570-2782-4580-a66e-c9baf5170c10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'There are three types of Tower users that can be assigned:
 
@@ -668,10 +668,10 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86770274-0d66-4e16-860a-02c41af533c7" control-id="ac-7">
+    <implemented-requirement uuid="3f996a42-c9b3-4f7d-8418-b6e041af0542" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="3df2006e-b0b6-409b-a954-71d3b03c4449">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="be04218a-fc40-4432-ac0a-a7ff9bba5e4b">
+      <statement statement-id="ac-7_stmt.a" uuid="9ed16087-8072-4f2d-bb7a-a7a2224e64c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2765dde1-c0ab-4bd1-9b16-72e35a55ae16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability to enforce limits
 on consecutive logon attempts.
@@ -682,8 +682,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="c232f14f-7eb7-40cb-89d7-9dca111fa1df">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2929e822-b223-4991-bec7-e3c0f2e3ce45">
+      <statement statement-id="ac-7_stmt.b" uuid="aed9b374-52fb-4a05-82f9-37a045a64e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b22518c-16db-4dce-87a8-76fb4d93b4f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability automatically
 lock an account for an organizationally-defined time period, nor
@@ -706,10 +706,10 @@ finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="129cf7bd-24c5-4f3e-8177-01b163724e67" control-id="ac-8">
+    <implemented-requirement uuid="355ed56d-434d-4e93-a07d-3ad038c1c908" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="6fb05bf7-1842-418a-affb-d6cd244d9b3c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="6fc35ee0-27e7-45b8-9b37-9edd82d38b4f">
+      <statement statement-id="ac-8_stmt.a" uuid="1f1f0f06-d21b-4832-acec-1740fc121d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0fdeb6-61ef-45dc-8c74-931d3748e6a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower supports configuration of custom system use
 notifications.
@@ -728,8 +728,8 @@ field. Note breaks must use "\n"'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="b934dfda-246f-417e-9173-a0ede78a5aaf">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="dc017270-e911-413f-9550-395128957059">
+      <statement statement-id="ac-8_stmt.b" uuid="1e940eca-2352-4ed1-9a2d-86faa54fd739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df7809ee-f81a-4997-add5-74b73dee367f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Custom system use notifications are displayed on the logon screen
 prior to the "login" button. This is default, non-configurable
@@ -737,8 +737,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="f2276736-355c-430d-8bb6-192c0fffc7e2">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1c6c38ba-c66a-440d-9aca-4a2cde48b72c">
+      <statement statement-id="ac-8_stmt.c" uuid="ef643b9e-123c-4c43-b1a4-7d4e67543e42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c92bcc5f-d5b3-4e83-9b16-5d0916817a4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not differentiate logon screens between private and
 publicly accessible instances. Custom system use notifications
@@ -748,10 +748,10 @@ procedures from AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bc22854-b205-4b5a-aacb-f319c669df2d" control-id="ac-14">
+    <implemented-requirement uuid="04df7290-eaa8-48ce-abba-b1cfd2d75875" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="43291372-342a-45eb-8cff-bc2d52be32d8">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="fc518188-508c-4d76-8510-90c9711e6957">
+      <statement statement-id="ac-14_stmt" uuid="794730c0-822e-467e-bd9d-13e6447c0cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd876e51-4edc-4be9-a2a6-9483d7172b9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Ansible Tower
 console, unauthenticated users will only be shown the
@@ -764,63 +764,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2e9f0c3-f815-4606-b1ad-b0b09c14f082" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="d7309f58-e436-4c7f-b516-cbd578eaffd5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="852f6671-2297-43b0-9f17-23e9b5826ba0">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd22479c-b431-4c54-9362-24d86adf5a1f" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="a2f94cea-b0b1-4a8b-9f47-6b9e9e65bdb8">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="d04f02ce-756a-46d5-95ed-ba44f274c754">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f9d5a3a-ccc9-43e7-9410-1367aa08c9fb" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="bed42067-1a39-49a9-a7ca-b221fe608cfc">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="74c5f919-b60f-4829-8f6c-d40fb66277d6">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b96f2e5-c297-4784-8e3e-26f80128bf59" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="546ce3b9-0a30-43bf-901a-00d8b21af5d5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3b8e0dd8-dfc8-4411-bfe5-c85d77983b3b">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f3137b8-e7fb-433f-ad1d-3c51cdfc119b" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="ede61006-59e0-4197-b675-ee1727933560">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b5fdd2af-dae2-496b-852f-5bc34a30af31">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9340dc0-bdfc-4113-bdfa-182e34595d4d" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="f182cc65-3ab5-4d39-b555-8db5cdce75d1">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="55fcdee3-58f8-4996-83e9-050e16b85574">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="9831aed5-fb57-4cd5-bc15-72b359917794">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3ebcaafd-8ef4-4cd0-bf7f-b1f4d8adbe72">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -828,26 +828,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b513f7f9-6a1c-479c-8087-fa1765b32649" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="3a175747-b9dd-4de8-8204-2b070aab4b43">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a6f0cab0-0581-427a-bf8d-c51a46059cec">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="f695baf4-e53d-4169-b4e8-b3a0af07d91a">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="10f249eb-3d7b-41d1-8ef9-dee5228b741a">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="07fdbcd0-ebe0-4636-8a8c-8a16d6312edb">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="9f0399e3-dbf9-4da0-9a35-6359ee47f453">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -855,26 +855,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1cd2076-60c3-43e0-bf02-f4730e2fdfe3" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="d20ab05e-45a2-4a9f-a911-5e4a395b5b6f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3e0b1a8b-6412-46d6-9678-3c54c8254521">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="e62fb117-d8dc-497a-9ffd-e9379723e874">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5b1e3135-b562-43a9-82dc-23fdb1dc21c2">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="b6fd04ed-15be-448e-b65c-2d2bac393050">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="0aca6c78-b364-47ee-872f-8f78b8af78c6">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -882,18 +882,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d4d973e-434f-4f55-a9e1-bad6c74d8ea1" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="6a8896ea-54d2-42e8-b9f1-8313591f92f6">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ec383d9b-840f-4214-bdd7-a39bf34d093e">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="410d11fa-50a2-4f5c-b853-9dbafb59d911">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="9f5dbb65-2c15-4f3f-b1a0-f7dabc70902b">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -901,28 +901,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d8a1da2-9824-41bf-861b-fa9975837934" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="3f3ab28f-88ec-4240-a3fb-d779ad2926d0">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ef412adf-96a6-467d-92e3-ac05d27a9a97">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c471e5d-dd05-4474-aa9b-daae6508e05a" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="8e1694af-ddac-4efd-b002-b716c068a5bb">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="e766a4d2-b4a1-45ca-b619-47e95aeb81f8">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="834d5cad-4d4e-4f5b-819c-ad9f7c487f01" control-id="au-3">
+    <implemented-requirement uuid="0bc7b038-2291-47f1-b95e-f27718ba9dad" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="b5044919-67bf-483c-893f-02830afe2803">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="08bc8218-1343-44c7-8f1d-b0ce3e1a5cf9">
+      <statement statement-id="au-3_stmt" uuid="bcbc1772-f72d-4ebf-940f-a87749be0356">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2243f0d-df11-4d3b-9feb-7843d573c755">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default Ansible Tower generates audit records containing
 information that establishes what type of event occurred,
@@ -1023,19 +1023,19 @@ https://docs.ansible.com/ansible-tower/latest/html/towerapi/activity_stream.html
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2b50c67-8024-44ef-ada1-43d6488d758d" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="849c6f74-fcfd-4f44-a6ff-1cbed1ca4550">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2627b511-9c21-4c5c-aa62-3cae768f8163">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ff794fa-5bb0-490c-a544-d550e6aa28d9" control-id="au-5">
+    <implemented-requirement uuid="4141f72e-f8c5-46b2-b788-ec3ad473ed39" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="4e9ba5db-07c1-4e8d-8852-7604d4f6bedd">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="efe26f06-7bf9-4b83-bdb6-d53210f3df27">
+      <statement statement-id="au-5_stmt.a" uuid="9d51e840-f6b9-4ab1-bbd6-f93358885e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1044,8 +1044,8 @@ Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="601bf93f-953c-4a05-80fa-3c6de7a7bf9e">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="32220680-ff96-453f-a8f2-ed066a8fa474">
+      <statement statement-id="au-5_stmt.b" uuid="fdfb5480-4156-4e8a-b268-80d158fa7b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1055,19 +1055,19 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9fdf2ab-b6bd-4ed7-94a0-6377c650964a" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="686f38ca-1bd0-4bb3-ab45-e8d63ad75e1f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1cd0695e-67d3-4543-a55f-6247b2d5e491">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e79d41cc-9bdc-405b-af58-767118443267" control-id="au-8">
+    <implemented-requirement uuid="becf8e32-f685-4e4a-bf9e-be88774fd26a" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="7244038a-a7f8-4fd5-97ad-d00b98c7e985">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="709660e3-c364-4f4e-b4c2-74af7fac8782">
+      <statement statement-id="au-8_stmt.a" uuid="998c237c-d0c9-4e6e-a78c-76cb2bfefe12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd476bbf-c7b0-4ec0-9434-3419bd161f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower relies on the time services
 provided by the underlying operating system. Utilization of
@@ -1076,8 +1076,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="89c48ff8-b776-42ce-84a0-50f46f9ac5e3">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="34858806-06f1-42ef-965b-6d0dacf4ee46">
+      <statement statement-id="au-8_stmt.b" uuid="9b88938b-72b8-4957-ae98-fa4158a1d301">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e5ac9f-1dad-4443-99a9-916e73faa646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the time zone settings of the underlying
 operating system. This is default, non-configurable behavior.'
@@ -1085,10 +1085,10 @@ operating system. This is default, non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f12b335-b681-408a-ae21-c007ea770af2" control-id="au-9">
+    <implemented-requirement uuid="3ec9f35f-418c-4efc-8f59-f18cc0171564" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="eeb9f21b-0ec9-4b65-8ccf-f45bb1ccc26b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="814fe861-5530-433f-b696-6f0d6ae9d0a6">
+      <statement statement-id="au-9_stmt" uuid="f4d285da-2c8e-40e5-a625-adf62450757c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0cf7e1a1-821e-42b9-bafe-1f376835c3e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower logfiles have been consolidated and can be easily
 accessed from two centralized locations:
@@ -1108,10 +1108,10 @@ to the accessing user).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3437249-7980-4982-af7f-b896d6945e12" control-id="au-11">
+    <implemented-requirement uuid="2ff74e9f-c91d-4851-9a09-bbf7fd625131" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="033c2a63-1cc1-450a-be51-1b73e57b0962">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8829fe42-1d7f-4bf4-a1da-021c7b22c1f5">
+      <statement statement-id="au-11_stmt" uuid="4b25af90-cc8e-4644-ab85-38b9090ec3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="657201e0-b861-4759-a353-a33f315df693">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'For locally retained logs, such as those recorded to
 /var/log/ansible, Ansible Tower utilizes the audit subsystems
@@ -1125,10 +1125,10 @@ outside the scope of configuring Ansible Tower.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f9d6a93-a413-436b-b3ee-16cda55bc7f3" control-id="au-12">
+    <implemented-requirement uuid="da920acf-393a-4df5-a211-a2b2b3c7eb8b" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="f2a9c912-94cb-460d-a49b-f17033ef6055">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="0cc4aa4d-5777-4af1-914e-1399089eadbb">
+      <statement statement-id="au-12_stmt.a" uuid="c9d7357b-b9c4-4857-99d7-5259ff704990">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfa206b9-bd1e-49b8-bef9-243817f2292e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default, Ansible Tower audits the following events.
 Audit of these events is automatic and not user configurable.
@@ -1363,8 +1363,8 @@ being imported and "status" field indicates success or failure:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="0bc7d982-1b91-4732-9798-78eba62e7483">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="481b6b51-4d72-45b4-9d9e-294568235b1b">
+      <statement statement-id="au-12_stmt.b" uuid="ff513e1f-4fff-41ac-aa19-fca0ea601659">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="250fa9aa-0867-42ec-a2ba-9b71bd3cf330">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to allow defined personnel or roles to select
 which auditable events are to be audited by specific components of the
@@ -1380,8 +1380,8 @@ https://github.com/ComplianceAsCode/redhat/issues/296'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="a291155a-3276-4459-9aee-49f50091d2b1">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="65644306-6cad-429d-a759-c0f875080388">
+      <statement statement-id="au-12_stmt.c" uuid="8faaa7d8-0fc6-4270-8743-8328ee1220f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d475dd-7fd8-43ed-a837-5425e4438cfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -1396,109 +1396,109 @@ https://github.com/ComplianceAsCode/redhat/issues/297'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fed6bd61-2139-4e84-8cd6-194bb065cb03" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="c52e167d-1919-41d1-af54-d23b227810d6">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="87d25022-bddb-4fdd-b799-5bc5b976a1f0">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e57b77f8-d32a-4738-a111-6c642f0da389" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="0d61a54a-6a62-421f-9903-c83930cbaf5e">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="839ce505-f7a5-4757-8026-4f5f7d903a36">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eceb396f-5dd9-4e31-bd9f-efe0beb4d1c6" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="7ca13c4e-2ffa-441f-b474-4c98139cf6f5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="f08b44c1-30c3-414e-9460-4101b040d107">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ed70b2d-04ac-4854-8ff9-90e363c1cd32" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="d7d4a5bf-8067-4f46-a56c-1bc01d3ab2be">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="58c87317-0fa3-4c74-8bf2-f9d78fab67d9">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45be65c2-85bd-4b6d-b109-e48bb3bf31f7" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="c273178e-cc05-42a0-9df6-138978c2580f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a90757c0-74ef-4e89-9d6e-5f6faa426e6b">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f74eaecd-79d3-4985-a061-f7992e36fadc" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="ed10cbf6-3d6d-4f1c-b1ce-1693d0d9e747">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="eee3008b-8f98-45ad-8e57-ca6df4ded1ab">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b25ee4d2-bafd-4e30-865e-2866486f1aab" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="723aca55-e7ae-4412-b982-81bb964fb298">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="375f2bb0-d74b-406e-8dfc-2d5c04dad3b8">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c536d850-80c9-4952-93ef-9baf74bdd1df" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="8070ce86-d43c-4de0-b435-814193b626e7">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="bb943be4-dfc4-4115-886c-102cfc70e794">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4033ca87-f7e5-4ff1-b236-099c6d318b53" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="a4e2212b-747c-4deb-b49a-3b348126ea69">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="0237b215-16b5-4c1b-bd3a-ca3c16740686">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27195c92-1a76-49ce-bc29-9a7abe190343" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="0cfe2254-f64e-4b07-b5c6-2d430929b5ad">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="7f4af754-6fd4-4e43-925d-c3ef9c81c512">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aabb911a-904f-4c43-ac71-693cc04e6194" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="7424dabb-3334-423b-be5b-72dc82fa59ee">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1f02c237-e833-4a15-9d09-add91df363a8">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb82e917-0451-4997-bdf4-d1fae86ac18f" control-id="cm-6">
+    <implemented-requirement uuid="fde226d7-7d67-4355-bbc8-71f20e317364" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="ce54b048-123c-4517-a82d-e9068c89c35f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="50d28afe-af87-4473-8f4a-5f07d4d1193f">
+      <statement statement-id="cm-6_stmt.a" uuid="4fa9858c-a284-4d75-b344-139e30e35aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e78a106a-eb43-4e69-af14-e7af054511d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower. Use of the NIST National Checklist
@@ -1507,8 +1507,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="9606f367-69e8-466a-a2c8-64f7939dc24d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="7bdf2a8a-50d2-4dc9-a408-f1f8c2541179">
+      <statement statement-id="cm-6_stmt.b" uuid="d81d0acf-4339-4280-96d7-48862c912509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb628c5-f152-43a0-97ad-a73c840900ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1522,16 +1522,16 @@ https://github.com/ComplianceAsCode/redhat/issues/299'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="076c8b6d-4ace-48a2-8048-0eac9c8ea933">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="9ca32ae3-7378-40d4-a0a8-6793bebedb48">
+      <statement statement-id="cm-6_stmt.c" uuid="56f21bb5-8370-4e48-8e9e-9e92d5708f6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="e5eb13eb-19ec-4a0a-82b0-3608b5706b3f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b5b009c4-d61a-4b9a-9a80-3ee4796e8f68">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1543,10 +1543,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c598f53-8954-467b-ae2f-adaa689f4bcf" control-id="cm-7">
+    <implemented-requirement uuid="342ffb57-0682-4fbc-abd3-c1a74e8296bd" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="2d1d341c-82cc-4b5a-8750-5572225257b0">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="84c2737e-8422-4275-9f5c-205c2e71e258">
+      <statement statement-id="cm-7_stmt" uuid="8997ae8a-a31e-49c5-afc1-631aa0487d39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b29c60da-efb5-4a9a-ac22-72e78771ae9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ensuring Ansible Tower is deployed in a minimal configuration
 is being tracked through GitHub:
@@ -1556,37 +1556,37 @@ https://github.com/ComplianceAsCode/redhat/issues/300'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ad0ee48-5c85-4497-88ce-432341acad55" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="d11bf972-b894-4664-b6a5-84d5e70ad401">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1c1c0e81-0d64-4dcd-b1e0-98a4f8b02960">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a841431-9c90-48ab-8948-e80a0e95a67e" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="64332557-9f4f-411e-8c9d-8eaac949610a">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="4f388c50-985d-4288-8370-9b0ea520092a">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12137532-844a-44b2-8457-9fac77c0d9ec" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="bd5a8935-cfda-4c4c-8f3e-94e1e8595d7c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="24db024b-1710-4f53-a2b5-a6b79dd7f6ca">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f57323e8-ca13-47dd-9878-4f9a87865003" control-id="cp-1">
+    <implemented-requirement uuid="817aa407-2d8e-45b6-98b9-3924740bfc4f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="4917c22e-fc24-439d-8d97-595989d86567">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="675289da-daa7-44ae-8819-e514a361a8f0">
+      <statement statement-id="cp-1_stmt" uuid="e0de154f-41c2-4ba7-942e-6aa40461900e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1594,10 +1594,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffd12c50-5900-4345-9a6e-eab904dba7ea" control-id="cp-2">
+    <implemented-requirement uuid="6128ae2d-fec8-4f37-adc4-72c9afd8be57" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="bb2cbbe7-8f50-467b-8220-4bd0ce800917">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a84cd2ce-4acf-4603-945b-d3c7b5937028">
+      <statement statement-id="cp-2_stmt" uuid="05bc64ef-f544-4d5e-ad96-e8e21b035818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1605,10 +1605,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efb01b91-d82c-4994-b15f-c1c4ed66e298" control-id="cp-3">
+    <implemented-requirement uuid="8f336932-5f5d-482c-bb93-891f6558844a" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="11e5aa76-e339-45bb-b14a-8491091ab827">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="d4a88877-409d-404f-aeda-34ade05c23e9">
+      <statement statement-id="cp-3_stmt" uuid="2a381acf-5960-4243-a8c4-1dd9e4a7cfb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1616,10 +1616,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84054d01-571d-4564-b710-24dfc323c27a" control-id="cp-4">
+    <implemented-requirement uuid="fe89b6b9-4856-4bba-a265-d6de21bded58" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="034cf3ea-b485-4926-b14d-2d5a76e8897c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ef5dd01d-897a-4325-8309-4111e883055c">
+      <statement statement-id="cp-4_stmt" uuid="d8698da3-c318-4ad5-994a-2d1f3a9f40a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1627,10 +1627,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd0572b3-4b17-411e-83aa-00366e2cf03b" control-id="cp-9">
+    <implemented-requirement uuid="c42626c3-79e3-429c-bf12-9f7fe675e345" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="7cf9ff96-bf9e-493e-b504-240518ea8f80">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1927eabf-3531-4e51-b34b-bbfa8745ed00">
+      <statement statement-id="cp-9_stmt.a" uuid="dcf4f455-b4e7-46be-ac29-ee3f20c0809b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -1651,8 +1651,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="01bf4f22-e3ca-4108-86a2-6ec51d639953">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1d5d0ca8-2871-43f1-9feb-7f62a5f193a6">
+      <statement statement-id="cp-9_stmt.b" uuid="1d0d882e-0d3f-4ea4-a5f7-1f0b4b8778cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -1673,8 +1673,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="05ff427f-80b7-4202-823a-e506517e8ea2">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="4401842c-6c82-4f5c-819b-1d0058de51e6">
+      <statement statement-id="cp-9_stmt.c" uuid="939b14aa-c91d-4b11-aeea-e90fb6c233a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -1695,8 +1695,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="5e5ca839-e239-4f0d-967d-40fc25fb6d8a">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="47388983-b0b9-4713-ad21-2088fc636603">
+      <statement statement-id="cp-9_stmt.d" uuid="b7ef92c7-efb3-48bb-8a38-5d178485dca9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1704,10 +1704,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d54fb949-d5f6-4fde-9238-3be835eee1a7" control-id="cp-10">
+    <implemented-requirement uuid="9ab3db9e-2973-4241-8a86-58a8392136ae" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="21f91374-0e78-4e03-a1d6-b9cfabf99bd4">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="bf7af4fe-019b-4f65-ae13-fe841b74860d">
+      <statement statement-id="cp-10_stmt" uuid="917e418a-a1ff-4431-9cd4-039411666940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac578ce4-9a5c-441b-82a3-ff8032c49bc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on establishing backup procedures can be found in the
 Ansible Tower Administration Guide:
@@ -1720,19 +1720,19 @@ reflects two distinct processes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe79117-13d4-4631-bcf9-b24eabe20e13" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="37ca25aa-cca8-4913-9269-ebe2c217c6b5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="c2a68824-15fc-4b7d-bcfb-3f8c9079bdb5">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac5d3612-7ba7-4d84-ab5f-4f0b51466332" control-id="ia-2">
+    <implemented-requirement uuid="371b0174-b58a-4b53-bc2b-9918c5dfa56a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="6cbb4a94-9d85-4952-b55b-28edd5880035">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="22004de2-661a-4683-b91a-3bb248aa3cff">
+      <statement statement-id="ia-2_stmt" uuid="2a30572f-4271-483b-95ed-f5dd0570e737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef6b479e-1a5b-482d-ba86-9fadb9c2f3e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely identify and
 authenticate organizational users (or processes acting on
@@ -1745,10 +1745,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bab3766d-eccf-4d8f-98a7-01f3e9c6162f" control-id="ia-2.1">
+    <implemented-requirement uuid="8a1d4f6c-1288-496c-bd0c-da79beb23d8b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="9c9bcac9-42c7-4e74-b0cf-1c8dfdb59777">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="92044a52-f0d6-473c-8661-299dcc606911">
+      <statement statement-id="ia-2.1_stmt" uuid="59b74a03-8f9b-4d5a-a8b9-6ace804461fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72479822-926a-428d-bc0d-04bb9d5c56be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1763,10 +1763,10 @@ https://github.com/ComplianceAsCode/redhat/issues/305'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec2ce8e7-d68d-4894-adeb-cd021013d773" control-id="ia-2.12">
+    <implemented-requirement uuid="f53bb0e0-cd3d-44e8-b1e0-4321fe49103e" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="b5b10452-35af-46da-b2fa-7c6c661c82cf">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="c5117347-30e5-4d9c-b8ce-81ea644d6800">
+      <statement statement-id="ia-2.12_stmt" uuid="16bbb60a-cde0-46b5-9d80-9fcb59849304">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2965a46b-a7e9-4591-bde4-a0545660b690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1783,34 +1783,34 @@ https://github.com/ComplianceAsCode/redhat/issues/306'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e804d683-7e5e-4248-83eb-16e0ac5c7fe8" control-id="ia-4">
+    <implemented-requirement uuid="2fb876e4-d80c-4efd-b6ea-4395761494f8" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="047025c1-5d89-4f54-aad2-bcf2d939dac6">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="e8ffee4a-ce11-4316-b727-5411be557d00">
+      <statement statement-id="ia-4_stmt.a" uuid="9a1880b5-870f-4829-af6d-3595d3c46747">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="80f8ec2c-d7f7-4d49-8eb9-192d75fe4dad">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5736f4de-fccb-46ee-82bd-dc28c518bf56">
+      <statement statement-id="ia-4_stmt.b" uuid="a9e0b21f-f9f8-495e-b507-c8052d91b838">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="ff717138-106e-4bf7-accf-0aa4bc2164f9">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="28abead5-546d-48d0-b2a1-b000b67f16fc">
+      <statement statement-id="ia-4_stmt.c" uuid="fce0656d-bbba-43fc-9331-c8a1ddcf462e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="b8547e84-578b-4fb8-8c21-136fb38c61ce">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3ba53349-b1ea-4902-95f9-f7e04520f053">
+      <statement statement-id="ia-4_stmt.d" uuid="c0c376b3-6f15-44cd-abcd-ca748e3f0f96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bd77aea-ff91-4d07-92c6-ae2974fbca31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to prevent the
 reuse of identifiers for an organizationally-defined time period.
@@ -1821,8 +1821,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="656c8cfa-8b8f-4b10-a4df-ddc3c9df6e9d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="148a3881-b645-44c6-bda4-aa80026c56ad">
+      <statement statement-id="ia-4_stmt.e" uuid="c6b12517-aecf-46a2-b41e-47db93a8551e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c0512e3-9b32-4049-a60d-e66256a64237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to disable an identifier
 after an organizationally-defined time period of inactivity.
@@ -1834,18 +1834,18 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83d3a2ff-ec9d-4bce-abd4-8e6d6f3e29ca" control-id="ia-5">
+    <implemented-requirement uuid="c9da835f-959d-42c5-83e3-133b0f133523" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="930144b0-0ec5-417b-93ed-bfe234efd563">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1b709b4e-9669-4ed1-95ea-9edde68f6841">
+      <statement statement-id="ia-5_stmt.a" uuid="c860bf89-2251-4267-b154-89892e906011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="d0dd39be-28af-4ddc-9c9d-e2f1b5f46e2c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="db0e7c25-f5e9-4edb-8e72-cb992f3b8434">
+      <statement statement-id="ia-5_stmt.b" uuid="d780ccfa-5d17-4fb6-b5d8-002a1bb91196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fd24638-7acd-49f0-ad11-24e1cb66bc00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish initial
 authenticator content for authenticators defined by the organization
@@ -1857,8 +1857,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="1d1e864e-20fe-4bb9-baa3-4edc3386e41b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8c58e15f-3dff-461d-89ae-a9d8bc58a067">
+      <statement statement-id="ia-5_stmt.c" uuid="bccd653c-dcc5-469f-a628-589d6b168d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fba1bcc-0376-45f4-93a1-685765ffb3f2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to ensure that
 authenticators have sufficient strength of mechanism for their
@@ -1870,16 +1870,16 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="341f23b0-9f67-4898-bc31-635a8460b3e0">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2c431e45-f879-486f-9159-428e2b7a002e">
+      <statement statement-id="ia-5_stmt.d" uuid="6ea5e500-9a54-4ce8-b0ca-284f84cb561b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="15ec9a60-86f8-4e8e-b53b-77ec892bae34">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2789142b-0094-483f-a6b1-703d96b93678">
+      <statement statement-id="ia-5_stmt.e" uuid="5e21d34e-3528-4acc-9145-49a9fb4d7250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="584dac48-67cd-4f21-b513-00c8c14132ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have default account authenticators.
 Authenticators used during the installation of Ansible Tower,
@@ -1892,8 +1892,8 @@ configuration of Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="45ba668e-aece-4741-ad20-be41ef239f67">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="504524db-a0db-43b9-a9f5-cd323924e046">
+      <statement statement-id="ia-5_stmt.f" uuid="76c6d3cf-34a0-4f48-bdcc-2eca1ef06792">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48cdb5ef-17c2-4659-a791-c0a69df35fd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish
 minimum and maximum lifetime restrictions and reuse
@@ -1906,8 +1906,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="38ceb27c-dd64-4f7d-8edd-8c0c16976bd4">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="70cb52f9-88b9-4377-9e17-3e2827b81b4f">
+      <statement statement-id="ia-5_stmt.g" uuid="1edb3597-9cef-4b18-99ee-16830cb78a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="772ffc08-0df1-40c0-bf07-d1bb23eb32d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to change/refresh
 authenticators after an organizationally-defined time period
@@ -1920,8 +1920,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="d3f8015a-f8b1-4128-8bf7-06545c1d1b64">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="142a699c-8715-466f-95ed-6627f62bc13a">
+      <statement statement-id="ia-5_stmt.h" uuid="470a74c1-968f-4a85-b411-027724a32231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b8910fe-57c8-419a-92cd-fc087a6beccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower uses SSH to connect to remote hosts (or the Windows
 equivalent). In order to pass the key from Tower to SSH, the key must
@@ -1958,16 +1958,16 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="91cc4abc-5f02-432e-bac9-89f066039241">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="40bbb420-ed30-4684-bf97-0108de072172">
+      <statement statement-id="ia-5_stmt.i" uuid="848dec97-d87d-4035-afaf-95846dc67fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="3561d936-096c-44f8-a2f2-77ad710a7a16">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="f637bbe8-0691-486e-98f8-e0974a1458d8">
+      <statement statement-id="ia-5_stmt.j" uuid="c0603fd0-07ba-487f-9910-2c7a853f7d3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
@@ -1975,10 +1975,10 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92072936-d3e6-4f58-8608-414d621ec7f0" control-id="ia-5.1">
+    <implemented-requirement uuid="442093fb-88df-4b5a-976d-7019c41f2bdb" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="bc7134a9-3d7e-4bf9-9ef9-8f6dacc226b6">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8b995892-18b6-4129-be64-2c3d02704183">
+      <statement statement-id="ia-5.1_stmt.a" uuid="4829f5a1-5e72-46c5-a366-5c1f3caece88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f722e76-3170-4205-b13d-636506171fa2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce minimum
 password complexity requirements.
@@ -1989,8 +1989,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="a212b948-2406-469e-8d6e-941061e8376c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="83bba88e-0d15-4d78-b8b1-bf30c0225592">
+      <statement statement-id="ia-5.1_stmt.b" uuid="5a016e67-3d19-48f5-9a2e-7579d5dd44ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c75dfa4b-6b21-4f92-8cf0-7d02730b9aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce at least
 an organizationally-defined number of characters be changed
@@ -2002,8 +2002,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="a4273f98-ad0a-4f66-95b8-a3d6800c3fc0">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5ab7cfbb-3c0b-4e1f-b29b-c903e7c84d15">
+      <statement statement-id="ia-5.1_stmt.c" uuid="4df30f7d-deee-4627-810f-36e90bc683a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69890876-37d8-4a97-ac90-0433ffcd3eca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'If passwords are used, Ansible Tower handles those by responding
 directly to the password prompt and decrypting the password before
@@ -2035,8 +2035,8 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="86368cbe-1024-462f-923c-0098ce3b219c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="dd613cc6-2568-409e-909b-8bb532c7bf53">
+      <statement statement-id="ia-5.1_stmt.d" uuid="324ee3c0-1524-4b50-81eb-e6ec751aa14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1b237a3-fc3f-4c15-b1d9-8a3f8791ec2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce password
 minimum and maximum lifetime restrictions.
@@ -2047,8 +2047,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="321efc3b-2f8d-40d6-92fb-5b5fab8d30c0">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="fe58a1a7-cc91-433a-84f4-e66faf3a15ac">
+      <statement statement-id="ia-5.1_stmt.e" uuid="1af302e0-ae92-4006-a576-8630677663d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="340ef716-a1d0-4147-a01c-8571db050ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability prohibit password
 reuse.
@@ -2059,8 +2059,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="78bf2c63-6176-474d-b0e6-711c55b68778">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="30b7fa25-d99b-4e89-8a45-87df68ecdf61">
+      <statement statement-id="ia-5.1_stmt.f" uuid="d538b56b-9681-4bba-be6e-475546134c1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b31d80ff-dbac-410b-8140-9b1d43464121">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability allow the use of a
 temporary password for system logons with an immediate change
@@ -2073,19 +2073,19 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc989d13-eade-4d0d-ba5a-9f9c6ea3d715" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="b947860c-6a27-46a9-9bc1-fbf2166e6f06">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="29746e8e-1238-4f09-ac96-240a99af2c60">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f07528b-1f7b-45ca-9819-b280708189f1" control-id="ia-6">
+    <implemented-requirement uuid="52e63706-e780-4498-b229-df02905c4bae" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="73b2b667-db8c-4514-ad16-a4850d525298">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1af555c6-2036-43cd-86f8-f939aa8bf0ec">
+      <statement statement-id="ia-6_stmt" uuid="b1427d3e-0f18-41ab-9fdf-1653e0f04669">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43ec1e2b-4874-4815-a27c-899f6b688ecb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower natively obscures such information.
 Ansible Tower cannot be configured to be out of
@@ -2094,10 +2094,10 @@ compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df96e2ec-6ade-4e57-a21d-58c464e54199" control-id="ia-7">
+    <implemented-requirement uuid="03d1bb60-c8f4-45b2-bb19-886634954cad" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="b1c154b4-3f66-470e-8875-cba30635303d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="16071a33-11cd-4bfd-8f09-173c92587801">
+      <statement statement-id="ia-7_stmt" uuid="c50d587c-9459-4058-86c3-303a824b3e45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a04cba0e-544a-4b60-a086-c6b1018ef518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is currently not possible to configure Ansible Tower to use
 appropriate cryptographic modules. This is a permanent finding.'
@@ -2105,10 +2105,10 @@ appropriate cryptographic modules. This is a permanent finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8caff494-db85-4d4f-aa9e-ea95b002c719" control-id="ia-8">
+    <implemented-requirement uuid="6bfaf3f4-0c06-4104-a0c8-a1b8e38138c9" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="2bd7c4f5-45a4-49c6-aa4b-d9d12b9c9969">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="f1dc6a31-0351-4e10-985e-7bb776ad1713">
+      <statement statement-id="ia-8_stmt" uuid="68db25d6-2d81-4938-9613-398b847608a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="50bfd45e-adc4-4859-a020-11f67e67db75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely
 identify and authenticate non-organizational users (or
@@ -2121,10 +2121,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4afd7649-2c62-42b3-bb4a-e97d6c06cdb1" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="ec136a8d-b881-4516-b42e-037fb4a41a1d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="e5862f5a-f51e-4895-a70f-783fa98e85dc">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2137,10 +2137,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f80fe1c8-aa41-4604-9108-77fb06e3fcfb" control-id="ia-8.2">
+    <implemented-requirement uuid="22e661de-b033-4fb0-9d1e-23146e8f9eaa" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="806c0dbf-64c5-4171-b1cf-e972001c9965">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b45358ba-73f3-4d60-a426-46a2a7a74f50">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2154,10 +2154,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="838f0c89-1372-49e9-81d2-a5bffe5addfc" control-id="ia-8.3">
+    <implemented-requirement uuid="d62f3488-6cc0-4bf1-8170-6510f1df9392" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="aeb9b71e-48c6-481f-a5ab-7093dc68a9a7">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="6dfd35b6-3bfe-45cb-8e03-8c071ba835de">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2171,10 +2171,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afc5314e-d201-471b-9b4b-85a822e0aca2" control-id="ia-8.4">
+    <implemented-requirement uuid="d8d58f64-4237-48c3-b94a-23b93f6aca24" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="3883ecf1-6b5b-4184-a67f-975e5542a4bb">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8e0acc98-574b-4d6f-b328-ad5445f67125">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2188,10 +2188,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a64223ae-980c-4b29-a175-41bcc123d1ab" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="598a5e94-7786-4afc-a5b6-a2108b7d5a6f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="7daa710e-702b-49e3-872b-81fb5f2ff168">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2199,10 +2199,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10304539-0bc4-405f-9395-81a92ccfe898" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="7553b9df-c4fd-4ace-8ed9-50611479231e">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="0a25d214-0b9c-406b-a2d7-3fdb1912c237">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2210,10 +2210,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4608f014-3162-44f6-b4fb-44ee24533c1e" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="9717476b-9f71-492a-a581-4010979260bd">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2ac03a24-ad7e-4e83-8e2d-9c05372fea5a">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2221,10 +2221,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6518869-1c70-4a1d-88e7-de324e1b8add" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="c3aba0b4-d745-44b3-af39-c9d79d2d06a7">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5850751d-86b4-45d9-9dd0-590057d00685">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2232,10 +2232,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a491fc1-fb2a-4ee1-9169-c3b712bb8036" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="a99f726a-8f8b-4577-8d0a-d72edfa6c3bc">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="95dab1bc-ac43-4289-9944-54b22f3c3b10">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2243,10 +2243,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fbfa8f0-d792-4188-ad11-ec9f49a4ce7b" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="e55fb629-7cd5-4821-aac2-0aa388e37840">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="f43884f2-5b95-42b7-9891-eec8014f56fd">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2254,10 +2254,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1f0a316-5fe0-4cf6-8d35-8d26b0298f58" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="b01ed4b1-4b12-4622-a665-d72360b80a7a">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="be04ca23-c18b-42de-b839-1b7689a3e413">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2265,172 +2265,172 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8704788f-9c93-480d-8cee-255de532f896" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="d0fd6548-f483-4ec3-a33f-4af7b123a47e">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8b8c07ab-1ff9-467b-b69f-47b875b2bd70">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ce0c58a-8564-4705-a171-5382e3754da8" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="25d32578-d12d-4105-b4ce-251251010189">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1f8796ce-444d-46e2-b1ba-9a47a4cea909">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cbd1f8e-0649-41f6-af48-1a904b62c294" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="61763331-64c2-41e5-9aef-4a4573a7cebe">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2e90265c-19bd-4f02-bd97-5bf783da3212">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e29a1fab-63a9-4aab-bb61-3e6a497fe786" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="298a1499-6b8f-404f-908f-4f730de6c91f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="45e5f4b7-f11d-4586-921a-1e2da59d6f3a">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6be6c072-d78f-45ef-b27e-796bec1bf241" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="c7c4f43e-7025-49d7-bb54-b40b0ef66ef5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="339f7d33-d332-41f9-aa66-753a16a2e758">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd4173ef-6d16-415a-8a44-041470f7754a" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="3f3ac4b3-33a5-4264-8064-b0125faf4feb">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="d4dd2824-ec84-430b-8df8-135354760db3">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64f99fee-4ef2-4b09-b557-73ce8d20478d" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="27d0f123-c76b-4605-a9b6-23dd978b0bc5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="44bd4ae5-c32e-4158-aa1d-8aebb1c34d83">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebb44f1e-10b2-4d2a-80b5-ef63ab3fb36e" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="6e90a58e-0f3b-4acd-bd85-f3d19379cc79">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3bf0d533-30bd-40e6-bf2d-08d2deb4964a">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c932a6d8-6650-4ab5-8119-cf02ec639b2b" control-id="pe-1">
+    <implemented-requirement uuid="2f7f0c97-6293-4bcd-b72d-48d898a85c69" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="6441aa6b-2cae-4e5f-8b17-46c76c46b22b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="38f24521-9ed9-4de9-9522-44ef880a5cd6">
+      <statement statement-id="pe-1_stmt" uuid="49128975-33cd-4a5b-b055-ec15d44fbd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afc37f1f-a1bd-4795-a036-21bbfaecd37a" control-id="pe-2">
+    <implemented-requirement uuid="99e9769e-d92b-49e5-bb4d-8d0e0d0bfd5f" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="97b82de3-ee6b-4ff7-aedd-eaac71b122c9">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a4e7d86a-6bf8-4ec2-98d0-540ebee171e8">
+      <statement statement-id="pe-2_stmt" uuid="4ac4c77c-6b19-45d0-b1cb-299060ae3873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f613522-4519-4e21-8391-183d4025f196" control-id="pe-3">
+    <implemented-requirement uuid="46bcf589-84e3-4bd0-9c21-7f0f7a5c2682" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="ec1ff7e8-d430-45e7-b5e3-229663d2250a">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="04057fba-af92-4c48-98fb-953c11d6bd96">
+      <statement statement-id="pe-3_stmt" uuid="7af14783-a56e-4e7e-b622-1ed3f5a2d534">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce1d5b35-f735-4726-ae98-aedc51a1a9d8" control-id="pe-6">
+    <implemented-requirement uuid="d29450a2-ccd0-4565-b5a1-136395ecfbb9" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="0253e7d0-9016-4a37-a25b-aeb68f7d411f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="84ff7cfe-591f-4e1d-99fe-1b9a973567b8">
+      <statement statement-id="pe-6_stmt" uuid="ec6c4c4b-033b-42e7-aacb-9009aac4e615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f995e8ca-a5ad-47d5-be7d-72512dbefe98" control-id="pe-8">
+    <implemented-requirement uuid="fd1a7d09-ad45-4281-8eb8-60471713fa5e" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="45d0493b-2911-4742-95d0-658a277baa13">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2e243ac8-102c-4d90-9a30-12942dd68fba">
+      <statement statement-id="pe-8_stmt" uuid="cebb755c-5a3c-4b68-9470-31b5866508f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a4fbfe3-d4b5-4174-a4b9-d783948e6738" control-id="pe-12">
+    <implemented-requirement uuid="1bf66550-56c7-49f7-936c-83a279d81381" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="0e848f00-69ac-40e8-97e6-936c07f568c2">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ae17027c-1bfa-42f2-aef4-23b9407322ce">
+      <statement statement-id="pe-12_stmt" uuid="e51bc885-c7a6-484d-a9bc-82fc55897514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a30e06d-3f1a-4956-89cd-2e5db9ccce44" control-id="pe-13">
+    <implemented-requirement uuid="461125ab-9fa7-4af6-ad14-25b5d7674053" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="54aef43d-067d-4304-b37d-17b86bde5fb2">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="10e9f05f-3cd1-4066-be09-1b72430ae081">
+      <statement statement-id="pe-13_stmt" uuid="272e29ab-c2fc-4613-945b-8dbd0fa31461">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81c22d9a-1e25-4ddc-871e-91689805f3d9" control-id="pe-14">
+    <implemented-requirement uuid="0c2e6c1d-668e-44f3-bb50-b9b7c4d58788" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="2ad1bd8f-4f04-4fea-b856-5990a49d3de9">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="843a6df0-691a-4368-b606-21a33417b652">
+      <statement statement-id="pe-14_stmt" uuid="71cfa9a2-51da-495e-b0e4-cd6ed446d5e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d23f481a-8e20-4e02-992e-77a3655fe139" control-id="pe-15">
+    <implemented-requirement uuid="fe4172ae-185d-42b8-a78f-c0f39067dc34" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="fbaba2c4-4a83-4248-8121-35b8e8c0960c">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="3783e9f9-5b86-42e3-bb8e-a6258b06eb39">
+      <statement statement-id="pe-15_stmt" uuid="0d79a669-82f8-4de4-88e5-cfa1fa7e0ee4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4ae1a6c-f417-4df4-85bf-6a280922f244" control-id="pe-16">
+    <implemented-requirement uuid="71f12c3d-ab07-4ce0-b016-609d6f02e9e5" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="f5baf9af-68e7-489c-9ff9-110c38d00681">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5f311a92-ce49-4f4a-876b-21f96ddfc880">
+      <statement statement-id="pe-16_stmt" uuid="bcd29e47-8369-492a-897d-e9fae6e0c867">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee402c4d-cf94-40e2-8cf3-2af820baf3a5" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="67af2e4e-05bf-4e0d-812a-4708f010783f">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ea72f026-0efa-40fc-9a1a-05c5ed017658">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2438,10 +2438,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e75a7cc2-3708-40da-8226-53e80bb74f7d" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="0a11e6b7-d0e1-46b0-8750-18e8318b8aec">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="14010c26-34a7-4de2-9686-9d64453806ad">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2449,10 +2449,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3c2707a-e0f9-4106-ab3f-93ad88d8da00" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="4c33a397-c77f-4fa0-ba41-ba26db5909fd">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b82d37e6-6b8f-4d0f-8971-9945a1ad7e0f">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2460,118 +2460,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c84398d-f099-428e-b0e1-58654c5170ac" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="0972184b-40f7-4c42-839a-83aabb615f3d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a29f007f-387d-49f6-b7bd-bb41b4eee0ff">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ece19206-1604-4da6-952c-41185859a3da" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="767cfcef-8dcf-4d50-8fdf-0a61c67f6e38">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ee1d3dad-bf4b-4bac-b613-4d4534855aae">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70e4187b-34ad-4ae3-9998-154cb9bf179e" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="890ec609-a527-404c-b40b-298494358e2d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="121b541a-7dbb-4799-9ed8-5b537ace2195">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72d76531-8f8b-410d-b7b3-37d88ec93c33" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="a7468eb2-5e20-4b34-924f-439665fb8c78">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="6e1487a1-7098-4e43-a449-e4bf7636ad6c">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1be0327-08e4-4926-8459-cfce8de65081" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="98632bf1-fd14-4155-93f6-5201b7f7ead3">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8701acca-9854-4ecb-8f54-e8dec9c74ddc">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adacf9c1-9cdc-4ee6-a45b-7bdebfa0ea30" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="90fa1a73-c7e1-4a04-83e7-b731acb90345">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="508ca773-586f-4b1c-a73c-b98fa4f334a2">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc598b9d-f18e-4db8-a1e2-6c78991e30db" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="1bee1911-0a46-41b6-af60-4beea39339ce">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="9a07d60f-82f4-472a-9ae3-6b08affd1a4a">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b668ae67-744e-42ba-abdb-ceeb9dddd69a" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="1423edf9-3441-455d-bbe9-75d09a689662">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1b0ede9a-3b9a-415b-912b-d09130cc3525">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac94fc26-6c5f-486e-b42f-841798f9a6d5" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="205e7e93-f62f-486f-bce9-4e00c04577ea">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="856096ed-2be7-4c6f-8e1c-69882a44613b">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16ff3a2a-a050-4af7-8114-6fdbf843b7da" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="8daace96-8d77-4aae-a668-502e8af22665">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ea4d798b-a931-47b7-ae59-536d34807591">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d804b38-8e9b-40c7-a211-69cb63e1bf0a" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="0c728eb6-3a83-40e7-9890-c50d477587e5">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="5164f51b-d8aa-49fa-90ce-989735bc1bfa">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf100d6f-5d59-47de-a6e7-2479795f67e7" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="14e42c42-44e7-449a-a47b-5afa8d109924">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="bc9b8263-d1d9-4391-b697-2bc9fc1afb55">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aea8148-0ac0-4b7a-96f1-3f26a071b750" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="5ce1c9b9-dbd9-42a4-a587-00b4154cb79d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="95f5944e-235b-4ab6-b183-3d06f207408c">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2579,10 +2579,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="901f431d-8642-4fea-8496-3ba7d3a875c2" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="181b1662-0ae9-4f53-a7e0-606d96eef5fb">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="1abcc826-553c-4804-8a8f-808e3590f262">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2590,10 +2590,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84169be8-c8be-4ba7-8bd1-97574353234c" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="5ce439e2-d3b8-4cdc-afe8-24ecc672bdaf">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="95e6f1c2-61f0-43c2-a737-dc8c18ceff3f">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2601,10 +2601,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27b01e02-1d15-4a6d-851b-4eb082fcc22c" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="b6ca37c3-cf59-462f-9612-8f3853b44262">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b906cdca-0a9e-4e90-a221-b9ac3276da8f">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2612,10 +2612,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c30274e-908f-43ac-bc9d-d730e4e28d8c" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="0cc2339b-e715-4b6f-9a27-679a7847127b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="8ecbed5d-c0d6-401a-b343-cb52baafc4fc">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2623,10 +2623,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cbdcc90-bab1-4aea-9938-5134e7f90c08" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="f6242530-b340-4973-bfaf-c66486965e69">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="d8c2bd6d-761f-4c64-8bc3-ce651d1f7443">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2634,19 +2634,19 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d36a9d62-d357-4838-8a2e-b8c4c12bb4cf" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="5936a080-3977-4ac6-b558-8a108efa5869">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="740dd70e-15e3-4e07-bf51-fc8e3446b8d4">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7572410e-c582-4ef8-998b-0c711f92b3df" control-id="sc-5">
+    <implemented-requirement uuid="f289d3c1-ea77-4218-bee0-d26c22b792e6" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="be6400c4-7276-4a1d-99cc-d1e474859371">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="40044581-dbea-439c-ae03-aa2fad7095d2">
+      <statement statement-id="sc-5_stmt" uuid="fd835df2-1964-4d23-93fe-320a0cce93c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eb04c3a-268c-4698-8ac3-07070531f142">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation of anti-denial of service capabilities is being
 tracked on GitHub:
@@ -2656,19 +2656,19 @@ https://github.com/ComplianceAsCode/redhat/issues/333'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1508daea-91ed-4ead-9f30-0da405e402e8" control-id="sc-7">
+    <implemented-requirement uuid="d1537646-d09d-4b27-8168-e2f8ac841f65" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="5b36392a-e09a-43b0-9d68-23b26c370c73">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="c35e6509-6464-424d-a2f6-aec648404b2e">
+      <statement statement-id="sc-7_stmt" uuid="95e9e235-41e6-46bb-b0a1-a1f95cbf5047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbc193d6-f859-4949-b067-317923d4dac5" control-id="sc-12">
+    <implemented-requirement uuid="4e57123c-f1fc-4c5c-8c0a-16efeec9b8c5" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="db749d88-0a0f-400a-893a-5e2b7d0e11db">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="15daaf07-d516-4b13-a7b2-fdcee71c1a54">
+      <statement statement-id="sc-12_stmt" uuid="c1a01dc9-6661-4f29-a9e7-1dac5c37004b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd03d06b-099b-4167-b1e2-6d7241efc817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Ansible Tower generates,
 distributes, stores,
@@ -2680,10 +2680,10 @@ https://github.com/ComplianceAsCode/redhat/issues/334'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e79e124-b4de-45fc-b535-52ee4ba3efda" control-id="sc-13">
+    <implemented-requirement uuid="167053ac-c758-4dd5-b2b1-6d57f85cc334" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="43c6ca8d-613f-47b6-92b5-39b0a1323c26">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="50697588-e656-45ad-9a98-4cf7bd383a29">
+      <statement statement-id="sc-13_stmt" uuid="fe1447c7-c6b2-402c-a493-70740422465e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32e15b57-5493-4344-a7eb-3b14d3f36cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Ansible Tower's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -2694,50 +2694,50 @@ https://github.com/ComplianceAsCode/redhat/issues/335'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff914ec6-f737-4d1b-a2ac-70f2367a6408" control-id="sc-15">
+    <implemented-requirement uuid="24d21625-55df-47e0-9ebb-3da75db7b953" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="f5add489-dccb-474c-a9c8-fd0e3f082549">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="a3999ec6-380c-46ce-adbe-503b96b76a18">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d87532d-dae1-428f-a740-04e4f9dee22b" control-id="sc-20">
+    <implemented-requirement uuid="9f9b9f7b-d437-4e54-99fe-5c761fd83e92" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="c3f2d876-e618-4583-bf12-37862b816c0b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="eecf6494-070c-4599-86ae-831ffb947a50">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c484cf9c-1b6a-43de-a511-9ca0094f04fb" control-id="sc-21">
+    <implemented-requirement uuid="cbf58203-fee8-449f-8667-d09d9c8f3784" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="047a1e80-671e-4600-b036-30034c03fc99">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="e353ad97-9ab2-4047-948d-2ea08f408796">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43124d35-4fbb-4054-a5bb-78486ea0f105" control-id="sc-22">
+    <implemented-requirement uuid="39cbd98f-3f6e-4f5f-8053-eaf39f064d4f" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="22b47f7f-de6e-44c1-89f7-b9e12132aa02">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="98ca5b5e-d25c-4b52-bfc6-057b6d1207d6">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe6286fa-6912-4352-a531-de4231cb1190" control-id="sc-39">
+    <implemented-requirement uuid="90ba4ed9-360e-4d8f-a52a-b1d0d64800bb" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="eaf88499-0907-4bdb-9943-72468d3340af">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b0a72b1a-8c19-4093-9a63-0f5fcacdb843">
+      <statement statement-id="sc-39_stmt" uuid="ef2bb7a2-b7ce-404a-b753-529eee8a76e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fff56306-7970-47e1-b6db-ca93a60de8f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on ensuring this functionality is
 configured is forthcoming.
@@ -2748,55 +2748,55 @@ https://github.com/ComplianceAsCode/redhat/issues/336'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11e20975-fbbc-42fa-a7c6-fd127c01354d" control-id="si-1">
+    <implemented-requirement uuid="56c0e671-8df6-4a5b-b567-d12378a4b229" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="5cde9cfc-13c6-40c2-af15-2cf2527faf9b">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="206bd29a-e0b6-4dd8-a1ee-91daeb607db0">
+      <statement statement-id="si-1_stmt" uuid="54378bbd-dcab-4b82-bdbf-8f22ef3a30a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a717a076-16f0-492e-bb35-8eeedc392c5b" control-id="si-2">
+    <implemented-requirement uuid="46ff5a8d-0def-4d98-ba00-a0ff062e0c27" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt" uuid="c57f8bfc-32c8-4a8b-a7a8-1296cfc3886d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="ffb3e709-8895-4236-8954-131d212ab0ca">
+      <statement statement-id="si-2_stmt" uuid="09658e39-0531-444c-9325-5486d6767155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7069de66-1b43-47a9-9f06-f783437fb121" control-id="si-3">
+    <implemented-requirement uuid="64d97460-7849-415c-bbe7-17373c00cf8b" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt" uuid="8847eff0-ab3d-4f2b-bc81-0dff00d8fdf4">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="b4f80e86-a3b5-459c-8a23-e42da994ee3e">
+      <statement statement-id="si-3_stmt" uuid="b1fa2f97-e94a-4d05-ad23-5e71c3dd9737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23985c6a-0721-4521-994a-d3ad0c97433c" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="0e068e17-2679-48ce-a5dc-7314409952dd">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="2d353c12-dc89-40bc-97e4-857ea965be37">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3422c14-aaf5-49d1-8e3a-3f719a5b1652" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="3a306f0a-7fc0-43ac-8ec4-4ab6a62db5e8">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="67425722-86d3-45d5-b101-6ed947c487bc">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fa604ff-2dcc-4d99-8010-b41f7874a344" control-id="si-12">
+    <implemented-requirement uuid="855f5b80-f73b-43a8-b10f-5b09d6b60917" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="dbf6baf4-1e99-4d0f-a7b6-93c1acc62f18">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="6a055d4c-04bc-4dcf-8695-1eb42e9888b3">
+      <statement statement-id="si-12_stmt" uuid="6b9b1a40-b818-4bf6-946e-48c195a1638d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf0273e2-470f-47b7-a9ad-acbbd3c39bf3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Ansible Tower in
@@ -2817,10 +2817,10 @@ https://github.com/ComplianceAsCode/redhat/issues/337'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b096ec0-3ceb-43b7-b84a-95236e9fccc3" control-id="si-16">
+    <implemented-requirement uuid="9e95d7ca-edef-4c70-892a-1eb0933fec78" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="db61c79d-9a93-4d71-87ac-ba9501a4675d">
-        <by-component component-uuid="7d1fb11d-50a4-4359-bfb3-2caca5336bdf" uuid="bacc12bc-367d-482b-8a94-070d241f6c4b">
+      <statement statement-id="si-16_stmt" uuid="69d22aaa-17b3-4d19-9a07-bb8ef6502c9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>

--- a/xml/ansible-tower-fedramp-Moderate.xml
+++ b/xml/ansible-tower-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="e376b829-d807-4f4e-bd2d-cb2f25a3a0ed">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="435c6776-2d68-42c9-b8ab-816a2009fc32">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.18+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.36+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="c884033a-3da8-4084-be86-5cd6be88df84">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="b8705342-5058-4011-9f4c-a3cd18fec1e1" control-id="ac-1">
+    <implemented-requirement uuid="25c4a27a-9fa7-4a09-a31d-3073e4efb8aa" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="de9d14f4-cdd5-4ab2-b36c-9555f3951144">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c23c39b4-9b84-48c9-ab3a-fb6ee21c3698">
+      <statement statement-id="ac-1_stmt.a" uuid="6903796e-b668-4d25-b438-a5a4c7cd70f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="deab5d94-041b-4b46-a22b-62e5888c6779">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="74edfb39-2dfe-49e9-a5c7-5fbfd53a393a">
+      <statement statement-id="ac-1_stmt.b" uuid="ef92194b-c5b9-4a06-8376-caffe5dec37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -503,10 +503,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8343d62-0ff6-4993-8014-6f9eadb5b83a" control-id="ac-2">
+    <implemented-requirement uuid="ea88ac6e-45e3-4858-8bff-8ede745929b2" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="e7e4e5cb-45f2-4b3b-90d6-8a09db133276">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b1ac8102-423b-4c44-b52d-6834534fc8b1">
+      <statement statement-id="ac-2_stmt.a" uuid="874a51a8-9ea5-4545-8926-68508f7ef1f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ea0928-3a6c-427e-b3ba-11e8545aeb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower's Role-based Access Control (RBAC) implementation
 offers multiple types of information system accounts, each
@@ -540,16 +540,16 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/security.html#role-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="3c49a632-ac4e-4a16-a59b-5338b8a94ce0">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="94767c3b-a826-4940-b453-4033050b530a">
+      <statement statement-id="ac-2_stmt.b" uuid="d7d82faa-dbe0-4a63-8aad-ce73e57aaae5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ae98e6-0009-4349-b613-feb56a7ff423">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning Ansible Tower account managers is an organizational
 process outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="6553e3e9-2b4b-49e6-a92d-7dd73e078bab">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="29948a7c-db4c-45de-aaee-74886a6fdeb9">
+      <statement statement-id="ac-2_stmt.c" uuid="9cdad719-4e03-44a9-878b-cc7ea716515d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ddebf72-5bcb-4605-9f4f-0e9eac18c527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role membership is an
 organizational process outside the scope of Ansible Tower
@@ -557,8 +557,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="5d67c0ad-6069-4bf6-aa82-3795e6446306">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="80453d5c-6849-4aab-8bf8-03e226b831ca">
+      <statement statement-id="ac-2_stmt.d" uuid="9c7781e4-f16b-4856-ad23-264539bd7579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b139daa8-ec36-49fc-b0f2-30d1d47c5caf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To specify authorized users of Ansible Tower, group and role
 membership, and access authorizations, refer to the
@@ -568,24 +568,24 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="c115b338-3668-4cc9-98ac-aadeabd694d6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f7d3acc4-c3c2-4541-baff-341449c3be0c">
+      <statement statement-id="ac-2_stmt.e" uuid="4c68b375-6f53-4efc-99b4-e6dfccf1532b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1068cd56-cf5d-4fe4-8d72-d8cb82f16c22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account creation requests
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="5aca4875-029f-4702-861a-d0b4ddecc80e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="736f80e7-aa59-4021-b975-cf056a04439f">
+      <statement statement-id="ac-2_stmt.f" uuid="2a8b1715-0909-4400-b154-eb810db9533a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a07a8330-3554-46c6-a735-8bdd8e4f1894">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding administration of Ansible Tower
 accounts are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="71e8a56d-e3a7-4d2e-80f5-5e9d66d33f05">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="dc5e2c87-48f4-42b2-8cd7-7205fd413ef7">
+      <statement statement-id="ac-2_stmt.g" uuid="a421ecf4-e4f8-417e-a6c2-8c388ba4219b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e7c0b80-832f-4f3b-b259-231d97e54f9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Ansible Tower logging subsystems can assist with monitoring the use of Ansible Tower
 accounts. Logging is a standalone feature introduced in Ansible Tower that provides
@@ -600,32 +600,32 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/logging.html
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="16f72477-8066-4c6f-8c3c-271fcb9b836e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="203c4eef-d777-432e-886e-dab4ef47d292">
+      <statement statement-id="ac-2_stmt.h" uuid="d5de5f33-0b8f-4187-894c-fc85314d9d0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d063cd68-f8a3-47a9-8539-4988e90b2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding account termination or need-to-know
 changes are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="304e7bc2-7413-4470-9da0-a8b27ba66cfc">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8f3abe30-4f3f-40e3-99bc-da3445ec58ab">
+      <statement statement-id="ac-2_stmt.i" uuid="7a5a51d4-b432-4542-8557-18425d3ca131">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="01ed9398-b45a-4a48-991b-18af48d4fa2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding access authorization are outside
 the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="5f531da8-ec08-4232-8bc3-f2d64b1ccbb7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1ab0e9cb-4040-405d-9297-dfea28c8a68d">
+      <statement statement-id="ac-2_stmt.j" uuid="bd3e33dc-cee1-4e02-b21a-c38dd5945ded">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7d2ca93-4412-4c9f-b131-baf0399a9064">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the review of account management policies
 are outside the scope of Ansible Tower configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="ea805135-69a3-4f1e-8565-a2420e67b917">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e44cf2cf-0187-4e10-b13a-c9cb25934c2e">
+      <statement statement-id="ac-2_stmt.k" uuid="80c46447-3584-46b5-81d5-41e2e25e745d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9379ac56-1fc9-42db-9f34-40ee9871b77d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for reissuing shared/group account credentials
 are outside the scope of Ansible Tower configuration.
@@ -633,10 +633,10 @@ are outside the scope of Ansible Tower configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9bf56c2-59c3-4764-9c6b-5e02fbd98566" control-id="ac-2.1">
+    <implemented-requirement uuid="c8d7f4f4-6edc-4aaa-9e1a-9b17afb61b03" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="919cad86-fad3-4dc2-8c60-9b0619cde540">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="491ec390-4396-4cd3-8958-4f125b045a59">
+      <statement statement-id="ac-2.1_stmt" uuid="d101db6d-de82-41a8-b858-e7eaef9a8bc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9167752-469c-49bc-9e4e-8dca520de107">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower offers supported integrations with many account management
 systems, such as Kerberos, Azure Active Directory, LDAP, RADIUS, SAML, TACACS+,
@@ -653,10 +653,10 @@ password complexity, an external account management system MUST be used!
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88064372-5f91-4e31-a85c-e0872af2b765" control-id="ac-2.2">
+    <implemented-requirement uuid="a2747b14-3629-4c1e-b392-69ed2c26f9c1" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="b87f194e-e43f-42ab-8876-06bbebf249ab">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="191e7a91-b10d-4ab6-b018-da3af4522a53">
+      <statement statement-id="ac-2.2_stmt" uuid="6509ce01-da80-41d9-b765-903dcedf7916">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da7a2079-d793-4be6-9f6d-53d8993fb9dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower does not natively have the capability to automatically
 remove or disable temporary and emergency accounts.
@@ -677,10 +677,10 @@ or disable the account.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53855a79-6a66-44a1-9c72-e7319dc901c3" control-id="ac-2.3">
+    <implemented-requirement uuid="ec3b2a88-118f-4f8b-8499-c9671216f60c" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="4a718ed1-1abb-4e41-95f5-9bdb98dbc14b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0a0c159f-0253-48f0-a74f-3bdbc7320f39">
+      <statement statement-id="ac-2.3_stmt" uuid="497224a3-74f2-4dd3-978b-e6f27c28cd0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e7dd1e8-b694-4dbf-b6b3-488ff2301505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower does not natively have the capability to automatically
 disable inactive accounts after an organization-defined time period.
@@ -706,10 +706,10 @@ remove or disable the account.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df9c17a1-fc9f-4b7b-b743-e2bcb2c1bb9b" control-id="ac-2.5">
+    <implemented-requirement uuid="a4c67b90-7062-40fb-bd4f-b84e52b59930" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="6df324d3-b53d-4a0f-8bbc-6d5662d1b7ab">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="232676f5-d224-4d71-bc3f-08000361005b">
+      <statement statement-id="ac-2.5_stmt" uuid="91206164-40bf-48ef-ad9f-f2217f128db6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29bff8c3-0ed3-4a85-8a98-78b06d2cf514">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Introduced in Ansible Tower 2.4 is a feature which adds an Auth-Token-Timeout
 to every response that includes a valid user-supplied token. This setting
@@ -728,10 +728,10 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/authentication
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4396203d-8ebc-490a-9131-033934a65ce5" control-id="ac-2.7">
+    <implemented-requirement uuid="bcd334fd-31cb-4dee-8928-8f8a5c0d1845" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="671995dd-a115-4abc-b0be-fea1bbef6ac2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b40274f1-ac8e-4e7f-962b-742d7c07e424">
+      <statement statement-id="ac-2.7_stmt.a" uuid="ff82fdd0-bc1a-499d-a28a-142abd5a8f59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ea0928-3a6c-427e-b3ba-11e8545aeb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower's Role-based Access Control (RBAC) implementation
 offers multiple types of information system accounts, each
@@ -765,8 +765,8 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/security.html#role-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="39cc92bb-1f5a-436d-8050-b08b58801549">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f926611f-5711-4bc6-a6bc-0ab84633d56f">
+      <statement statement-id="ac-2.7_stmt.b" uuid="55536e22-7c1a-4865-810e-42edd17e4eba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="880869fa-26a7-4b45-924d-cb65952fbe20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ansible Tower automatically logs creation, modification,
 and removal of Role-based Access Control (RBAC) privileges.
@@ -774,8 +774,8 @@ This is non-configurable default behavior.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="0941fde3-575d-4945-92e1-a06902e48d1e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8c20b22f-de80-45a3-ab14-5bd89ee91004">
+      <statement statement-id="ac-2.7_stmt.c" uuid="287ae148-3681-429a-bee1-4f7ad3152e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6591f6b8-f784-43c3-a6c0-d573cc08f73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational process control
 outside the scope of Ansible Tower configuration.
@@ -783,10 +783,10 @@ outside the scope of Ansible Tower configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d352ff0-7d2b-4eda-b25e-d1740a86fc10" control-id="ac-3">
+    <implemented-requirement uuid="80eaf071-6ce3-4d01-87f7-61bdf0ac7b11" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="b8e02937-4ad4-493a-ba70-52632c9fc4d4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="423ad608-093a-4488-9cb5-d09f42f7adae">
+      <statement statement-id="ac-3_stmt" uuid="f4ec59d1-9343-4ba5-b732-76a5ea36e80f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d876b570-2782-4580-a66e-c9baf5170c10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'There are three types of Tower users that can be assigned:
 
@@ -818,10 +818,10 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/users.html'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ad9599-a7d5-4349-ac7d-a5487055717b" control-id="ac-7">
+    <implemented-requirement uuid="3f996a42-c9b3-4f7d-8418-b6e041af0542" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="64843cc8-fa7b-4a8c-a650-f8df0b720007">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1eb3a426-f4a7-4842-a0e1-0b01762bb91d">
+      <statement statement-id="ac-7_stmt.a" uuid="9ed16087-8072-4f2d-bb7a-a7a2224e64c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2765dde1-c0ab-4bd1-9b16-72e35a55ae16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability to enforce limits
 on consecutive logon attempts.
@@ -832,8 +832,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="89e39501-9306-4075-b0f0-a3736a88d16d">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7ecfbdf8-db35-41dd-b834-f63d1fb34afc">
+      <statement statement-id="ac-7_stmt.b" uuid="aed9b374-52fb-4a05-82f9-37a045a64e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b22518c-16db-4dce-87a8-76fb4d93b4f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not currently have the capability automatically
 lock an account for an organizationally-defined time period, nor
@@ -856,10 +856,10 @@ finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba2fe287-7cf9-4801-8a82-5a2aea7a355f" control-id="ac-8">
+    <implemented-requirement uuid="355ed56d-434d-4e93-a07d-3ad038c1c908" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="f0318858-a481-4400-950e-4572eef7b71f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="bdffc473-2cee-4d17-881e-4bb521a98f67">
+      <statement statement-id="ac-8_stmt.a" uuid="1f1f0f06-d21b-4832-acec-1740fc121d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0fdeb6-61ef-45dc-8c74-931d3748e6a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower supports configuration of custom system use
 notifications.
@@ -878,8 +878,8 @@ field. Note breaks must use "\n"'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="2033be26-c8eb-421c-84e0-1cb21c821322">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="dd48606e-f9a2-4142-9538-3916716baf8d">
+      <statement statement-id="ac-8_stmt.b" uuid="1e940eca-2352-4ed1-9a2d-86faa54fd739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df7809ee-f81a-4997-add5-74b73dee367f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Custom system use notifications are displayed on the logon screen
 prior to the "login" button. This is default, non-configurable
@@ -887,8 +887,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="ff86f42e-cfc6-4b59-9a08-f2b8f3f79c6f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a3430cb8-d3fe-4478-9931-a10dbd207172">
+      <statement statement-id="ac-8_stmt.c" uuid="ef643b9e-123c-4c43-b1a4-7d4e67543e42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c92bcc5f-d5b3-4e83-9b16-5d0916817a4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not differentiate logon screens between private and
 publicly accessible instances. Custom system use notifications
@@ -898,10 +898,10 @@ procedures from AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="369ac1d1-2f21-44a4-af81-348038ec12e6" control-id="ac-14">
+    <implemented-requirement uuid="04df7290-eaa8-48ce-abba-b1cfd2d75875" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="dd10410c-77d2-4a2d-bb98-a558bea7472f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ef92e1c5-3603-48ab-9a2e-bb64483707c0">
+      <statement statement-id="ac-14_stmt" uuid="794730c0-822e-467e-bd9d-13e6447c0cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd876e51-4edc-4be9-a2a6-9483d7172b9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Ansible Tower
 console, unauthenticated users will only be shown the
@@ -914,63 +914,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66a2b95b-443b-4785-81af-3c8651bfe0bc" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="c8dae3e4-fdad-4e4c-8fa9-4660ad049469">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d7711fde-6356-4ea1-8125-30042608ddb4">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f578b3b5-65b4-4a2d-bd61-5698bcf78d2e" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="259b6dd8-47e1-4146-ba01-2a84704f0481">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fcc206ee-5e7b-4008-b289-068fc6c7a91e">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04751a0e-162c-46f9-8636-c1f1302ea66b" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="039e5c55-f6eb-4a91-858a-5e3f0ec50d88">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fd502b16-553d-41b6-ae87-670ef9b54220">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b9905b7-c63d-4e56-be14-d3dbf2e2c6a6" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="2a82ba03-82bd-41a2-8b26-cf0ee76746ac">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3d883616-ac8a-46a3-a160-afb850ed42c3">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ef182c9-0e24-4aef-999a-a65e0b1ce051" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="b6a22662-e332-4141-86f3-baa77f658f4c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="562bfa15-2966-4574-8f61-10e383077512">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33ae7ce4-2af6-464f-8d95-ca00ef12fe2d" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="31a27051-e28f-45b9-b589-af020792ce63">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9e9fe306-d4ae-4f4c-9932-e2b67afb46a5">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="0e152ed7-482f-4df0-8c9d-6a13a35d7c8a">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="731cce40-c848-4eeb-9261-193dc8ea7d40">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -978,26 +978,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="722657c3-20b0-42f4-a3ef-9eaff3021b6f" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="8f895de9-4be5-4089-828e-3eb049896445">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e4277543-abb9-47ff-a92b-d315d3886b60">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="ef0ed920-e707-43c5-a7d9-a62407e3e75f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fefae2a1-42b3-454e-81ab-ec21bc26bf52">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="0d97bb0c-5b4c-4482-aca6-0c352a9403eb">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e31ccb5a-4b61-41ef-bf3b-cb0fde54edf0">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1005,10 +1005,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="359837bc-050e-42f0-8f14-3ade7b30b276" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="7a6b79ef-69f1-4d61-b0bd-ccf8c116b21b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7f8ff5bb-3b04-4434-ba85-f9fa85d15d01">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1016,26 +1016,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edb3353f-1530-4043-8dd9-23e44736711b" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="4ccf08c4-c617-4428-80e2-0da46a687ca4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a2293fd1-3dba-456e-9093-aabec063821f">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="f6e81f40-b02a-49f2-98af-1cf7a458d17c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1a7b35fb-42eb-42c7-a322-40196461d42c">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="1b75f663-2097-4ba9-b1ff-cf4e781e5f17">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d2c27ffd-b9db-4952-a515-a397de40656d">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1043,18 +1043,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ddb6cb8-4bf3-4ad2-95cc-ebabbd6a912c" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="a58a76f5-3a92-47b6-a747-1224e68b1fc1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b12bf58f-22cb-42aa-9949-4619206fbbed">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="e6d892f5-2140-40c2-ac15-4d60ae61fcab">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="cc4a78c3-a623-4832-b0a3-b75e67ffda80">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1062,28 +1062,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac04cead-f2de-480b-8f58-d83c702d96d7" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="caced9ba-a1ac-485b-a7f9-f00fcd5eeb27">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="018c1a58-db92-45df-8293-8ddf249f8bdd">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5520ff9d-b8fa-4572-bb21-7b6c042c3b50" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="46f8216a-43e4-4b10-a430-2e2bb38e441e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="bfdfa864-0ca7-4b99-abe9-0b30faeedfbf">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce97594b-cfd1-4f27-858b-91974c2c926e" control-id="au-3">
+    <implemented-requirement uuid="0bc7b038-2291-47f1-b95e-f27718ba9dad" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="659b6540-42b3-49db-ad26-805473a42467">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0c3d1170-0ae8-4f0c-b7d7-35c428043503">
+      <statement statement-id="au-3_stmt" uuid="bcbc1772-f72d-4ebf-940f-a87749be0356">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2243f0d-df11-4d3b-9feb-7843d573c755">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default Ansible Tower generates audit records containing
 information that establishes what type of event occurred,
@@ -1184,19 +1184,19 @@ https://docs.ansible.com/ansible-tower/latest/html/towerapi/activity_stream.html
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07fd33f9-0888-47ac-a190-6c360c8719a0" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="097e56d4-640f-4905-b8e2-ae64eac4ddb4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="336e0dd6-18e5-494e-b2cc-156b46287c13">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0707ff43-8a6f-40fc-af45-209746e168f8" control-id="au-5">
+    <implemented-requirement uuid="4141f72e-f8c5-46b2-b788-ec3ad473ed39" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="06ed7d70-7099-4362-acda-080eae94aad7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2c345991-6c9c-4e81-906e-125fe2aba002">
+      <statement statement-id="au-5_stmt.a" uuid="9d51e840-f6b9-4ab1-bbd6-f93358885e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1205,8 +1205,8 @@ Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="ecd34ba9-dc09-4f66-894b-08981e4dd3d6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="03239200-0bab-4b26-8c19-66cc1e43b4a3">
+      <statement statement-id="au-5_stmt.b" uuid="fdfb5480-4156-4e8a-b268-80d158fa7b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da456340-a675-49d8-8171-6f934929e3b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the audit and syslog subsystems of the
 underlying operating system. Responses to audit subsystem
@@ -1216,19 +1216,19 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0b38c9b-4754-4571-aabc-19fb2235cac3" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="885cb808-6c3b-4380-a6c7-18d48a11aa69">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c1e9a7e5-94fe-44f3-8c9c-1ba36ee839b5">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0652589-8424-4a68-b3e4-92c3b53c5fb4" control-id="au-8">
+    <implemented-requirement uuid="becf8e32-f685-4e4a-bf9e-be88774fd26a" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="aeffe7d8-6c61-4cd8-aad3-fae1cdcbfc55">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e5848738-1a38-4783-88d5-6a16400ae5b2">
+      <statement statement-id="au-8_stmt.a" uuid="998c237c-d0c9-4e6e-a78c-76cb2bfefe12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd476bbf-c7b0-4ec0-9434-3419bd161f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower relies on the time services
 provided by the underlying operating system. Utilization of
@@ -1237,8 +1237,8 @@ behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="c2f643f6-71cc-461a-bd14-8efc3e513503">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="988c3db5-a629-4f29-a7ff-8206b0421f40">
+      <statement statement-id="au-8_stmt.b" uuid="9b88938b-72b8-4957-ae98-fa4158a1d301">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e5ac9f-1dad-4443-99a9-916e73faa646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower utilizes the time zone settings of the underlying
 operating system. This is default, non-configurable behavior.'
@@ -1246,10 +1246,10 @@ operating system. This is default, non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b73589e5-2a61-436f-a2c2-4bdc8c9d579c" control-id="au-9">
+    <implemented-requirement uuid="3ec9f35f-418c-4efc-8f59-f18cc0171564" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="8eaa7cc1-4725-4ee2-881a-e1746796bb09">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="236fa540-0ea4-43fb-9322-3d3978b1d451">
+      <statement statement-id="au-9_stmt" uuid="f4d285da-2c8e-40e5-a625-adf62450757c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0cf7e1a1-821e-42b9-bafe-1f376835c3e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower logfiles have been consolidated and can be easily
 accessed from two centralized locations:
@@ -1269,10 +1269,10 @@ to the accessing user).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e197a15-169c-4157-9394-aa5f7bc9b0d7" control-id="au-11">
+    <implemented-requirement uuid="2ff74e9f-c91d-4851-9a09-bbf7fd625131" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="5af7d083-9259-490b-ba7a-7dc4c63c10b7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="78563655-b4ea-458b-bcba-3bd989ecd48d">
+      <statement statement-id="au-11_stmt" uuid="4b25af90-cc8e-4644-ab85-38b9090ec3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="657201e0-b861-4759-a353-a33f315df693">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'For locally retained logs, such as those recorded to
 /var/log/ansible, Ansible Tower utilizes the audit subsystems
@@ -1286,10 +1286,10 @@ outside the scope of configuring Ansible Tower.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ef1d62d-0439-40dd-9138-c0dfb1e64f21" control-id="au-12">
+    <implemented-requirement uuid="da920acf-393a-4df5-a211-a2b2b3c7eb8b" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="c4e505ff-c710-41fb-95d5-0218d9e20e5c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="20e4b747-c4cc-4eb3-80cd-0017a2d98b09">
+      <statement statement-id="au-12_stmt.a" uuid="c9d7357b-b9c4-4857-99d7-5259ff704990">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfa206b9-bd1e-49b8-bef9-243817f2292e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'By default, Ansible Tower audits the following events.
 Audit of these events is automatic and not user configurable.
@@ -1524,8 +1524,8 @@ being imported and "status" field indicates success or failure:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="ab85a597-f661-43d8-851b-d8c57edbf55d">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a340cb9d-d526-482f-907f-861b40d85a80">
+      <statement statement-id="au-12_stmt.b" uuid="ff513e1f-4fff-41ac-aa19-fca0ea601659">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="250fa9aa-0867-42ec-a2ba-9b71bd3cf330">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to allow defined personnel or roles to select
 which auditable events are to be audited by specific components of the
@@ -1541,8 +1541,8 @@ https://github.com/ComplianceAsCode/redhat/issues/296'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="e54539ee-3d43-4e72-9412-3c198a35fdb0">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="594d1413-1696-46c6-82c5-66eba00eac57">
+      <statement statement-id="au-12_stmt.c" uuid="8faaa7d8-0fc6-4270-8743-8328ee1220f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d475dd-7fd8-43ed-a837-5425e4438cfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -1557,109 +1557,109 @@ https://github.com/ComplianceAsCode/redhat/issues/297'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82c3cd31-21a6-4979-8f66-3e5aee226bbc" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="dcc097f2-a513-48dd-b80e-ed22febc722e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="6b172d1d-de9e-4aec-b761-afa57181d98e">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9770d9f4-c1fb-4712-80d3-ed4e2789a68d" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="8dab465e-eda1-4718-beee-b5644cb8ada3">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8a4b6722-6232-43af-90e0-ec4d8e2c57a9">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc2d15de-0ca8-458c-8021-230769391a2d" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="b0ec8f43-9e27-4aec-bf9c-075cc0012543">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="037e0498-5225-4b23-a8b0-d7a1d1533c12">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e64e4d53-2ac5-4202-9f20-60e2be5ed61b" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="0ef4efe0-0387-4d27-b2e0-178d852d957f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="62c8a558-0fca-461b-a8ad-32ecb2bcf1ef">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bc256af-d578-4b82-9185-2e96a5526b9a" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="3d2add6b-7e73-401a-9d5f-8d9463dc98d2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="740d20a5-a335-482f-bde1-c73b9be582f9">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b327903-a463-4e9e-8176-d28ada8e1161" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="03d546cd-2f55-438b-9059-3a985b138438">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="daa6ee8d-d157-4d9d-963f-e00ab2c86c50">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00ac80cd-3142-4b53-aa26-661f4b379e6c" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="022de06a-b9f2-4991-bf6d-bf7ca1f55a56">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5be2731f-f8e5-4976-ab3c-71596a1e523e">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="516ed254-0cee-4bdb-97bd-fe1887a049b7" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="82252d36-ab6c-47cc-a0e7-f9ac1c820fc7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="29f60148-00c3-414b-b2dd-5977b317782f">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb4e1406-6505-4ed7-a78d-3314d1d6773f" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="140fe449-9da0-4be1-8e8c-3e1bff6c3e96">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f5215902-ab29-4dd1-8031-495a2d24aad2">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b9c8a51-4523-44bc-9298-c4a6d3d751e5" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="652591dc-775d-41c8-bde0-8b855b07d12b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="431b1248-6ccb-4690-af8f-e95d1a99d696">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7974f230-064a-424a-8a82-4946663f713f" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="f020d070-6585-491a-83b7-f6e284e9166a">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2ab3fae3-fc44-4328-8653-b2cbb7edde38">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c417dde5-1389-4c92-8f2e-9a70410c86b4" control-id="cm-6">
+    <implemented-requirement uuid="fde226d7-7d67-4355-bbc8-71f20e317364" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="c63643aa-4165-4eb5-b202-76390a5d11f5">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="08669da9-0a90-48d9-95e0-d7b47c80df37">
+      <statement statement-id="cm-6_stmt.a" uuid="4fa9858c-a284-4d75-b344-139e30e35aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e78a106a-eb43-4e69-af14-e7af054511d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower. Use of the NIST National Checklist
@@ -1668,8 +1668,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="01fa81c4-7072-4089-9891-7ec30ad0cf0e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0e5d3fd5-8d90-48f2-937c-8e10596ec03f">
+      <statement statement-id="cm-6_stmt.b" uuid="d81d0acf-4339-4280-96d7-48862c912509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb628c5-f152-43a0-97ad-a73c840900ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1683,16 +1683,16 @@ https://github.com/ComplianceAsCode/redhat/issues/299'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="17b0738a-2b11-4739-b002-e864ed2d8a53">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5630bc0e-d871-421e-be78-90d83480378f">
+      <statement statement-id="cm-6_stmt.c" uuid="56f21bb5-8370-4e48-8e9e-9e92d5708f6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="efd2441e-1921-436d-b55b-884355c304ec">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a6688a7a-6030-4412-94e5-698cc7a38f0e">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1704,10 +1704,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80cb957c-6bbb-4e01-bd87-5069f1443d23" control-id="cm-7">
+    <implemented-requirement uuid="342ffb57-0682-4fbc-abd3-c1a74e8296bd" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="812be090-f360-459a-afc5-1e22fa2c64c6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="cfa031ab-8454-4fb4-9ec7-bcc7e98bf682">
+      <statement statement-id="cm-7_stmt" uuid="8997ae8a-a31e-49c5-afc1-631aa0487d39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b29c60da-efb5-4a9a-ac22-72e78771ae9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ensuring Ansible Tower is deployed in a minimal configuration
 is being tracked through GitHub:
@@ -1717,37 +1717,37 @@ https://github.com/ComplianceAsCode/redhat/issues/300'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="351dcd99-f861-40aa-8418-42f4dbc76e88" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="c20bcef0-088e-4087-ada5-c3a9e92af1b9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1f3902ea-9716-42c4-a82c-787548f6f78c">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad6e361f-b4ee-4c89-8536-637a53c44049" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="307c0ac3-6225-4886-9a36-46212d721e0a">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d8c67545-c780-426c-9811-e81d5c38f15d">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2926f21-4604-4ec1-8766-ac0d473dd354" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="3b827526-4243-4613-a9eb-cc81cd256dba">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3780afe4-e563-43f2-8ae5-11ec755f1508">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="252ec7db-be3d-409b-9811-4673f071e213" control-id="cp-1">
+    <implemented-requirement uuid="817aa407-2d8e-45b6-98b9-3924740bfc4f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="b06b505d-4d4e-4cb5-b988-2aba81f32714">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="bc356998-4dc8-4651-bc03-469c4e22d4bb">
+      <statement statement-id="cp-1_stmt" uuid="e0de154f-41c2-4ba7-942e-6aa40461900e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1755,10 +1755,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5b230ff-b0b8-4f60-88f3-e609263b050f" control-id="cp-2">
+    <implemented-requirement uuid="6128ae2d-fec8-4f37-adc4-72c9afd8be57" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="7ac8a931-27a4-465b-9739-4f387c59b918">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f1f68118-cd92-4314-a09c-e8e23db73437">
+      <statement statement-id="cp-2_stmt" uuid="05bc64ef-f544-4d5e-ad96-e8e21b035818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1766,10 +1766,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee5b92f9-b00b-4ed5-b03e-c7fbf7ed75f2" control-id="cp-2.1">
+    <implemented-requirement uuid="443c3d6c-5cf5-41c7-9f58-2ee399dc27a4" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="601ad7c6-ef36-4778-9b1c-1f98c8f05515">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f8ab8188-5e97-417d-ac0c-6faa432b5846">
+      <statement statement-id="cp-2.1_stmt" uuid="396224c8-0b3b-4326-98af-1e98e29c4b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1777,10 +1777,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f067fd3b-ba5e-439b-8142-9e33e92d0faf" control-id="cp-2.2">
+    <implemented-requirement uuid="9547f7f0-ac58-4bc7-94df-14f1eccd8f89" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="12b4bf93-c915-492f-a2cd-4a4e48e953ff">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3b6e2182-42df-458e-9810-4c9538000ce8">
+      <statement statement-id="cp-2.2_stmt" uuid="7d014629-227c-477d-bc5d-f780163e5063">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09438de9-00bd-48e3-abfa-d4a39595c003">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Ansible Tower capacity system determines how many jobs can run on an instance
 given the amount of resources available to the instance and the size of the jobs that
@@ -1795,10 +1795,10 @@ https://docs.ansible.com/ansible-tower/latest/html/userguide/jobs.html#at-capaci
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bae1ba6-5ac0-43b7-bcea-bcfee3dd6863" control-id="cp-2.3">
+    <implemented-requirement uuid="ca8a83a7-37b8-44a5-b8ef-6732e37b3171" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="bca0eda3-ad53-41b6-b8eb-24f227805bd8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="90afda96-2d80-4a3e-9a60-287a16a31583">
+      <statement statement-id="cp-2.3_stmt" uuid="d02da8c3-8ff7-42ab-a62d-6ef628be873f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1806,10 +1806,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e60cd02-bc22-4962-a1b4-ade9bc82de9c" control-id="cp-2.8">
+    <implemented-requirement uuid="2bfbfcef-7399-46bc-a1aa-3938f82620a6" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="6b302e12-252b-4966-abb9-cf81cb177a03">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5d607cc7-9147-44c3-a9ed-94947c72a43b">
+      <statement statement-id="cp-2.8_stmt" uuid="65eb1bd7-7e85-465f-81c6-c55d421e9711">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1817,10 +1817,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f0d9a45-630c-418c-920e-5d608f0f88f3" control-id="cp-3">
+    <implemented-requirement uuid="8f336932-5f5d-482c-bb93-891f6558844a" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="4faf0c48-f36a-41d9-bdcc-6f4095cdd365">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9247a7cc-9d30-47e7-ba02-8114397733f0">
+      <statement statement-id="cp-3_stmt" uuid="2a381acf-5960-4243-a8c4-1dd9e4a7cfb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1828,10 +1828,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94814934-70d8-455c-ad71-0aef0fa538a2" control-id="cp-4">
+    <implemented-requirement uuid="fe89b6b9-4856-4bba-a265-d6de21bded58" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="bfb594aa-8124-4262-9707-625f23f67b8e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="36ac42b5-6280-4767-94b7-d5678e27e6e2">
+      <statement statement-id="cp-4_stmt" uuid="d8698da3-c318-4ad5-994a-2d1f3a9f40a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1839,10 +1839,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2dcab0e-c239-437e-b83c-c535df4bf664" control-id="cp-4.1">
+    <implemented-requirement uuid="35f68508-22b1-4606-8dab-7db1f48a167a" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="4166e4ce-5106-4459-9f5c-0ff25da47042">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="57f6b60c-59b8-44bf-a8a5-0d11700b1a53">
+      <statement statement-id="cp-4.1_stmt" uuid="149c9f21-1835-4e28-8e89-5a9ad40d5499">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1850,10 +1850,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fadc267d-f9e1-425b-be4f-a4649b06946f" control-id="cp-6">
+    <implemented-requirement uuid="6702202d-608f-42df-bb89-96bac9195812" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="8a545f34-c651-4446-bd18-24f1eb2f4c56">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3bce0ede-fcdf-480e-8642-f831e8ee2b49">
+      <statement statement-id="cp-6_stmt" uuid="41770b17-a878-47e6-b989-bf9f10e68977">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1861,10 +1861,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a9d51c9-29e4-46e9-933e-fa3b1c48cf35" control-id="cp-6.1">
+    <implemented-requirement uuid="ee7a4bd6-3de0-40b0-bd5a-b5e89d680878" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="1e375e74-425e-4a95-8fee-c19553e4c7c1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5021c0b5-8912-436d-803d-41bf7fbed7b0">
+      <statement statement-id="cp-6.1_stmt" uuid="85627f8a-9c40-4d75-b2e0-2bc6cd31d239">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1872,10 +1872,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd3218c8-7010-4b92-a367-35a37ecf3f39" control-id="cp-6.3">
+    <implemented-requirement uuid="25e99e64-bb50-468d-ae5d-67a917bb0de7" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="a1f61b75-16b5-41c7-8ddb-ea1ce24a7800">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ad0da58a-0230-4be7-8666-9af99099fcad">
+      <statement statement-id="cp-6.3_stmt" uuid="53baf1c2-ef64-4151-a123-c86529b8ce83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1883,10 +1883,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d70fedbe-8bf9-4850-af10-963390860c88" control-id="cp-7">
+    <implemented-requirement uuid="35004d48-fc3d-42a8-9526-87ee35704be8" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="67f5c497-b287-4da4-9d64-a782a12f90d4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a2b6e57c-f46b-45ff-9efd-f231dcf11add">
+      <statement statement-id="cp-7_stmt" uuid="9f7f327b-4692-42e1-8880-f7aa1ba05f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1894,10 +1894,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4bd1dbb-43ef-4578-b039-e0c3c6e0facd" control-id="cp-7.1">
+    <implemented-requirement uuid="ac4b90cc-c415-41dd-a2ff-76adc602c1c2" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="3dee1591-63ac-4416-9c70-60dc3ece6c57">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="859561ef-446b-4c55-a92f-6a6be3e8ea2e">
+      <statement statement-id="cp-7.1_stmt" uuid="1c08d553-a02f-46eb-9089-eca7fa24ebe5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1905,10 +1905,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c08407aa-152c-4f3a-bf04-125d36bca4a2" control-id="cp-7.2">
+    <implemented-requirement uuid="36b050b9-4f9a-40e2-85d8-9d0a1b1f925d" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="e31e58c8-0438-4afa-acb6-42c564040204">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8c0ac180-818d-4e7e-abf5-b0905c2d5b5a">
+      <statement statement-id="cp-7.2_stmt" uuid="a144f534-b92f-4996-bf2c-b7885c142253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1916,10 +1916,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1f85ded-e04d-4343-8187-ba66383efacf" control-id="cp-7.3">
+    <implemented-requirement uuid="5741fa2a-7c2a-4b29-bc92-d189a19bee72" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="c1b9c330-58d5-4db1-87af-5e9e8b63d4b8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d7410e30-355e-4d9c-9ecf-6a1354bc87ad">
+      <statement statement-id="cp-7.3_stmt" uuid="d4712154-9585-4d1f-8167-078622321a7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1927,10 +1927,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa613cf7-be3f-41e0-a8b9-79d284b94cc6" control-id="cp-8">
+    <implemented-requirement uuid="3ab3d3b0-e75f-487e-9b21-f444df4b32cd" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="819ff2cd-14af-427e-b35e-3d374214dab9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="cd3a94b7-a8b4-419d-b3e1-f9893556eb2d">
+      <statement statement-id="cp-8_stmt" uuid="6b87e6f6-fcaa-4665-ad57-411fe94efa02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1938,10 +1938,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82657732-7476-4eb7-a5bb-9f75a5d997b9" control-id="cp-8.1">
+    <implemented-requirement uuid="a97dbdc3-d355-4154-9e14-d4c4a029e00e" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="e1270bac-c78a-4b3a-8ba6-821e8b62b9be">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a4122225-b9f8-4709-b3c2-27f8f1071b82">
+      <statement statement-id="cp-8.1_stmt" uuid="749430d8-0b05-4517-a9ee-caaedce7e714">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1949,10 +1949,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b97eaa01-8ec7-45ac-96b8-e2d14ef227e7" control-id="cp-8.2">
+    <implemented-requirement uuid="58fe5cc5-6bbc-4525-80b7-1fa633e8fe7d" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="eaa746ea-c6be-4d3d-ae3e-26abf6bced24">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7aff9a64-2459-4aed-9a34-db18e08a90dc">
+      <statement statement-id="cp-8.2_stmt" uuid="04c3c8a1-5538-4ceb-95f6-edd9a626f200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -1960,10 +1960,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28f0384c-9f4b-47cc-8bd3-64fc300e4025" control-id="cp-9">
+    <implemented-requirement uuid="c42626c3-79e3-429c-bf12-9f7fe675e345" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="6039a8bb-d31e-47a9-b948-abea1035157d">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="75f50982-91c8-48d9-a5fc-f1c3cd9247d6">
+      <statement statement-id="cp-9_stmt.a" uuid="dcf4f455-b4e7-46be-ac29-ee3f20c0809b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -1984,8 +1984,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="2e6703a0-35de-4a87-888c-f77da5dbd965">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b67166d0-47fb-492d-bac2-52263ed8a4ea">
+      <statement statement-id="cp-9_stmt.b" uuid="1d0d882e-0d3f-4ea4-a5f7-1f0b4b8778cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -2006,8 +2006,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="67f116bf-fe01-48a1-a1d7-f466764ac871">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="dbc4c162-7629-43ce-9cec-60f6fb1a576f">
+      <statement statement-id="cp-9_stmt.c" uuid="939b14aa-c91d-4b11-aeea-e90fb6c233a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6db2e17-6bc9-4daa-a510-43e97695435c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>As a procedural control, the process of backing up Ansible Tower
 is outside the scope of a configuration guide.
@@ -2028,8 +2028,8 @@ https://docs.ansible.com/ansible-tower/latest/html/administration/backup_restore
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="7e83df5c-ad8a-41b8-b811-a6230675d03e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9b06bd27-00b6-41e1-ac97-058e21cc2269">
+      <statement statement-id="cp-9_stmt.d" uuid="b7ef92c7-efb3-48bb-8a38-5d178485dca9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2037,10 +2037,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd87a73c-96c3-44f2-8f83-e941441821d2" control-id="cp-9.1">
+    <implemented-requirement uuid="e20b88e9-72cc-4223-9b8d-faedb2834c67" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="4a028e47-12a7-41ea-9bfb-7b223878eba1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b795136e-f709-430c-aad6-c9a5a1e08424">
+      <statement statement-id="cp-9.1_stmt" uuid="afe52a67-a2b5-442f-aa15-f8d979d86064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2048,10 +2048,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5e30370-750c-4a29-aeb3-7b72b5ab4276" control-id="cp-9.3">
+    <implemented-requirement uuid="bcf315a6-84c2-4771-b6b7-e1637ca46ae8" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="bb74ffb0-e02a-4aa1-a8a5-16ad58bfb992">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c6a9e7d6-cb0e-45c2-a7cd-aacc72417ae6">
+      <statement statement-id="cp-9.3_stmt" uuid="206b1614-e40a-40c3-81ec-73cc84f951d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2059,10 +2059,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54e33733-45e8-46ca-9850-718f2d5a17b6" control-id="cp-10">
+    <implemented-requirement uuid="9ab3db9e-2973-4241-8a86-58a8392136ae" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="fc6e9d2b-ec0f-4e9b-b74f-05ae1e9d91c4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="55286554-5b4f-4bf6-9323-cf2c43925ba9">
+      <statement statement-id="cp-10_stmt" uuid="917e418a-a1ff-4431-9cd4-039411666940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac578ce4-9a5c-441b-82a3-ff8032c49bc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on establishing backup procedures can be found in the
 Ansible Tower Administration Guide:
@@ -2075,10 +2075,10 @@ reflects two distinct processes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e707469-21a8-4110-869c-460d37abce17" control-id="cp-10.2">
+    <implemented-requirement uuid="867698d4-e6e9-4a7b-9202-9e1d8e469630" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="ac50f42b-75e1-4323-a14a-f21413553e13">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="12f8ec3a-1d39-43f1-b3d6-1d88d833a499">
+      <statement statement-id="cp-10.2_stmt" uuid="485fd960-7c56-44da-8ca9-377179edda96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce02850-c1c5-461d-bffe-1c5df987d416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 component-level configuration.
@@ -2086,19 +2086,19 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc3557b6-473f-4197-8266-25e6e3e11412" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="6b29ffae-9d8a-4c01-9d85-d2e9a417a0e2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3ebcdeff-3ad4-4eb7-b223-50224a26ef91">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a02fcde6-2e04-46a1-ab06-6181f76a0880" control-id="ia-2">
+    <implemented-requirement uuid="371b0174-b58a-4b53-bc2b-9918c5dfa56a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="cff09ea5-18f9-4e16-9946-5b11814e8451">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7d5fe596-91fb-4e10-b89c-325051d53615">
+      <statement statement-id="ia-2_stmt" uuid="2a30572f-4271-483b-95ed-f5dd0570e737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef6b479e-1a5b-482d-ba86-9fadb9c2f3e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely identify and
 authenticate organizational users (or processes acting on
@@ -2111,10 +2111,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43b98a46-2565-42c6-8cd1-d85f50db8257" control-id="ia-2.1">
+    <implemented-requirement uuid="8a1d4f6c-1288-496c-bd0c-da79beb23d8b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="e94eb6eb-2a59-4adc-a0e2-b092e6848c06">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b6f439f8-488c-4d8e-8a29-ebf0a9fca8c2">
+      <statement statement-id="ia-2.1_stmt" uuid="59b74a03-8f9b-4d5a-a8b9-6ace804461fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72479822-926a-428d-bc0d-04bb9d5c56be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2129,10 +2129,10 @@ https://github.com/ComplianceAsCode/redhat/issues/305'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cd4e004-29d4-4d13-97f6-7bcb174e2ff7" control-id="ia-2.12">
+    <implemented-requirement uuid="f53bb0e0-cd3d-44e8-b1e0-4321fe49103e" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="f6338d51-e282-4e92-8951-f80125495488">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1ff548ba-ed28-4bb7-84bd-f1d6da28760c">
+      <statement statement-id="ia-2.12_stmt" uuid="16bbb60a-cde0-46b5-9d80-9fcb59849304">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2965a46b-a7e9-4591-bde4-a0545660b690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2149,34 +2149,34 @@ https://github.com/ComplianceAsCode/redhat/issues/306'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fb0884f-bc0b-4501-b203-9c690aad06fe" control-id="ia-4">
+    <implemented-requirement uuid="2fb876e4-d80c-4efd-b6ea-4395761494f8" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="d69a9492-377f-4540-af84-173897a52157">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7ffd40e7-8ff1-4493-8505-7861aaedc437">
+      <statement statement-id="ia-4_stmt.a" uuid="9a1880b5-870f-4829-af6d-3595d3c46747">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="74b1b30f-2212-4e68-87f5-1f9c60959658">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c1b61a05-f1de-47b6-898c-729bbd0115ba">
+      <statement statement-id="ia-4_stmt.b" uuid="a9e0b21f-f9f8-495e-b507-c8052d91b838">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="f02f9ea2-4d35-4f00-8de2-875796add414">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b07def29-eb34-466b-9403-bf7c55276970">
+      <statement statement-id="ia-4_stmt.c" uuid="fce0656d-bbba-43fc-9331-c8a1ddcf462e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="b6b90ba2-cc05-4042-9333-4011baee059b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c673ef77-8d53-4024-bd94-51f00ae0dd8d">
+      <statement statement-id="ia-4_stmt.d" uuid="c0c376b3-6f15-44cd-abcd-ca748e3f0f96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bd77aea-ff91-4d07-92c6-ae2974fbca31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to prevent the
 reuse of identifiers for an organizationally-defined time period.
@@ -2187,8 +2187,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="344cc052-126f-4f90-9492-6585171620e9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c3f67bb1-0d3d-4257-b537-b8e1bdc0b530">
+      <statement statement-id="ia-4_stmt.e" uuid="c6b12517-aecf-46a2-b41e-47db93a8551e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c0512e3-9b32-4049-a60d-e66256a64237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to disable an identifier
 after an organizationally-defined time period of inactivity.
@@ -2200,18 +2200,18 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c349712-dbc4-4989-a81b-f5a090b6e612" control-id="ia-5">
+    <implemented-requirement uuid="c9da835f-959d-42c5-83e3-133b0f133523" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="02cd2b7c-0a5e-4d23-9faa-73785ca0feb8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b15f5dfd-48e0-4ffc-a4cd-011740b689cb">
+      <statement statement-id="ia-5_stmt.a" uuid="c860bf89-2251-4267-b154-89892e906011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="7d9c5a00-943a-43aa-b08d-009980762226">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c82ce32a-03cf-450a-8aec-f0432937548d">
+      <statement statement-id="ia-5_stmt.b" uuid="d780ccfa-5d17-4fb6-b5d8-002a1bb91196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fd24638-7acd-49f0-ad11-24e1cb66bc00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish initial
 authenticator content for authenticators defined by the organization
@@ -2223,8 +2223,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="2a33ab12-b123-43f2-b19c-4864fdd91ef8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a0423027-7270-43a0-a7c0-99642cb0e284">
+      <statement statement-id="ia-5_stmt.c" uuid="bccd653c-dcc5-469f-a628-589d6b168d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fba1bcc-0376-45f4-93a1-685765ffb3f2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to ensure that
 authenticators have sufficient strength of mechanism for their
@@ -2236,16 +2236,16 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="051c7a62-7528-4adc-ae0a-13b0719dd47a">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2c83f338-cc25-4eef-bab3-6e853eefb976">
+      <statement statement-id="ia-5_stmt.d" uuid="6ea5e500-9a54-4ce8-b0ca-284f84cb561b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="4acccec2-b68a-44b5-84fc-30378f2be2b7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b54e81ae-c294-45e8-8bba-e4dd4513d825">
+      <statement statement-id="ia-5_stmt.e" uuid="5e21d34e-3528-4acc-9145-49a9fb4d7250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="584dac48-67cd-4f21-b513-00c8c14132ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have default account authenticators.
 Authenticators used during the installation of Ansible Tower,
@@ -2258,8 +2258,8 @@ configuration of Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="1b277078-5090-483d-8913-533d5190dbb9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d198f2ac-1cad-4f95-8e75-4d18d4d05147">
+      <statement statement-id="ia-5_stmt.f" uuid="76c6d3cf-34a0-4f48-bdcc-2eca1ef06792">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48cdb5ef-17c2-4659-a791-c0a69df35fd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to establish
 minimum and maximum lifetime restrictions and reuse
@@ -2272,8 +2272,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="fa4cbc07-d3f8-436d-9e41-5781bb78cb68">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b628a1fc-0a67-4b2f-8c33-9cc9a799c8a8">
+      <statement statement-id="ia-5_stmt.g" uuid="1edb3597-9cef-4b18-99ee-16830cb78a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="772ffc08-0df1-40c0-bf07-d1bb23eb32d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to change/refresh
 authenticators after an organizationally-defined time period
@@ -2286,8 +2286,8 @@ service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="b0b369a2-d4fb-43a1-931b-efe71d990703">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="87ac4bb2-943e-4529-b3c7-5d9d343342c8">
+      <statement statement-id="ia-5_stmt.h" uuid="470a74c1-968f-4a85-b411-027724a32231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b8910fe-57c8-419a-92cd-fc087a6beccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower uses SSH to connect to remote hosts (or the Windows
 equivalent). In order to pass the key from Tower to SSH, the key must
@@ -2324,16 +2324,16 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="8222e7a4-0607-49d8-8b5b-37f41b6f9b4f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8fb95b74-85f3-4ae5-8349-c96a3831339b">
+      <statement statement-id="ia-5_stmt.i" uuid="848dec97-d87d-4035-afaf-95846dc67fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="9eae618b-8df5-4793-a184-d98aed2be1c7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d3835792-095b-437c-95be-0baedb2a3dd1">
+      <statement statement-id="ia-5_stmt.j" uuid="c0603fd0-07ba-487f-9910-2c7a853f7d3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="229b9fe1-4ad1-435e-9be4-d4a2db4e57de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Ansible Tower.'
@@ -2341,10 +2341,10 @@ Ansible Tower.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4aca12f6-42e7-40b4-8cf0-45a17d9c4269" control-id="ia-5.1">
+    <implemented-requirement uuid="442093fb-88df-4b5a-976d-7019c41f2bdb" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="c594ac2d-d78e-41ff-b373-6fbd7b4c8a14">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="535e7b84-97d4-4ba1-8d32-5051533a2697">
+      <statement statement-id="ia-5.1_stmt.a" uuid="4829f5a1-5e72-46c5-a366-5c1f3caece88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f722e76-3170-4205-b13d-636506171fa2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce minimum
 password complexity requirements.
@@ -2355,8 +2355,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="bf6b3d12-7731-409b-96a3-6f789839750c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="704f94ce-b2fe-4345-a7b7-68c2c218d18e">
+      <statement statement-id="ia-5.1_stmt.b" uuid="5a016e67-3d19-48f5-9a2e-7579d5dd44ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c75dfa4b-6b21-4f92-8cf0-7d02730b9aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce at least
 an organizationally-defined number of characters be changed
@@ -2368,8 +2368,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="b4356a31-25c9-4295-a590-265ddfa97a86">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fed04779-c24a-416c-abc3-4a66be0d2c65">
+      <statement statement-id="ia-5.1_stmt.c" uuid="4df30f7d-deee-4627-810f-36e90bc683a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69890876-37d8-4a97-ac90-0433ffcd3eca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'If passwords are used, Ansible Tower handles those by responding
 directly to the password prompt and decrypting the password before
@@ -2401,8 +2401,8 @@ secret.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="8663b294-6efe-4190-bb3e-231717799a12">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c02d5903-1827-46d9-8bf4-65d9a0149eb3">
+      <statement statement-id="ia-5.1_stmt.d" uuid="324ee3c0-1524-4b50-81eb-e6ec751aa14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1b237a3-fc3f-4c15-b1d9-8a3f8791ec2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to enforce password
 minimum and maximum lifetime restrictions.
@@ -2413,8 +2413,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="84db14a8-770e-46b7-b30a-9427bf7a85bb">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ff74364b-6f7e-46c7-9473-5ed9e8c5ed44">
+      <statement statement-id="ia-5.1_stmt.e" uuid="1af302e0-ae92-4006-a576-8630677663d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="340ef716-a1d0-4147-a01c-8571db050ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability prohibit password
 reuse.
@@ -2425,8 +2425,8 @@ Ansible Tower when an external authentication service is used.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="ebc188e5-5de7-4b5b-86df-489c42eb7499">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b4fb0db0-c931-41a1-bf34-351d00d07262">
+      <statement statement-id="ia-5.1_stmt.f" uuid="d538b56b-9681-4bba-be6e-475546134c1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b31d80ff-dbac-410b-8140-9b1d43464121">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability allow the use of a
 temporary password for system logons with an immediate change
@@ -2439,19 +2439,19 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b35faeb1-5853-49ab-8ae8-2da5938bae20" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="c705d69e-7949-481d-9e5f-27dfea091c83">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="35689996-d4d4-4219-a8fc-13ef8aad7db2">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38f2811a-5a5a-47c6-9ce0-6e0fb4ffdac5" control-id="ia-6">
+    <implemented-requirement uuid="52e63706-e780-4498-b229-df02905c4bae" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="1dcfa21d-4d2a-441b-9c80-1be0388d3b30">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="33495b85-680c-4dc1-acf8-a1156b721376">
+      <statement statement-id="ia-6_stmt" uuid="b1427d3e-0f18-41ab-9fdf-1653e0f04669">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43ec1e2b-4874-4815-a27c-899f6b688ecb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower natively obscures such information.
 Ansible Tower cannot be configured to be out of
@@ -2460,10 +2460,10 @@ compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddb85469-8982-4270-9740-e2bf20ad3526" control-id="ia-7">
+    <implemented-requirement uuid="03d1bb60-c8f4-45b2-bb19-886634954cad" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="40451e56-d91c-4859-b949-4eb8229291cb">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8fd4f816-1ced-4444-b48b-73c22592d218">
+      <statement statement-id="ia-7_stmt" uuid="c50d587c-9459-4058-86c3-303a824b3e45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a04cba0e-544a-4b60-a086-c6b1018ef518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is currently not possible to configure Ansible Tower to use
 appropriate cryptographic modules. This is a permanent finding.'
@@ -2471,10 +2471,10 @@ appropriate cryptographic modules. This is a permanent finding.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbf58f30-424b-46dc-b720-cfa29c2a512e" control-id="ia-8">
+    <implemented-requirement uuid="6bfaf3f4-0c06-4104-a0c8-a1b8e38138c9" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="e09396cd-920f-4928-b3a5-ab6c839d72a5">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="79b5b7bd-b5ad-457a-a2c1-f3d8c00ba476">
+      <statement statement-id="ia-8_stmt" uuid="68db25d6-2d81-4938-9613-398b847608a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="50bfd45e-adc4-4859-a020-11f67e67db75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Ansible Tower does not have the capability to uniquely
 identify and authenticate non-organizational users (or
@@ -2487,10 +2487,10 @@ Ansible Tower when an external authentication service is used.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56292c5d-6a95-49c6-aa8c-9d41a61744f6" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="c62bd18e-f478-4a97-b7ff-3b70a3f00d7b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3c0e1bfe-98ad-4cb9-b836-579ba678d8ee">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2503,10 +2503,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="215f570b-6597-4cf4-bb39-b672aa92a783" control-id="ia-8.2">
+    <implemented-requirement uuid="22e661de-b033-4fb0-9d1e-23146e8f9eaa" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="c34e3033-b3f6-466d-ab99-272b12382d6f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f4af8939-86cc-4435-87e5-71ba57ac513f">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2520,10 +2520,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db1d8db4-7bf0-4ee8-9d61-7530a005b4a6" control-id="ia-8.3">
+    <implemented-requirement uuid="d62f3488-6cc0-4bf1-8170-6510f1df9392" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="978bf45e-9d4f-480d-a290-4407691824b4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="576126f4-f96a-45c5-9e4b-8d6920d0f4b9">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2537,10 +2537,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97ee28bb-90ac-468d-a96d-b8fc1faafa5f" control-id="ia-8.4">
+    <implemented-requirement uuid="d8d58f64-4237-48c3-b94a-23b93f6aca24" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="ff0f217e-ee05-4905-83fb-7d6345644a69">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f0c0c270-79cf-461c-92e2-8a07a5b64832">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2554,10 +2554,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97348d85-0342-4d41-86f0-a3ef5d7246c6" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="3632d5a4-ced3-4fc7-aea0-a09e984e4a24">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d106ef80-0d6d-4159-ab6f-64cb505a688f">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2565,10 +2565,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a4f0d96-013c-4ca8-abaa-bf6d4df22210" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="c83bd2f9-a77e-45e2-b250-a0126fa36678">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="8fe5a543-b6f8-466e-9c2f-dc94faf08a32">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2576,10 +2576,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ed87e74-2a7a-4a69-84fa-e1550722a2f8" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="50256103-9c21-4f73-8700-097707b9a647">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="95b67de8-fa25-4ccb-a842-2704c1ea0b6f">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2587,10 +2587,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bff9828-baa2-4156-a96b-097df66096c4" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="b1773578-58db-42aa-9d83-ec3c7e1325c5">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2683d786-b8eb-47ab-b4e1-ebf6e75f9e1a">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2598,10 +2598,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ce1a62d-d695-4de3-9376-0169b42c76ec" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="4a476666-51c8-45a2-8b9e-5cd8a377d672">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d1ed8bf4-8164-4bbc-9b61-8716891b52db">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2609,10 +2609,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="483111d1-7bbf-4d62-a438-486b477492a1" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="a02bb6cf-bcb7-45e4-b3b7-905fd310b4d5">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="86b52e6e-1ee9-41f1-b6ea-914311c553f8">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2620,10 +2620,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5d091ad-a061-44c0-a5c0-112e599ed146" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="dd60dd16-cb47-4aad-9bd1-f27d4ab73856">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="88c3a42c-6f01-4ff5-947c-76b58c0ab37e">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2631,10 +2631,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d806ddcc-446d-465a-89d1-3ea2f3b9bd5a" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="03d6c7a6-30b5-46b9-81c4-7ae1308ad4aa">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="007529ae-4cde-433a-8e78-542f58165f73">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2642,10 +2642,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="872fdca7-e5ae-49fa-b33b-7862fa069dc7" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="079abf51-88ba-41b9-b6e1-83c828665943">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="18c90672-c3f4-41f8-ad0e-d5b56e4bebc3">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2653,10 +2653,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6021bcee-d07c-4163-9b3d-760adb7aed4e" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="265a830e-aafb-49b3-9083-c3ff45164fb4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="26af00aa-6e1b-46a7-a839-b68eca5e3a1d">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2664,10 +2664,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21a92ffc-a6d9-41a5-9940-b3711006d25b" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="0ee6dacb-7a08-4f9a-983f-2029fbb553c4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="624014dc-3ecc-4c06-9ab5-e6a4db01d2ce">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2675,10 +2675,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48dbc34e-f6f2-446d-89a9-8da913025bc2" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="802c88cc-ae63-455f-b78a-3557058e8c5f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="83d7baff-d705-4ed5-9848-8a6102af891e">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2686,10 +2686,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f960ec4-d8df-46a1-9797-35cc674d6059" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="be168cd2-cae4-4fd1-b443-571ef2472ecf">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f0f92963-b83f-4aea-92ad-cfe61fa34e55">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2697,10 +2697,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb9ebb8f-9e33-4da1-8a5c-e9cfc1d6a05d" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="9543a4fa-d199-4c5d-972e-d35a8c3cabf5">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5d3226f7-70d5-4bbf-be26-bc6740a780b0">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2708,10 +2708,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1af1806-fcd8-4b1a-b191-ab20d9ed0b7c" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="dbed6dee-9958-4fcc-8409-62bf878e5360">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c8e3b028-5c97-4d7e-93b5-16607db58fbe">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2719,10 +2719,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2cb28f8-d003-4b95-b389-741259e69ea1" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="83e454b7-35e2-4a63-8cfd-c67d7a1c2541">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7bac8c1d-beb5-409d-b9d5-343bc6ccaf2d">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2730,10 +2730,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="654b86ea-8f8c-41a2-8997-e582911ab328" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="2f7972c5-b516-4ce4-9d8b-f3e3ae1de232">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e9b35ea3-e6b1-4805-88f0-4be659d3ca5a">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2741,10 +2741,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44ef0e06-c2fc-45e6-894b-e41752644dd1" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="d592844b-abd0-4c40-8cd0-15b7445d78f6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="820c7efb-39bc-4ec3-8b10-20a7f038e25a">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2752,262 +2752,262 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31fbd5b1-c2cd-49c6-b2d0-95e2982453d1" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="39d2b69d-30c3-4c59-8f84-b3e1a227ac95">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5981d1c2-4f5f-483c-b1f0-e50ae53aee66">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7992b854-2bbe-49df-b4df-d42bc66d5e6a" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="b9470394-5172-49d7-9aec-e5623f4e0cc3">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="933bf87c-f7aa-43b1-8ec8-a222bec6b0dd">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47fb5646-7001-44c6-b745-6b3b9bf8bab3" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="b41a838c-e9d0-4744-a6a9-8acb4f8bc938">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5857e5bd-1862-4a85-9a48-e7d3e12a125c">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98309339-3385-4134-a26c-a81d55da51c1" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="9a26a143-99e4-4e79-be81-47a413e296ec">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e16fc484-a758-44ec-b712-c96f2b5bef64">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e996d2f2-0e7d-4b1d-a19f-161c9f83eddb" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="ee9eb62f-a7fe-4675-93e4-8cca2e441d69">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7023a167-c48c-45e8-a054-3fe4501dc948">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="758d5d02-09db-4fe4-9368-f28950227b55" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="161c6dfd-7da2-4e7c-851a-7b3e4e9f27b1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="509474c5-8e42-4f9f-a2da-3356d07e43e6">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4989d517-9656-48e6-8adb-d0841da32270" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="7c0d2e1f-13a7-4302-a16a-5250d650c064">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9c1b9882-aac1-4858-af07-dd7023d33344">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12d16664-54ea-441c-926d-470b1b8bd5eb" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="a192c4dd-126c-4f73-8b99-4019caa456dc">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c97a4f17-82ae-4e15-a474-54af402d272d">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4884a979-c0ee-4f82-8fa4-9167d563839c" control-id="pe-1">
+    <implemented-requirement uuid="2f7f0c97-6293-4bcd-b72d-48d898a85c69" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="02e3c850-03ca-46cd-ac6d-eb0643e16f48">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ae6c2ccd-9248-4395-98ec-6a0094fbe675">
+      <statement statement-id="pe-1_stmt" uuid="49128975-33cd-4a5b-b055-ec15d44fbd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da38bff9-6576-4de2-8351-0ce4e214a080" control-id="pe-2">
+    <implemented-requirement uuid="99e9769e-d92b-49e5-bb4d-8d0e0d0bfd5f" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="6bfcc434-f461-4d99-ac94-f9add7eece15">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d41723b2-dbc1-4ecf-8c53-961d6963e909">
+      <statement statement-id="pe-2_stmt" uuid="4ac4c77c-6b19-45d0-b1cb-299060ae3873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="198ebf81-89e7-4122-b3bc-7b7da96b11a6" control-id="pe-3">
+    <implemented-requirement uuid="46bcf589-84e3-4bd0-9c21-7f0f7a5c2682" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="b58443ad-13cd-4f51-b791-9017ac2f4dd7">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="88d51ab5-c651-45b1-a5e4-f09235e19e2f">
+      <statement statement-id="pe-3_stmt" uuid="7af14783-a56e-4e7e-b622-1ed3f5a2d534">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13c7eedb-04fa-4495-8bef-cf90704205a9" control-id="pe-4">
+    <implemented-requirement uuid="5398beb6-0bcf-4ecd-8411-c99d79fadd98" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="9c792a8d-3422-4dbc-b3b2-74f6a7fe4c63">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0dd9ce93-69a1-4337-ae73-cca55e4dfdcd">
+      <statement statement-id="pe-4_stmt" uuid="ce67f5f8-1825-4d71-9bd3-54fc406ce2ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3eeb57f1-bef8-464c-bf1c-71620ad263e0" control-id="pe-5">
+    <implemented-requirement uuid="adf6841e-cad0-4d46-adb2-29a6678fee44" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="6ce700bb-2ea7-4495-8a0e-ad21360ca5d4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="7d5fc918-aafe-42d3-b9b1-f0ce6887b65a">
+      <statement statement-id="pe-5_stmt" uuid="0d04fd69-6ae8-41e5-ad6f-7b735659189b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a713cabc-4f72-4eb8-b86d-680704d73a00" control-id="pe-6">
+    <implemented-requirement uuid="d29450a2-ccd0-4565-b5a1-136395ecfbb9" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="6cfbad8c-1699-4b5d-b8a7-b35fd159546a">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="98ae39ce-7c56-45b0-a176-16a686f0e724">
+      <statement statement-id="pe-6_stmt" uuid="ec6c4c4b-033b-42e7-aacb-9009aac4e615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95eae609-1a4e-43de-847b-b642a23872dc" control-id="pe-6.1">
+    <implemented-requirement uuid="3cb204b6-7e26-401b-a771-5587034add8a" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="873c0d47-5199-45f4-ac1a-6f251c650f96">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ecd33158-118e-4114-8b28-86bcd5fb57e4">
+      <statement statement-id="pe-6.1_stmt" uuid="ebbb8901-f3a2-4844-acab-cad0db5c5b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41b8f0d2-a1ce-4824-b4cf-7a071d4dc211" control-id="pe-8">
+    <implemented-requirement uuid="fd1a7d09-ad45-4281-8eb8-60471713fa5e" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="c90579a4-fa6c-45e5-932c-f297f46b9055">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="3fa94065-835a-4cd0-868e-a79eb323eec9">
+      <statement statement-id="pe-8_stmt" uuid="cebb755c-5a3c-4b68-9470-31b5866508f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df9816c2-7778-43b7-abcd-94301c171989" control-id="pe-9">
+    <implemented-requirement uuid="0e606685-a2cc-4e48-952b-d1585845579d" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="ea2f4104-eff2-4d28-b0b5-7c327074ac1f">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="079b45ae-52fe-4110-b92e-3112f3c00bf9">
+      <statement statement-id="pe-9_stmt" uuid="a1aeba62-6ef7-4afe-9f7e-8a275f2c503b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="493a24e2-432c-4d42-892d-10d259556d50" control-id="pe-10">
+    <implemented-requirement uuid="fc2b981b-a537-4c9b-ad52-2f1f766fd2af" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="7c0c1339-fe68-434e-aafd-8165979353c2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="50f71dfb-52d5-4c11-b256-efa81da8e11e">
+      <statement statement-id="pe-10_stmt" uuid="740f2b7f-3ad3-4bc3-86f9-243d75ecaa27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e54a6d8a-d57a-4d3d-8fdf-26ee7ceafb56" control-id="pe-11">
+    <implemented-requirement uuid="4e378dac-3cb2-4ef9-9715-df80215b71fc" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="a056fb9f-504f-482d-adf5-60de306543b8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0cf5d241-0856-4c79-8dac-308588e658b5">
+      <statement statement-id="pe-11_stmt" uuid="2ce19ca8-7e5b-4029-bccb-fa0867337ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b981742-bedc-4a07-946f-560b06c6a971" control-id="pe-12">
+    <implemented-requirement uuid="1bf66550-56c7-49f7-936c-83a279d81381" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="8fd09ab9-897f-41f9-80c8-5f41c31b1143">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c16935af-370e-4dd0-9501-5134c74e77e3">
+      <statement statement-id="pe-12_stmt" uuid="e51bc885-c7a6-484d-a9bc-82fc55897514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa1ccbcf-4659-4016-89b0-8a9697b79ca7" control-id="pe-13">
+    <implemented-requirement uuid="461125ab-9fa7-4af6-ad14-25b5d7674053" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="e05029c0-faa3-48d1-9b60-084b402fd187">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9e2dd8d0-efdd-4873-9d16-d025ffbbd0b2">
+      <statement statement-id="pe-13_stmt" uuid="272e29ab-c2fc-4613-945b-8dbd0fa31461">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d9b6c7d-286d-4abc-97a3-a5f6158b1462" control-id="pe-13.2">
+    <implemented-requirement uuid="f45e7c31-6e6c-4b48-8672-84d1baeedb32" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="340a0694-f3fe-4ebd-8496-f661d5122f63">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="56e3cad0-c31d-40f2-a630-73496d302713">
+      <statement statement-id="pe-13.2_stmt" uuid="a30d566f-7c76-429a-8dae-bf11cfbbaac0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b77fbc74-fb1e-41d2-9549-57d08e8de73a" control-id="pe-13.3">
+    <implemented-requirement uuid="5e69a9e2-b3a2-4913-9e73-19b074b9d6f7" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="63ce5a8d-cf20-444f-8cd0-6f7d32bfdaf6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="dda3c9c0-514c-496b-a6ed-55823efdd41d">
+      <statement statement-id="pe-13.3_stmt" uuid="6ed87f30-a2d0-4a72-ba7c-b4942e76f14f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f87d5784-f31d-4d38-a878-38e11bbaad2c" control-id="pe-14">
+    <implemented-requirement uuid="0c2e6c1d-668e-44f3-bb50-b9b7c4d58788" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="df9b6602-189d-421f-bb63-b506d8de67a6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fe5f1b14-d9c6-4773-9065-a62753370474">
+      <statement statement-id="pe-14_stmt" uuid="71cfa9a2-51da-495e-b0e4-cd6ed446d5e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d93f2474-c85d-46b3-977d-4e163af1a890" control-id="pe-14.2">
+    <implemented-requirement uuid="c1839e3d-ae60-46cf-88bd-d1d95591b36e" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="eda8c2ec-52f7-49ff-b431-b139911ddcbd">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="c502311f-0126-4583-8504-063fc5afc021">
+      <statement statement-id="pe-14.2_stmt" uuid="643fe30e-156a-41c0-931b-3bd53d1bb318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="488b3698-6300-42cc-8b17-6f0e2f742a40" control-id="pe-15">
+    <implemented-requirement uuid="fe4172ae-185d-42b8-a78f-c0f39067dc34" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="c33e0305-8d64-4f0f-a50a-40ed210c46f3">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a95d0918-78ea-4e9e-b742-6197900264d1">
+      <statement statement-id="pe-15_stmt" uuid="0d79a669-82f8-4de4-88e5-cfa1fa7e0ee4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="745bb04f-78c2-4381-b6a3-4c6c39025b13" control-id="pe-16">
+    <implemented-requirement uuid="71f12c3d-ab07-4ce0-b016-609d6f02e9e5" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="3c36bc35-a432-45e8-8f1b-84b3bbaf8451">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="22b8240c-4b5c-468f-b7a9-e9409cf084ec">
+      <statement statement-id="pe-16_stmt" uuid="bcd29e47-8369-492a-897d-e9fae6e0c867">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34aef281-c754-46bb-a8bb-2cb325b42cd0" control-id="pe-17">
+    <implemented-requirement uuid="db25ef54-eba9-4543-97bd-402949471b78" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="736eecfd-edf1-4373-90bc-ea0415da70d4">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9e16f5b7-c923-4b25-b556-48898a2f500f">
+      <statement statement-id="pe-17_stmt" uuid="09976af6-2514-4c59-a721-4cb5a4bda261">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f31a5281-27d9-4e99-82a9-fdf8915e7ae2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Ansible Tower configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df95f8d5-08dc-4153-82a7-f8cc04115910" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="fe24e1cf-bd5f-4767-ba55-9b11855b58c0">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="82c1bf72-eb8e-45b7-ab8b-68b6ae9e20df">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3015,10 +3015,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16f87eb5-118a-4b05-ab1b-a068c78e3b31" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="f5fdf615-706d-4b52-b497-9f0146636195">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ce46c2f7-ee76-401c-a7bf-0a43ce937a27">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3026,10 +3026,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="072e8c36-f1ab-4ae9-992c-fd54ac68b7bb" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="ceadcca7-70f0-4c63-aa8f-c75ee9327c4c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="db056c67-8786-45c1-98a7-a4affb1fc7e5">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3037,10 +3037,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3218b2f6-1a57-4395-adbe-f71ee330faca" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="1cd4fdfc-126d-4341-8e6d-c9a5d5b92a97">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="632fb4b6-becb-44b9-acb4-9af25309712d">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3048,10 +3048,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66872c84-08e1-4fcf-abce-03d55bdb49e7" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="ae2016cf-54eb-4c24-b8a8-a78d60112538">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="02aa62b6-f4d1-4f9c-85e7-9d6f4082f61c">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3059,10 +3059,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c219a7e-404a-4f2c-8a05-283633639878" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="a9594214-713f-46b7-a13b-7fed62b98adc">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="19b21d09-2a08-4ccf-90e3-47a3fcd7f1e3">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3070,118 +3070,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a523f126-852a-4e9d-88fc-516e04057c52" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="5bd955e9-2521-49ca-84c4-050f00aac0d1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ea055d3a-e837-4384-a9f8-4ee36e6275be">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9b7f7e2-2d55-45e0-85ca-af262bf388d6" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="326d741c-122e-48f8-b60b-cebd38abb676">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="f9cb057d-65a9-4c19-9040-d8fc0c116125">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2771567-48c7-4443-9902-029ee8bc71a8" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="22ec381a-d8e7-43b3-843b-b54f2c9a790b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="88fd4abb-ad86-4f83-a755-c5570a101dd2">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd763977-5c41-4139-a796-38ef06c7241f" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="a6dd731d-499a-4d6d-82c7-9aab702e6581">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1fed8f64-31d5-4a1f-88af-8b44da68dadf">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad263c50-8596-4125-b43d-48adaf0913d0" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="35b7cb48-29d2-4914-818c-37156f614991">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9e76a6cd-ca30-4912-b480-84f5230ef26a">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6be4c39-93f6-47ec-b65a-286205ff4fe8" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="3d54e32f-1bd2-457e-82c5-8fa7d9b0f3be">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="cae4eeb8-fb63-4dc1-af42-d6df7a63b23a">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b606343-8113-4514-b49a-e8aedaebfdd2" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="5f6a0c7f-01df-4c1d-9a64-de4e8e69d74d">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ba9dcb98-11f3-4c67-a380-9be2eb0b5602">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09338f79-dd87-45c5-9d2c-7ccd2c5a1d98" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="5d4728bf-69ff-4ef0-8dd7-b6b34cd0ea67">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b270a976-a917-4795-8859-6bfc28b42f45">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="807ec771-6745-458f-bec2-dd0657c0bd7a" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="632a9bb3-fea3-430c-948c-d60e80247bd9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b00192bf-9584-4850-af38-d64c468213e8">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4664e83e-1ba0-4af3-9c68-501b0a7f1c88" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="5f2a6b5f-4a11-40c8-a4fc-c562d2fc4de8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="41d60a67-65e3-49a7-907b-e0a861624123">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc82d2a8-8277-4b01-9d36-c3e3cd76fbc3" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="05bd0b36-46d0-4b0a-8ce8-ebb4a8ff8804">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="e3fb3790-7be7-4799-9fb1-115e22453347">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e66a5a4-73e7-4ed0-a11c-00ca2a696442" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="dd53eb4a-89c5-4e0e-babd-ef2dec3b4743">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="811e5571-c8ca-475c-bcbc-1a778ca26018">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f78dde02-01ea-40c0-a399-97f195ed4f7f" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="7ec633c2-1945-4ff9-8d32-14098f5c5225">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="25323042-378b-4d97-86b3-b8bbfae99598">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3189,10 +3189,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7e865ec-e477-470c-a695-b1492bcd0d76" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="ea79c787-f389-4891-bdef-cb8a70eb1da2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2bbeeb57-8ac9-4b5a-8de1-80f3de1f645f">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3200,10 +3200,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae8c4813-998e-4b32-89c9-e94f7750200e" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="23d7f976-bc3d-4add-8b17-677325ece250">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="546a747a-a3ee-4d46-ad05-1baadef584fa">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3211,10 +3211,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c33402c7-eded-409c-9987-df5079cdf4ff" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="20ab6bc9-dca9-49c4-a1fd-80a1bfa9d345">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1d4dde21-dae8-459b-b1e9-73e256df70ef">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3222,50 +3222,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a008726-a8e0-4564-b6ab-b9c6276595fc" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="e360666f-971a-4337-b546-9a343c0c8ae0">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="edfe4ffa-e0d9-443e-ab21-e7a54e440d39">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a43604ef-0d2b-4272-bb59-4c060f369b3c" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="a6c072e5-23bd-4c82-82c5-74cae42e8220">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="45ed43d4-ecbc-4f2b-9575-8191a997cfd3">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbb454e8-c4d1-4214-b3e2-75a7fe8e1d53" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="f352de5b-0388-4d11-914f-87eb7b07f2da">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fae9df0f-2558-42e7-959c-a19e8e59c266">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cbdb061-c8d9-41c3-a6b2-9550076e92c6" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="563dc6dd-c1bd-480d-a171-811ee0c680fe">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="4fa67a79-c865-4616-afae-e92a15bcfbd9">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09e27fdd-23c9-4fe0-b0a3-a2089a514e5c" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="20de30f0-e094-470d-afd0-45b55bb9c444">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a8644e04-7d9b-4db1-9c72-c78d513a7640">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3273,10 +3273,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5adc9b46-8307-41dd-a093-b6ae16a52546" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="8e70edc7-7a8f-41cc-b3f1-564f97369de6">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a42c499c-24c4-48dc-aaee-c55ba55eef2d">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3284,10 +3284,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f70ceb3d-39ff-40ba-a9b0-309e84ba8313" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="696311c8-2363-4507-91dc-b50bc1fafbfc">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d118b87b-8180-4612-954e-b42243b75bab">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3295,10 +3295,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cf2e477-8758-4639-bf1e-d98ba51b39d8" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="f86d955b-61de-445c-8e25-daf78e3ad2e1">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b7873d3b-a2ed-4074-9fcc-ca9f15011705">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3306,10 +3306,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c23eab8-fae0-437e-b466-37e1b2a01451" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="b292f306-dd67-4104-9e22-d63514ac1e3b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="b50f2f9b-5526-470a-bde2-0aec42cefca9">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3317,10 +3317,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ededcb4-3e3f-4017-87f5-568399ae3a6b" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="c1438fa7-b0a4-4e94-9358-f5d3238cda1b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="38ceb26b-5215-4b3d-b639-9605bc16dd61">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3328,10 +3328,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95a3b133-7560-4346-938f-0a79a77bd2f8" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="4be02b5e-7a8a-4a19-a7aa-c2930aa9cb22">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d3063166-f4ef-4921-9d54-eec6f4ebc7d6">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3339,10 +3339,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffee16c1-a819-46b8-9e80-70c844a3521d" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="50e82a84-d977-4838-b6bd-0ee04a23e3f8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a5078bb6-6d27-46cf-82d7-28bea0414ef9">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3350,67 +3350,67 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f22d688a-2c16-4fa8-be65-6689cbaace37" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="727e0c6c-ea1e-4ed2-8fab-d9970e4ff7d8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="2ab8f6d8-b43d-4299-ab54-eeec20d695ba">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="e0ff6e19-d409-4cb2-8c12-fc4a8757e390">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="dcd9f4da-2672-4c9f-99e3-747755fed71d">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="2362d35a-8759-4e5a-bbd0-30023fd109cb">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="fb0a493b-e782-4597-93cb-1ebd340a48b7">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="f4cf295a-f334-4556-b22e-59bea94fada9">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a21c9f32-1f1a-4e3a-abe2-cb6dd14fc90d">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="57d50dcd-0a1f-426c-a33d-30419fbeb08d">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="ff9c873c-5e78-4772-bbfb-20bd7bb19cc8">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cbf020f-42ea-49b5-8c4a-c2a1aea3f982" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="9e1ba86b-91f8-4ed9-9957-cbef751f48b2">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d99319b8-659c-455e-bfe1-4993cbcd8d0d">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1999e478-e1e6-4d2f-b904-0579d4205820" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="c4e2e90c-d2d5-4bb3-858d-af6ea5624750">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5bb769c9-a2ea-4f66-8565-5deca5112470">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b58dfa9-71db-41fd-9563-cfbd8aab1a4d" control-id="sc-5">
+    <implemented-requirement uuid="f289d3c1-ea77-4218-bee0-d26c22b792e6" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="5b8dcf65-a681-4101-a70c-baa7e9f00b59">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="a4b390bf-1b8e-4720-9c05-36d051915884">
+      <statement statement-id="sc-5_stmt" uuid="fd835df2-1964-4d23-93fe-320a0cce93c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eb04c3a-268c-4698-8ac3-07070531f142">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation of anti-denial of service capabilities is being
 tracked on GitHub:
@@ -3420,19 +3420,19 @@ https://github.com/ComplianceAsCode/redhat/issues/333'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0d3906f-0147-4aca-a2ac-779e11e12348" control-id="sc-7">
+    <implemented-requirement uuid="d1537646-d09d-4b27-8168-e2f8ac841f65" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="3c0d7fee-52a4-4bb2-bdcc-91322ea1e24c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="de768542-9f4a-4855-8d8d-3dd3420d50ee">
+      <statement statement-id="sc-7_stmt" uuid="95e9e235-41e6-46bb-b0a1-a1f95cbf5047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c33510fd-d3cd-4e9f-8dcc-6f64d0633cbd" control-id="sc-12">
+    <implemented-requirement uuid="4e57123c-f1fc-4c5c-8c0a-16efeec9b8c5" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="af55cbd2-c5a6-4e22-9bcf-c952cb563eba">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d3bcf99e-378c-4ecc-8146-8f62692c88c7">
+      <statement statement-id="sc-12_stmt" uuid="c1a01dc9-6661-4f29-a9e7-1dac5c37004b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd03d06b-099b-4167-b1e2-6d7241efc817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Ansible Tower generates,
 distributes, stores,
@@ -3444,10 +3444,10 @@ https://github.com/ComplianceAsCode/redhat/issues/334'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84344c5a-fa7e-423c-8a0f-cc889c334e40" control-id="sc-13">
+    <implemented-requirement uuid="167053ac-c758-4dd5-b2b1-6d57f85cc334" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="9a22c24a-9bf7-4d0f-8071-6d2380dc8a60">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="36abef33-7211-4b55-9f84-2c4abf9eb586">
+      <statement statement-id="sc-13_stmt" uuid="fe1447c7-c6b2-402c-a493-70740422465e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32e15b57-5493-4344-a7eb-3b14d3f36cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Ansible Tower's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -3458,50 +3458,50 @@ https://github.com/ComplianceAsCode/redhat/issues/335'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb2b86bd-b1cb-458f-a698-b777790595be" control-id="sc-15">
+    <implemented-requirement uuid="24d21625-55df-47e0-9ebb-3da75db7b953" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="9ac204a0-ba4a-4527-83c3-57312bb52e7e">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="15764e4c-df25-4d12-976b-8fc98181e169">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67717424-d2c5-48a9-b531-2aa8ed6fbdfa" control-id="sc-20">
+    <implemented-requirement uuid="9f9b9f7b-d437-4e54-99fe-5c761fd83e92" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="dacccee4-2008-42c9-8e15-b3d166cd0cfe">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="bf97bae9-a00e-4b9b-af43-503bfe672451">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a019de7c-d85a-4bcc-acab-20340535994b" control-id="sc-21">
+    <implemented-requirement uuid="cbf58203-fee8-449f-8667-d09d9c8f3784" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="890a9e99-2462-4bfa-a67e-88ff9502308c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="5702f9a1-76e0-489e-bc93-82614ce8009f">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd3c74a9-8513-4e73-855d-de241c76bffd" control-id="sc-22">
+    <implemented-requirement uuid="39cbd98f-3f6e-4f5f-8053-eaf39f064d4f" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="d2b33f68-7f00-4eee-a4d0-6075a3fb3a47">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="1bd47f14-dd7e-48a9-ab36-95d808ea3698">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ff325ef-b4e3-4e69-ae77-3ff55e75417d" control-id="sc-39">
+    <implemented-requirement uuid="90ba4ed9-360e-4d8f-a52a-b1d0d64800bb" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="f151dbfa-27a1-4571-b6bc-d8692184fd5b">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="cb9b50ae-b04f-4397-a30e-a95d98722c29">
+      <statement statement-id="sc-39_stmt" uuid="ef2bb7a2-b7ce-404a-b753-529eee8a76e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fff56306-7970-47e1-b6db-ca93a60de8f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on ensuring this functionality is
 configured is forthcoming.
@@ -3512,55 +3512,55 @@ https://github.com/ComplianceAsCode/redhat/issues/336'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="011e1b51-edaa-48fa-a6ca-871b6a1a1843" control-id="si-1">
+    <implemented-requirement uuid="56c0e671-8df6-4a5b-b567-d12378a4b229" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="50e5f981-1ac1-4d75-aafb-7b83c0f2c982">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="523d4bb2-4817-4990-8f09-0baa199148c0">
+      <statement statement-id="si-1_stmt" uuid="54378bbd-dcab-4b82-bdbf-8f22ef3a30a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a6d8021-8e28-43bc-a350-3d216d89dcc1" control-id="si-2">
+    <implemented-requirement uuid="46ff5a8d-0def-4d98-ba00-a0ff062e0c27" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt" uuid="3fab9187-745e-421c-8f4f-23665a1b139c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="0fa9bcca-ea2a-4c95-9386-718225137168">
+      <statement statement-id="si-2_stmt" uuid="09658e39-0531-444c-9325-5486d6767155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9098e55f-0605-428f-9e11-6ac8f4fca6da" control-id="si-3">
+    <implemented-requirement uuid="64d97460-7849-415c-bbe7-17373c00cf8b" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt" uuid="2ee16621-c8e5-40a0-b222-3db88e5d33f8">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="9b8c4c03-f7ca-437a-b018-8d72577774c7">
+      <statement statement-id="si-3_stmt" uuid="b1fa2f97-e94a-4d05-ad23-5e71c3dd9737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b084b548-8da0-4f97-8a86-03d231ad05db" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="31d1fe81-b467-408a-8e78-664e35377e3c">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="efc6e927-0e01-4d15-abee-9cb82d78151f">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="859607a6-f358-472b-855c-e17b29897c75" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="54dc5080-6eee-4699-87c9-de54f1f92c46">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="71b64413-7f27-4e5e-85a3-5d42fb70f3f4">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6638cc13-8cd4-45e2-b1fd-befb7ddc7e54" control-id="si-12">
+    <implemented-requirement uuid="855f5b80-f73b-43a8-b10f-5b09d6b60917" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="a381bbca-dcd6-469c-ad84-8e929781a310">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="baa9deec-8167-4ab2-b43b-9523a40c6f28">
+      <statement statement-id="si-12_stmt" uuid="6b9b1a40-b818-4bf6-946e-48c195a1638d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf0273e2-470f-47b7-a9ad-acbbd3c39bf3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Ansible Tower in
@@ -3581,10 +3581,10 @@ https://github.com/ComplianceAsCode/redhat/issues/337'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e713ed79-b3a2-482e-8b92-25574a228f1f" control-id="si-16">
+    <implemented-requirement uuid="9e95d7ca-edef-4c70-892a-1eb0933fec78" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="20c522fb-e81e-4569-b783-da461a260639">
-        <by-component component-uuid="9fcfed86-8f66-42ea-9254-eac2868be6cb" uuid="d85df20d-850c-4df5-b510-cdeb774cee43">
+      <statement statement-id="si-16_stmt" uuid="69d22aaa-17b3-4d19-9a07-bb8ef6502c9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>

--- a/xml/coreos-4-fedramp-High.xml
+++ b/xml/coreos-4-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="860d7680-cb41-4330-93a7-0df76ea2d595">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="415247f4-6b50-46b8-bffc-374750c256e0">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.40+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.72+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="273185df-1e6d-4730-89d1-9c171bd72e7a">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="617c783a-1208-4a30-8555-f3c4642ec09a" control-id="ac-1">
+    <implemented-requirement uuid="6f8fc8e9-f526-43ff-9aa0-8ffc41f2b51d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="aa5a627b-3d7c-4b7a-9df4-dda6b5b9b2ca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="13227ad3-7446-4a2b-9912-a07712c88aea">
+      <statement statement-id="ac-1_stmt.a" uuid="1ec2691e-ff83-4ff5-b27d-605ba12af54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7be8eab-6fe9-4b04-b51b-bab9d86e5655">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="8f298d2f-2381-4231-a408-69a05e543a45">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fb3237ac-eedf-46ad-b8e1-aea69ff0bcc4">
+      <statement statement-id="ac-1_stmt.b" uuid="879eb157-d51a-4028-8e7a-0080b30a15fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edf524ea-5b3f-4612-8aea-a3b5a9e48d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d889bcf5-3075-47df-8b32-502dc96e14df" control-id="ac-2">
+    <implemented-requirement uuid="1e499a5f-dbf8-452d-927a-cfa2859f5e75" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="2793947b-7277-4c0f-9cb5-b4d718d309f5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5ec294e7-69f8-4fdc-9cbb-7ddd53fc651a">
+      <statement statement-id="ac-2_stmt.a" uuid="8f9b18d3-1fc4-40e7-b8ca-3052a4c9430e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57c1db98-8a0b-425b-a0a6-b9f027bcb747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="e1fb073c-b92c-4b0b-911c-239b10bd673c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="234c3a0e-16a2-43ae-81f3-3907dac65127">
+      <statement statement-id="ac-2_stmt.b" uuid="b62b8180-4d99-48b7-afb4-d8265f4c35d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe059028-d2df-4472-8f55-6c037617da7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="916ec007-6848-4ccd-b51d-e9a22edf04b7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8e3f8554-0e1f-4037-b964-664ab28e6910">
+      <statement statement-id="ac-2_stmt.c" uuid="f21b17fa-1e6e-4859-a43f-6d5001f70932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c3a878b-68b4-4a62-b0d5-b589f4f394fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="c88804fd-35af-4f3b-9c14-37eaab527442">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4a801708-9ade-4d56-acb8-822fdf417bed">
+      <statement statement-id="ac-2_stmt.d" uuid="737ed433-52f6-4cfe-90fe-a6097ea1591e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48e0ab4b-ee61-4b1f-b427-1fa022ae556b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="6ab57cfd-1d35-4f11-bd1f-232709e4c05d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="93874fb0-8aaf-4f0c-8040-4debc8f83144">
+      <statement statement-id="ac-2_stmt.e" uuid="6eb2a353-e46e-4216-922b-a33c499caa02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2761bff2-9aa8-4b6b-8e27-ce9fe156d502">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="f64a57a4-60c2-473c-a892-c14850db5779">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1f3a54dc-02b4-4c02-bf1d-7ef9d99497e4">
+      <statement statement-id="ac-2_stmt.f" uuid="5604aab6-740d-41c6-b081-957f0b162b5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd7eb988-149e-46d4-8511-9558e63c5edb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="eacd291a-3b31-4e7c-806e-74a1e28314d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7fc79eb5-dc46-4043-b991-ecc474a907e5">
+      <statement statement-id="ac-2_stmt.g" uuid="e0e395c4-bd90-4852-9c75-6239fe7e1a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0a08956-265e-4f35-8e96-87c56c9d6157">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="ac6386d2-5bb5-4aa2-a66a-8c4120bf6187">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5b62e221-15b2-47d1-8d26-63099f02741a">
+      <statement statement-id="ac-2_stmt.h" uuid="2e96297d-49dd-4413-9e03-f82c946876b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd502b78-27e0-4b0b-852f-5bc209d708a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="612597dd-ec46-4465-a16d-1496ae7f6cd9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2cb653bd-33e0-47be-83e0-41fb69013ffa">
+      <statement statement-id="ac-2_stmt.i" uuid="fbc7d733-8e39-4339-9fe5-89ab0050e7f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f499a8ed-a851-4a30-9a5f-16ca6ae97ecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="f7b7408b-cc29-44d5-b283-30981b1ba753">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="907f07cc-dfa3-489b-ba35-d9f737dd1814">
+      <statement statement-id="ac-2_stmt.j" uuid="76ac689d-66dc-4e51-805b-902263860091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b90c24-fb80-44e0-bd9f-64cc4f9d530d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="13fa0948-2c17-46cc-ac91-42e1aca5e746">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="95b854eb-ccd0-4b29-8799-2bff66392b30">
+      <statement statement-id="ac-2_stmt.k" uuid="2a7fd158-28ce-45ff-9d4b-7a0e4644d4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e90a2ff-91a8-4ea8-89a3-7b606be091db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efc3f8df-c4e8-458f-8754-324dd7293b72" control-id="ac-2.1">
+    <implemented-requirement uuid="eded554a-0682-479c-9d98-920bfd758dc1" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="30dd96a2-6581-4dec-99d4-c7a9515faef2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9ba3b2de-8a58-4a87-9d00-328c91d1abd0">
+      <statement statement-id="ac-2.1_stmt" uuid="8d8f505d-70a9-4f50-8be9-d9f685f8c0be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f77043-43a9-4191-a8d0-6780af8b2ae4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS components of the system support automated
 management through monitoring of accounts and system
@@ -608,10 +608,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2e6c3b3-6fe1-470e-9a94-897a5901fc01" control-id="ac-2.2">
+    <implemented-requirement uuid="02dcf8d8-7b09-4c1b-a9ea-0f84310e7796" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="4910d308-4f18-4e18-96e9-1abe22e917ad">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4178548b-e725-4655-b83d-7445d474a759">
+      <statement statement-id="ac-2.2_stmt" uuid="04c1bd25-a2ac-43f4-a380-a64057715737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c73414c-c967-46d4-9b37-96f486afe5bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS does not have the capability to create
 guest/anonymous accounts or temporary accounts. Any
@@ -628,10 +628,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbb2e999-cc3f-4639-9fae-623a13a6fdfc" control-id="ac-2.3">
+    <implemented-requirement uuid="07264740-0867-4c9f-99a2-a6d8d25f7e5c" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="49284a5f-a81b-4084-bedf-37ed4b951a40">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9cc34021-4628-41c7-a32b-ef96311245ed">
+      <statement statement-id="ac-2.3_stmt" uuid="4da09b35-f7f6-4a40-a9dc-a5c679cf080b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08bb0b0c-e8e4-4d59-8a06-47a9ab070aa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS end-user account management is inherited from
 the hosting environment. Automatic disabling of these
@@ -648,10 +648,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3951aa3-15dc-4400-bcb9-abede064da26" control-id="ac-2.4">
+    <implemented-requirement uuid="e2531160-6221-4052-9b48-c36af2ca9524" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="8744ce3d-8a43-4fbb-859e-fa4453abc9bc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="27331918-f975-4c5b-8189-27eea8c4cd13">
+      <statement statement-id="ac-2.4_stmt" uuid="39f02a55-6bfb-49b8-abf3-defa200d7329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcbe4ca0-2deb-4e83-8b88-237dd2dee6bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To meet FISMA requirements, CoreOS must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -671,10 +671,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61873223-fc7b-4f84-8d68-4db1d6b0e0b8" control-id="ac-2.5">
+    <implemented-requirement uuid="b2009884-8e3f-43a1-92b2-92b5729f2d7c" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="68a63609-1ff2-46e9-bc5d-4685d09f74f4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="02433aa2-3588-4e4d-b129-fac07bf69495">
+      <statement statement-id="ac-2.5_stmt" uuid="04fd2aa3-2ba8-4604-80e6-5200b2843c27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="688b06a0-687e-4f23-be5e-764580e26c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2 (5) is planned. Engineering
 progress can be tracked via:
@@ -690,10 +690,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccdec8c7-fb7a-49ee-bfa3-d1b55b66c9ef" control-id="ac-2.7">
+    <implemented-requirement uuid="b0f186b5-4f1d-478b-b03f-0b2e9b3c83c8" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="4c594d8f-8ed3-4bfe-96a2-bf0b35f5ff29">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="869ce5e9-6bf0-4b6a-9d56-1652360c0ab1">
+      <statement statement-id="ac-2.7_stmt.a" uuid="cb087f11-2c7b-4215-9494-6f2d577fbafa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21350fe2-0e01-4b99-894d-c42aa132f9d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -717,35 +717,35 @@ More information for SCC can be viewed at:
 https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="d3393e41-2d0d-4e64-9311-24e5f5bfafe7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ab55c1d-3a72-456e-b78d-4621029c8af6">
+      <statement statement-id="ac-2.7_stmt.b" uuid="7155eb11-bbed-4961-9759-d086ef297059">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="148a8d31-28fe-466b-a8dd-a280cecc3e6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of CoreOS.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="a1b5f4f5-5dcc-4930-ae7f-dc0b314aa3e0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="923016e6-fdf2-4d99-a18f-588446f360fa">
+      <statement statement-id="ac-2.7_stmt.c" uuid="d47b55e2-35b2-4740-9d80-1b64f23a788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93749a3-34bf-4d6b-bb6f-757c0efcc2d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba409597-9bab-42e4-8cac-f76b80693a4d" control-id="ac-2.9">
+    <implemented-requirement uuid="2ba66307-7d4d-4eda-9a77-0a936daacc6a" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="4edfe17a-02bc-42c4-aa88-e1c6be89ccbf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7a498cbe-bf06-49b4-9848-d4e0ed175e51">
+      <statement statement-id="ac-2.9_stmt" uuid="46153aa5-fdd3-4c8e-8320-ebe418c40e82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23a2eb0d-d4b8-4296-9e57-2122fcce503a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7d3594f-5e43-423b-a499-aefae9e0c7e1" control-id="ac-2.10">
+    <implemented-requirement uuid="3eb43f24-e00a-4031-96d3-0c9777739c0e" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="d4823b1f-30f2-4118-ac48-876d19ce9a6c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="255c18c6-a231-4b8f-97fc-7add73572ced">
+      <statement statement-id="ac-2.10_stmt" uuid="133c97ae-85ef-4436-b81f-289f0ac278a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="753a3224-6163-4eba-b69f-8a67ffcb371b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS does not have the concept of group accounts.
 
@@ -755,10 +755,10 @@ responsibility of the shared identity service and not CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="249b0861-4bc2-4230-ba57-41b63aa248c9" control-id="ac-2.11">
+    <implemented-requirement uuid="495d67ab-bcf6-4c17-b19b-eab88d6bfdfe" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="b37289b8-a5e4-485c-922d-dbf9d3f5febf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a4b3c3ec-534a-4458-b80e-3a2457ad916f">
+      <statement statement-id="ac-2.11_stmt" uuid="646a6f8b-cd2b-4bc6-837a-03d0c181afa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08cc380f-08df-4f1f-9d31-b551a4ede0b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-3 (2) is planned. Engineering
 progress can be tracked via:
@@ -767,10 +767,10 @@ https://issues.redhat.com/browse/CMP-210</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bdd5cc7-33be-4141-a1e0-7dda92b39059" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="2924340d-eb4c-463a-9377-4801e430e165">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="508fd768-e8a6-4b4c-8fad-40e42963eee6">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -778,8 +778,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="03db8dc1-fb0f-4e9f-91f5-564294692d5b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="28607c3e-0080-4805-84fe-4546adc95d71">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -788,10 +788,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1239f6cb-9fcb-40de-9fb4-47f7bf885eb2" control-id="ac-2.13">
+    <implemented-requirement uuid="9acf0cc8-f955-4bdc-b6ba-168f06052b5e" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="0b671e15-a844-4073-b349-f7676f52d0ae">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3ea8a260-20ac-4513-accb-acffdeb0f2be">
+      <statement statement-id="ac-2.13_stmt" uuid="f102a128-ddfb-41e6-b2d0-93af2e08babd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74cf5a18-ead4-4dc2-a5ef-b0e174d6435f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(13) is planned. Engineering
 progress can be tracked via:
@@ -800,20 +800,20 @@ https://issues.redhat.com/browse/CMP-211</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bb3b3d7-8a40-451c-b5b6-ff9d8a48fa6b" control-id="ac-3">
+    <implemented-requirement uuid="54eaf0e8-a603-4de6-957c-02d360dff060" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="c4e4c220-4c92-40e7-bdf8-e0eb917d1b92">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="93483557-45d0-44a9-b7ea-af6c3added9c">
+      <statement statement-id="ac-3_stmt" uuid="77b67dec-bc0d-4dad-ad78-bb20120e4c7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e678ff1e-eba1-4013-82f4-03456ae8554b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met by CoreOS when SELinux is in Enforcing mode
 and configured against the SELinux Targeted policy.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="785093aa-6427-4a7a-aa5b-9b72682f146e" control-id="ac-4">
+    <implemented-requirement uuid="52d4a6ad-af88-4e7d-92f8-effe11d5f363" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="58245301-9a28-4fd8-9c6f-6b0d4c68d78f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fa0ba9cf-1b6d-4701-bc28-ec9f3cab2b6f">
+      <statement statement-id="ac-4_stmt" uuid="d22b8559-ef87-40a0-96c1-9b10c8adb3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6345764-c22c-4e76-b06a-f8c1d20537d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -821,10 +821,10 @@ https://issues.redhat.com/browse/CMP-98</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf051799-828b-4cb5-b13a-41fda527da74" control-id="ac-4.8">
+    <implemented-requirement uuid="721e36ee-4972-4f66-917a-f0a50e5b2e70" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="c9d01d44-3b23-4416-b422-b4f6ec32d742">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ab74e49-cbd1-4357-8db5-3bf98bdf0dee">
+      <statement statement-id="ac-4.8_stmt" uuid="8709ed06-0aa5-4116-8e96-797cfaf6a239">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="312139bd-3d1f-41d7-bad3-93d576adf533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -833,10 +833,10 @@ https://issues.redhat.com/browse/CMP-103
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df1c4898-1c78-4230-89cc-b39d997b7b34" control-id="ac-4.21">
+    <implemented-requirement uuid="013bf472-055f-4057-a9a7-67e12094efbf" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="daa81277-4710-4514-b773-9a89a9351491">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6655abe0-9bb2-4a42-9da7-67346c4074e6">
+      <statement statement-id="ac-4.21_stmt" uuid="726b5013-677d-483e-8063-362924525d43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58c793a2-66e5-488b-bdd8-eb09cd4d03c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -850,18 +850,18 @@ https://issues.redhat.com/browse/CMP-113</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aea79740-e91a-4b9d-b4ec-f13c8b8c3a7b" control-id="ac-5">
+    <implemented-requirement uuid="fe3ba54c-031d-4f59-9a38-348ed2d37035" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="e16cf309-085b-40c2-9db7-c1dd7f57733d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="13ab2e4e-95cf-4a36-84c3-0fde1dbac313">
+      <statement statement-id="ac-5_stmt.a" uuid="56ad1915-7c59-42b9-a31d-895b127a3c47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0269de03-f278-4bbc-8ce7-70c126f74b7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="00f08e6d-d382-4bc9-9973-9458042e50f8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aff4a454-75bf-44b7-b365-25651899c5a0">
+      <statement statement-id="ac-5_stmt.b" uuid="3e9015ea-1dde-437c-bea5-3fa7cbbb9173">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65c3671f-e596-4721-b594-0472fd051355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of CoreOS
@@ -869,8 +869,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="a6dd58ec-0273-46f3-9066-d0542c3f3971">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="18912bcc-4ffc-45dd-93b0-29c883033de3">
+      <statement statement-id="ac-5_stmt.c" uuid="c00b6896-4456-4a1b-809b-4a0725de246b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a99707ea-72cc-408f-abac-0f35e7dfeddb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -879,10 +879,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef043406-70ca-411d-bfb2-741b24766a82" control-id="ac-6">
+    <implemented-requirement uuid="88abbdda-8e98-4645-80b9-5595e5f7d2c3" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="7730f779-d481-420b-82c0-4c379f3df035">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a5cc7fb8-09a6-459f-94a1-444296d60c51">
+      <statement statement-id="ac-6_stmt" uuid="2919dd72-8813-440e-95aa-eb4a48e9292a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f513ea4-777c-4021-88e1-d944a78e84d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -891,10 +891,10 @@ https://issues.redhat.com/browse/CMP-115
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c01c7b2-fc23-4940-a7b7-c3650a19f2d2" control-id="ac-6.1">
+    <implemented-requirement uuid="be17b2e2-832e-40b8-8b3f-ecfca434f4cb" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="ffa429fc-b71a-4d71-8090-99cd48d8ec9f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0d108958-3c9f-4ab4-8645-344472502834">
+      <statement statement-id="ac-6.1_stmt" uuid="3d1ce575-6e16-4e36-a4ba-c376990f21c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d844c0-1c7c-4fb3-a161-cf80cdee6df3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -903,10 +903,10 @@ https://issues.redhat.com/browse/CMP-219
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c51a8f18-26fc-4409-96a1-aea38b1c436c" control-id="ac-6.2">
+    <implemented-requirement uuid="e1235cf2-448b-486e-89d4-1cec7e1ef3e9" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="0aa1473b-58dd-46d2-b70e-e2f827253104">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6cf6e762-43ff-4059-bce4-7d20f5526258">
+      <statement statement-id="ac-6.2_stmt" uuid="104cb488-67a2-4d16-9ada-134be0de1a0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11abbae2-3fb9-445c-8e8e-ae1fdc534cb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 CoreOS configuration.
@@ -922,10 +922,10 @@ https://issues.redhat.com/browse/CMP-220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38a65702-9aaa-4612-b187-b32e167b05de" control-id="ac-6.3">
+    <implemented-requirement uuid="4100a8f8-1f78-4407-b795-bdf0701c0f12" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="37969ce3-9035-4999-a472-4a35a562ba92">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1bdd5533-892e-47de-a26e-6d4e332e6f03">
+      <statement statement-id="ac-6.3_stmt" uuid="499aa97e-3b1e-420e-add9-8448f116f6cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818e1642-8cbf-4280-a5ab-8144eebf9490">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -934,10 +934,10 @@ https://issues.redhat.com/browse/CMP-116
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bc29390-41f9-41a2-8b22-ae7829651213" control-id="ac-6.5">
+    <implemented-requirement uuid="e3e3efab-5461-4dd0-8720-65773f2e5379" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="b425f075-98d4-4a85-8f9a-358ccd669d62">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d2bbfdb2-196e-4177-98bf-05f8bba025af">
+      <statement statement-id="ac-6.5_stmt" uuid="6582b7a1-0f0e-4d84-98f3-ebe259e0b29d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626ddc47-b7c5-417f-9610-19c21a97cfcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -946,10 +946,10 @@ https://issues.redhat.com/browse/CMP-118
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04e30034-ef68-4dd6-a196-137b4cadd4a0" control-id="ac-6.7">
+    <implemented-requirement uuid="2a68cc68-51ca-4be6-8b16-f1502d1cb844" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.7_stmt.a" uuid="6c7b14b4-e346-436f-9759-eb1868872ad4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fb0fc481-1bc5-4fa2-bf35-67782e760872">
+      <statement statement-id="ac-6.7_stmt.a" uuid="99469d77-e2ea-4e2d-ac5e-8dbb5dbd9a01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fc363e0-de94-43fd-867c-525b51ed2a6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -957,8 +957,8 @@ https://issues.redhat.com/browse/CMP-120
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-6.7_stmt.b" uuid="13cfb0b5-d45b-4917-a86a-d7071ceab869">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f7797ef8-e103-4212-a706-820f7c20f075">
+      <statement statement-id="ac-6.7_stmt.b" uuid="a9c46f7c-06d2-48e6-aea5-ec2587b9034d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fc363e0-de94-43fd-867c-525b51ed2a6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -967,10 +967,10 @@ https://issues.redhat.com/browse/CMP-120
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98d9ba68-c00e-423d-8354-6c99bec2b01b" control-id="ac-6.8">
+    <implemented-requirement uuid="4df7c521-e3cd-4eda-bdc8-16124c4e954c" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="cce8267b-317a-40cd-9d3b-8a6155ee9822">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f4e0809f-35f0-425e-8061-a15fdbd829db">
+      <statement statement-id="ac-6.8_stmt" uuid="7e007e2d-0b19-4f3f-8b9a-213513d71f65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e00fda25-a5ed-47ed-8e6f-3a356934e6af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -979,10 +979,10 @@ https://issues.redhat.com/browse/CMP-121
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8d8f80c-35e6-4aaa-81b1-3ce2374274c6" control-id="ac-6.9">
+    <implemented-requirement uuid="a46cc993-69c0-40a9-b1c7-3b51a8170ecc" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="04171f16-c26e-4ea7-99c6-f366240f937c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1420de22-666a-4b6c-92cc-342ce26601f9">
+      <statement statement-id="ac-6.9_stmt" uuid="1b950782-4ef9-4f2f-aa12-d01c6885456e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7754724-50c8-4d11-b4a0-d4235cb8ef81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -996,10 +996,10 @@ https://issues.redhat.com/browse/CMP-122
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59b9b430-3a45-4f20-ba52-352951c980d8" control-id="ac-6.10">
+    <implemented-requirement uuid="3e6efe21-9357-46fb-9506-c930ed1c9bd1" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="613c6fc7-1f93-4862-89d2-282d3d206804">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e1db5409-cf16-4c8d-b89e-44099ba48260">
+      <statement statement-id="ac-6.10_stmt" uuid="fcec7506-27c3-45a4-abc8-25e198fd2ca7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f817e29-325b-449e-9120-08bf8dc62dca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -1014,10 +1014,10 @@ https://issues.redhat.com/browse/CMP-123
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd5628f0-7380-4d0d-9f6a-0b65789ae8a1" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="8ce07095-28a2-47a1-a7eb-5f22277b1914">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="39dca794-e1af-4335-a15a-3794bd2b8b1a">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -1028,8 +1028,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="66b9fd94-f5b9-46b9-afc2-64f4df1d508c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fed23c02-5b85-412f-9f02-5462cd066694">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -1041,10 +1041,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e99e5935-115b-4220-a042-14a2acaae7fe" control-id="ac-7.2">
+    <implemented-requirement uuid="be8263df-597a-4016-97ac-a2acd45868d6" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="4c794f21-0522-44ad-b401-892b33d1fa60">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="714b0834-b622-4ac3-b58a-51a7f40d2caf">
+      <statement statement-id="ac-7.2_stmt" uuid="3d3605d4-5b9b-4e4a-9a13-a5303ee492fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e7d9f28-5b82-40c5-a3e2-72b54938285a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Management of mobile devices is outside the scope
 of CoreOS configuration.
@@ -1052,10 +1052,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="882a5fac-05ff-4dc6-ac18-76d04d5c4dd5" control-id="ac-8">
+    <implemented-requirement uuid="b364dab2-3da7-492e-8c0b-744c78232918" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="3c9e676e-26b3-49e8-9604-427e7f9ba3c8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7ec729f5-c257-4c26-b36f-1203e7d7fc12">
+      <statement statement-id="ac-8_stmt.a" uuid="32e61082-a341-4794-b630-59a2e468e8de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713a10e8-f5ee-47f8-90ea-bba9658cfd59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -1075,8 +1075,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="4a7285f1-9cb6-41de-a44b-359a5224e396">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc63607c-d73d-4060-aef9-e4676bad8581">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -1091,8 +1091,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="2502d503-9bf0-4e20-bd3d-b3993679e71e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="06edf137-074d-480d-8f98-0b34cd7da7d3">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1110,8 +1110,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="9cbb42dd-efe9-44ce-8474-8cd5cc84fd4e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d1a3ec57-fb1e-4f27-9c95-c080e080036a">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1124,8 +1124,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="b2c92d6b-ff90-41db-b8d8-d37ffc738756">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d1e823ce-eb27-4567-9c34-192f5f186e43">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1139,8 +1139,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="f4fdfab2-3a91-439b-b955-ad2ac1f0fcfa">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f7b04f88-8abf-44ba-82d5-c020f99ff3de">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1156,10 +1156,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec11534f-10ff-4a0e-91e2-18858d743326" control-id="ac-10">
+    <implemented-requirement uuid="317d48f2-c463-4fd9-a033-49c4ef0fa7d0" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="aa851a92-e456-4af4-8e9f-ea1f7aae731d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="49d4b6eb-330a-4951-a401-60a7a481f0dc">
+      <statement statement-id="ac-10_stmt" uuid="3f970970-cbef-4fb6-a9b4-26b91e499a28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aed70d9-b8b8-4e83-89c0-337f33551afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1173,10 +1173,10 @@ https://issues.redhat.com/browse/CMP-131
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecd42583-af8f-4700-a02a-3626bee3afb5" control-id="ac-11">
+    <implemented-requirement uuid="e915b154-d306-4240-b477-551192bcedc5" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="8d2be48e-d8a2-4713-8aa5-a02789a22211">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dda8f90d-1382-40d0-b839-a5fc3dc8ae2f">
+      <statement statement-id="ac-11_stmt.a" uuid="ddde43f0-56b3-481b-96dc-95b0befdff3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1184,8 +1184,8 @@ https://issues.redhat.com/browse/CMP-222
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="8a19860a-7950-4f4b-939b-d3a42e56eaf8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="61974a98-517b-49ce-b61f-c6f5827aa5b6">
+      <statement statement-id="ac-11_stmt.b" uuid="9cfa0153-ccc7-4fad-baac-e5e5beee1046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1194,10 +1194,10 @@ https://issues.redhat.com/browse/CMP-222
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27435a2d-93c8-4a7e-be5e-4c3b2e9638c8" control-id="ac-11.1">
+    <implemented-requirement uuid="ab6903c4-8a5b-4507-ad07-184780da55aa" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="de596292-5858-40b8-956e-181c74d6603f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16b81d96-7158-4ed7-a9db-ed4a60a8da23">
+      <statement statement-id="ac-11.1_stmt" uuid="e16650c5-8d95-4e15-bc8e-5d3e7457ba56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09896195-8492-4293-a137-628ef9ab4ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1206,10 +1206,10 @@ https://issues.redhat.com/browse/CMP-221
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ab4456f-9e2a-49c6-aa78-77951b92be36" control-id="ac-12">
+    <implemented-requirement uuid="80d9fe3f-ec91-44e1-8c30-69b9aaf4e472" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="4f783ef4-edd7-461e-a735-60d1f02ba610">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f3299f11-2397-4362-994e-fc34085864d1">
+      <statement statement-id="ac-12_stmt" uuid="fc0fc943-da69-4c4e-946a-4d377389240b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="292db0d7-a6a2-4127-a9b1-4efb2359e579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1224,10 +1224,10 @@ https://issues.redhat.com/browse/CMP-132
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60766207-c0be-46ae-8517-06fbe0fb92b7" control-id="ac-12.1">
+    <implemented-requirement uuid="edcfc5d5-054c-4603-ba23-fbb6e12a7953" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="4a92b3bb-1e94-446a-a425-fa14b66fe88a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c90e9c25-974f-4c2b-ac4b-492779997f35">
+      <statement statement-id="ac-12.1_stmt.a" uuid="ef94f017-ef31-4e14-8be6-7ddb45ce7650">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea329058-ee40-4d53-9f8c-a69dc05d21d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1235,8 +1235,8 @@ https://issues.redhat.com/browse/CMP-223
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="7efc4e22-aab4-4a6c-9e03-c83955be4f5f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fefa13a1-e4ab-4f37-89b7-fde212b49c07">
+      <statement statement-id="ac-12.1_stmt.b" uuid="090cba7d-410b-482a-a704-1618cd44d50a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea329058-ee40-4d53-9f8c-a69dc05d21d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1245,10 +1245,10 @@ https://issues.redhat.com/browse/CMP-223
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bb7c0c6-f4b6-4d75-8eaf-c560e8d7426f" control-id="ac-14">
+    <implemented-requirement uuid="74aedd6e-0b78-4029-9487-224f5fa1a3c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="8cb37c6b-d982-44f8-9026-eff3bc74cd13">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ee1b5e4f-984e-4b53-8cfd-3368fb56abf6">
+      <statement statement-id="ac-14_stmt" uuid="85ab16ac-f3b6-4835-ba7b-f80b13e2880f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caef0d25-057d-44f7-b0e3-b578d96b11e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the CoreOS Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -1258,18 +1258,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aba2040-877f-446d-9301-df8f41bd00ab" control-id="ac-17">
+    <implemented-requirement uuid="52338ece-b04e-4a7e-baf1-32ab40979a4d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="ef8be855-2eef-45d1-82fa-827481adf6e6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9ff36736-8cf0-4651-8822-a15ae9da8cf5">
+      <statement statement-id="ac-17_stmt.a" uuid="6f5015e4-d2de-4ac4-8679-471fc4d1b336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="fc6788ed-2c4e-49b9-b37a-4c7144edd024">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="764ec024-a872-4a31-8d77-1ac7842cd926">
+      <statement statement-id="ac-17_stmt.b" uuid="28a3c8cc-80b9-47fd-840a-75943f6d4a93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -1277,20 +1277,20 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41acd8c7-34f3-4388-8e49-f56f934c04c9" control-id="ac-17.1">
+    <implemented-requirement uuid="42fa24ee-797d-405f-aa57-199244f3d3d9" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="274923d7-81d2-477f-9464-491b12596c80">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="40ff5fe8-95d1-460e-9e73-f94b41055b45">
+      <statement statement-id="ac-17.1_stmt" uuid="7ba47ef0-ad23-4dc4-a755-5b6c0c59954c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de20252c-d63e-4210-92f7-be1a133f519a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89187f4c-fba0-4f6a-8554-a043a359548a" control-id="ac-17.2">
+    <implemented-requirement uuid="dc19e26a-01b7-4749-9e63-cf54f8dc6294" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="8d5fcde1-29d0-4c24-b262-b2401512d85a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e75cf974-434c-4762-b9c4-354a7f1a1642">
+      <statement statement-id="ac-17.2_stmt" uuid="fd7194bb-d878-4f49-a85e-66269e4d4031">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44885b26-7c16-4c6e-89a1-29fac2a242f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1299,10 +1299,10 @@ https://issues.redhat.com/browse/CMP-144
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="770d1485-b3b0-4bb9-8bd8-28f9e38989b8" control-id="ac-17.3">
+    <implemented-requirement uuid="39d48f16-1d4f-47cd-a477-ddb3574cdf02" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="2ef0600a-97ad-4da7-82dc-46bdb787ffe3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b3e78e43-e3da-4b64-9e8a-03e53b60a8db">
+      <statement statement-id="ac-17.3_stmt" uuid="7967ae9c-1cd4-42ae-bdcf-f84c036ae938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09af0121-32d6-4b5b-8587-b4c4adeea806">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1329,10 +1329,10 @@ https://docs.openshift.com/container-platform/latest/networking/routes/route-con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53ccc861-6b5c-453d-a5a6-b1c382b88fdb" control-id="ac-17.4">
+    <implemented-requirement uuid="89b3ebb2-f648-40b4-afe0-830e5931e47c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="0506ae5c-7671-4d46-958e-a670a96a26e8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0490fb86-f018-40ce-a9c8-4ffac44b6d8b">
+      <statement statement-id="ac-17.4_stmt.a" uuid="c2a6bbb0-2fb8-4c48-82f6-8d8601699e90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f8f0216-6223-4f9e-b182-623eab4fe16c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to security-relevant
 information via remote access only for organizational defined needs is an
@@ -1340,8 +1340,8 @@ organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="a7fe159f-0681-48b3-8168-e5b932bae974">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2a01305d-cd94-4155-9c57-095ad6ed1307">
+      <statement statement-id="ac-17.4_stmt.b" uuid="37dbf564-e7b2-4adb-be21-a8b879a9a69f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c50f7adf-4044-419b-b0e6-194b17399e55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and access to
 security-relevant information via remote access in the security plan for the
@@ -1351,10 +1351,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="056cd6b9-4483-4732-ad01-619fd706e41f" control-id="ac-17.9">
+    <implemented-requirement uuid="66bab541-40ec-44f3-83e3-11c5057f4513" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="57ba0ea4-8cf4-4035-8118-1f339f86b768">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="262f0ae2-8da6-4d8f-87f9-2225ea7ebd94">
+      <statement statement-id="ac-17.9_stmt" uuid="dc1fa1c7-7c80-49bf-8494-05e250cb03d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fdf9daa-52fc-4d4e-81b6-068aa076e3ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS utilizes the firewall technology embedded into the
 distribution. This technology, named firewalld, allows a system
@@ -1373,18 +1373,18 @@ for tenant applications immediately.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a63567b5-1f15-47a5-8058-e1de5da73383" control-id="ac-18">
+    <implemented-requirement uuid="5d4b56aa-8e14-491a-9b7e-52f4a3dc6e89" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="5d080d9f-9b3b-4e06-932b-a5b72a5d9650">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="089b72cf-b009-4a99-872e-9de08e605b98">
+      <statement statement-id="ac-18_stmt.a" uuid="1b94291c-4f38-4d22-8161-79d388d32758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf9153f9-1db6-4e2e-88a7-634b9cbef1f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="9f751fa6-ad2f-4956-a4d0-fa298b2a9392">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1600135b-c1a7-455c-a34a-d212c8538481">
+      <statement statement-id="ac-18_stmt.b" uuid="eb73f1fc-c8c8-4fbe-8b48-4fc3ad09a3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18432f18-2002-42e0-abcc-b0131b443d64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of CoreOS configuration.
@@ -1392,10 +1392,10 @@ system are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a15e97fd-adc4-4e38-bfd1-790c79d0886a" control-id="ac-18.1">
+    <implemented-requirement uuid="3ee98bff-7810-479b-9e0a-8c18917a14aa" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="92fa9215-7361-484d-9f75-d4c08844e6b9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="270694b2-160b-43ff-9201-8619bbf83db3">
+      <statement statement-id="ac-18.1_stmt" uuid="47d60365-f0c4-4573-b060-9d548acc2678">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f3a6d1e-4d81-4dca-99a2-d586ddd6211b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 CoreOS configuration.
@@ -1403,10 +1403,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ed3509d-53f5-48db-82a8-fd95c2451d10" control-id="ac-18.3">
+    <implemented-requirement uuid="6f816497-4d5d-4ecc-a3a3-12a9cb5a19dc" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="689bda75-ae34-4082-b770-5adb5c706f74">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0837d8f3-64e2-4760-974b-a93193c6db4b">
+      <statement statement-id="ac-18.3_stmt" uuid="0c19a6f4-e9ea-4d10-adf0-59767bd7df8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6393a203-3c67-41a2-94dc-7d208223c6f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1415,10 +1415,10 @@ https://issues.redhat.com/browse/CMP-148
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a2b6e1a-a849-40b5-b3b9-b48260d0aeab" control-id="ac-18.4">
+    <implemented-requirement uuid="bbed9704-30f7-4639-abac-d348cbdbf691" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="42523498-2e57-41b1-a2f1-5702909c6184">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="87ea16d8-d2e5-43d4-8354-f4a3cb84b4d4">
+      <statement statement-id="ac-18.4_stmt" uuid="191b8ab3-eb22-4fdf-a2b4-5083390aa2c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ec82b54-7830-424c-a8a2-f043de69f6f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1427,10 +1427,10 @@ https://issues.redhat.com/browse/CMP-149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2da4efd3-e06e-481d-b1cf-69bc8b8a5ffe" control-id="ac-18.5">
+    <implemented-requirement uuid="888ead83-0fd6-4c30-a489-62d6f20beec4" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="3b211246-4b6e-4bfc-bb24-49a6c9d421fe">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cb98d281-c616-4730-915a-b0ed1483e934">
+      <statement statement-id="ac-18.5_stmt" uuid="17507af7-b332-4f31-8340-7750899f26d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e330160-9225-43a6-bf30-add239921b7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Radio antenna selection and calibration is outside the scope
 of CoreOS configuration.
@@ -1438,18 +1438,18 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02761bfd-f6a0-441b-a4d0-46e7d4fdd45f" control-id="ac-19">
+    <implemented-requirement uuid="2eaa2377-e027-48eb-b623-9707bc43ed8e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="5ec368b0-45eb-4c95-8725-3c7f5c42e19b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d13ef41c-295f-4ca8-b8f9-5a47066a4096">
+      <statement statement-id="ac-19_stmt.a" uuid="5beee672-d457-41f9-8b66-7129b0ef1e2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14640741-0e7b-446d-ab60-c038a9c67acc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="5d39c900-593c-4487-aa21-b3b3493dce85">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="43e49693-6864-47fb-a48e-77491cd26112">
+      <statement statement-id="ac-19_stmt.b" uuid="1489caf3-35df-42d0-99ac-34ee9fe939a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daea7828-b48f-4e2f-8838-95871dfdf677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of CoreOS
 configuration.
@@ -1457,10 +1457,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d81c75c8-a30f-4060-a8d4-1256bc262668" control-id="ac-19.5">
+    <implemented-requirement uuid="83b2e6c9-d5d5-4911-84c8-f0ba757e66f3" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="0c7b67b5-7e7b-4f7e-8142-3419956018a1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc81a4c2-f4c6-40c8-9512-1cde4ae9d703">
+      <statement statement-id="ac-19.5_stmt" uuid="886ba590-18d0-467e-921e-68f6d5f4102d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cdf081c-4c50-49b0-b3a9-2c87299ff572">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of CoreOS configuration.
@@ -1468,10 +1468,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e5f8183-b450-4605-a374-e9b867643434" control-id="ac-20">
+    <implemented-requirement uuid="8da17d11-aaff-4b42-a8ef-239c2f037ed5" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="75357491-9470-403d-8f8c-ec53d516e6d0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3aeaadd2-70d0-4585-ae5e-2e61edf69c6e">
+      <statement statement-id="ac-20_stmt.a" uuid="9016e096-ae1d-4e6c-b0b0-715631291e3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e863569c-9595-42c1-bc0c-eb2b2ba883d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1479,8 +1479,8 @@ systems is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="7e02eab1-fafe-41e7-9e72-8983360a5c52">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="60e37a71-c2cc-41d5-9c63-db96dd67f3a3">
+      <statement statement-id="ac-20_stmt.b" uuid="de1dade3-ce08-4dab-831c-fea500622d95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83299231-fa17-4a90-a250-282ce6fd5114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1490,18 +1490,18 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd58554a-24c7-4442-b430-73547652f871" control-id="ac-20.1">
+    <implemented-requirement uuid="13ac6de4-c191-4e06-9ad1-ac7b96b9b9a5" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="8951c5ff-f596-470a-a445-7649a22a8254">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="30fd409f-77fa-4f1a-8c1e-87fcdf8154ba">
+      <statement statement-id="ac-20.1_stmt.a" uuid="17b58b51-88ec-4f3d-9f52-6f3d9c0263c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7037104a-af44-4aad-9582-199502cc1fe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="a170d70f-fbf9-4652-b2d8-4df5f980d906">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc4a20c2-847c-40b6-8a1c-44f98d394611">
+      <statement statement-id="ac-20.1_stmt.b" uuid="90a525db-451e-4b3c-9183-07bc9e1a8c88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8617a61e-cddd-467a-87b6-57d35da9d52e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1510,10 +1510,10 @@ information system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5a125c9-f85e-4dbe-9795-74b1e8f15691" control-id="ac-20.2">
+    <implemented-requirement uuid="9c66575e-1b8d-4489-8b18-2138b50a75f0" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="572186a0-323d-4a5c-ad29-939757ea4591">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8567d0fb-cbc9-4d96-9434-f1eb02bc670d">
+      <statement statement-id="ac-20.2_stmt" uuid="40db944c-5c88-469b-a39f-a57862cdadc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9991679-ce94-45f2-aff3-c6d262722b4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1523,18 +1523,18 @@ systems is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f9f060d-9889-4b3e-aa4f-a13604625b62" control-id="ac-21">
+    <implemented-requirement uuid="e37f4554-c00d-4133-ad4a-bed4a4c8bede" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="5236f68f-da9f-46b5-909b-6298320fafce">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="99918644-ae94-40cf-aad5-3de040529a20">
+      <statement statement-id="ac-21_stmt.a" uuid="2a8e00ea-f586-4055-bc92-7efaed1ea197">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e9791f5-4e25-4c22-a192-c04489d0a8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="cf8687fd-34cb-4206-bf46-503cf02ea5bb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="35d6a90f-8af1-48c0-9b8b-343c5ca43185">
+      <statement statement-id="ac-21_stmt.b" uuid="5c844891-296a-4448-b939-4e5f7e6588d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bea71ff-4fda-4995-9f37-27e7df7be6ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1543,10 +1543,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="833ca95b-3356-47fb-98b7-a4fbddd9ecca" control-id="ac-22">
+    <implemented-requirement uuid="15e4e849-3ea8-4bf6-b2f9-fc35f51e78b4" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="5c8ebc81-ea80-4dbf-b975-3c93d659331d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="120ff8a9-d344-47c2-9aeb-a2168f557570">
+      <statement statement-id="ac-22_stmt.a" uuid="3f7fe930-3993-44d8-aed5-145487858da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c8349a-1b72-4922-98a2-f679ae0e98e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1554,8 +1554,8 @@ system is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="a1c65d0d-c3cc-48cc-9584-1b5a5c311a6d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="de489049-0b43-4e4b-93c8-26be4ca2e93c">
+      <statement statement-id="ac-22_stmt.b" uuid="dc5d118c-ae8d-49b6-bfcd-e7de78038687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9618069e-d920-41de-a880-e10126de5e64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1563,8 +1563,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="4d455cea-a6dd-4f01-b810-241c83f2325f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96e946de-ed4a-4508-a065-d5161028815b">
+      <statement statement-id="ac-22_stmt.c" uuid="daf95474-b47d-4768-8927-8a8f7423d930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5244ca92-85c0-41d8-a9ab-7751eb4989be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1573,8 +1573,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="37cda206-af79-4bca-ab6a-695dc2e51ce3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d6e53409-fc37-4f28-80ce-7a3179608e61">
+      <statement statement-id="ac-22_stmt.d" uuid="eb208ca0-9b96-43a9-93fb-c381c7a6eca8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ff72021-3f80-4705-aaef-9766c09ab9f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1584,18 +1584,18 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bb52d5d-86cf-46ff-9493-46adbbcdc001" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="8172ea7e-ebad-4317-a4be-6d05e401203c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="42a0d849-1348-4440-bd42-b045bf8548d7">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="55c8d25a-644e-4cdd-ba25-a77db2ac5336">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9686cbe9-30f4-4e42-b667-393c60ce252f">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1603,26 +1603,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbdad7d5-70c0-4d99-aefe-a0c1a6bca48a" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="159fb3f5-12aa-4849-8d64-079d04897e18">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ee9bc69f-596b-414b-ad23-ebff2b39b002">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="5a670df3-dd30-4101-abc2-6ca70d3a4aac">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5db34b89-7167-4b1d-8e1e-d516c21ee73a">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="085af819-4e4b-40cc-b280-919a1f0f3f47">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d307c237-9e5a-467d-b988-619cbeaf2db0">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1630,10 +1630,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79d96e0c-2765-41b1-975f-3d7dc49e118d" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="e09526ec-fd64-4bb1-8cb4-2750b76babd3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1f00feff-ab4e-4680-9d9d-4b7960b61792">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1641,26 +1641,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc63f1f2-a148-472c-acd0-5b53428d71d5" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="4aff60b9-465f-420b-bbd8-c29f37d4a9fa">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="da9d89e0-a50e-4994-94a9-e6dd9de1c327">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="03ecd370-ad18-408e-a513-93173a485370">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9e05f1c9-3d8e-4a8d-a734-1a0b7dae157e">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="4fbc3017-7c4c-4659-9b0f-9ad3d2056fb0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="44dea172-9dfd-4da3-a46b-fb29d131e7ec">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1668,10 +1668,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9710cf8f-f9f4-4a36-b3b7-2a1808c29d4a" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="9f0e996e-47f0-42be-b788-89bc5bbfe2b9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="06ff43d4-ee4f-483b-ac1f-933de51d5083">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1679,10 +1679,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d4d34b7-65e3-4bf4-89c6-c4057ae6ade2" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="81da84e9-f2c1-4f40-892b-7ad6141f2b60">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="29c100f4-7807-4458-8200-27a5026a16c2">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1690,18 +1690,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c38e1ba0-3d4c-43b6-a319-29f3b72a44c3" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="b743f99f-cbee-4107-982b-4c02d4d745f6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="de07df16-4c71-4b5d-a73a-1fc3f1e6d80b">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="044f1c41-7255-441a-9a19-047628c1c796">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="736e692f-478d-4edb-b05d-c2d5dc268eaf">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1709,10 +1709,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96f04e66-19ee-4459-8bfb-d8ab4dd57941" control-id="au-1">
+    <implemented-requirement uuid="4d9e7955-92c6-499d-ad77-1afaa84b2c5a" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="960b907e-4ec5-491e-b9b8-41dc1d30174a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="506284be-4749-4d05-932d-c6dd0beeaa55">
+      <statement statement-id="au-1_stmt.a" uuid="b9675a53-dc16-4ace-915a-7ee6e1961c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92243957-9a7a-4469-9b0c-758387037f88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organization-level
 audit and accountability policy is outside the scope of CoreOS
@@ -1720,8 +1720,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="537be5b7-1e1a-4722-8b68-d183212a2b42">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a312ea00-68e4-4bac-bdb6-d464eec7650a">
+      <statement statement-id="au-1_stmt.b" uuid="997ea394-2e91-4991-b19b-b18e33273887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ee0a85e-a540-4050-945f-06eef494c233">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of CoreOS
@@ -1730,10 +1730,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fad37b8a-bddd-4394-9946-7847c94dbbab" control-id="au-2">
+    <implemented-requirement uuid="287ece19-bf2a-4a48-b52b-45898307cbbe" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="e09fe072-88fc-4360-928e-8b3c129dbdcd">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="98ba00a4-d3dc-4068-8fb8-33668d7d8d69">
+      <statement statement-id="au-2_stmt.a" uuid="3291559f-d71c-4339-879f-b59cfe1b654a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5595f04-f8b8-4e30-9a87-86e8f3760141">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS was designed to satisfy the audit requirements outlined
 in the Configuration Annex to the Protection Profile for General
@@ -1786,8 +1786,8 @@ Selected audit events from ICS 500-27 include:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="2a66e45e-9f9a-48e1-b494-7c4d91d27ba4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c2323390-5473-4413-a507-f2cf83a729c8">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1795,8 +1795,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="303861d8-d6d6-4534-9e81-e7b9d05f4d0f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bca23b8f-274d-490e-a316-68ff09b43e82">
+      <statement statement-id="au-2_stmt.c" uuid="b615cc45-8590-44a1-af90-f91621e87e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f806b1ca-cbbd-403a-902e-8a3ecb18a518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat did not express judgement in the rationale for why auditable
 events are deemed to be adequate to support after-the-fact
@@ -1811,8 +1811,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="5552dee9-b5e0-4fa6-9208-2ef37c527032">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ec6989b6-e45a-4604-97f6-52096353bab6">
+      <statement statement-id="au-2_stmt.d" uuid="7998da4f-89c7-42f0-89d7-9c844cf8b189">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1641516-0f4f-40cc-a25b-79b30da4ac14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Determination of which events are to be audited within CoreOS from
 the subset of auditable events defined in AU-2(a) is an organizational
@@ -1830,10 +1830,10 @@ realtime (e.g. immediately upon an audited event occurring).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb6631d5-4327-49ca-91d9-ab6d2524dd48" control-id="au-2.3">
+    <implemented-requirement uuid="bead2ab1-53ea-48a1-a6fe-f5a9faad6647" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="ae6cbd3c-b6fa-4b8b-a88a-1e54e78dcdb9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d321c3db-20a7-415a-aaa8-14174a9f7110">
+      <statement statement-id="au-2.3_stmt" uuid="e63869d3-e5d9-4713-8ae8-91fe070dcae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="053a6ee7-85b1-499d-821f-931f13924619">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of CoreOS configuration.
@@ -1841,10 +1841,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="802df7a2-e699-4684-a5a9-1ba72b0dfa91" control-id="au-3">
+    <implemented-requirement uuid="0e32b747-e74b-4dc8-90cc-8dc694f485a9" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="bf8fb190-c995-42ee-b334-639d01420900">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6a52caa1-4442-45ae-a4c1-7c4246ef7617">
+      <statement statement-id="au-3_stmt" uuid="7c00bbc5-bed3-4987-9b1b-401a96763521">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="822d2d2d-9e81-4bae-8f7c-37f141b9fb7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AU-3 is satisfied when the following configuration checks have been
 implemented:
@@ -1856,10 +1856,10 @@ for OpenShift 4.x.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d64f78a6-7335-436d-ae24-2f485bd2b01f" control-id="au-3.1">
+    <implemented-requirement uuid="c1e0e21f-dcd1-496e-8035-c390c79d8ee5" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="70c3b7a0-db85-4413-8445-b5539815d3d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="704b1522-b18c-4454-95d0-cfefcebb5dea">
+      <statement statement-id="au-3.1_stmt" uuid="75fb7866-11a8-41b8-bad1-b9155c8ffcc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dc50397-62c3-4794-9b21-da85086bc5ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1868,10 +1868,10 @@ https://issues.redhat.com/browse/CMP-157
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c074d5e0-96ed-43c6-9f57-07d416bb137a" control-id="au-3.2">
+    <implemented-requirement uuid="25e3d638-55ab-41e3-8419-8af242870322" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="7b6a269e-dc65-4d70-a4a2-e0969996efb4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="83170523-fd2c-4829-a41c-2b47435d2c72">
+      <statement statement-id="au-3.2_stmt" uuid="e2d7f1db-1330-40eb-92f5-7d3684aaea29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac67f87f-a691-499e-b0cb-ca3480061d70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1880,10 +1880,10 @@ https://issues.redhat.com/browse/CMP-158
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="368a07b5-b26c-460a-862f-bf1acc443658" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="b685a8f3-03c8-4cce-afca-0e475ea5c013">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a3d281fa-e2a9-4226-83e8-8e8f5da969aa">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1892,10 +1892,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="861ad2bc-b217-4972-87b5-43074023a140" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="3c8f1b93-ff06-4a48-b7cd-79abb2be233d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="27b091a2-10c2-48d1-9e11-7e24013b3721">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1903,8 +1903,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="6057bc45-e2cd-427d-8bae-1b97150bd1a0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ba9cd2fd-57f1-458b-a099-43398e380155">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1913,10 +1913,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fa6e9f0-7565-41f3-a23b-31df3d3715f9" control-id="au-5.1">
+    <implemented-requirement uuid="2e89a770-e938-4cf3-9f8a-7420bd9fa4e9" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="37d8f198-8f95-4f54-804e-6dadded088e9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="09270e04-48a6-4e70-abae-0d3ba9510920">
+      <statement statement-id="au-5.1_stmt" uuid="dcd1a857-b0c8-4703-b66c-adf58cdea558">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6af428a-7963-4178-9852-66a5bd50c9fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1925,10 +1925,10 @@ https://issues.redhat.com/browse/CMP-162
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa7383aa-1e9a-4ee6-a8ce-28a43d83ff59" control-id="au-5.2">
+    <implemented-requirement uuid="6a79d009-e381-4bbb-8e52-8060b292bd61" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="44b6e445-58d7-4e19-81bd-317c71f45d39">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b7a34ea3-4480-4a3d-9efc-9ba2e05d08a1">
+      <statement statement-id="au-5.2_stmt" uuid="d7d48242-d792-4c50-84cd-19e48829b55c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="274573cc-54ec-4bf5-8e71-e5eea86312eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1937,10 +1937,10 @@ https://issues.redhat.com/browse/CMP-163
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dab3aa61-4791-4e2f-a1c0-b3577e013b5d" control-id="au-6">
+    <implemented-requirement uuid="d6a49803-12f0-427c-aaef-b980628e3a93" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="acdb8bce-03a6-4548-ac70-e4eca8a88ffb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b7a38185-776a-4e57-b678-744ff455b9d4">
+      <statement statement-id="au-6_stmt.a" uuid="4605a12f-fc92-465a-8048-b224db829c2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b183e222-7171-4f1d-88ab-fbd547eb99d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1949,8 +1949,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="e98ac741-9b8d-481e-9f32-4f8795c45ca4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f19520e7-1c12-4637-98bf-4be1bb7dc4ac">
+      <statement statement-id="au-6_stmt.b" uuid="ffd8c14a-413e-415d-8e38-d50aabd5420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdf2e4d8-f1bf-4822-a619-d759550ae3a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1959,10 +1959,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bef05419-4d05-4eba-abc2-a0f6c6f22c70" control-id="au-6.1">
+    <implemented-requirement uuid="8aabc505-f7bb-41a3-a480-ac1a395dfa19" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="acc77933-b876-478b-94e5-7c59d65db05d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="88f662e5-751e-4650-8f15-ad0f8d63c2af">
+      <statement statement-id="au-6.1_stmt" uuid="28329b18-d848-42f2-993d-46e449954e92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7fd9b2f-a136-4ce4-b51e-0bb00545754e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1971,10 +1971,10 @@ https://issues.redhat.com/browse/CMP-167
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b27a1887-4552-40aa-8320-98031fba17cd" control-id="au-6.3">
+    <implemented-requirement uuid="0c9ca6a7-8388-4dfa-bdcd-d00bdaafd3b3" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="ff3698c0-3cab-4451-af1e-9f087a31afe3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b8e9a378-c923-41eb-8dde-a6a0df6a0885">
+      <statement statement-id="au-6.3_stmt" uuid="e8c748d6-7e7a-48a3-8cba-07d91a13fd3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4bfb747-ce68-4d58-8864-bd47dbfbe264">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1995,10 +1995,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="765dfac3-df55-43c0-a326-5cf191553194" control-id="au-6.4">
+    <implemented-requirement uuid="d98b7f31-3153-4b23-8a6b-b806283ed4db" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="b105090f-f795-49a8-8e5f-5f172254664f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a5800c18-7911-4b1f-8332-a10c4ed0b169">
+      <statement statement-id="au-6.4_stmt" uuid="c5d03a4c-07a8-41ea-aa7f-7e5065d96fb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecf72597-ee0c-4760-8849-fbe7de1debc9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to centrally review and analyze
 audit records from multiple components within the system
@@ -2015,10 +2015,10 @@ applicable.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ceb06e2-0a1f-4629-9fa3-be5d7ae456e0" control-id="au-6.5">
+    <implemented-requirement uuid="9266bd11-8d91-48d8-aa24-90a49162edd0" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="99fb6abf-9a31-4b3f-832c-a7d2df592163">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="04c5e084-70f8-4769-a47c-3aa72ac177c1">
+      <statement statement-id="au-6.5_stmt" uuid="f74384ea-b323-40dc-9d0d-3fbab7a42862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84cfe096-d256-4955-81bf-192e649ab827">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to integrate analysis or audit
 records with analysis of additional organization-defined
@@ -2041,10 +2041,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c52f9168-e73e-4f29-a9f3-0a07afad5d81" control-id="au-6.6">
+    <implemented-requirement uuid="d6e86b42-92d2-414c-953d-564f4738ad04" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="cd037b3d-d820-4a2e-8e28-9b220dad848d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16d2a127-51b4-49b8-8d12-7ca81732050e">
+      <statement statement-id="au-6.6_stmt" uuid="b8f4163b-a17a-4e7a-ac44-0f66de256375">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b850e2bf-b69d-4f33-ae92-32f27202c85c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to correlate information from
 CoreOS audit records with information obtained from monitoring
@@ -2067,10 +2067,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3693cea-1980-4e49-8cde-b3094a374ca5" control-id="au-6.7">
+    <implemented-requirement uuid="401d7cce-4f71-4ff2-a361-73a274fd3585" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="07d9b851-5354-4828-a164-d30dff003aa6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ece24cd2-b270-41bd-b234-6fdfa5c4df60">
+      <statement statement-id="au-6.7_stmt" uuid="ca4dfbac-435c-49c3-9b47-807f84742581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ac89d24-c8a7-448f-8548-4964f77807bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational specification of permitted actions for
 information system processes, roles, and/or users, associated
@@ -2080,10 +2080,10 @@ information is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6cf7882-7c17-4e9a-9a4d-75321fe260ac" control-id="au-6.10">
+    <implemented-requirement uuid="5e982fb3-8cc4-4fc9-8abf-323c9610c5c1" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="755d449b-4805-411e-bb7d-e61a2020000b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="17f268a2-315b-4b8f-8f3b-2b06d3624327">
+      <statement statement-id="au-6.10_stmt" uuid="da3beba4-9c4b-48c8-8612-95c86cb68498">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eece4c-54ad-46e1-a254-19ff198caddd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational adjustment of the level of audit review, analysis, and
 reporting within the information system when there is a change in risk
@@ -2094,10 +2094,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fe36fa0-2ae5-43a5-ac94-bfa05879c604" control-id="au-7">
+    <implemented-requirement uuid="fcee1857-8555-4629-8bba-af53fa98fdd8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="ddbcaeee-53b6-4ffd-920d-eb7019a83313">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ed7dc003-c77f-45ef-bd34-395fb4017ae6">
+      <statement statement-id="au-7_stmt.a" uuid="b3dd1b17-9bce-4dbd-902c-298b68b5f6de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac2c4991-8f4e-4055-b74a-079501969db3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -2116,8 +2116,8 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="839abcc6-68a5-4016-9de6-3c218d63b293">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0313a8fa-845a-4c95-8950-d471352a1084">
+      <statement statement-id="au-7_stmt.b" uuid="c748f2fc-cf92-44c9-9806-ba1248fe7e40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a54018e-66bb-4e1b-9b2d-38a087c60965">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When OpenShift's Cluster Logging Operator sends CoreOS node logs to a remote log store,
 the operator does not alter the original content or time ordering of audit records.
@@ -2125,10 +2125,10 @@ the operator does not alter the original content or time ordering of audit recor
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bb51487-f1f8-4859-89d0-2fd5b7285c59" control-id="au-7.1">
+    <implemented-requirement uuid="99511d4a-09fc-4a44-ace9-52945e8cad80" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="8147ca9a-43f5-4436-b6b0-546e8bd39fb3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f81562d3-2926-41b5-aaff-8772b5d14660">
+      <statement statement-id="au-7.1_stmt" uuid="846a5d5d-db26-40a1-b86f-0177b6a36baf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a6a566-1a42-4583-9a4c-681d5318b419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -2148,10 +2148,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="759c159e-e115-491f-9d1a-c54bd213e74b" control-id="au-8">
+    <implemented-requirement uuid="cfa63b2f-753a-4c92-9cee-f8e5ce20299e" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="63f2f710-9be2-457a-b3e8-630177ba9af4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1ca44978-2868-4b73-9666-a616d7351904">
+      <statement statement-id="au-8_stmt.a" uuid="3c14208a-a876-4029-87de-5036e4a2969e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dea8b84e-ea73-455b-b435-b4fa13787d7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, CoreOS auditing uses the internal system clocks to generate
 time stamps for audit records. At the code level, this is accomplished
@@ -2159,8 +2159,8 @@ through the use of the C programming language time.h which is part of the
 C Standard Library.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="cc18c785-9af8-45a3-b915-6edd7ae0e58d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="115832b2-de58-4004-870e-232350696263">
+      <statement statement-id="au-8_stmt.b" uuid="55eb61ed-02b8-49fc-a370-e76892d9fce6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1016d760-97fb-4c10-9011-6d9b1c99a5d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the CoreOS auditing records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -2181,10 +2181,10 @@ for more example and explanation of auditing.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7569fc42-07b8-481f-bb9c-4364e52c0a1d" control-id="au-8.1">
+    <implemented-requirement uuid="0070376d-7fc5-4aca-a10d-a9240b6d6818" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="487ed913-ef42-417f-9fd0-90d16e3044ba">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="951ffa33-4d6e-48a4-b03a-dbcf5932caa8">
+      <statement statement-id="au-8.1_stmt.a" uuid="dde13b89-d5ff-40fa-af21-a4954e1c9be4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2192,8 +2192,8 @@ https://issues.redhat.com/browse/CMP-232
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="92628b6e-478d-4b3c-9a49-a0e93d2f44b8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b499e1f6-226e-46ac-9ffe-b30bd6937ada">
+      <statement statement-id="au-8.1_stmt.b" uuid="7a8ebdb0-51bd-4f15-b55b-a6393dc71d94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2202,10 +2202,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a7695a3-27a7-4339-af1c-5ce1cf0aadc2" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="1ab3a263-121e-4349-8046-15559d5bab4e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3ce55fb4-6853-414d-b09e-f8f6a74ed97a">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2214,10 +2214,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5628084e-5037-4cb0-82fd-ab3768117c90" control-id="au-9.2">
+    <implemented-requirement uuid="8da0c910-0bf8-4170-9672-83b82d2e48ef" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="b910ef0d-e81f-49c3-8f92-ec97b4bfaa59">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="eb25dee7-925a-4fe1-b76c-5d0dd057fc66">
+      <statement statement-id="au-9.2_stmt" uuid="2ea89db4-c679-45f3-96b0-402c5b837cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8937265-8b0a-4436-b148-4083efa33711">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2228,10 +2228,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4465b01-08fb-4ed9-b4f9-b38b03455105" control-id="au-9.3">
+    <implemented-requirement uuid="d9af3243-40ce-4013-919a-34fa861da6db" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="713d5636-ca07-4838-89b3-d4883ff73882">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="97247850-40de-43c9-9646-944dfe847b18">
+      <statement statement-id="au-9.3_stmt" uuid="83a67435-1fc0-48cf-923a-6c164b999990">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3439f73-d646-4d3e-808b-8c6cbe8756fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2240,10 +2240,10 @@ https://issues.redhat.com/browse/CMP-236
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39fdbae3-8c9e-4250-a500-4ec7aeaee944" control-id="au-9.4">
+    <implemented-requirement uuid="2e936dfa-c426-4c14-b9bf-b4a2585f877c" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="3dbe184f-d18d-4743-a5ab-a2079703bf45">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="398d6309-6e94-42a1-9ad3-b5f17f88f400">
+      <statement statement-id="au-9.4_stmt" uuid="67384918-d292-4ecf-907c-a9a006bd813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c316f2ae-f82d-4182-a625-9ce6bf288afb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be tracked
 via:
@@ -2253,10 +2253,10 @@ https://github.com/ComplianceAsCode/redhat/issues/863
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e6deea5-14d5-40d0-8c95-24106c162cbb" control-id="au-10">
+    <implemented-requirement uuid="a8912fe8-a2c0-440f-a252-d977dfa1f0bc" control-id="au-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-10_stmt" uuid="54dd3868-36c9-4ab2-97e1-303b553caa9b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="36036ccd-ae46-46d1-a2c9-f417b6ebca9e">
+      <statement statement-id="au-10_stmt" uuid="c2f0541a-5d78-4cb2-ae65-2579c4173d2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2265,10 +2265,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec1df31c-1b49-4e8c-a125-f913e59cecf9" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="6b2fadf9-c5e8-47f8-9452-7ed72227e942">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cef14136-642e-4f6b-b907-339d00b4fe98">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2277,10 +2277,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2eb7d820-0678-4789-bbf8-1f756b5e56e9" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="9e550507-ac43-4849-b416-94e9e8cae737">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f3ad2046-127c-4602-a31a-be9251076b02">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2288,8 +2288,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="42bf37f5-2397-48c4-9e3c-d1333dd824db">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="490eb25b-c4ae-4c91-9d96-6ff4b768fb97">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2297,8 +2297,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="787dd2fc-603c-4834-bca7-de271a441b69">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c76a04bf-21d1-4a53-840c-b920826bcbc5">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2307,10 +2307,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89afbee6-439c-4117-8885-104ea921ef64" control-id="au-12.1">
+    <implemented-requirement uuid="fb1002d1-76a3-48d5-8b34-e6b6fa126fac" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="37cabea4-3cce-4918-b145-37c7eaa826c1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f221b236-5edb-49dc-b508-a5afb6223d0c">
+      <statement statement-id="au-12.1_stmt" uuid="a7e4e309-6e3b-47bd-9c7b-1edb4051b33a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c016671-eaf2-44de-b4e8-65772fb0d46b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2319,10 +2319,10 @@ https://issues.redhat.com/browse/CMP-181
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bff0777d-a180-4f98-a742-0c6542469db9" control-id="au-12.3">
+    <implemented-requirement uuid="68e7eab1-370a-4a93-9585-646848d58228" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="c6a92c1c-51f2-48ce-b733-2865f5f67576">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d421025b-05b3-420e-bcd2-58e3682e4e1d">
+      <statement statement-id="au-12.3_stmt" uuid="4f1962f7-8e80-4e22-9dd0-d14292e79638">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f777ccd-7ad1-4d71-8151-788d6f6ba024">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2331,10 +2331,10 @@ https://issues.redhat.com/browse/CMP-247
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d47274b-0050-4c6e-b098-2dd5bd035d89" control-id="ca-1">
+    <implemented-requirement uuid="99daba6d-133e-4957-b69e-abb25b8978cc" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="d350e2ff-cee9-4f48-922d-7ec74ab6d68e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="03e15653-4100-4616-aa87-fef7fc76a0f0">
+      <statement statement-id="ca-1_stmt.a" uuid="c6d6d9cd-b8b5-4f2e-957d-f57dd1ae55c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2342,8 +2342,8 @@ the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="2cddf6e5-b939-460b-ae2e-a6cf0fcbeb5d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6a74f5d7-559b-48e9-b76e-66c06c0ecb1c">
+      <statement statement-id="ca-1_stmt.b" uuid="d910896e-a8ef-4e87-85ea-661516ea4969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2352,34 +2352,34 @@ the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdf01acf-44cd-40c9-a2bd-83b6e596a8b2" control-id="ca-2">
+    <implemented-requirement uuid="13cc8da5-63b9-4ad7-8027-2dc6a4f82694" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="b7368d99-0ab7-4670-afc0-a6062f2af3fa">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="31402b4e-ca20-4603-bd27-40c3c8a465cb">
+      <statement statement-id="ca-2_stmt.a" uuid="dd41448d-5fae-4cc9-a688-7852824d178e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="8fb498f8-6839-4e18-939c-2ad91b0effdf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="491e1587-8881-4fcf-943f-b5d54d2f162a">
+      <statement statement-id="ca-2_stmt.b" uuid="bf74b610-4372-4e81-ab09-173a1640dd60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="8b0f2d9a-95a7-482e-bb98-a2dbe5ce0507">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fa53dfa5-52b8-421d-a44d-9793065adce5">
+      <statement statement-id="ca-2_stmt.c" uuid="473814f0-520e-4b66-af54-dfbb6e18368a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="eb35be13-071e-4373-aec2-eb99048a74c0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e3afab86-a3e2-4bc8-b454-7e8f3ab9bd18">
+      <statement statement-id="ca-2_stmt.d" uuid="bb1f6262-9d2d-42e8-b22f-523d3449139d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
@@ -2387,10 +2387,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b498a69-c5b6-4a9c-8e94-abba3efe2e0d" control-id="ca-2.1">
+    <implemented-requirement uuid="38874da0-214c-4491-a3a1-bbb1ed6840ec" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="cc49452d-68ff-4501-a93a-29fbf4299d40">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e6a867b5-fa79-463c-a042-2cd6cb6e18cd">
+      <statement statement-id="ca-2.1_stmt" uuid="db6413d3-b953-4ccd-958a-d009b9723385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dc6837b-8db9-4350-a142-d836a51793a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of CoreOS configuration guidance.
@@ -2398,10 +2398,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2c3a079-729e-4006-b31e-e4d70c677a3f" control-id="ca-2.2">
+    <implemented-requirement uuid="7337b6d7-4a42-4730-9349-d8ff84c44e89" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="79ee6a12-fdc7-4e6b-813d-e349aff365b7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9a858538-cac0-4cde-aeed-6521fc233748">
+      <statement statement-id="ca-2.2_stmt" uuid="d4081db8-7aa1-48cd-86ec-1283251fc33a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7a98cd5-d563-4698-9551-ee5f0ec8118b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of CoreOS configuration guidance.
@@ -2409,10 +2409,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05578476-d1ad-4c58-a610-41c6f9532061" control-id="ca-2.3">
+    <implemented-requirement uuid="cc67f3b4-fa28-46d0-a4db-c33507f2e15b" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="cd2d7a0f-921e-44dd-97f2-3de7dbc80cb8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e010f106-6e69-402a-881e-3a8f94a28eca">
+      <statement statement-id="ca-2.3_stmt" uuid="14883387-097b-466e-a9e9-8b8e628b5068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f442262-dc3e-46f5-a6e3-41717cad4434">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of CoreOS configuration.
@@ -2420,10 +2420,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8410580c-d53f-4794-a517-dc541f165e5b" control-id="ca-3">
+    <implemented-requirement uuid="c8f891db-8b24-4efe-939b-56da63f73605" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="c252d24b-899a-4e55-9a32-06aafdce2102">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0bd84cc3-d50e-440b-9b83-4d9fd6a970cf">
+      <statement statement-id="ca-3_stmt.a" uuid="60cc31b1-571e-4c25-93bb-2ce12b41c657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2431,8 +2431,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="f4d4ab29-2ee4-46b3-8a5d-7778daea0289">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="82c28ec7-4462-46b8-91ed-e6b2f6b327f7">
+      <statement statement-id="ca-3_stmt.b" uuid="d181dd2f-df60-4e59-b08d-0e353d957d07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2440,8 +2440,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="febe969d-855e-44d4-8830-acbb0ad337b5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2fc2226b-1848-4720-986c-b4c790f6bc74">
+      <statement statement-id="ca-3_stmt.c" uuid="77478ec5-5cf4-47ac-b9e2-73ba4fbfaeae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2450,10 +2450,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6428baa-643a-403a-97bc-6ce7fcac0801" control-id="ca-3.3">
+    <implemented-requirement uuid="5c2a70ef-ee18-49ca-9c70-afed8c3a37c5" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="138b41d8-f2d2-4c8c-89c8-5c9c19cc7aeb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="90a14d13-c767-428a-9cec-e76f22c79efb">
+      <statement statement-id="ca-3.3_stmt" uuid="bcd681a2-4cdc-47fc-b568-37617c3ae9e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5715310c-9830-4454-a30a-ae328e97a06b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 CoreOS configuration guidance.
@@ -2461,10 +2461,10 @@ CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5cfd0b54-1e95-472b-942b-8f5f7e86bbde" control-id="ca-3.5">
+    <implemented-requirement uuid="877f2a7b-35fb-4332-833a-e20c1d9a75b4" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="6c60bc39-ebf2-4398-b997-ad8ab77192cb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ba8395bb-5117-4799-9372-9567aa539d25">
+      <statement statement-id="ca-3.5_stmt" uuid="681aa9a0-07c2-4c6e-aea2-b51a79fe2e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dd3477e-6236-457c-950c-104b6f8579af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to CoreOS and applicable
 through host-level firewall rules.
@@ -2476,10 +2476,10 @@ https://issues.redhat.com/browse/CMP-253
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f47aa206-72a9-4336-b7fa-5ae1c065c70c" control-id="ca-5">
+    <implemented-requirement uuid="04cf2e93-8e53-4c29-a789-31dae68b1f8d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="db713dac-d05e-4137-9b09-2c0dc70c1d99">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f8c0ca29-ff72-4906-83b3-336b5b450446">
+      <statement statement-id="ca-5_stmt.a" uuid="395a7806-3504-4444-8b1f-14bee13b1d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f244e5d7-c63c-4700-85ea-5e38983a62bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of CoreOS
@@ -2496,8 +2496,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="2b633eb0-79ef-45e3-ac60-74d8d20a52e8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="95c13874-5eab-4923-86cd-e8abdd351b9a">
+      <statement statement-id="ca-5_stmt.b" uuid="e29dae32-0560-4ad0-b328-14dd6e89d073">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="614d44f5-285d-4cee-8d2b-4c90cbf4325b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2511,26 +2511,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acffef34-9f8d-4c41-bdb8-63cb5ac85e1b" control-id="ca-6">
+    <implemented-requirement uuid="607608f2-fde2-4334-a6f3-4e9027c959d0" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="f4bb415e-b46a-4029-bcc0-e41c5a6e44ec">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="803892d5-a65f-47b2-b0cf-2e76f5167127">
+      <statement statement-id="ca-6_stmt.a" uuid="511137db-c306-44a7-b081-11ce5a8a0be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="7b609ea0-74ad-40e0-b792-b924275a6dbc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0704c52b-667f-467f-84b2-2a986be7e29d">
+      <statement statement-id="ca-6_stmt.b" uuid="68ee121f-2444-42f2-8269-8779a2b68269">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="866c6c8d-a552-46c6-bd0e-1125dd3daa31">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1d17e479-540f-4185-a8a4-b01833f2a9b4">
+      <statement statement-id="ca-6_stmt.c" uuid="590e46e4-2052-40e9-ad70-c1116fc37a51">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2538,10 +2538,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5234b921-352f-4df1-9899-b28f10656735" control-id="ca-7">
+    <implemented-requirement uuid="066ece2d-9278-43bd-9aa0-abbb1e9ad96b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="3f289d93-da35-46b8-98ae-10d31089f34b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5f36684f-9e9c-4a5d-b882-ce476bdbbafd">
+      <statement statement-id="ca-7_stmt.a" uuid="1455a053-6e81-4928-89a7-b1ee8dabbaad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5ddd44f-3d95-4ca2-bf11-bdc4a2e5deb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2550,8 +2550,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="3f33909e-8a9f-4499-97ea-ac8ea5cebc16">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="63a622c6-603c-488b-bd86-8bd28689bc44">
+      <statement statement-id="ca-7_stmt.b" uuid="b3f7a7fe-e740-4842-add2-0515352403e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa91273-e3a4-49d1-9b4d-8947af8ec22e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2560,8 +2560,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="097a9979-da29-4f44-b675-f3b2c471af1f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1347e34b-7d3e-489b-a85c-454c35c1dd3f">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2569,8 +2569,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="cd6bb9ca-3a81-4446-a23e-f335d72fa236">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="528039c0-ebf8-454a-acf0-6d8e56d248cd">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2578,8 +2578,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="bcda9bda-9c14-4e6c-a491-b66a4918ddca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9cb4919d-7aef-48a8-8b38-b521e65964f0">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2587,8 +2587,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="9369827c-13a1-4392-a53e-cb2799eb435d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8aef51d4-a14f-4e9e-a29a-b1692aee2b0e">
+      <statement statement-id="ca-7_stmt.f" uuid="f3822d6e-2a18-4228-8299-967d9f1ca26b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a396b00e-1a45-4eff-bb9d-bcf705d7e2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of CoreOS
@@ -2596,8 +2596,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="dd52b0ff-b934-40df-ae39-af21e03e5c9d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3fca51f8-abda-4ca3-bf2e-ac7e5794dbfc">
+      <statement statement-id="ca-7_stmt.g" uuid="004d1a1c-403c-4be9-ba6d-54b91176e631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8a4b2a0-f735-4371-a45f-2726c489d9e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2606,10 +2606,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11ff7373-adf4-476b-ba0c-b1674b7e7501" control-id="ca-7.1">
+    <implemented-requirement uuid="52512572-aadf-4f6d-be4f-61114e6e457a" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="8d63ff17-11e7-4f21-99bf-ec8e58d97e9a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="468955d1-e423-4ac5-ba55-3f111f0adff3">
+      <statement statement-id="ca-7.1_stmt" uuid="f29d7e91-df3f-483c-a086-70171bb44dbc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5583a506-0008-4d23-b513-a671b314fea7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of CoreOS configuration guidance.
@@ -2617,10 +2617,10 @@ scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa7db60c-0886-46cf-bbcc-88a820c83436" control-id="ca-7.3">
+    <implemented-requirement uuid="a055a731-b321-4c50-98b1-56c2e8df18b9" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="54dd855c-8374-4c9f-ac94-5be4aac33c66">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0b56d068-7cbc-41ee-b714-390c3aa35b30">
+      <statement statement-id="ca-7.3_stmt" uuid="ef15457d-63da-44d5-91d8-afcd89fcd104">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b64f674c-04e0-4c27-bc7a-af42180fb603">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational trend analyses processes are
 outside the scope of CoreOS configuration guidance.
@@ -2628,10 +2628,10 @@ outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="858cf54f-4aa9-4698-b914-6ed59c483f6b" control-id="ca-8">
+    <implemented-requirement uuid="ea97dbf6-8b81-4f9d-83fc-fdc5a538295e" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="8c858f88-fc0a-45e8-aadd-1a1eb44fb28a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ba3e537-4ea6-49aa-9c40-8df24db16938">
+      <statement statement-id="ca-8_stmt" uuid="db987961-b72d-41d0-abef-19306d8d7da9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="605ab3e1-23b6-486f-a5a2-eb5e4feb881a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 CoreOS configuration guidance.
@@ -2639,10 +2639,10 @@ CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c76508f-7209-48b0-91a5-f6ce84d08c82" control-id="ca-8.1">
+    <implemented-requirement uuid="ad132af0-ff44-4e60-8a23-f450b92915eb" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="de7c15c2-5ef9-4596-ad0b-6ff1d6d0e57f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c98babdb-282a-482a-99e6-5960866682a6">
+      <statement statement-id="ca-8.1_stmt" uuid="3d5b02a0-89c2-482a-a4ad-7acabea48da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16a0e298-9e53-4860-94f5-3bc9aac29dce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for CoreOS configuration
@@ -2651,10 +2651,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2359fe3e-3a36-4b44-aef9-03aa5897576c" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="cda68cf0-78f4-41fc-acf5-6ce0e0f8fed3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c4f94e1f-39f2-4f94-8008-98e9a0cdc196">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2662,8 +2662,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="cfd6ea1f-bf27-4ac3-b8f9-fb64ed11c1d9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="04c2ea49-fe59-463d-a408-96c339ef88c4">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2672,18 +2672,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0369f4ed-eb35-40fb-86e0-c7457e67b819" control-id="cm-1">
+    <implemented-requirement uuid="115e2333-0921-4c67-a4b5-12379b2478a5" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="f38acb7e-161a-4ea7-93d6-ab694d39b2b3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96bfb8f9-5159-4ebb-97bd-d4e6b5e70dcf">
+      <statement statement-id="cm-1_stmt.a" uuid="9d54d106-6d17-47ea-93c8-c84ce10158b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c65750c-dcc8-43ff-82ab-4ad8ea4da2e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="3d08d9e7-f33b-4097-a0bd-5c6456e5187d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aebbd3fd-a7cb-4bf4-81b6-03348bbc409b">
+      <statement statement-id="cm-1_stmt.b" uuid="7e95f0dc-7904-4a82-ac38-1d526f64de65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="129d3029-87cd-4b0a-b766-282cef0783bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of CoreOS configuration.
@@ -2691,10 +2691,10 @@ management policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="483da622-1326-413c-acef-df85fed5657f" control-id="cm-2">
+    <implemented-requirement uuid="d4e8ab39-ad10-43cb-92c9-b282ec92e657" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="83023861-f33c-4c4c-a60c-c74ec1ab0f3e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a37294dc-802a-4cb9-a887-8777396a77fa">
+      <statement statement-id="cm-2_stmt" uuid="1af42b2a-18c8-49a3-894b-b9f2139c9340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce35a501-1e1e-4e7b-9f14-187b04fc37fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration management is enforced through Ignition configurations
 and Operators.
@@ -2723,10 +2723,10 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1e09f14-8943-46bf-9c15-88247c1b6051" control-id="cm-2.1">
+    <implemented-requirement uuid="c08ed4b6-dce7-40d8-b0f8-b38e7a3d0383" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="043bc5d1-a405-49d0-9c93-3d946df76f1d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="576028b5-3517-4f16-9e3e-65b4c3340beb">
+      <statement statement-id="cm-2.1_stmt.a" uuid="9e8c7ec0-ed37-454d-a4dc-42980335e634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f220af3e-2912-4338-905f-3f5fb7aa0ff0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS per an organization-defined frequency is outside the scope of
@@ -2741,8 +2741,8 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="6afcc5bf-2bce-4a3e-b5b5-f72a9b56587d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2606da9c-0545-4a34-88e3-986faea95996">
+      <statement statement-id="cm-2.1_stmt.b" uuid="344cae84-267a-4f72-b976-6de9c9acc251">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9480c18-43e5-4d83-8002-becc7e8f069e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS when required due to organization-defined circumstances is outside the scope of
@@ -2757,8 +2757,8 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="f8de3e3b-f13a-4f82-95ca-b75c20eb77d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="406174f7-da33-43d4-8de5-4a2f957d5832">
+      <statement statement-id="cm-2.1_stmt.c" uuid="912ec445-1b02-4ef8-a13e-7b031b4e705f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f445927c-ccfc-479a-bf06-5dd2c7a8da0a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS as an integral part of CoreOS component installations and upgrades
@@ -2776,10 +2776,10 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db0c2276-2d7f-40fc-b3cf-7c3a255677c9" control-id="cm-2.2">
+    <implemented-requirement uuid="9811f427-cb9f-4959-839e-c1ad0e3b1f69" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="a04329d0-1dbe-4e45-a16a-b42fb8e7e71b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8d621179-bc28-48bd-bdd1-0a53ffa1647a">
+      <statement statement-id="cm-2.2_stmt" uuid="1a85e226-7846-458e-87aa-daabb3024acb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbf585d-7073-4272-9b00-0e9a10603a48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2789,10 +2789,10 @@ https://issues.redhat.com/browse/CMP-262
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52ec8645-db8a-44aa-a203-6bb7962c5d31" control-id="cm-2.3">
+    <implemented-requirement uuid="61c72c52-9e74-443f-a3e2-1e2ab6294b48" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="31a11a84-0d09-4821-bbd8-7218996091b6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d217f306-326d-4444-bf94-0b89da9b79ad">
+      <statement statement-id="cm-2.3_stmt" uuid="5defd3a0-8190-424f-9d7f-e744e1a156ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="463ccdde-031c-4459-8680-3d60772598e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2818,10 +2818,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37bb7eaa-e99e-4aff-8d9f-7daa7a5afb40" control-id="cm-2.7">
+    <implemented-requirement uuid="d3915c81-b498-4570-ba51-ff42853ce066" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="543c4ab3-915e-48e8-9d76-a07a64b18655">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="219453bf-3bf6-4e3f-ab3d-cf449714c1d6">
+      <statement statement-id="cm-2.7_stmt.a" uuid="177987a4-6352-4c14-a47c-cb0c21c216ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="522d40e7-e47c-445b-aedf-355f153eb239">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2831,8 +2831,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="77a25ade-31ec-4180-81cf-7ba90807f3c4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5c9adc4a-a54b-4272-bb7d-372b62c0d9d4">
+      <statement statement-id="cm-2.7_stmt.b" uuid="9bb1f72f-1b3c-4c1e-85dc-95c6ed48e00a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5829f28d-b726-4e28-b648-991a5f24cf63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2841,10 +2841,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f65d2ec-0003-4a6e-91cf-32f08eddc2c4" control-id="cm-3">
+    <implemented-requirement uuid="a541cf41-be0d-4f16-9682-4c25f54441d9" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="dc4a0b35-112b-4d0a-b46c-cee15d766e11">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="060f7c5e-f37c-493f-bd55-b85635ef24e1">
+      <statement statement-id="cm-3_stmt.a" uuid="cd86af9e-b2c4-42f9-bd08-622642ee246a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2853,8 +2853,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="7ece2355-bb99-4d7e-9ccf-18d5a6c6013d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e4204d3c-0cfa-4e31-9d65-ce9289e2f046">
+      <statement statement-id="cm-3_stmt.b" uuid="55b2e92c-81f2-4fad-b3dd-456c93a1fbac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2863,8 +2863,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="83517da0-ea1f-44c2-a4b4-dc5418951922">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e7577c6b-1d58-4f66-ae0d-b25d84146578">
+      <statement statement-id="cm-3_stmt.c" uuid="684a0521-4ea2-4b94-b6b7-7b7a50b3f2aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2873,8 +2873,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="546b5955-2042-4b1d-afd8-ead45829deb3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="50facf51-8705-4192-a3f2-6b2bb759727a">
+      <statement statement-id="cm-3_stmt.d" uuid="b1245fb4-2e87-497b-9ad1-8332e3854425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2883,8 +2883,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="a835db04-be8a-44d9-be21-375778cfaa94">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a379a828-1230-4572-9430-420300b2c404">
+      <statement statement-id="cm-3_stmt.e" uuid="2a387d15-e1e8-4940-bce5-98bf905dd8d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2893,8 +2893,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="05f885a1-eadf-4d8c-abe2-1ddcfb958c38">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1f88743c-5e7d-451c-b789-f2a894bd35e1">
+      <statement statement-id="cm-3_stmt.f" uuid="dfaa0f29-9d3f-4979-97ec-a7128d6afa16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2903,8 +2903,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="c300e43e-3d77-480b-be54-c38890072663">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="67178c32-b50a-43f0-be63-4a4183b9b58f">
+      <statement statement-id="cm-3_stmt.g" uuid="e40bb466-a8d8-4b85-a5f8-656ff4eb52d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2912,50 +2912,50 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a09e824-b8d9-4772-9dd1-63dd432259f0" control-id="cm-3.1">
+    <implemented-requirement uuid="c209bc36-bd9d-4e44-8bcb-ab2dab4ffab9" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt.a" uuid="a16c2440-d362-42a0-89e3-8864b2d796d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8916e02f-b05b-45ec-95cc-677d6187928c">
+      <statement statement-id="cm-3.1_stmt.a" uuid="d001f4ab-f654-4a29-b5ac-1bd7dcfcf9d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.b" uuid="6a7eaf0a-2bbd-404c-9a64-8dec0395029b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dac1ff04-9a3c-48fc-b976-adfab80c6515">
+      <statement statement-id="cm-3.1_stmt.b" uuid="93069f97-d2d8-432b-a6e2-c98714d6821f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.c" uuid="26517930-b487-4f52-a849-99660d59b41b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fd0d9833-878a-421a-bf2b-fc3e943d5cf6">
+      <statement statement-id="cm-3.1_stmt.c" uuid="fbc05cc4-d02f-47b3-aaf3-4217cf0196fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.d" uuid="2e507d80-7075-4224-9409-a906bf6d24ef">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="32dab77f-bd09-4f92-b02f-9786e840afc4">
+      <statement statement-id="cm-3.1_stmt.d" uuid="8297391d-2d84-44cd-879b-e2fc6d29d7f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.e" uuid="8f4cbd16-6d92-4be5-983d-362510185f0f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="316a84af-2bb9-4835-81b8-264120219695">
+      <statement statement-id="cm-3.1_stmt.e" uuid="49e1af11-846c-48ec-b399-fe9f6016bec1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.f" uuid="091a8b4a-ac41-417e-99f3-a21146f708d4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="428fe996-4143-4794-accb-fcdfa0eb5769">
+      <statement statement-id="cm-3.1_stmt.f" uuid="70074bcf-6ffb-4267-911d-45b7d1e0599c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2963,10 +2963,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f63aef0-90e3-4834-a1f0-3d8d33e6cc22" control-id="cm-3.2">
+    <implemented-requirement uuid="fb20364b-6292-4bbc-a8d1-a41a9adf421e" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="981fbf3a-79a1-4bb8-be63-589cf0c729ba">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="03518f8c-78c6-41e3-b865-898ed70beb50">
+      <statement statement-id="cm-3.2_stmt" uuid="5deacb82-0b37-41c4-b84a-c01261c3fd8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2974,10 +2974,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="782dfb17-b642-4b26-8856-bc73a4e17d45" control-id="cm-3.4">
+    <implemented-requirement uuid="8edba956-1d08-46df-bbc1-65fc5e41f1bc" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="11ba866e-d2b0-46ef-b023-6d724af92e00">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f2a99d86-aa99-40a6-9317-0000fa80f1b8">
+      <statement statement-id="cm-3.4_stmt" uuid="a6417564-3687-4be6-adc7-8dc1bfbbe576">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb9cc1d1-6451-40fc-8a1d-c6ad6e289896">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The requirement for an information security representative to be
 a member of the organization-defined configuration change
@@ -2986,10 +2986,10 @@ control element is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20917d63-140d-4ba6-a1d1-b122c46ed930" control-id="cm-3.6">
+    <implemented-requirement uuid="61cd825a-b1ee-4f88-9902-7584c461ed98" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="65f8d04b-9367-49ca-9ae6-1069e8c711a9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="772bfc45-5fa2-4996-a3ea-9c4a5e5ad63d">
+      <statement statement-id="cm-3.6_stmt" uuid="6c95e840-d4ef-443d-a25b-f24944fe2d09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93e4280-05f0-43a2-a4ea-eba2203f78f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2999,10 +2999,10 @@ https://issues.redhat.com/browse/CMP-268
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="018cdb19-8586-4ddc-9751-72e2c3d73c4f" control-id="cm-4">
+    <implemented-requirement uuid="0c074561-38c6-4f50-9c76-d1f298a8f245" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="5869887c-e049-4a2c-aaa6-2953b49e4dad">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c5c9c8e3-057b-4614-97a2-2f8cd521d88f">
+      <statement statement-id="cm-4_stmt" uuid="ceb5d10c-effb-41fb-9f4a-feb7759b4c2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7133f40-2f37-4417-97b3-de7e200ce50c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -3011,10 +3011,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d76f907d-3b5b-43f1-a320-60de5efb4296" control-id="cm-4.1">
+    <implemented-requirement uuid="7213bfcf-1142-4a7a-92b4-f64c64bcc968" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="4f6af582-f344-4d24-ac8c-6ad270276f42">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e28a969f-f3da-4535-99eb-e796260c6f0d">
+      <statement statement-id="cm-4.1_stmt" uuid="4b753d1e-4a6d-4be6-8daa-023b12fb7c06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d57d518-18b4-40a7-a11a-53e3639e476f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3024,10 +3024,10 @@ https://issues.redhat.com/browse/CMP-269
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4f4ca4f-0152-4b93-9b2a-95b143b5f46e" control-id="cm-5">
+    <implemented-requirement uuid="b4f990ea-f8ec-443c-9b4b-72dcfcc1cfea" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="d6950bc3-0518-4834-892f-df0709cfb12a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2ac2f065-8ff8-4012-93bd-464ea8a18d88">
+      <statement statement-id="cm-5_stmt" uuid="bfab5f89-6a89-49ff-aee8-747b7cab7422">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5617b51f-189e-46b5-9afb-239398c61146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining, documenting, approving, and enforcing physical and logical access restrictions
 associated with changes to the information system is an organizational control outside
@@ -3046,10 +3046,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="748c5c98-a45d-419e-bea9-2e93c2460d2b" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="fecbb64c-fa17-4900-a278-eea70de1b1fb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="652966c5-6488-4afc-b49b-61e9042d37f0">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3059,10 +3059,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc63961c-2d60-40ff-9327-f7d713b38d2d" control-id="cm-5.2">
+    <implemented-requirement uuid="8557444a-4aba-47b8-ad61-41e0b8b9444d" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="298b05e7-3b6b-4aeb-a71c-cace6a61b706">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="961e3207-18be-4e43-bc04-40ada4dda0b6">
+      <statement statement-id="cm-5.2_stmt" uuid="3f038f53-fc67-4837-a01f-585d3ed9e30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -3070,10 +3070,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6110a50-7185-4788-8e1a-d0b721454902" control-id="cm-5.3">
+    <implemented-requirement uuid="49523066-b7d9-4d77-a2c7-59366937787a" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="cf04bee2-7194-40f8-97a1-faa31103affe">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ef4c4fee-533b-4bad-bb73-7cfed7c8c261">
+      <statement statement-id="cm-5.3_stmt" uuid="84764f58-0c4a-4051-bc47-08d6a39f7317">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca577a36-3847-4240-9bff-912466fccf24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3083,10 +3083,10 @@ https://issues.redhat.com/browse/CMP-187
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf26bde6-fe99-40f0-8335-f30f3acafa7d" control-id="cm-5.5">
+    <implemented-requirement uuid="767160ac-33c3-44d1-9df1-e2f139f5e8a5" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="4c2695ea-446c-48d1-be62-ff8042788af6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="946818cc-9d5c-4e5b-95a3-7e9c99e7832c">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3dae2524-5241-4fdd-978d-beb381490964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d823359b-250c-49fe-954d-f6be6ba9d33a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3095,8 +3095,8 @@ https://github.com/ComplianceAsCode/redhat/issues/901
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="f08f7d5e-fa59-4a22-b8bd-1fa671e15db8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="10e46ea0-4928-4ef7-bf97-4e2ed8c6377b">
+      <statement statement-id="cm-5.5_stmt.b" uuid="25979d90-68e7-4bcd-a7bd-c80ba1eeac1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -3104,10 +3104,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e87914-c0c0-4541-a474-618c3b660413" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="5e462b28-c0c6-492a-891f-656fc5b861dc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96bf68c4-c53f-48b1-9a78-d7649f429537">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3116,8 +3116,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="45d9e4b1-f61b-4672-8698-91edf90d0735">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6ac76b32-d919-4f0c-bfe8-4065e3e42b43">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3126,8 +3126,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="010cddbf-733d-4f64-8a56-e986deff02e2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1fc11576-c8bd-4369-9b36-d5d5e14ae3d7">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3136,8 +3136,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="cb364f2f-7737-44d9-970a-f33db6b7faa3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="52d91223-8dee-45c3-9384-e5936452a790">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3147,10 +3147,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67eb06de-2a19-4996-86df-ef4142eaae9c" control-id="cm-6.1">
+    <implemented-requirement uuid="23adbbfd-9d1e-417f-934e-fedba07890ae" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="cbe06024-838c-4632-80da-5094040ff47a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f5792803-27b5-4459-96eb-b83fd22dbd15">
+      <statement statement-id="cm-6.1_stmt" uuid="2f1e18cc-ae8a-42f4-b1af-e6941dd5209c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4551de61-8db5-440c-bfab-68c6bcb8968e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3160,10 +3160,10 @@ https://issues.redhat.com/browse/CMP-272
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd7e2ab4-e037-46b3-b964-3f0851b97d1b" control-id="cm-6.2">
+    <implemented-requirement uuid="b8faa8c5-efc3-4b7f-b2b5-49150b7f4cb3" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="2991e818-c756-454c-9206-3f2bac88ad13">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="37d71da3-0901-4300-8b60-9aae7ea2059a">
+      <statement statement-id="cm-6.2_stmt" uuid="e28040d1-74a7-461c-bba1-454098537f9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -3171,10 +3171,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39ccda5a-09f1-45bb-a327-be6c3b39e14b" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="30bfeeb0-ce2d-45f0-a3ba-212e76529531">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ae94a039-66a0-4a0e-be7f-4a8bd5399af1">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3183,8 +3183,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="05532207-9d24-4bff-8b66-8113839befe3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ce7913fa-d64f-4d9a-9956-67a5dcfd943d">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3194,10 +3194,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f19c1d7-d818-4edf-a7f5-db607acca809" control-id="cm-7.1">
+    <implemented-requirement uuid="681bbf04-881f-448a-b207-3183b7066a64" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="da984a4b-0b2b-4894-8f87-e0eca01189cc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a5f7c22c-59b9-42c1-a337-57b0b6936d58">
+      <statement statement-id="cm-7.1_stmt.a" uuid="712afed5-3de9-4f0b-a3cd-93267d37b136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3206,8 +3206,8 @@ https://issues.redhat.com/browse/CMP-274
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="b7039ce0-01fa-40e7-a253-fded3e380e3e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ae80cf9d-1baf-4309-b247-6c1d3bc58c8b">
+      <statement statement-id="cm-7.1_stmt.b" uuid="ec980658-104c-4e52-8631-2d923aff4c85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3217,10 +3217,10 @@ https://issues.redhat.com/browse/CMP-274
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="434090f4-6a25-4b9b-9cb1-9c47c9b5fe78" control-id="cm-7.2">
+    <implemented-requirement uuid="2045f042-6725-4305-b4d5-dfab9f16e180" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="771c06bd-50d8-4e1a-8181-9aadd1937a5b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="daafdcd7-d5cb-4c37-b6c6-a2ef8d6acfab">
+      <statement statement-id="cm-7.2_stmt" uuid="70ab7b0c-c1db-4c82-b9b6-f464a23a1371">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76bedc11-066b-41c5-b5b0-8b40dc36c3c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3230,10 +3230,10 @@ https://issues.redhat.com/browse/CMP-275
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="679fdd1c-a91c-4fb3-9cb4-62ef64936d61" control-id="cm-7.5">
+    <implemented-requirement uuid="afeb82d5-0753-4ca1-90fd-3866f47e1b51" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="bb7764a7-0c6f-40f5-92f5-fca1c165818d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2c2a76d8-260b-48ea-8a72-c09601aa68ea">
+      <statement statement-id="cm-7.5_stmt.a" uuid="664d44d4-5274-4bcf-b887-31cd4a5ac1d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3242,8 +3242,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="699cb34b-44b6-4867-90d7-e4095b164396">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7784ec10-0663-4918-95cd-0ef20b06efc5">
+      <statement statement-id="cm-7.5_stmt.b" uuid="76448ea7-3d83-415c-add0-9cb8a842af1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3252,8 +3252,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="e0c74a3a-ace9-4606-aaad-e5ecc0c5452c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="081ca13e-cfff-4567-9d83-b8fc7756faea">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3b3a6030-4ee2-4050-95a8-c28aaaa8e862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3263,10 +3263,10 @@ https://issues.redhat.com/browse/CMP-205
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd4e06bc-4bf2-40b8-82e1-11f1ab78c98e" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="62fe3b1a-2bd8-4488-991b-cd75f670b9cb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f246628c-2a49-4651-b368-0e5944c5ef86">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3275,8 +3275,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="26ccb05c-520a-4b83-8452-603c4e8a4195">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c5f69111-c0d6-408b-9fb0-17a4d0b37f27">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3286,10 +3286,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cd66726-373e-41bf-90a0-ec310156054c" control-id="cm-8.1">
+    <implemented-requirement uuid="a2d7594d-e346-4274-9265-d46540911822" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="3da9c6a7-3112-4553-ad3f-c9acfb2f6e45">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f92ab6ab-5951-482f-a049-10113241cfab">
+      <statement statement-id="cm-8.1_stmt" uuid="e8f890bc-f312-4f4a-b859-d8ae6b11b6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8df6da4e-b135-43b9-86fe-b966c8589097">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -3305,10 +3305,10 @@ https://docs.openshift.com/container-platform/latest/updating/updating-cluster-b
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2544b74a-e619-42be-9de0-7c305dcca711" control-id="cm-8.2">
+    <implemented-requirement uuid="efec02dc-a7f3-4c26-8c97-12a768d47a8d" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="bb4c7ae8-58be-44f9-b547-28181ed6db64">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2b46fcfb-8893-43d5-92ef-d86263732129">
+      <statement statement-id="cm-8.2_stmt" uuid="fbd5169e-c8cf-454c-b310-f9ceac64689b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96f30624-9ae0-4a5c-8987-728732b902c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3318,10 +3318,10 @@ https://issues.redhat.com/browse/CMP-279
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22027f74-843f-4554-807a-d386d2f44c87" control-id="cm-8.3">
+    <implemented-requirement uuid="9f65e091-76eb-4b8b-a90d-01dfcf2d492c" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="14b64a66-f612-4b44-abe9-36f56f315c78">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7077ba2c-550b-4461-89c9-c7ba55b328e5">
+      <statement statement-id="cm-8.3_stmt.a" uuid="23171812-48fa-443e-9266-3902cb35ff08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3330,8 +3330,8 @@ https://issues.redhat.com/browse/CMP-280
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="fa68e351-885d-44f7-b846-9a76b2e77813">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b5195f40-6518-4ca6-bbb7-098d439e2ffe">
+      <statement statement-id="cm-8.3_stmt.b" uuid="7af95e64-9f75-464f-86de-26378e862fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3341,10 +3341,10 @@ https://issues.redhat.com/browse/CMP-280
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4991b3c2-094b-4893-b6a9-34793201f6a2" control-id="cm-8.4">
+    <implemented-requirement uuid="2a381148-0d1e-4e09-8aa3-c41cab975bc7" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="49e6cbc4-7685-4bb9-b573-020cb5ac09bb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5e38374d-b7db-49ae-a693-ec65ec350529">
+      <statement statement-id="cm-8.4_stmt" uuid="8f5a344a-1454-4384-9495-be2be95a4d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="97dbd5a4-754d-4cf7-904c-9d2cb30e7cbe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include in the information system
 component inventory information, a means for identifying
@@ -3355,10 +3355,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30e772da-5a5e-4660-af58-2f06735b06e5" control-id="cm-8.5">
+    <implemented-requirement uuid="780e7ba5-4a78-4965-81d8-9c71e29ebf78" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="1a6e9b6e-13da-43be-8fd9-55854a6f646a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e8615b05-d414-4ecd-9794-81b0b0ff5981">
+      <statement statement-id="cm-8.5_stmt" uuid="6eeac808-579a-44c3-9352-f27062cf6e8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a48448e-2c01-444b-a600-69b4b418e96b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3368,34 +3368,34 @@ inventories is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cea4f2ae-8a8d-4d83-9423-7803f93aea38" control-id="cm-9">
+    <implemented-requirement uuid="d7a00663-3e5e-4e8b-8877-0fb65a72caf8" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="78d00f4f-3c4c-4cbb-8ab4-4d4a5c3128f1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5aa1f949-7e51-4152-be48-31868d16bd38">
+      <statement statement-id="cm-9_stmt.a" uuid="c8d7bf32-bf20-4b42-825e-34ad1f8bc208">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="7b1debc9-fe46-4671-be2b-18331183be97">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="57c9ef7c-25ba-4a67-8128-e7df2019f38c">
+      <statement statement-id="cm-9_stmt.b" uuid="c6a2b555-5b87-43e5-8651-921942b9802c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="f1627254-2c80-4862-ad90-181ee23ed172">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9e070b86-a78f-4c65-aea7-ff367a80aea3">
+      <statement statement-id="cm-9_stmt.c" uuid="dc022556-0ab1-49ea-96e0-a3154d2782ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="98ec100b-4c7d-4195-8261-cf7e6c036d99">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="370fb734-c243-44e4-b096-2a4539b4c704">
+      <statement statement-id="cm-9_stmt.d" uuid="65b2fc13-4a24-4ba9-9a60-56836e7aab0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -3403,10 +3403,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eaa1f114-a450-4d22-a7b0-f58d61572a2f" control-id="cm-10">
+    <implemented-requirement uuid="9c12e422-ddf6-49cd-bf9b-a80f8c950df9" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="68e14126-c65d-4fc3-a434-6a95e67ea9e7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="18dc6f90-68a0-470e-a641-b2eb8fc17c0a">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -3418,8 +3418,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="82a21005-8ed1-4ce4-9319-353014836e7d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="71d6078d-ac2f-491f-bb68-81738c87e851">
+      <statement statement-id="cm-10_stmt.b" uuid="c8349289-6521-426d-844c-0e559e03346a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1d08f7f-119c-402c-abdd-e35d81e70bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -3439,8 +3439,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="3b00a2bc-ad64-4ef9-81aa-42ecb7b64d3a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="200644c4-89c7-48b6-88bc-19f0f85a0e1d">
+      <statement statement-id="cm-10_stmt.c" uuid="6022e056-feb9-4aac-9ec7-aba2b09afb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33326b1d-2e3a-4939-b0d0-a6e9450910cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -3451,10 +3451,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed5250a9-7dc2-495f-b8d3-98b8e2df4cf1" control-id="cm-10.1">
+    <implemented-requirement uuid="c173a71e-b386-443e-9366-e07f879eddd6" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="d8086e94-e9e9-448f-b2cd-a8ee7af94019">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="eaf4fa24-4ac5-4b73-ad7a-06322848a8c4">
+      <statement statement-id="cm-10.1_stmt" uuid="081e3c31-2f63-42c8-bc82-d6a7f4ab4c40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="715d4079-67d7-4b59-bbdd-787d84c23cbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of CoreOS configuration.
@@ -3462,10 +3462,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc408c1d-2ea9-4273-be52-2d9ea9434af3" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="26dc8068-87a9-457a-b8bf-bc2d97c7d7cf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c78721f8-e77b-4033-b617-4138146376c7">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3474,8 +3474,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="77ac7a99-1229-4d54-976f-0acffc7dd29e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c1120893-8f2c-49da-8856-109c73be1302">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3484,8 +3484,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="ec7e0cbe-ae04-4047-bd52-e2bf1b0c7d11">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="090e727f-0000-4c4d-ad4d-8589a3974d59">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3495,10 +3495,10 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a46c5f9-a738-49aa-953a-ebd385d52a41" control-id="cm-11.1">
+    <implemented-requirement uuid="05674185-3d02-4342-9837-b98cbb249e81" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="9ab5f3ab-504f-4cf8-8bf6-d5a6c3d3c9f6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9db20809-802f-4d3a-8a42-789c1cf6938e">
+      <statement statement-id="cm-11.1_stmt" uuid="28d0535f-885c-4b5e-a73a-588c7cafa5ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677b360d-fb1d-4552-8436-63f7a3e58923">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3508,18 +3508,18 @@ https://issues.redhat.com/browse/CMP-286
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e955eb8-61e5-4a6e-bb55-ddb55017b771" control-id="cp-1">
+    <implemented-requirement uuid="6b7cbaac-f4e5-4b5d-b8da-9ff2bb76b9bf" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="94cbf588-5842-47e7-b14a-69e0635b8a81">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3a41eb50-37e5-4f3d-932c-bd272da7189f">
+      <statement statement-id="cp-1_stmt.a" uuid="736c1891-f977-46c2-9091-bab9684d3048">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e140afe-57d2-4aac-88d4-79901b4a865f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="04006199-51b6-4872-bc8b-eaa2a8aabc68">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0e314734-3a5e-41a9-bcc9-f53f8d5cbf48">
+      <statement statement-id="cp-1_stmt.b" uuid="dd8d1fb9-bab2-4fde-861e-72841defd393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f5be2e8-3159-42d9-bc1e-55f082d78b6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
@@ -3527,10 +3527,10 @@ policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="233f640b-3bb8-4646-be5d-0f6acfb587e4" control-id="cp-2">
+    <implemented-requirement uuid="d034a012-6d34-4314-ab52-aceb05eaf925" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="73639120-f4a6-4575-a902-66d55a86e6da">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0ad0a253-f12c-4a14-8149-15cc4ad33aad">
+      <statement statement-id="cp-2_stmt.a" uuid="fdf0a5ab-f5a6-400b-b075-28f6c336363e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6311f816-aacb-4ae0-b282-e50434f1c4fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
@@ -3543,24 +3543,24 @@ recover/restore the CoreOS environment.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="04c52907-bbf8-415a-abbb-70ee5c83e099">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8219fd30-ee16-4f98-a466-f66f84a21703">
+      <statement statement-id="cp-2_stmt.b" uuid="c59e57a0-cbea-4411-99d9-1aa73b612ae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89ac414a-5381-45ef-b0cc-cc44765ddd35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="35540aa8-9eac-4d11-b387-ac8e2a2bc3c8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="731d1596-06d1-49a8-9918-8ef248df762c">
+      <statement statement-id="cp-2_stmt.c" uuid="fddaa849-3a2e-44ea-9f56-6e4cb58d821e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3dfed86-0354-4cee-bd64-c9e95efb53b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="d91f0096-c9e1-4b83-9aed-3d443d1ea967">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ee984654-20ec-4de8-a17a-764d48fe3998">
+      <statement statement-id="cp-2_stmt.d" uuid="3f374816-464e-4d92-8abd-a5dd6f749d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="894ea615-37b9-491b-9931-d15976f6699a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3568,24 +3568,24 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="3d9f641c-ad86-479d-9ee0-1081a831fc97">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f54d5e38-64ca-4e30-a32b-ae8495c44eb7">
+      <statement statement-id="cp-2_stmt.e" uuid="0bf3cbd7-d938-4884-b955-a7b633590246">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713bcfda-0b2b-4126-8f25-2af62d934d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="df273a89-bafb-48c2-9b88-3fba200a3f8f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0585e515-6d29-4bb4-85f2-053202e8c93f">
+      <statement statement-id="cp-2_stmt.f" uuid="fb61d8de-1066-4bc5-b73e-8525be8784db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bc60506-ba79-48f9-9435-3be7baf7c1f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="7f6bc709-09a1-41d4-b788-27d9e9a22b55">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="207ae604-1bb9-428a-bb8b-82b3bf81fc4b">
+      <statement statement-id="cp-2_stmt.g" uuid="ac2fd90c-1cd4-426a-98d9-2676d772c4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a59dad64-7bd4-4dae-8bf1-aae9e7c99213">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of CoreOS configuration.
@@ -3593,10 +3593,10 @@ modification is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a998f122-fc6b-43f5-86ea-a9b94a00237c" control-id="cp-2.1">
+    <implemented-requirement uuid="76e31b3e-422b-4b82-b9d2-f4a67f9d600a" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="5c5e5d9a-4bfb-41ed-b637-e1b1e19ea43c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fdacc55c-7c2a-47d4-a6e5-d0dff073c4c0">
+      <statement statement-id="cp-2.1_stmt" uuid="89e94a31-2510-44d5-83ed-4dc2b10bada1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31507ba5-fe31-49ed-9ab6-c2df14e19b9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of CoreOS
@@ -3605,10 +3605,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="378bbc15-b082-468c-949f-ea3a44ddb817" control-id="cp-2.2">
+    <implemented-requirement uuid="3ed2435a-49e6-4337-a5b9-a29b86b28a6f" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="3493b0dd-3e23-423b-949a-e08fc486bff7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="badf025b-1db1-42c4-820b-d253e37216a5">
+      <statement statement-id="cp-2.2_stmt" uuid="6b6067de-bacf-4e09-a9b7-500366be488d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3616,10 +3616,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2da54822-a625-4cf6-ac76-9ea77b26b4e1" control-id="cp-2.3">
+    <implemented-requirement uuid="fb91b490-7180-4457-bdcc-09647f14c2f1" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="bb3d9ed2-1281-4a9d-bf7a-40027af0e374">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8e863fd8-0c52-45d5-8f59-b3a79ebd8935">
+      <statement statement-id="cp-2.3_stmt" uuid="f769faaf-5cac-4531-bdbb-0da941e084d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fd71d48-660e-4564-882f-a078daf7c212">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3628,10 +3628,10 @@ plan activation is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12092be4-f195-4d77-a29e-fe85dbd7eca8" control-id="cp-2.4">
+    <implemented-requirement uuid="ceb05831-bd98-47b3-a204-083adcac4772" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="3327d054-dcd0-4dff-8e5c-543bb992fd26">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c144cbbc-4306-4c64-b111-8116864839fb">
+      <statement statement-id="cp-2.4_stmt" uuid="41b39eb8-776f-46ee-8ecb-814fe2099d71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f94b089-4ddc-44a6-9a40-34d35125cffd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of all missions and business
 functions within an organization-defined time period of contingency
@@ -3640,10 +3640,10 @@ plan activation is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e429125-c92c-4701-9bc3-2b9946dcb7f1" control-id="cp-2.5">
+    <implemented-requirement uuid="12107313-c278-4667-aee9-76b6a641119e" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="5ceb89d3-bad2-403a-b42c-20866e18ebc5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4f6303c5-dc45-4f46-81d6-b0fc588a3696">
+      <statement statement-id="cp-2.5_stmt" uuid="227f156e-6370-4b6e-9ea1-df4507832618">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c0ce5fd-f5b1-46ca-9463-9fcee194eb80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the continuance of essential missions and business
 functions with little or no loss of operational continuity and
@@ -3654,10 +3654,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2973449f-c62a-48b1-ab4a-9f0b81a1e3c6" control-id="cp-2.8">
+    <implemented-requirement uuid="f326c1f7-fa6b-4276-b603-8e748d76da35" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="7759d150-e1b0-4a19-8158-ba06f5f3a6ca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="370e2acd-5011-4e46-8835-c52c357489c6">
+      <statement statement-id="cp-2.8_stmt" uuid="74972022-00ba-47b5-bd04-600889ca564e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3665,10 +3665,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed0bb8ca-97d4-470b-895a-706f8cd775d1" control-id="cp-3">
+    <implemented-requirement uuid="488f88e1-c977-4f8e-8141-c5a836717ece" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="716acca4-308a-416e-b2fa-75615e09b18e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="00bcc594-da1a-48ee-a2bd-c864d0845f13">
+      <statement statement-id="cp-3_stmt.a" uuid="2c42ff0e-d889-483a-b2d2-4397ce93462d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a78089aa-ea53-42d2-a550-c26f9fcc8430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3677,8 +3677,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="769aa4c2-05e7-4542-bdd8-4740cf9bfc54">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="30d3df13-2afd-49a9-9d84-7c444ad3b5d4">
+      <statement statement-id="cp-3_stmt.b" uuid="29caf479-ac35-4419-9258-542e1c304f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa849a2e-44d3-47e6-9c09-782b20ba7b55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3686,8 +3686,8 @@ system changes is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="42ec4235-ab51-4aca-b19e-ba1aeece3aa9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8ad757e7-2ea0-4565-84af-9dc053e0fc7d">
+      <statement statement-id="cp-3_stmt.c" uuid="df7614a3-07f1-41fa-8fd1-5180452355c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95f14aad-9eb2-4303-9431-064dea10fe80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3696,10 +3696,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0941133-861e-4628-9cd0-12c4a08ddbf3" control-id="cp-3.1">
+    <implemented-requirement uuid="74cfa29d-b988-4582-a9df-f73cfda4691d" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="c8c2203d-255f-43e9-891a-14720d70246d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ba2021aa-d4da-4a91-8036-11b693d96449">
+      <statement statement-id="cp-3.1_stmt" uuid="73a86d85-4f99-4862-9496-8d69c5d3df53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64fd89e5-52b3-4ac0-b67c-99e7502db54a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into contingency training to
 facilitate effective response by personnel in crisis
@@ -3708,10 +3708,10 @@ situations is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f1c2170-a9d3-4d2c-a6de-3f011c53fe6b" control-id="cp-4">
+    <implemented-requirement uuid="517d445e-c3d4-4768-b44d-58ca4bd6a85e" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="6dd82554-d209-4f68-8e50-acdeb2e2e79e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ddf50e78-0e65-488f-b3b9-b1df60862176">
+      <statement statement-id="cp-4_stmt.a" uuid="0f2d92d3-09ba-4cec-b823-860292845602">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ebb990c-8eec-43b6-9a6f-aedd77f38b03">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3721,16 +3721,16 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="5ed3fb08-ad04-4d2d-ac25-96faddc2d572">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="819b71e6-4edc-4e5c-81a9-f7b1ec4bf5ae">
+      <statement statement-id="cp-4_stmt.b" uuid="8adaf079-4ea5-4b02-b78c-e7ea33003a26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f81e51-fc2e-4416-b64a-1acdb36b3955">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="aec75d6c-5313-4261-92a1-ec0f85fe5ddf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6c7ba892-cd32-4974-8435-d19a6faf7779">
+      <statement statement-id="cp-4_stmt.c" uuid="875c27c1-f0ac-4098-8a7e-4004d3628197">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8c5099-a674-4a51-ae0a-c966d42b5eb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of CoreOS configuration.
@@ -3738,10 +3738,10 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aca08fbb-9e42-472e-a7b0-1a5dc60f9282" control-id="cp-4.1">
+    <implemented-requirement uuid="416b0954-8258-45cc-82c9-8fc43691803b" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="59954d75-e2ea-4204-a3dd-4f18cf5b5b5d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="95bbcb1d-b3ba-420e-8e65-47dd8030d586">
+      <statement statement-id="cp-4.1_stmt" uuid="25d8cd0e-5be4-4500-8de6-c79e71455802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca3f0332-70cc-435f-893b-09434e67e3e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3750,10 +3750,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be06e973-fb1d-4c98-87a7-a1c369e68e1a" control-id="cp-4.2">
+    <implemented-requirement uuid="d8db0383-d45e-407b-97a1-62e2f8361cea" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="8c4f56e5-3c28-486e-925d-06e29ba0122e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="27c62170-3b19-4ed5-a2d4-eff9f4f00052">
+      <statement statement-id="cp-4.2_stmt.a" uuid="71547964-437b-4dce-8027-00462a4cd5b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de20b161-ed57-4c7b-a462-62ae341b44df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to familiarize contingency personnel with the
@@ -3762,8 +3762,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="a8e63b10-537b-4c05-9281-cfbab2285172">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b29374d4-f1ab-4620-948f-d59e3a93c20f">
+      <statement statement-id="cp-4.2_stmt.b" uuid="fb2c3c26-6efa-4a15-b972-bb3c28c77955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31ea8334-630f-430d-b4c5-58bea2075f85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to evaluate the capabilities of the alternate
@@ -3773,10 +3773,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5c80fcb-3eca-4dda-ba7e-4ffbeba7efcc" control-id="cp-6">
+    <implemented-requirement uuid="33297ac0-084f-40a3-b153-ce70354c7a92" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="195e896d-2a40-4c10-acd2-588759738821">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8fa1df65-af61-4347-b9e7-1d085a1b67fd">
+      <statement statement-id="cp-6_stmt.a" uuid="dd11cfe1-d254-4ec6-83d4-8048405ff6a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a60899ec-f25d-4d3a-af83-9f8087f3e0ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3785,8 +3785,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="1f0e1384-71e8-405a-9737-f4f08b955736">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3c505469-86f4-4f3d-9e42-72ac230c5f65">
+      <statement statement-id="cp-6_stmt.b" uuid="4b3437e7-e571-4257-b64c-0ce829cce5a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b71d2c2-5537-432b-9e36-9777dcd03a81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3795,10 +3795,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="732f0ce2-1f0a-4e38-a7d7-db13fc0150e2" control-id="cp-6.1">
+    <implemented-requirement uuid="df0ab68d-d846-459a-b7ac-4a88cb89505c" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="cc870df0-fd5e-473e-85f6-22891ee77999">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7f7d537c-0689-4b82-a178-d931821f6fb6">
+      <statement statement-id="cp-6.1_stmt" uuid="d752dcd3-b144-4d5e-ac35-4a74910e9611">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec272e5d-cab0-457f-90c4-d7165704150f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3808,10 +3808,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac5e03ae-05e4-4950-bc3e-b00a76283a46" control-id="cp-6.2">
+    <implemented-requirement uuid="57e3f096-373b-4498-b52e-c47de9075fe9" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="fd03dfca-02b9-4e24-83b4-2bf6d3547349">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e25122de-e9ef-4a27-9ac9-e505e68827c7">
+      <statement statement-id="cp-6.2_stmt" uuid="184096f3-2054-426f-91e0-1ab71d5a38ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3819,10 +3819,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba7fdcc6-34c4-437f-b51a-8581d830f308" control-id="cp-6.3">
+    <implemented-requirement uuid="38ebc2e3-1b08-4426-ae2d-656753d8ab8f" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="d1637ef2-cd85-4850-8983-c65f03d9fb96">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f43ff433-e2f8-4301-bfd0-891fcfd686b8">
+      <statement statement-id="cp-6.3_stmt" uuid="dccbb24c-4283-4d45-9e2b-5e298773f298">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80398667-5529-4b3a-8b47-ee83d9b36a06">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3832,18 +3832,18 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0614b6a-7c59-4c88-ac77-324978063e3e" control-id="cp-7">
+    <implemented-requirement uuid="f3533d94-0f44-4e77-93c8-262555d091f8" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="d1a6606e-499d-49a8-aaf8-2815cc27e54a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ebfce79-9807-4230-9a84-bcd3c243248f">
+      <statement statement-id="cp-7_stmt.a" uuid="5e4fc735-6102-4035-8fde-65efe795d832">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="d7e5528c-7b28-45f9-a179-6fcdcc14e6e6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6ca70897-99a1-41af-9209-773be5974f05">
+      <statement statement-id="cp-7_stmt.b" uuid="23fa3af5-5217-4981-a4e4-c8757382338d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="796b4ab7-7086-44bd-91c4-71f84ff2dbb1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3857,8 +3857,8 @@ at the cluster layer and not the individual node layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="3531dd74-3f19-489b-9580-22c00fed2b85">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f2e64541-b52c-4138-90f4-49debc8a05dd">
+      <statement statement-id="cp-7_stmt.c" uuid="5535ed3f-0ec9-4d7f-a266-c6f0e703dfce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3866,10 +3866,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d224477f-29b7-4778-a123-ca1cf178f6cf" control-id="cp-7.1">
+    <implemented-requirement uuid="89a4466f-b3f9-44eb-9817-c61e81a20f0b" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="892a972b-c919-4fde-b8fb-dd7e0e737dad">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="17219103-abdc-4671-93e0-fd3d44761411">
+      <statement statement-id="cp-7.1_stmt" uuid="8cd8e19a-4ef5-4350-a97f-50b514d399af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92fa3087-2e66-40f7-9e85-be1aebe5593d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3879,10 +3879,10 @@ scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="268a83c2-068a-4600-a1aa-85b67cc70eda" control-id="cp-7.2">
+    <implemented-requirement uuid="31982630-30ec-492f-af62-1a8cf8b9080b" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="e62b88b5-e830-4679-a769-c0e773b5dc79">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2b64d85b-6cb6-4e08-a4c0-7cb51736ed4a">
+      <statement statement-id="cp-7.2_stmt" uuid="68e1370d-23d9-4f56-bf9a-74e5d4350d03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0022bced-9090-49a0-b688-4cbe1cdc8b49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3892,10 +3892,10 @@ actions is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f25d81f7-2312-4b7a-b36a-a28e43abad86" control-id="cp-7.3">
+    <implemented-requirement uuid="95024607-d422-4744-97f1-bf428b6302a5" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="3a9c24c6-119b-4185-989c-90f6224ed354">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7b6804b5-0741-47ae-90d1-72cc7fbedf7b">
+      <statement statement-id="cp-7.3_stmt" uuid="2b980aa7-a5b3-4a7f-95f1-b0795f186636">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc015b8b-2d3c-4b46-800c-4543db6ba705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3905,10 +3905,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29a61b60-9808-4a2c-abec-bdc4850f3ab5" control-id="cp-7.4">
+    <implemented-requirement uuid="d92f2030-0285-4322-910b-719c86176343" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="1bf7ee79-022b-45f6-ad6d-91607b808d41">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f71eb2db-193e-4e07-956d-7d758c0748d2">
+      <statement statement-id="cp-7.4_stmt" uuid="509d426f-141b-47b5-85c3-1cae72cca0ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3916,10 +3916,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cf57919-21b5-432d-bd58-f6f5c14bebdd" control-id="cp-8">
+    <implemented-requirement uuid="6b9ebaaa-84ea-45cd-a54c-948937c852d2" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="c503794d-0204-441b-ad42-4024059d8bb9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f3b35ab7-a776-402b-bbce-69c4d6192248">
+      <statement statement-id="cp-8_stmt" uuid="f613d871-454f-494a-8092-029a5492853f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09905f4-ff48-467e-9d97-71c24ff2b84a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of CoreOS configuration.
@@ -3927,10 +3927,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b7676b3-47be-46fc-9443-7548ddea80e4" control-id="cp-8.1">
+    <implemented-requirement uuid="7b53957e-e029-4474-953b-a95a8b404120" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="98639216-21fd-41b4-9cae-0892da1697a2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="466c24d0-29fc-49b6-b6e3-71537ccbac40">
+      <statement statement-id="cp-8.1_stmt.a" uuid="13ddf18c-ebf5-4b47-95af-89c0ffd448bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e486185-ab2a-4c88-b3b9-d6845c35e3eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3939,8 +3939,8 @@ time objectives) is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="dd2609b4-4284-488e-a4d2-4cefd0029796">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="447ffa7f-beee-4841-82e7-e37b4bf85299">
+      <statement statement-id="cp-8.1_stmt.b" uuid="e84ee943-311b-4036-ac62-d02b72d8426f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb0b5a84-2ab8-4b46-8fa6-80e6650de336">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3951,10 +3951,10 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67833989-21d2-4bf0-943e-e7bf9f36b6fe" control-id="cp-8.2">
+    <implemented-requirement uuid="6b7256fe-bee1-4794-8916-90b47c1e0928" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="677d14d5-73e6-4936-b67f-8ef45c3d99d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b5d8d5e6-cc01-43c7-82d4-5cf79ef6fe60">
+      <statement statement-id="cp-8.2_stmt" uuid="dae765e7-f3ee-4baa-9096-0d74b56e1edc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2197222-54c1-480c-8150-ed20a49092f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3964,10 +3964,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="618ac55d-a715-42a9-99e1-75ecf6a99e9b" control-id="cp-8.3">
+    <implemented-requirement uuid="c892ee18-7342-4b46-a3a1-d3e405ff6268" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="e111f635-a598-43f7-bc3b-7003d8da81ae">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b4b27763-3624-471b-91d4-0b0a62b69060">
+      <statement statement-id="cp-8.3_stmt" uuid="5fd353c8-d936-4da0-a645-3f5ce5880d6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0f081d7-187b-418c-a8dd-15cb2bdd60fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services from providers
 that are separated from primary service providers to reduce
@@ -3977,10 +3977,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d8dab33-0931-4d2e-bed4-fd6d07a9e672" control-id="cp-8.4">
+    <implemented-requirement uuid="d12574bf-6029-4538-a7e2-e4d9e140ca56" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt.a" uuid="e302a266-1252-416c-b317-47236d943dff">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="24f2464e-9a5a-4b2e-afbc-af2ad7c77a2e">
+      <statement statement-id="cp-8.4_stmt.a" uuid="55cec1bc-3e75-4913-878b-133d1d9b8c83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b44ef2-10e4-443b-8488-88903d550737">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring primary and alternate telecommunications service
 providers to have contingency plans is outside the scope
@@ -3988,8 +3988,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.b" uuid="4d0d1e25-a88f-4abf-90de-d54a839c0398">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3a617fbf-87a0-4b03-918a-589c4da7b6b8">
+      <statement statement-id="cp-8.4_stmt.b" uuid="b7a29674-c814-40b0-bd48-523a99151420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1a7b2a8-6db4-468f-81e5-3d855bc21f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing provider contingency plans to ensure that the plans
 meet organizational contingecny requirements is outside
@@ -3997,8 +3997,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.c" uuid="49006847-d230-4277-ab4d-4338254cc22c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4b936180-170e-4e56-8348-4c443eff7522">
+      <statement statement-id="cp-8.4_stmt.c" uuid="4f482c1b-ba45-486a-9107-e7c7e71e68ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e644b20-3438-4b6d-8e27-e52eb98b1083">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining evidence of contingency testing/training by providers
 at an organization-defined frequency is outside the scope
@@ -4007,10 +4007,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba11be2c-35f1-4861-957d-e079361457eb" control-id="cp-9">
+    <implemented-requirement uuid="d9ebf0a0-b779-4d30-93f6-19808ebc103d" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="a2d9df2d-9afd-4b52-99c7-cc3a01ea9577">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0beaf636-2376-4ed2-b177-5880ea01b178">
+      <statement statement-id="cp-9_stmt.a" uuid="e21640a8-ee15-4f40-8389-e389acc1d61f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd4b3b4f-ae69-4660-a361-fd28a230152b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -4042,8 +4042,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="26f77ad0-cf3d-465f-8c26-a96403f72c3c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ebb1e145-aa8f-4a09-86d2-73c770e1f452">
+      <statement statement-id="cp-9_stmt.b" uuid="cb59ca89-0a5e-48fd-9854-0a9a0146025d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac97c356-cb33-4444-a30a-6c8fe49e99e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -4074,8 +4074,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="6b3bc202-9292-49d3-a316-dfeae6b7289b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ea15b5b9-caee-4034-bdb8-389e6da7fb6e">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -4086,8 +4086,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="91c2f24c-f4d3-4e90-a5cf-54c353de5bf6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc759812-3060-4227-bed4-615a9ce381e9">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -4104,10 +4104,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e70cd559-f848-4ac2-be9a-070f8d7ccdbc" control-id="cp-9.1">
+    <implemented-requirement uuid="ae8590fe-2a3a-4b7e-9774-0f98d99dd544" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="5e224817-50b6-4424-a4f7-233832c33a6b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="77b5faa9-2321-4991-90c8-f9dcd1e0c46a">
+      <statement statement-id="cp-9.1_stmt" uuid="ee0d4d91-c0c9-46e0-b445-c6dd22e6699d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28e73fda-a022-4852-827b-63896f3573ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -4116,10 +4116,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbb700f0-c498-4f04-9dad-4d479f3b7723" control-id="cp-9.2">
+    <implemented-requirement uuid="beed14e5-9fe7-4843-96cd-13f050d7f29d" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="c910c196-5063-4129-870f-93884c1d86e5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ac22a496-0a3b-4336-befa-a7618867ff3d">
+      <statement statement-id="cp-9.2_stmt" uuid="197b8749-9b90-4d18-b628-d1af270aa6a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7767ca0e-d302-45c7-964a-1fb0ff2021e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -4129,10 +4129,10 @@ https://issues.redhat.com/browse/CMP-293
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afd39d73-93f7-4641-9a1a-4aa003aa71c9" control-id="cp-9.3">
+    <implemented-requirement uuid="5b918628-8ca2-4d46-9a7d-0138c8fc3ecc" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="9c22eae9-6e8c-49ff-a317-20aa90aeb454">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b34e24bf-837e-4bf9-8bfd-db124c091ddb">
+      <statement statement-id="cp-9.3_stmt" uuid="56d56000-5ec2-4fe0-800b-af68e3ac547d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d58df8b8-2c4e-4167-a21e-b29d6dcd1b2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -4142,10 +4142,10 @@ operational system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3454703c-6484-4f44-92a7-53c9b9e02c76" control-id="cp-9.5">
+    <implemented-requirement uuid="863d17a7-fcce-4439-8834-84fe42465bc7" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="c4aa48bc-2a1d-4f12-9806-a219326f6dc8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cd2926ff-3be9-4eab-996f-b863f5213aeb">
+      <statement statement-id="cp-9.5_stmt" uuid="33f02f54-0307-4787-a14a-064a107ca349">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4153,10 +4153,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d962603-c9e1-44c6-a342-53cdbd15ac6d" control-id="cp-10">
+    <implemented-requirement uuid="18c26625-857f-42e0-8fb0-0f7bb56e24c3" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="72fb21a6-4cb2-4df1-8ece-e57309ae2f23">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="af71fdec-df14-4011-b526-e92f6d0b8ae1">
+      <statement statement-id="cp-10_stmt" uuid="62aa28e1-61f6-45e3-97f8-a43ab7567c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="745a7e2b-3a65-4b5a-a6d0-712de9382982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their CoreOS environment. A successful control response will detail
@@ -4180,10 +4180,10 @@ https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-workin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34624514-2136-47f2-a1f8-db9a0b0e2b78" control-id="cp-10.2">
+    <implemented-requirement uuid="f38b682d-5a68-4e3a-93ea-77d208867808" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="a58506e0-0758-48dd-a19d-a3b8f1e405ac">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8551ab88-2e80-478e-86fa-b51d56924c1d">
+      <statement statement-id="cp-10.2_stmt" uuid="1e5bdebd-7dc2-4315-954d-3e911ac29edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4191,10 +4191,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da828a20-675f-4eb3-a9f3-c0bfbea40bf6" control-id="cp-10.4">
+    <implemented-requirement uuid="b3a13834-7f0e-4d08-a644-bb096e6adbb9" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="40acab4a-bc47-4def-8700-9647cf67cb13">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e2e46411-6c8d-403d-bb21-68e2dc36d16d">
+      <statement statement-id="cp-10.4_stmt" uuid="82de4f15-493b-4b9a-8aec-50193435726c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4202,18 +4202,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16a8ccab-c5db-4ec9-b4a8-0b04a38e7f17" control-id="ia-1">
+    <implemented-requirement uuid="9f4f8d15-4472-43c6-b214-95cc5a6d146d" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="1cf73e9d-9fd2-4802-a4f7-4256975d759d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="686d42dd-1fbd-4969-980b-630ce87c22cd">
+      <statement statement-id="ia-1_stmt.a" uuid="f7f6f54f-eff4-4350-83f4-3e39ae53dbde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31dd12f9-2bcf-4a34-8cf1-fb8174f72c65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="e94facda-85f3-428c-9bec-b854b579192d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="235cf403-0b83-4788-a716-230d271ee202">
+      <statement statement-id="ia-1_stmt.b" uuid="f8a8eb5a-6754-4d09-8a0f-776340c6a57c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91e2d7c9-6f39-4976-a809-edf8fc802309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
@@ -4221,10 +4221,10 @@ policy and procedures are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da6ac017-7ee0-4276-9a80-5eef9e2fe44a" control-id="ia-2">
+    <implemented-requirement uuid="6b49cd9e-d1de-4845-b766-89344094f9eb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="3bde7254-89e9-49ea-b0f6-ea3b2520a976">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cf3efd9b-af75-4e0e-ae1c-c5c91db41bf2">
+      <statement statement-id="ia-2_stmt" uuid="3ec41b83-c748-459f-a660-40c1a281aa5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb02e477-a99c-4084-9775-6f3863a4788d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4233,10 +4233,10 @@ https://issues.redhat.com/browse/CMP-299
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ca57499-64ec-4564-bda7-34d751e5a977" control-id="ia-2.1">
+    <implemented-requirement uuid="06fe78c5-0865-49a2-a9b3-3aa2aea4b826" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="a79be7da-5db6-48ea-a5f7-66734c33bd40">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4a07109b-02ea-46c3-b4be-db61f19816fd">
+      <statement statement-id="ia-2.1_stmt" uuid="715ccb15-6d68-4238-8949-8c78c50da9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d315b66-3eba-4daa-854c-b40d92188be4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4245,10 +4245,10 @@ https://issues.redhat.com/browse/CMP-300
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01ec0bba-db6a-4c28-9a50-f1a5ac080976" control-id="ia-2.2">
+    <implemented-requirement uuid="cda69d68-8b6b-4fdf-b072-09609b1b0ec6" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="f5250234-5d0b-4e29-b2c6-1cba8c68f6b1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e2001b85-c111-4edd-9bee-111327e916a3">
+      <statement statement-id="ia-2.2_stmt" uuid="d6814443-46ae-4d17-a8cc-01ea9e6849d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8432818b-50d6-4a81-8f5d-a8e5916c2ef2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4257,10 +4257,10 @@ https://issues.redhat.com/browse/CMP-301
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31cf87f0-8e87-43b5-ad26-b507e873f008" control-id="ia-2.3">
+    <implemented-requirement uuid="01aefa39-92dc-439d-9a23-bcf7d10adc0d" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="b0918786-7ed1-4009-a89c-93bb7fa4b5c9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6f9d48f2-20d0-4805-ae10-c04d1807b178">
+      <statement statement-id="ia-2.3_stmt" uuid="68e20929-077f-4a5c-b563-a734e2f77bfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a60cfd9a-f3d4-4b87-813e-c1cee5ad1f64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4269,10 +4269,10 @@ https://issues.redhat.com/browse/CMP-302
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ebb4e5b-4fab-4677-bfbe-47486c44df82" control-id="ia-2.4">
+    <implemented-requirement uuid="41b3a59e-fbb3-4579-8370-373c8069600d" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="93f1387f-6dfd-4641-a156-c8198dc42f47">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9fce5a51-4a84-4d70-b884-6d99210b6c82">
+      <statement statement-id="ia-2.4_stmt" uuid="57101488-3882-48c5-95b9-6664e579e4d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a90a1b57-e533-443e-931b-60bb53223305">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4281,10 +4281,10 @@ https://issues.redhat.com/browse/CMP-303
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d93a143-6a1b-4c63-b3ca-116dfd624df9" control-id="ia-2.5">
+    <implemented-requirement uuid="8b576bea-91dc-434e-a3dd-451691905a07" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="8f50003d-1f71-41d2-a2d3-00bd42370616">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="35983abc-ab33-4b8f-910a-46c734ffc150">
+      <statement statement-id="ia-2.5_stmt" uuid="3dac95ed-519e-469e-8c43-1a040edc12c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38e79e04-34ae-4195-ba94-11adbea2be7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4293,10 +4293,10 @@ https://issues.redhat.com/browse/CMP-314
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ceb4efd8-4c58-4a08-967d-cba7926d17e0" control-id="ia-2.8">
+    <implemented-requirement uuid="e9032379-595c-454f-9655-a039cf2da783" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="42c6e209-c559-45d9-b43f-184f6dee38b2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3a96fb9a-0b68-40db-922a-9eaa22ce2416">
+      <statement statement-id="ia-2.8_stmt" uuid="0ea245a9-5c70-4447-8309-f2540f413fab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ef864c-153d-4201-8a38-23145f5c511b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4305,10 +4305,10 @@ https://issues.redhat.com/browse/CMP-573
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="518cfa30-5068-4bd7-951e-cb6b9a8ade3c" control-id="ia-2.9">
+    <implemented-requirement uuid="98417dab-863b-452c-abb3-6acbb158aaee" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="d9f1c73a-3185-43a5-ab4e-d23eac182337">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="68871e0d-b25b-4bf1-b060-664bb3fe556d">
+      <statement statement-id="ia-2.9_stmt" uuid="d7dddc8a-8b4e-45c0-b32b-4b895bd297a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6a31d9c-ab6e-4bf0-87ba-b2e78fbda952">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4317,10 +4317,10 @@ https://issues.redhat.com/browse/CMP-574
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d52378e9-8458-4425-8501-c3b524830739" control-id="ia-2.11">
+    <implemented-requirement uuid="5f547165-2b45-4c90-9dff-9ad990c518f0" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="43786db6-feb3-4e9f-979a-41f8c903b203">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a8de1d81-8fcb-4c5d-9346-7d0b89d69d4b">
+      <statement statement-id="ia-2.11_stmt" uuid="89837ccf-f7a6-4485-b58c-bbb201bd918a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2d8bb037-fb37-48b2-98a7-f7e35dac16b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a separate device from the system
 gaining access to the information system using multifactor
@@ -4331,10 +4331,10 @@ guidance of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b599078c-c129-49c6-9ddf-9c93399a96c3" control-id="ia-2.12">
+    <implemented-requirement uuid="45d37aeb-8b02-455d-8ef9-95144b4575cd" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="642925f7-843b-4809-8e04-9c85d3dd3c0b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="208f28c7-d2c2-44a3-98c1-2406af540df8">
+      <statement statement-id="ia-2.12_stmt" uuid="539ceb70-a71b-4d6a-979b-85e42826c873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af00b192-2944-40f8-853a-96d85d52bfff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4343,44 +4343,44 @@ https://issues.redhat.com/browse/CMP-317
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bd802fb-cdac-4aa8-86e0-ab5a91b17c6e" control-id="ia-3">
+    <implemented-requirement uuid="391666d9-8c02-4fb0-9db4-7bdbc624b1a6" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="c305c5bf-56b2-49d7-80e6-7f394986674b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="51dcb90a-0e34-4b37-ae06-7b800ccc41a7">
+      <statement statement-id="ia-3_stmt" uuid="5491c3d4-3225-4f5a-9863-fc5337254439">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6842ae93-655f-493f-9929-c12d12ca06c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6b40939-5cae-438c-8529-d9c1e3469487" control-id="ia-4">
+    <implemented-requirement uuid="87aeed69-4e40-46a2-bb66-84611a0189a5" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="b4f68dfe-3ace-4df7-b675-2314708531b5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6195f59e-1b3d-42de-bccb-f223f25ae7f3">
+      <statement statement-id="ia-4_stmt.a" uuid="952ac5db-5177-457b-85a8-9d9982249390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="ebd67586-15c6-4725-878b-4ff95f795eb2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1886b403-7981-4a91-84e1-d8c9cc748904">
+      <statement statement-id="ia-4_stmt.b" uuid="3c0fee9c-0979-428d-b941-b161dc588fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="5e550881-2654-46bb-ae4b-3cbe1adde978">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="117da156-2e2a-4905-bb3d-9c760ec593cd">
+      <statement statement-id="ia-4_stmt.c" uuid="d9d158ca-544c-455a-9f9e-ff5c6016cf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="d9c08f6c-5655-4880-a9fc-82a1210531ed">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9453f045-ac94-4a7e-8e7e-7fb49777d254">
+      <statement statement-id="ia-4_stmt.d" uuid="b6dcd342-64d6-47ec-84fc-4204e11b1969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4388,8 +4388,8 @@ https://issues.redhat.com/browse/CMP-321
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="3bf8edda-fd79-4bb7-b09f-37f9a6038e4f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7694855a-9f83-4597-9c8c-f52e142a4283">
+      <statement statement-id="ia-4_stmt.e" uuid="6b0b3383-d354-418a-8882-a91c23fc4ee3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4398,10 +4398,10 @@ https://issues.redhat.com/browse/CMP-321
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87f0d636-4ac8-4969-b41d-ac68cf072781" control-id="ia-4.4">
+    <implemented-requirement uuid="90cb7590-8af3-480c-bc07-721ee7aa7274" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="81587fe2-8be1-4dc7-94e2-04fe3048f79b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5a6867bd-60f7-4541-9afc-d49a204544ef">
+      <statement statement-id="ia-4.4_stmt" uuid="468530a7-a640-40f8-98c8-1ac8aadf3af8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -4409,18 +4409,18 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c2957ff-9b68-4658-b043-1b94232ffbd5" control-id="ia-5">
+    <implemented-requirement uuid="625b4fbf-2c0f-40de-8a20-b0552f64ade7" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="d5449d72-cb75-462b-b84e-a95981b36308">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a52ae0ae-2905-4343-bc2b-8d622f5bc449">
+      <statement statement-id="ia-5_stmt.a" uuid="aa62b80a-2651-45e6-8edb-28d1a6f3a48a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="d3ad183e-d668-4937-9e7e-b59cc3808604">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="502d2582-81c0-4d1e-9525-17f0ae10e3b6">
+      <statement statement-id="ia-5_stmt.b" uuid="7675e20f-4a79-4710-8f04-6679de7375fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4428,8 +4428,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="0658956d-d475-489f-8e91-c58a5d9e60fd">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="95633dc1-ca31-45dd-9d5f-3e5255764a54">
+      <statement statement-id="ia-5_stmt.c" uuid="07ba01f2-7389-4b79-84a5-9c40775876ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4437,16 +4437,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="ac31b46f-c137-479b-8c27-52f8eb5f1532">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f4f47cc3-dbac-4d3a-a75b-9b75e3f93b6f">
+      <statement statement-id="ia-5_stmt.d" uuid="542ddcdb-4ae8-45c3-8989-df62a727aa1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="eaf23633-6a46-4d68-8acd-b87024c7da8c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7823579f-3ef1-4988-9fc6-aa7b3f8582ae">
+      <statement statement-id="ia-5_stmt.e" uuid="f68df002-5ba4-4afa-aff2-dfc5685ad985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4454,8 +4454,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="0b8342b5-db0f-46fe-9048-75e4a6199e77">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7752945e-8390-45f6-aed3-0619b6cc3b2b">
+      <statement statement-id="ia-5_stmt.f" uuid="f7a5edc3-8789-42db-851c-f426f31a409a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4463,8 +4463,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="5e21e5db-12c8-4d61-a12e-7db43b2ea5ad">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9ad4b459-32d6-4dea-8a77-2af3ebbd43a5">
+      <statement statement-id="ia-5_stmt.g" uuid="b3872af9-fcee-4b75-9358-556a7d9ce2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4472,8 +4472,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="484d1d92-3de9-4842-89a5-8940302f30f8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d5a9e2fa-825d-4e3c-884f-577f65d370a8">
+      <statement statement-id="ia-5_stmt.h" uuid="1dcef40a-162d-48a1-98f0-53af0391fea3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4481,16 +4481,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="e122412c-c346-41ba-b130-b66f2c0c6b15">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dba69494-d3b8-4012-96a6-95d80ab1beb4">
+      <statement statement-id="ia-5_stmt.i" uuid="61a23821-f7a5-4c42-a8cc-0757408fc66d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="bc123c2b-f354-49b7-9f32-41a8230dd1f2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5a2f4e6d-6856-49cc-b504-43a20c555949">
+      <statement statement-id="ia-5_stmt.j" uuid="b92999f4-4612-44aa-9fb5-c2ce1df52918">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -4498,18 +4498,18 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92897205-e983-44f7-8e4b-a6b5ed9dbcbb" control-id="ia-5.1">
+    <implemented-requirement uuid="267b5f9e-f797-48e4-bcf1-5a7368856bca" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="06a6a70d-dca3-4417-bc9e-ac73d793129e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="13dd71e2-8cf5-4db6-989e-319cfa83c738">
+      <statement statement-id="ia-5.1_stmt.a" uuid="a4b2d0a8-7ae3-4118-a638-349e3d20bc05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="2ec436ca-f10a-48f7-b223-3e7731fbb20e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="09a7a30e-7912-419d-a49e-c22f52e8daa4">
+      <statement statement-id="ia-5.1_stmt.b" uuid="b0da37b6-5cc5-4d12-be5e-d0ce97842b1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4517,8 +4517,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="c23957fe-cd80-42e4-9769-02d9249b1600">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8a5609b9-5d29-4971-9591-d40c7717ac81">
+      <statement statement-id="ia-5.1_stmt.c" uuid="6a4f689c-b3e4-4faf-92e3-0de9d5ea204c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4526,8 +4526,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="28b424d1-2ffb-42e4-ac35-9cc6c27b7374">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b0be9e5e-b4f2-462c-a655-bff964689600">
+      <statement statement-id="ia-5.1_stmt.d" uuid="57231353-874d-455f-b0bd-1505e1e147f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4535,8 +4535,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="030ccef9-b4bc-49d8-b600-b63ede1cce86">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d14789a9-9abe-4bbe-b626-94f63c24f0fa">
+      <statement statement-id="ia-5.1_stmt.e" uuid="ce80d2f9-98ff-4216-bfcf-b6166252988c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4544,8 +4544,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="d0eb1557-5001-4f8f-a4d5-2c8d17a48731">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8f952bb1-da4a-44b3-8044-0e3073491c22">
+      <statement statement-id="ia-5.1_stmt.f" uuid="661295ca-7fe0-430f-9037-d877834d4d69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4554,10 +4554,10 @@ https://issues.redhat.com/browse/CMP-326
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c80f6cd6-056a-4b6b-a5e3-981ee3723806" control-id="ia-5.2">
+    <implemented-requirement uuid="53ecdfe4-7be2-4032-b5e6-cfbaa729a623" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="588c26cc-8b2a-4076-ac5f-ef99acd6c29b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="26abdbd8-275e-4695-a261-6368fbeca8ed">
+      <statement statement-id="ia-5.2_stmt.a" uuid="be958084-3712-4395-bdaf-4836a9a54d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4565,8 +4565,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="cc620d6a-7be4-4489-951c-987a9e26f820">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9b2d11e1-c2ee-475a-bf80-7bbcfd26db95">
+      <statement statement-id="ia-5.2_stmt.b" uuid="4f8b15eb-4938-40e6-ae48-212a82ee9553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4574,8 +4574,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="d952d3c8-056b-4045-8e29-2d47bcff492d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="03f0c09d-bf98-4282-9881-4e29fdf89291">
+      <statement statement-id="ia-5.2_stmt.c" uuid="660a15ae-c1b2-4cb2-a069-eb5573697314">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4583,8 +4583,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="6958ed0c-1f59-4fd1-9304-35dd20c9d0c0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2976facd-2c65-4dec-bd51-ba75b92ea9c7">
+      <statement statement-id="ia-5.2_stmt.d" uuid="df341d82-0d74-4d70-80ce-21f428ed35d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4593,10 +4593,10 @@ https://issues.redhat.com/browse/CMP-327
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="026d60b2-f874-4c64-ac36-692e99ac93ca" control-id="ia-5.3">
+    <implemented-requirement uuid="ed758708-06af-4da3-8362-0d7fce322636" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="fd45e528-bb3a-4093-9a88-5bde39ce09eb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4d4e3c3e-6907-4e23-83e9-89d1eae0acf7">
+      <statement statement-id="ia-5.3_stmt" uuid="329144f8-0949-4774-8d3d-8b546f672be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9850fc6-cf99-4e75-996b-e78e4aac27a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4608,10 +4608,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="124a484a-4c68-40d6-acd1-3d02fc5400ee" control-id="ia-5.4">
+    <implemented-requirement uuid="fbe408c7-8881-4ca0-b798-339ad41eeacc" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="f95d1a24-a70b-4bd1-95a6-8892e049e0f8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8aec0194-a976-410d-b523-c1b3d60edec1">
+      <statement statement-id="ia-5.4_stmt" uuid="0bcbb011-c9de-47a1-9b92-43939b740541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b3bca23-1c65-465f-a165-dabb90601292">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4620,10 +4620,10 @@ https://issues.redhat.com/browse/CMP-328
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89242193-9961-4095-8c72-d3ec84e51f9f" control-id="ia-5.6">
+    <implemented-requirement uuid="b7985c2f-f691-4d9b-8891-94b62e98ba62" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="847bc584-e0a6-401c-84e9-3ca15e46fb19">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ab024ce9-23a5-4446-9342-e9785b105c06">
+      <statement statement-id="ia-5.6_stmt" uuid="84d41cc4-a843-43f0-9a2f-0c4fb6534eac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -4631,20 +4631,20 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="878b50cc-92aa-4d05-b87e-f738d8cc27e4" control-id="ia-5.7">
+    <implemented-requirement uuid="304428b1-71c3-47d2-af28-c26324880566" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="dce3798e-2c62-456f-a3f8-42e95ea041a7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="948091ee-cfc0-4b4d-af7f-ecf0d9b430d3">
+      <statement statement-id="ia-5.7_stmt" uuid="1a08af12-3f36-4c34-a57f-7e8c27084277">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ed29355-2781-4fef-9358-96e4908d46f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-5(7) is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36e095da-0791-4447-b463-f872cf5270a3" control-id="ia-5.8">
+    <implemented-requirement uuid="b68814c5-4df7-4129-a1d0-9b3c991e8f55" control-id="ia-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.8_stmt" uuid="054ad8e0-3d47-49f7-b047-2831fee5f74b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="510e5b50-4d40-459a-aa9c-3041a1f53d0d">
+      <statement statement-id="ia-5.8_stmt" uuid="bd885fdd-c5d0-49a4-82c4-8019aed0d952">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bdeddde-57ea-44bb-9f56-9c69f3402bff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational implementation of organization-defined security
 safeguards to manage the risk of compromise due to individuals having
@@ -4654,10 +4654,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c218075-b991-4ffa-970e-f177deba7d6e" control-id="ia-5.11">
+    <implemented-requirement uuid="8ab48681-5092-4b20-aa14-10f1981f3818" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="75719e51-620e-4a51-a35c-dc74f7d99cfd">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="adcca2f7-89c1-4eb3-91b0-d9a0553804ac">
+      <statement statement-id="ia-5.11_stmt" uuid="15842798-f01a-4905-b300-8cb508bd629f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a8092a5-66b2-4abb-b930-0f30f40f8ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -4666,10 +4666,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a40d7966-c7a1-4158-a12b-c04a6ec91068" control-id="ia-5.13">
+    <implemented-requirement uuid="f458e5b3-f5d1-4525-a06d-ff78061ad78a" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="96ac9bb2-fd8a-4a10-a446-669fa46d85cd">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2b52fbf9-b909-45aa-8da8-2af764b49e29">
+      <statement statement-id="ia-5.13_stmt" uuid="b38e9251-af29-4fb9-8265-edce569796fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62f01083-4ba0-4b64-9d01-9219d479324f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4678,10 +4678,10 @@ https://issues.redhat.com/browse/CMP-331
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38303d4a-07e8-4ee4-8810-dd421a1e7da8" control-id="ia-6">
+    <implemented-requirement uuid="865eebb3-b85c-4e9c-b0cd-dc5ce446cecf" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="87681943-c671-4098-9676-683df199bf34">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6f5e22b5-8469-46ca-a7c7-6bd133447c90">
+      <statement statement-id="ia-6_stmt" uuid="a6a61e98-b7e3-49ce-bf87-b19048f9bbb7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dfbef3f-9d21-43cf-ab83-b1fe5d6125fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4690,10 +4690,10 @@ https://issues.redhat.com/browse/CMP-333
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98b94384-0d01-47da-9905-8dc1d51bbac5" control-id="ia-7">
+    <implemented-requirement uuid="50b7752b-5f00-4d46-9cf1-1fc7adddbd8c" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="c287f402-5f53-4ff3-87c0-9d898d7b040a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="417c2b80-7953-4b56-bad2-dada29d7a12e">
+      <statement statement-id="ia-7_stmt" uuid="23d94d20-a397-4a53-8400-4d64686e6e26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4a15e2d-8d2b-46d0-a90b-6286705fe5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4702,20 +4702,20 @@ https://issues.redhat.com/browse/CMP-334
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36aae18e-14f2-43e5-b0ec-a3c646202406" control-id="ia-8">
+    <implemented-requirement uuid="ca731b60-3d8e-4540-94a0-027098462df6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="054b1288-0eb1-4159-bb0d-f58a148dfd94">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="148141e2-f32a-4213-a2b1-201f7e216c63">
+      <statement statement-id="ia-8_stmt" uuid="5dc8de3c-c093-46eb-9727-918ffb8a4603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5e23088-66e5-4637-ac25-c63231140c55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f064cfd-156b-4933-a614-7e788dc78233" control-id="ia-8.1">
+    <implemented-requirement uuid="9eba357a-02ce-4bca-b506-982efb5fb335" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="327fabc1-5069-43f0-98ef-2607dfbb6944">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="708a7cbf-74f1-499e-bd44-39bfc858e767">
+      <statement statement-id="ia-8.1_stmt" uuid="93bfaa19-1dd4-423d-ad9a-b73eb1b6e5f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9c5c9c5-e5d8-405a-b968-467718cf284c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4724,10 +4724,10 @@ https://issues.redhat.com/browse/CMP-370
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="749e8ad6-27a7-4951-bf43-2373174cf6ff" control-id="ia-8.2">
+    <implemented-requirement uuid="8f0564cd-efeb-4326-a6e3-67066fdd2952" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="f925c1f1-771c-4b9a-9457-9bd3d6a0ed82">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7916f5fd-bcb3-441d-a575-08d8a29344cb">
+      <statement statement-id="ia-8.2_stmt" uuid="6ad10106-b7fc-4ac3-99df-8664987a7afd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9e23f93-3c11-4119-b8fe-87a54aaa2f57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of CoreOS configuration.
@@ -4735,10 +4735,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1a00b41-6b29-4be3-92c1-90aa3a0efc74" control-id="ia-8.3">
+    <implemented-requirement uuid="f95af47a-ef4a-4f5a-8b74-330c4063104c" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="bc952c1b-3dcd-4adc-968c-25f1fa308a67">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fe994799-71c8-471b-b23b-b6ae01db25b8">
+      <statement statement-id="ia-8.3_stmt" uuid="3b8e8f20-e66b-46da-88d0-dea35b8f96ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fd1c869-9bf2-46d3-b6e7-ac4179f9757a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -4749,10 +4749,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6168259-59b9-499b-8408-f3a6d013b705" control-id="ia-8.4">
+    <implemented-requirement uuid="75184568-9d36-4b85-93da-89bd20786246" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="90459fa5-0b88-4894-be00-fdb12d5476d2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8bb6c2b4-e277-4e6d-92c4-8412d0d3dc2a">
+      <statement statement-id="ia-8.4_stmt" uuid="8b9a54e4-f379-4f74-9cbf-291acd9b7af7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75876a5b-6071-4a72-9c51-a8304a1ca69b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4761,10 +4761,10 @@ https://issues.redhat.com/browse/CMP-335
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2032edd-197a-4f62-8cbc-ffc69e17f9ed" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="6f3c56be-3edb-4e5c-a9ab-9a20a95d5853">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c9ca7f01-d521-4692-9d7e-b5b22528db9a">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4772,10 +4772,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0078787e-4479-4f98-9afb-56864ab2ff00" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="9cccff0c-f179-476b-b8c1-15c3deb90570">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="448d1aa1-cf30-4a59-9c97-b394b3d8f724">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4783,10 +4783,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bfb3fc6-9cb8-4050-ab37-633ee4532d49" control-id="ir-2.1">
+    <implemented-requirement uuid="78d7845f-de00-4c63-bd97-4e0839f3f0a2" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="9fdd97c4-d10a-4d08-ad2c-c462f662d984">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="84ca7cfc-68f8-4018-a8e6-06926bcd864e">
+      <statement statement-id="ir-2.1_stmt" uuid="2a2123c8-220a-4661-8f26-18515e8eb566">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4794,10 +4794,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9b2b243-49af-49d1-a375-a43ecd9bc7a5" control-id="ir-2.2">
+    <implemented-requirement uuid="246aa74d-9372-4467-ac4e-954bae434f90" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="12a22281-9c2f-4d29-bde1-1fb1bd746aae">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="990ad287-260b-453c-9929-9cc471d9e5cf">
+      <statement statement-id="ir-2.2_stmt" uuid="f3b8f0bb-f626-43e6-9afa-be7e82b405e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4805,10 +4805,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e318789-0698-4f5b-b8de-e0f13f85d116" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="78355c75-32e0-4da4-8dde-5bbef51fce13">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1762f94b-b1fc-434a-90c2-3321a3211142">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4816,10 +4816,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fd2ce2b-2bf2-4da6-b231-72aececc7264" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="a7d464ab-4ebc-4263-896a-77c520fd30d5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="eefbb13e-e666-41b7-bcce-5ccc71d1dd30">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4827,10 +4827,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1975ad0f-1f25-430e-99ed-dc3b62e5968d" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="093ab264-0e8c-43f4-bdc8-e6e8bbf74cc7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="86aa9a52-5667-4ad6-978e-b4dc577cb352">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4838,10 +4838,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26ecedaa-dd81-4dd7-a11f-9dd054c1216d" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="a71694a5-d61c-4e2f-92ea-805642622b7c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="05351dce-337b-4dc1-856d-0748cf1f6b19">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4849,10 +4849,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf948bdb-e9c6-445e-8ba1-6b448f365b5f" control-id="ir-4.2">
+    <implemented-requirement uuid="7f0a3982-d079-4924-b580-f0dc1d216e85" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="2a00c3d1-9db8-4528-8b81-a117a9926b38">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1392a02f-e332-45ae-bc42-5751464af504">
+      <statement statement-id="ir-4.2_stmt" uuid="9c563bcc-5237-449c-a4ab-d3b700a97da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4860,10 +4860,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b5fc320-c2b1-4dbb-882a-feb3e376267a" control-id="ir-4.3">
+    <implemented-requirement uuid="13b97b42-76d6-4061-b638-febe0cd90231" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="745de79b-3313-4f01-8b35-34e672fb596c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1d3f2cd8-990d-459c-b0f6-fc4611d03b5f">
+      <statement statement-id="ir-4.3_stmt" uuid="5e0e6990-1ff8-49bf-be0d-5d2737ce63e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4871,10 +4871,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c7aef7c-ae64-425b-a709-7272990da786" control-id="ir-4.4">
+    <implemented-requirement uuid="3f7d2d28-2608-42b5-be50-8da2df81d87f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="96df098d-d094-4b28-80ec-a62d151f8104">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3ded24b9-809f-4b99-aac1-7be75decedd8">
+      <statement statement-id="ir-4.4_stmt" uuid="ac63043c-31bb-4d93-b0da-40a829860d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4882,10 +4882,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb881b0c-7f6f-4a64-8262-f531cf0c9c5c" control-id="ir-4.6">
+    <implemented-requirement uuid="37e8a5cc-59e9-4a7c-9bdb-cbeee02214ca" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="7434c295-3d4c-4473-ac18-c7eab1158c5a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc761023-1a40-4f3a-9a8b-4043e1c1e258">
+      <statement statement-id="ir-4.6_stmt" uuid="7ef8f800-1279-4b68-9615-3565349db7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4893,10 +4893,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88d8c4ef-286f-4763-843c-434afd59a4db" control-id="ir-4.8">
+    <implemented-requirement uuid="4e72b7dc-4243-419a-8f07-49afa8e6bb71" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="77e59f65-b8f0-4b05-b852-47a1898ceec8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cf9f368e-6da8-4c7b-9b55-a3b163ab505b">
+      <statement statement-id="ir-4.8_stmt" uuid="eeea2ede-129f-4055-8e4e-5f5514fae167">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4904,10 +4904,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1d473de-c7e9-428a-a5ef-a6facc27327e" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="c8e1b04f-370c-4509-9366-e65d52445ea0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1304de2d-d0b2-4b8e-8017-eca8f7803716">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4915,10 +4915,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b152d48-7d0f-4790-8040-080c35565d0d" control-id="ir-5.1">
+    <implemented-requirement uuid="6d97e9c2-2cde-4770-915c-0fb3374028bf" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="b5470955-aa6e-45da-bf32-cd2466c243f7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="45970279-91a9-4c04-b009-fe756e26928a">
+      <statement statement-id="ir-5.1_stmt" uuid="555bebe2-f2d2-489a-99b8-98b462646d4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4926,10 +4926,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f652c983-7d18-4092-933e-0bf7b426a97a" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="223814f9-6106-4f9e-8e46-c065c6c8c51c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="32983d62-23da-4e9c-a71b-fe2f08e8dadb">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4937,10 +4937,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdfc7151-ac95-4963-b8d9-dcc7563f455e" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="121ad200-1b46-485b-b281-274d2b7c1791">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e8ccbbd4-fdd4-42d5-afb2-36c6f2c9d41f">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4948,10 +4948,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8e7944a-7c00-4e79-a391-2a43f806af42" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="5cb09dae-e46c-46cf-8767-9a9ac41778a7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7d26f3b0-f0ab-438d-98f1-cbfdfef3b56a">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4959,10 +4959,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f5fe34b-da8b-44cb-a5e4-2e1d5bd6ab6e" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="afdf39e6-6450-4c75-81d1-ae7853b6736d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2592916a-c33e-437c-9e00-c3d29081377e">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4970,10 +4970,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00284f36-14d7-4641-aacb-430eac84e3d2" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="bc2565d6-8f85-4463-b512-5ccf039ff9db">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5a90ea27-c112-4a1d-95f5-b25ce066e32c">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4981,10 +4981,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92b1bc35-5ea4-46ee-8c35-5d25c48d81f2" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="7bc05177-7185-47f7-886b-05eff2587b66">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4cc24e0d-d65e-474d-8660-e3cec0853ada">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4992,10 +4992,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a11878b9-7964-46bc-a83f-1a05f422a0fc" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="e4880d1c-fc76-4f2d-8289-c94fb62e2010">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1f7e3ffc-7a6a-4cd8-9483-6c41f7333d08">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5003,10 +5003,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39a9993c-f991-4b8f-87dc-b836d2adf7f6" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="3cf56e46-bf2d-44da-b79f-aebedd093797">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8bc0727c-71ac-47f7-9299-7f35da1096e0">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5014,10 +5014,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41ee6470-480f-49c3-85f5-bb0bc593d0d9" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="9c77d236-09d8-4271-8ab1-7c0f2b05a0f8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e6cd0e93-8bb0-4951-a59c-270d6008b73e">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5025,10 +5025,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0b1c4a3-b56d-4e16-8eaa-d0880fb89eee" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="8acf1d2e-8ade-46f1-8834-acf121625dee">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3bb4e929-fcc0-4cea-b321-6743f145667d">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5036,10 +5036,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d416b521-f7fe-41c2-a99a-853ed0398995" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="96ce07d9-8741-4021-8add-f884289f3c6a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6fa82800-391c-402c-9695-e8767ec8454b">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5047,69 +5047,18 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b966a952-52c6-4cb8-8c49-914dc9b4d9a3" control-id="ma-1">
+    <implemented-requirement uuid="50b14c60-c01d-4085-a382-fa457b35fd61" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="fbabab86-4fa8-467e-9850-2d2d03b36919">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f8d21868-6189-443f-b975-8d8d0e92608d">
+      <statement statement-id="ma-1_stmt.a" uuid="b6f304cf-f3d9-47d0-8518-a57d506847f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="b663ad9a-563d-4565-8a1c-e1cf1016410c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1bbaad6d-f0fa-40e9-9233-51e3b2887575">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1aa38749-baf2-4892-8bc9-87d3532ccaec" control-id="ma-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="b3619ba0-8029-4dc9-997e-d16658c3b22e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c751df0c-ede7-404d-b8a8-b8194c7048be">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="d76cb663-d1fe-4114-aeb9-ebe09e177a6e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8971bf70-7c0e-4841-8282-68c39df3e183">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="fa26107e-e93b-4609-9ae1-17573f4c1dec">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="35ea5813-ab7d-4708-9dbd-3d48bd82b092">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="eaa1bab9-9791-4d65-bfc3-ad7b54f680de">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8b256f27-306b-4dba-988c-b6145f22c5de">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="9014ed15-af12-4601-87c7-7b87a9bff5b3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4dfdef83-0646-4361-bef9-6ca589c8c8d9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="45e2d0de-4599-4f13-8b3d-4ccad8e70ad5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fa869ef7-a9f6-4f87-8c18-13d5b2fed11a">
+      <statement statement-id="ma-1_stmt.b" uuid="71cbcfa2-f0dd-4327-9039-3bed09db8ad7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5117,10 +5066,61 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6dd7596-c18e-4f4f-bec9-bb0a0c026ad7" control-id="ma-2.2">
+    <implemented-requirement uuid="7f9d8c44-fd37-4b6e-b97f-73ad22f8bbf1" control-id="ma-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ma-2_stmt.a" uuid="9126811a-76df-449c-abf7-e0430a8b6464">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.b" uuid="11e3771e-3161-49c6-b9e7-b28e08121dae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.c" uuid="789faac6-28dd-454f-9f45-f4fd86906164">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.d" uuid="50d4caae-391a-4c9a-be44-1f7740100c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.e" uuid="d6374385-f18e-494f-9c78-5b28c007825f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.f" uuid="98d0fbb6-3723-4fbf-9375-d4060f218d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="32ff53c2-e820-4f97-a568-c9d06222273f" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="eb8440dd-cced-4f13-b2ca-cbd4f146234d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d0e2eeda-7c53-4c95-8ed8-b0b615abb888">
+      <statement statement-id="ma-2.2_stmt.a" uuid="40691090-1a06-4ca9-baa8-eb1a08ac07fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="840ac7ae-8951-4ac5-90ae-23b9db3ae518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5128,8 +5128,8 @@ https://issues.redhat.com/browse/CMP-341
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="5b384a2b-d432-4dc4-939b-0d90bf0ef304">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="de26c1df-764f-455e-9ca1-2304df349852">
+      <statement statement-id="ma-2.2_stmt.b" uuid="74cb7095-d4cd-4af9-802a-df57ac04233c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="840ac7ae-8951-4ac5-90ae-23b9db3ae518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5138,10 +5138,10 @@ https://issues.redhat.com/browse/CMP-341
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5c3b254-a614-441f-b676-5661b55aa22d" control-id="ma-3">
+    <implemented-requirement uuid="be52b005-e2ff-479d-94a6-a6e188d751ec" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="63e33f08-edb1-4d30-a349-05b569e66c4e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9b6ffcbd-7efc-4b16-9e63-62612d2efb74">
+      <statement statement-id="ma-3_stmt" uuid="dd03bb5b-d84f-489b-b97d-e98e991a6b75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5149,10 +5149,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d89a4ed-c076-4bb9-a7be-7f56212aefea" control-id="ma-3.1">
+    <implemented-requirement uuid="c522921d-0e04-4791-801f-dd09b4e463d1" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="c2de9da9-b5f2-49d4-948d-cc0c62ee9d9e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="844a1ef9-c231-47ad-8ff1-75b689eb0652">
+      <statement statement-id="ma-3.1_stmt" uuid="f0558790-7ff1-4071-af13-7c6d1eec9a1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5160,10 +5160,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68f1b2a1-cd79-4e9b-a6ce-7fbd8f525582" control-id="ma-3.2">
+    <implemented-requirement uuid="4379d187-09be-456c-83c4-b0484cc43e9a" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="837cf43d-a54c-4894-9370-77a4b8ea09ca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a2a15b19-c1a4-4ce0-857a-8ba7d8b923a8">
+      <statement statement-id="ma-3.2_stmt" uuid="237ab4d2-5f79-49e9-875d-5b8e724a98d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91c9aa24-7bab-456f-b192-2b42502e6917">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -5172,10 +5172,10 @@ system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c221583-0db3-4903-9daf-9ebc37f721dc" control-id="ma-3.3">
+    <implemented-requirement uuid="12e93686-78ba-4c88-ac0d-e38065b6b708" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="83a1cd0e-9173-41f0-8286-ad2f3bb6df66">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ccc70468-6b8c-4640-acdb-12036981d72a">
+      <statement statement-id="ma-3.3_stmt.a" uuid="9655b3fc-abdc-4b78-8572-c65edffd9d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a6bb18f-ddd2-4f22-bb5c-a486938a6f4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -5184,8 +5184,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="43c1ddf2-fee3-405e-bea0-cb879bc57a64">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f4632ed2-34fb-4cb7-a4ed-d3460b18a972">
+      <statement statement-id="ma-3.3_stmt.b" uuid="841bee45-cb0d-44c6-ae9c-cc2dbd74ec38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="85ed37c7-1058-4173-98be-68e27ffa7c68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -5193,8 +5193,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="5a246b9f-d494-4b1f-932b-b950a6543fd2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16f74405-974a-462e-ae5d-cfd5df32dc19">
+      <statement statement-id="ma-3.3_stmt.c" uuid="f7878744-e864-465e-9d0d-5d2c375062fc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f66a31d7-b889-4ea9-a2ee-6eaad43683bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -5202,8 +5202,8 @@ facility is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="6445371f-c209-4b03-a2ec-3753afb8daef">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16ae3577-123b-4628-abae-f6afa1d7ee6a">
+      <statement statement-id="ma-3.3_stmt.d" uuid="325407f8-d9e2-4643-be05-210fde8809e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc35676f-af48-4e0f-94f0-fee75f18899c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -5214,18 +5214,18 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da2f1b03-f008-48d6-9903-73299cf83d2a" control-id="ma-4">
+    <implemented-requirement uuid="e38aef0b-901e-4933-b193-830da092e215" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="61fbdfb7-b351-4b65-a32f-a50d6c4015f7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fd53d15d-c0df-442e-88d6-890bcdaeca56">
+      <statement statement-id="ma-4_stmt.a" uuid="9b4fa041-4366-499f-9dbe-aca03562a942">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70acaca1-c029-4a48-b6c6-a29275ac6879">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="500f9a90-952c-4b24-a311-791ab385a063">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5592e55c-60e2-4784-be77-c5592178224e">
+      <statement statement-id="ma-4_stmt.b" uuid="68f4a8bd-5e99-4f80-9089-45a252290af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e635f2e0-b395-48f6-832b-d60922bbc7a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -5233,8 +5233,8 @@ orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="c1d28e7a-78bd-4939-bc5a-4bc9577a4a38">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f9856cc1-48f9-4ca5-abeb-a3774137160a">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5242,16 +5242,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="ee414026-5db1-45cf-8965-b40a51d0bcd6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c8bddfa5-14bf-4d68-9980-ef65fb9b4e96">
+      <statement statement-id="ma-4_stmt.d" uuid="ef043a60-760f-4c9e-864c-01dcea2b9f93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18daba6d-0a0e-4309-846f-cbc8a83b60fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="95bff608-1948-44d1-ace9-8f853b73d3ec">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="46528706-cfc6-4d68-a744-7178594d9cb4">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5260,10 +5260,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="645ff89a-ec4d-421f-a637-33f55ec1d09c" control-id="ma-4.2">
+    <implemented-requirement uuid="477eb849-5756-413c-b539-913cd96296c1" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="834470cf-2609-443a-81a4-d6674db5f28e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="27786720-40cc-4018-920b-3e142f3e6aa9">
+      <statement statement-id="ma-4.2_stmt" uuid="2f10933f-a75c-46ce-adb8-3a12ecdbc5ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5271,18 +5271,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39b51b18-1512-4265-ab40-d17ad85d1215" control-id="ma-4.3">
+    <implemented-requirement uuid="4df7c8dc-6e83-434a-81bf-661400de6cb3" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="127887af-f872-4681-98ba-a570c9dd3706">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6a922d39-b421-4041-9b05-3369c7d04fed">
+      <statement statement-id="ma-4.3_stmt.a" uuid="6133aa82-dc0b-47f7-ae09-5e38138f75ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="a4b60694-c4f9-4463-a662-e1937f308117">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d602ca05-65b1-4dca-89db-2b02d9ba5823">
+      <statement statement-id="ma-4.3_stmt.b" uuid="36add7bf-8160-4df6-af3e-6997a1074938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2726f156-7a73-4fdf-a9d6-46d670ad0a17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5291,10 +5291,10 @@ https://issues.redhat.com/browse/CMP-371
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09bec0c9-4fda-43aa-879e-08310d32ea29" control-id="ma-4.6">
+    <implemented-requirement uuid="79fe8c81-dabe-4866-98ae-c330540ca036" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="8a8cafe6-a899-4bfb-a5ab-c0411af19363">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d65598c4-d49a-45da-bbbe-87fc57046ea0">
+      <statement statement-id="ma-4.6_stmt" uuid="4f07b841-19b9-4f3a-8202-e5df6fb84798">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26d1954d-0b65-4aaa-9294-05774d80dd67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5303,10 +5303,10 @@ https://issues.redhat.com/browse/CMP-346
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a8b01497-fb06-4db2-bd63-ea4351fd3023" control-id="ma-5">
+    <implemented-requirement uuid="60cf192b-4c54-49e4-9491-0ba3a68e05cb" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="d9b4ac9d-ae2b-4643-8aec-c1a91ebc60ca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7bb6b517-c403-4058-9ac5-79e6aa539231">
+      <statement statement-id="ma-5_stmt.a" uuid="2aeae088-c7e3-41c5-87da-95515fbf80c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4643d896-4c18-4a1f-8e5f-2fc5e15b8728">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -5314,8 +5314,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="563b4c82-9b38-4f03-89a4-253bcc953d8c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a35bcfa5-43a1-4fb1-85e1-0fedc3341d8e">
+      <statement statement-id="ma-5_stmt.b" uuid="fc9cdbb1-004e-4786-8dab-904941239160">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fd5cf2e-d52c-4bab-afb4-912b678f8e60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -5323,8 +5323,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="aed28921-7f27-40c7-a438-723619dbdd0f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f26902da-fc3d-41c8-90e3-bcf8b0889055">
+      <statement statement-id="ma-5_stmt.c" uuid="1bc8381b-03f5-4434-9f66-8a0d45a42c2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31a876f0-3b3b-446b-800b-b65e77a928e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5335,10 +5335,10 @@ scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="947ad81e-f67f-4b09-9a4f-776899c30cea" control-id="ma-5.1">
+    <implemented-requirement uuid="a407480d-7ff0-4fff-ad65-2dc4961feeb7" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="5fc00142-791c-467f-94fc-204b83fe4436">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="74a94918-6c81-40af-a796-c2a5e74150be">
+      <statement statement-id="ma-5.1_stmt.a" uuid="c78267aa-b035-45d0-8b1f-afd653caa783">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e76c9677-6fe2-4e40-835e-8d94057b7ce2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -5346,8 +5346,8 @@ citizens is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="316dfc35-4fd0-45b8-ba80-53a3ff8621b3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ccaf6b11-35bc-4027-9f56-0a8cfaf8bf44">
+      <statement statement-id="ma-5.1_stmt.b" uuid="dfc4e419-5d32-46c2-ad2c-edc3e5768bcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fea33215-9f04-494e-ad08-e870fa9a747f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5357,10 +5357,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4e066a6-d2e1-404c-b6d9-714e3503766b" control-id="ma-6">
+    <implemented-requirement uuid="b76ac05d-9b0a-45c0-b761-e5703e10d170" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="202ba056-103f-4ef5-b98b-727dd627d603">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5b414a0c-ec6d-4998-a89a-33e140f4a742">
+      <statement statement-id="ma-6_stmt" uuid="8ee4443f-6c07-41fb-a14a-8e96c70a6ab1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5368,18 +5368,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07abef33-d7b6-4362-bb89-08c7d2f0c547" control-id="mp-1">
+    <implemented-requirement uuid="db6de972-7474-4a78-928c-103473959819" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="d55ca07c-4486-4bb7-a4cd-ae2b600cdff6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="59ac85e0-8b6c-4409-b037-b47d4f780df2">
+      <statement statement-id="mp-1_stmt.a" uuid="323ea68c-9123-4ded-865b-111d13e5bc8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="6bf4dcca-9729-4769-9ca2-49a168c9914b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc936342-f8c1-4893-bc19-2a06e1a470f8">
+      <statement statement-id="mp-1_stmt.b" uuid="0097f982-adc9-42f4-a94f-7ad598d57f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5387,28 +5387,28 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="829d7fc2-5eda-45b8-ab9e-08b87f881f96" control-id="mp-2">
+    <implemented-requirement uuid="98250c5d-4122-4fae-8c8e-5a991dfb578c" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="9308208b-0a03-46fa-b243-b027897c9e8a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7855b8bd-c161-4663-b6c7-322a7c83e257">
+      <statement statement-id="mp-2_stmt" uuid="0e13fba7-27c8-4803-9ec4-8677e06d9587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7269cbb0-98b1-4d75-922d-1f6b6cfb1f78" control-id="mp-3">
+    <implemented-requirement uuid="025a8033-119c-45f0-91f1-8edc6c28faf2" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="f8732907-f62b-4990-a30c-c02b31b79421">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="543df57d-3137-4d2e-91e4-22b1f83c1d14">
+      <statement statement-id="mp-3_stmt.a" uuid="0d3c80ed-ff0a-4ed9-9950-e71d07a65278">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="db518ed9-b917-450e-8676-faf0262c0c91">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="13ec0c07-06a3-49c9-bc12-65ebba7b458e">
+      <statement statement-id="mp-3_stmt.b" uuid="bc2e6de5-0c28-4a15-8fa1-63f0886effd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5416,18 +5416,18 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad048d9c-4d2c-4c73-a575-c25ebd7b6e61" control-id="mp-4">
+    <implemented-requirement uuid="1af33049-40aa-4604-827f-bf30ad77d2ba" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="0435eb76-3763-433f-9afb-d9c62e75406d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="46f5eb2b-a554-46a7-82c5-29f3239b9517">
+      <statement statement-id="mp-4_stmt.a" uuid="1c91c49e-c2d4-4a51-b312-0f1e9797a955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="72b89ec5-854e-4d7e-9572-a5c9498c7291">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="43a41ff4-f7aa-4ea9-8d47-312c3df32a91">
+      <statement statement-id="mp-4_stmt.b" uuid="1afe60cc-bcaf-47e1-8fb0-3f2a7622b7a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5435,34 +5435,34 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d132b856-e0c3-4d97-a03c-3aba452c6a6c" control-id="mp-5">
+    <implemented-requirement uuid="769abcc8-05b7-489a-b785-f9e42ad6f9ee" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="1479d2e3-c632-433a-9c03-c5c990bdec72">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4c0213ff-cf69-4d44-b8ed-bb91e34c1d0a">
+      <statement statement-id="mp-5_stmt.a" uuid="eedb4e7a-1800-4f97-9c36-e3dc66c21501">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="706badb6-49c1-40b4-a468-9ee4093e173f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="af04ee68-4128-4180-b218-d87ea2dbbf90">
+      <statement statement-id="mp-5_stmt.b" uuid="b54b9175-1652-46ba-b64b-2957dac00e07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="73a4300f-8453-405b-9cac-86699e07cab2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1838725e-4b44-4e95-9a05-95d16370724a">
+      <statement statement-id="mp-5_stmt.c" uuid="c3d78544-835f-43f7-944c-997901ec399b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="854300a5-e3f4-4d8b-9fd1-3e44d00aa2e5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4bb40dbd-952c-45f4-ac44-e8ae489a1434">
+      <statement statement-id="mp-5_stmt.d" uuid="2af91afc-267c-4bf8-ab52-1019803c1eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5470,28 +5470,28 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48e83377-5d0a-4d2b-aa4a-6c671a3c8bc4" control-id="mp-5.4">
+    <implemented-requirement uuid="1ad9ffee-54ac-4cdc-a721-9f1cf774e66a" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="c1634c0e-40bc-4c89-a5f7-0318f78120f9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cb4f5e53-6853-45c1-b634-60a388659228">
+      <statement statement-id="mp-5.4_stmt" uuid="34ce79f7-2335-4852-8d02-0a89e7ec4857">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e093824-0df1-4ba4-8485-02a027492ba7" control-id="mp-6">
+    <implemented-requirement uuid="c7724dcc-1780-4c27-ab8a-4948baa96830" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="f4d40631-b5fd-435e-beb5-8fa3d8f12f6a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a5b1c61c-bf73-4e33-8423-39918896322e">
+      <statement statement-id="mp-6_stmt.a" uuid="bf44b130-318c-4ea9-8b11-917cc390dde0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="abd2c4ca-60df-465b-9de9-679c318e4a51">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="63883e73-e6b5-4a1f-b82e-f91c11cc8b4f">
+      <statement statement-id="mp-6_stmt.b" uuid="065997b5-c670-4635-ae8b-c011cf223764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5499,40 +5499,40 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f0173fb-4f4c-4686-9ab0-a07895517593" control-id="mp-6.1">
+    <implemented-requirement uuid="e85cec52-3295-4e41-bfa7-464e62c71c99" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="802a7925-85e7-4a82-8c65-97b257f0807d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2598c7c8-a469-45af-9ef5-4537655bc532">
+      <statement statement-id="mp-6.1_stmt" uuid="25fa3973-994f-45db-b43a-da52c38514f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cda26e2-398d-4122-9e41-4bd254ffd75e" control-id="mp-6.2">
+    <implemented-requirement uuid="18e5101a-f9eb-4518-b493-428411cafb6c" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="8c2862d0-cf98-4a12-881d-7a3f42afca2e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0568f05c-8f80-41c4-93a4-575589bd6f03">
+      <statement statement-id="mp-6.2_stmt" uuid="f8a891e8-46cc-4f93-94fa-e24961fd8e99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38c7d4df-14ac-45c0-a61c-2f131c3579c0" control-id="mp-6.3">
+    <implemented-requirement uuid="a8e83cd7-beef-48f9-959b-557337731f08" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="c297b29c-17f3-4439-8783-26c5777ce01b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96ad4e76-de3a-4fd1-891e-94da33a8382e">
+      <statement statement-id="mp-6.3_stmt" uuid="4fe846ec-0ef7-430e-9fd1-73de4ab76670">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30ffb48a-23ea-4a61-92b2-3148b477f09c" control-id="mp-7">
+    <implemented-requirement uuid="6ac60336-91b5-4c2b-97e8-4fc19d3f4d01" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="9e5cf627-7d53-42ee-a110-2091f44263dd">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6168d923-5795-40f2-914c-76a19dec8a2c">
+      <statement statement-id="mp-7_stmt" uuid="53a598db-cd5c-4596-83c8-a23ab639973e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9b28071-a891-4e8a-b0ab-da77b0872c8e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to CoreOS configuration through such
 actions as kernel module blacklisting. A full control
@@ -5544,20 +5544,20 @@ https://issues.redhat.com/browse/CMP-351</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50ce50ba-1ca2-46f6-a735-46de157c5251" control-id="mp-7.1">
+    <implemented-requirement uuid="54ec318c-921b-403c-8c13-2d29d0e6de79" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="f927352e-8d77-422d-b8d6-55a6f8a3cac1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b801ce90-2ebf-4d2f-be0f-a1ab31b1e931">
+      <statement statement-id="mp-7.1_stmt" uuid="d63a95b4-8b3b-4f55-bd24-cae7caa4fe38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d7f8dbe-b7fa-45a3-9bc7-8ce1a932398f" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="c851eb9f-56a6-491a-acfc-197c2732f364">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1aa026f1-93b6-4d13-8a98-f50f84d274fa">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5566,8 +5566,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="ed2c3626-e58e-4665-a4ba-ea93cd55b427">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bc78cfdc-24e1-4e45-837a-3c6f112995fa">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5577,10 +5577,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed604c3c-5604-4e09-9cc3-996b96befb44" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="e15225db-a759-4b33-b876-1bd7fefac442">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="01f15570-3404-450c-b1a9-58ec17830996">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -5590,8 +5590,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="d8e183b8-0a55-47f8-b68d-daab627f2d47">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc56a6f1-769e-4dab-826b-8cb34fceda47">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -5599,8 +5599,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="2922d0c6-7d94-4ef0-9e30-fc18f4d49cde">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9ffb0093-6996-4cdf-b673-c1ec8cae6511">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5609,8 +5609,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="2d396cb3-c1b1-4ba7-b6e3-089f4829c887">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16ef5f15-8a38-4c6e-8381-0f630ca7f07a">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5619,10 +5619,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64a5a70a-3e75-45a7-ac64-f555ddff0599" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="0db2160a-d9b7-4430-b44a-06d9111ed670">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7e3ebc49-beba-4d63-8346-05003f23f537">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5631,8 +5631,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="37c34273-9785-4ac7-97f5-4187fb69243c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0e71e856-0961-42e5-9f83-c50f5be3e51c">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5640,8 +5640,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="6c6c13f6-aad2-4587-ab14-a3ca53c98a4e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e921495a-466a-4684-81d6-7b26baa1a3a7">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5650,8 +5650,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="93ff6988-46d3-4736-ae3a-c9718fd49d5b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b1d99525-b322-4ba1-91e1-a8c2ecd2695b">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5660,8 +5660,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="6176f0bf-25d0-409e-8f35-162ed3274515">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bb5ffeb6-3aa0-46b4-8936-8129e5c8ee81">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5669,8 +5669,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="c84e1964-3e8e-43e4-829a-be3878355629">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="792af003-8c51-4509-b3cf-4379265d009e">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5679,8 +5679,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="17c9be8c-5618-4bb6-b9ee-d01bcff2b5bf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b947f557-28a5-4979-94e1-9670f2fbd6bf">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5690,10 +5690,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13d2dcf3-2a94-49ab-aa9d-16df79154a2f" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="ad616165-b55b-4be5-b945-82f1a08f74d0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="25128053-1247-4db8-bca8-cbc1406dcaed">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -5704,10 +5704,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfd93ba7-0444-4c2d-921e-f75edd373cc0" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="6ba5dbb6-4a9d-4098-9ebe-596e19bee6ef">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b2189dd8-3b97-4910-ba71-04cdefa8a9be">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -5718,10 +5718,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f392999-4ae0-410e-8c4f-78926a6081fe" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="7e97c772-5999-47b2-9a08-a82451a032a0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f61ff90d-ff85-4a43-8627-336c6e2951ae">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -5731,10 +5731,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec8c9954-e603-4937-a42b-e0e803ea6b39" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="2181781b-9e0e-48d4-a6b0-a762e3dad652">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b3ed89b7-cef0-4312-8651-8f37cc452a4d">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -5743,8 +5743,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="b55ab7a5-59de-4b9b-a909-62db3d15a911">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8dbdef61-0c07-4e69-b95f-f1699a44663e">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -5754,8 +5754,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="c2c448ea-f426-4d1d-859f-3505ab234f27">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0a46b996-a762-4b55-8a6a-ed0eafc6676f">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -5765,10 +5765,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="758b95cf-60b0-4bb4-9e08-d41b014a0eae" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="c8e3e2cd-f31a-46b6-b66f-5d1ba8ced827">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d37bc1ed-a5fc-4bb0-b17e-41f13fbda087">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -5777,181 +5777,181 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03b3767f-85cf-4c4b-be28-4e303b02fc1d" control-id="pe-6.4">
+    <implemented-requirement uuid="8e458070-875c-49f1-8693-631087715102" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="f067869d-4590-4865-bc5f-f435b656b92b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4954308f-ffd2-4e1c-9689-fed982b75108">
+      <statement statement-id="pe-6.4_stmt" uuid="cf8ad1dc-fe4b-4ab6-95e8-92c553cd8fa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62108123-940e-43e9-9d8d-855b9872bbdf" control-id="pe-8">
+    <implemented-requirement uuid="b9f38e4a-2e80-4aa0-ac02-213d63b5f964" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="ece70c41-87c1-423c-abd5-909762a838cb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1d69d9a3-4e15-47a1-81b3-20820032a485">
+      <statement statement-id="pe-8_stmt" uuid="3dbccc27-b1fb-4181-b57c-6c97616584b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6f2ee73-aa63-44a6-94ad-13b466250308" control-id="pe-8.1">
+    <implemented-requirement uuid="fa25c659-3589-4054-bf99-27965b85b5aa" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="3df585bd-cd21-4ecb-882b-16a7e5753182">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0c2b8fe5-a226-4429-adc9-4e50c95a9765">
+      <statement statement-id="pe-8.1_stmt" uuid="04f6f215-f0d6-463d-ad7c-0b1ce2ae8281">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6501a37-ad1c-4fa2-87e1-0f4f98b5d36a" control-id="pe-9">
+    <implemented-requirement uuid="f9f4b119-31ab-4b7f-8916-07f8a22a3523" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="4a5b3c13-4250-471c-ba63-d0605f20ea03">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="618d84b4-983d-4dfc-a8ae-5e77a2628e1b">
+      <statement statement-id="pe-9_stmt" uuid="78d35767-66e6-434f-8b8d-5278419de9a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2c829b0-4461-405a-93df-d15e44aa0fd7" control-id="pe-10">
+    <implemented-requirement uuid="87455508-8dd6-4207-b55b-e4d92917f6d6" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="0ee2741a-eba5-4212-8051-d61d60da1357">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cdff8601-e196-47b6-8199-fa4844d05267">
+      <statement statement-id="pe-10_stmt" uuid="77205cc3-91f3-4ea3-84ca-ee75581e1e4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0e7436c-bdd7-4651-8009-917d38037cd7" control-id="pe-11">
+    <implemented-requirement uuid="396b23b6-bbbd-42a5-88f6-43da51f0bb1f" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="08c634aa-1666-4899-ad0b-31f9ff85ba2a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="51cc81bd-c618-42b0-9509-0358c47c4c5d">
+      <statement statement-id="pe-11_stmt" uuid="13c54bfa-dd61-4a09-9b31-e8baa38aa4e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14c02f3c-c492-4c88-8426-a92ecec97e94" control-id="pe-11.1">
+    <implemented-requirement uuid="98354df1-bbb3-460b-bf3d-3e97285ca92c" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="234a072c-31a0-49aa-b561-f199c5243299">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="945399c2-5263-4238-866e-0847eea75edd">
+      <statement statement-id="pe-11.1_stmt" uuid="8d3e29ae-855d-4223-a36c-91f0789fe169">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8fe5f93-bad9-4040-b7f2-6edb4492b6ee" control-id="pe-12">
+    <implemented-requirement uuid="bf2148cd-725d-4d33-bca9-e6059f48ae69" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="38c6fb96-3e70-4a27-bedd-f61d1c5aa8bb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8277fcb8-622e-425b-a8ef-d212acc0e4a1">
+      <statement statement-id="pe-12_stmt" uuid="1ba7c150-e414-4755-acbb-b677abb04a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b708bb20-78df-4ec7-ae0e-e9aeb32d93bd" control-id="pe-13">
+    <implemented-requirement uuid="67ab882c-0e48-47d6-ae34-e14e8eed800e" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d5b01f4b-5ff1-48dc-831b-8400fd0083b7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9c7c9b26-9fe4-4111-a872-7290e73ccc47">
+      <statement statement-id="pe-13_stmt" uuid="cd19567e-4199-4191-88dc-f8a79f7fe5b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5fde685-e4d2-4fc4-8903-4f54f16d205d" control-id="pe-13.1">
+    <implemented-requirement uuid="c3f248f0-73cb-43c7-9302-6720eb9b4559" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="78da23c4-dd92-4d4e-afca-96d12ce7246d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1a1d8b3e-0c86-4863-8e62-2583284ac2df">
+      <statement statement-id="pe-13.1_stmt" uuid="fabf1fa4-7e6c-48e6-bd7c-545586a89770">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdc18243-2e8a-4cac-9db2-24c51fa8a008" control-id="pe-13.2">
+    <implemented-requirement uuid="5318475b-c454-4729-907f-5b140615f3c5" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="51868797-b902-45c7-bd12-891eb1c4bbbf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="61af595d-002b-4e9a-8f47-87d52557b9a4">
+      <statement statement-id="pe-13.2_stmt" uuid="99bd783b-7ef5-4e4b-9502-352f59798c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f1c174a-c9c8-498e-9253-ad8dc261c647" control-id="pe-13.3">
+    <implemented-requirement uuid="d291abfc-d0bd-45bb-9fc3-36ce1fe22d59" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="d55815fe-deb7-4e7d-a121-8062aef36b9e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e89086c5-b30f-48af-9268-f9eda80c73f5">
+      <statement statement-id="pe-13.3_stmt" uuid="e363535f-ae2d-4e5b-8b2a-a5a713e44f49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da4dcde1-24bd-4d96-84de-c8e0776d4023" control-id="pe-14">
+    <implemented-requirement uuid="98fb3296-437a-496d-853b-92c71a0b01c9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="8867a022-ec10-447d-843d-eb88edd64a2b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc95623a-f9b7-499b-ab90-2b02cbea826e">
+      <statement statement-id="pe-14_stmt" uuid="f410cb6f-ecea-42da-89f1-16544b34d9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5101b45e-3407-400d-b554-a8056706ede0" control-id="pe-14.2">
+    <implemented-requirement uuid="6d838923-a33c-41e4-ad07-dcc1e8183353" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="a29048c5-c6b9-4fa6-b2bd-734d539c80ba">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fc5acabc-19a3-42d5-a9fb-68f9a5e7cfdc">
+      <statement statement-id="pe-14.2_stmt" uuid="348023ee-2218-48da-b632-51741a234bed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d9c1a6b-ec22-4d09-bbfe-24951d908559" control-id="pe-15">
+    <implemented-requirement uuid="3b494e54-817a-4771-a20c-62d7508a39c7" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="cac4656a-973a-4bdf-b323-100736b37a84">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="be2380ea-8303-4dc2-a805-31ac4b32af83">
+      <statement statement-id="pe-15_stmt" uuid="91e060ce-e238-4e32-a2e3-2c485523f69f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c5f9b58-f99f-46d0-99e1-e120ac6e6f5c" control-id="pe-15.1">
+    <implemented-requirement uuid="895a3635-1eb7-4bd2-aba2-360fc22dc003" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="5ee4f57c-42c0-4cb2-a22f-edc08128d414">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3880998b-bec7-4707-a0cd-bca9ac859870">
+      <statement statement-id="pe-15.1_stmt" uuid="95c26ee1-26b0-4fcd-8acf-d968a90c75d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a72c8512-e91a-44ba-9d85-d997a051e263" control-id="pe-16">
+    <implemented-requirement uuid="a3e84d2f-1ed6-4c19-8c72-25e6cdde0d46" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="11881585-a488-4fc7-935a-5b148a694dbc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="09caec9d-e8aa-4470-b8ff-b3913d3d1caf">
+      <statement statement-id="pe-16_stmt" uuid="acde645c-992b-490d-b159-d6d5576e2bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="834d09e5-c603-4ee5-83a8-688c0cc21343" control-id="pe-17">
+    <implemented-requirement uuid="0c34a9a9-de9f-409f-9ce0-1fe6cb861ad8" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="00d9c6cf-35f6-485d-99e7-3549120aa3ff">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fa540468-e563-4278-b0c2-505396864fca">
+      <statement statement-id="pe-17_stmt" uuid="9636f382-0552-4eeb-8a10-cad17bb743e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2c46b6d-71cb-47bb-8b18-8e697f6265fd" control-id="pe-18">
+    <implemented-requirement uuid="25b749cb-3625-4056-9bd3-393e17b65ace" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="4f2729a2-a33a-4cdd-bb6b-80adf5f3e886">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="67d91f35-1b75-4d00-9f8e-696ed35d0c69">
+      <statement statement-id="pe-18_stmt" uuid="bee411db-78be-496f-924b-9c6452cccdc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6a66f79-5f3a-43f5-8ea6-a096f6ada6c7" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="b188323e-c5b8-4d6a-a1f7-90249da6a23c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3baebc37-7a57-4585-8801-2fa3fb37c89a">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5959,10 +5959,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e71f7264-bb9d-441b-bd53-8a086f87cc29" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="d5df421b-dcac-4ad8-a02c-f7d14c911e34">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fa566fef-8a68-418c-9053-ff9c55e97fd9">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5970,10 +5970,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37dc320b-9a9b-4688-84a6-751d26aa1799" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="9da98103-0db8-4ad3-80ed-21e06d1aeecb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8f005621-e755-43fd-8be1-4c1ee397595e">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5981,10 +5981,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd0a9f42-98a7-461d-a835-13380e7ee794" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="07ec9edf-210e-4d34-be53-cb9edec264c4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f416d8ae-03bb-46f3-9e0f-0831cec96245">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5992,10 +5992,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c248057-8bdf-4e02-8cc7-f9570e8fe171" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="51c6299a-c66e-48f5-b1e7-22708dab1a57">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e21506e4-c887-4645-85ad-3bfd4e492ffc">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6003,10 +6003,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4858a032-5052-42e6-a973-bdf89eb56f0e" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="fe549e2f-69ee-41a9-b806-75cb699bb5d3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2cbefae3-fc83-4559-81f2-bd59809a4cd7">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6014,10 +6014,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59ae51b0-4988-4244-b8d3-31dafdf8acff" control-id="ps-1">
+    <implemented-requirement uuid="0d6fc93b-9959-43e7-ae1b-0fab7ac39726" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="02feacc5-26c9-40ea-a85d-63f529923f45">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="71a0a8f5-79dc-4a64-96ce-99491bf1980d">
+      <statement statement-id="ps-1_stmt.a" uuid="484243d3-184b-4b25-98c7-ce076f11694f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6025,8 +6025,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="b7e9e10f-64f8-4066-8733-2277609d0772">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f81c24d9-5872-431e-8e9c-f750014b0822">
+      <statement statement-id="ps-1_stmt.a.1" uuid="e90c6c0d-1a1d-4b71-a894-3f62807bd565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6034,8 +6034,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="f52d5d05-4adc-49f1-827a-e7e55e9faa06">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="de9e96d8-b2ae-4449-81c4-4d6ca0b0b613">
+      <statement statement-id="ps-1_stmt.a.2" uuid="ad2e7acc-28f3-403f-ac8b-3d73a4738beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6043,8 +6043,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="f5f2a5d8-b1df-4cd7-97ac-4f25666d0944">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96a7b37f-f444-40d4-91d1-e189bd330d63">
+      <statement statement-id="ps-1_stmt.b" uuid="fae8b684-9938-4b25-bb6d-8b44b03bb116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1fab7a44-4e0c-4a4a-b0d4-f65722d402fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -6052,8 +6052,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="b5f59e0d-39f7-4c91-b253-9a028978acc8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9e57abe6-a026-4adc-bb82-f29b120fe65a">
+      <statement statement-id="ps-1_stmt.b.1" uuid="388bd160-ca4f-4ecd-adb6-8d9b11e76c5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6061,8 +6061,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="24da3f52-6007-4903-94df-8541cf617d59">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="373db34c-2462-4ff9-ad86-2b0cb2de79d8">
+      <statement statement-id="ps-1_stmt.b.2" uuid="9aba6ad7-81c7-4531-b797-ea7ab09eb431">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6071,18 +6071,18 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44b1d8b7-74f3-4cf1-b316-59827a301953" control-id="ps-2">
+    <implemented-requirement uuid="2063b7cf-d7c9-4a47-820f-192605a7c815" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="d9679b13-5a78-40b1-b604-7b0f761c7670">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f8e044a4-ba8b-4041-853c-ff90b056b03a">
+      <statement statement-id="ps-2_stmt.a" uuid="04f38777-f10d-4327-a851-9b634b75d3d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5470435-d97b-42f1-9cb8-e8ee2e6a3e93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="2649b987-54c3-4773-b123-60a01846c698">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e746b71b-9755-41a1-b0fa-6d25d36fba90">
+      <statement statement-id="ps-2_stmt.b" uuid="1cc918ee-67b2-4d62-8c94-ecdb6bb8bfef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc2e4b27-069f-455f-ba9d-b60e392f2594">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of CoreOS
@@ -6090,8 +6090,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="a567261f-894b-49a2-931f-8e74a3c152a8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aec88006-07ee-4a8a-af93-4682c010f940">
+      <statement statement-id="ps-2_stmt.c" uuid="042591b6-eed4-4da1-a24c-7244deea296c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68978f4e-23a3-4f5d-8f7c-f2b83b063eb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -6100,10 +6100,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18d04ad5-81bb-4711-bcb5-1765c1a119f3" control-id="ps-3">
+    <implemented-requirement uuid="60c3c056-17d1-483f-9781-99b6bf925ce1" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="534ea5ae-24f2-44fe-97b7-74b47f93b48e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7b8ffd8d-3255-45fd-9cd2-b765d3d896e7">
+      <statement statement-id="ps-3_stmt.a" uuid="9ea78d95-7f29-4f79-8867-d329d8d22877">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5499886-17eb-4843-960f-88b0489759fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of CoreOS
@@ -6111,8 +6111,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="ce337826-adbc-4c93-9045-67322ca1429f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6738327c-ec55-40ed-845f-3497a35a1fa8">
+      <statement statement-id="ps-3_stmt.b" uuid="eac234db-81b5-4efd-9a8a-6c1bf5d205a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04005097-2b0e-4353-b3d5-9bce89a97bd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -6123,10 +6123,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9205265d-65ef-49b3-8eee-d89deb4513f3" control-id="ps-3.3">
+    <implemented-requirement uuid="3a12fb07-f633-470a-afcf-7c9b9d7eb8f7" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="2b697106-274b-4b35-bdc6-9ec24d64d552">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1706193d-851f-4744-bd8f-fbe60b7c0683">
+      <statement statement-id="ps-3.3_stmt.a" uuid="18c3f100-99ad-4d92-b0fa-12660062418d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eaccea77-dd4e-4b09-880f-1c2e403146e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6136,8 +6136,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="f5fae919-039d-4ae8-ac59-e81a52a60290">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f2536587-a820-4fcc-963b-27083412d5f6">
+      <statement statement-id="ps-3.3_stmt.b" uuid="d2c69587-74f3-4500-af61-7323363ac6ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40b961b6-1fe6-4af0-9c50-e55df3cff159">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6148,10 +6148,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4bc236d3-7c0f-4e14-96bc-60c68a2585fd" control-id="ps-4">
+    <implemented-requirement uuid="da10f8fb-cc1a-4199-97c4-ee86b21da08c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="791ff162-04c5-4e97-b227-d22c581984ce">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8efac8f2-9806-4331-a90e-042296c26efc">
+      <statement statement-id="ps-4_stmt.a" uuid="d7a444d7-a380-4f01-8cfa-3ed8c6d65386">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f5127ab-95d5-44b2-ba3d-9623d6a768f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -6160,8 +6160,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="a8b6841c-af07-4721-8e75-ac77f3a59eb4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d7091011-290c-4f39-b42b-d4ffa1eea30a">
+      <statement statement-id="ps-4_stmt.b" uuid="e1088a65-d6a1-4170-891f-afd60daa1151">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de39dddc-4466-41f5-8b59-20a8fbc7090c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -6170,8 +6170,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="12744f40-81e4-485e-b7d4-195e2a7a468e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5958de08-9667-4025-a74e-2fa94b35b686">
+      <statement statement-id="ps-4_stmt.c" uuid="c2914a86-37a2-48df-9651-f2d4fb21af3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71b8f8b2-f052-456d-9504-39e0c6e226f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -6180,8 +6180,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="64ab5f5e-2516-4506-9b03-a559d2dadf0c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2d0f5c2c-0553-42a1-80d8-6e8eaba5356e">
+      <statement statement-id="ps-4_stmt.d" uuid="be7521aa-782f-497c-a2a3-327a5aa1f541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a8c3238-643a-45a0-a54e-3cedf8269e87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -6190,8 +6190,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="253d5989-0360-40c6-a38b-874d2a896578">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="94980db1-4ab8-47ca-b058-60a300c14e8a">
+      <statement statement-id="ps-4_stmt.e" uuid="d68f408f-28d5-43a4-88c8-ece7c6985979">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c74c79b5-8455-4a63-b3f8-e95436fdb805">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -6200,8 +6200,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="7232af0b-6a5b-4003-afd9-2f78f273168c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b7ec74f8-e174-4f17-8084-a480c3d77065">
+      <statement statement-id="ps-4_stmt.f" uuid="84630747-db8d-4b27-8d27-2a95b929881b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f54285a1-8b65-49f0-8a67-e3eb9f3344d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -6211,10 +6211,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b74f7908-a4e8-425e-a727-bbcf5c1ac631" control-id="ps-4.2">
+    <implemented-requirement uuid="33dd9947-31e1-4185-aacf-c7dff8c72db6" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="b4702ce5-1a9c-4dce-af4a-03ba4fc3a27b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cae81128-9070-4257-8404-f6212fbd534c">
+      <statement statement-id="ps-4.2_stmt" uuid="381852e6-f739-4c30-80e3-05c06841c8f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca6fda2b-b4ed-40cd-85ca-6d30be1b81f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -6224,10 +6224,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0aa6158-1c98-4dcf-ab2f-8220c014aeb5" control-id="ps-5">
+    <implemented-requirement uuid="b6f0483b-9352-4587-8500-bc8cd994e8b2" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="30747420-ff2d-45bf-9e37-31879da94b16">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="71da4ce9-7e9c-4d82-ad5c-2a495f9b2eee">
+      <statement statement-id="ps-5_stmt.a" uuid="0aa3e87c-188f-43ef-9d7c-8ae9239ee640">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e279f94f-02ff-4a52-8b68-9e4cfab9c79e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -6237,8 +6237,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="e13ee0f2-760a-4ce3-8529-833c385f5305">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="61f2def7-2f5a-4c03-aee4-86d20a32a2b0">
+      <statement statement-id="ps-5_stmt.b" uuid="515c35fe-d4fc-4ca1-bd8f-6d5c45605427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d517900-4646-457e-87ca-8ab4718cb546">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -6247,8 +6247,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="ce5fdef2-05a6-41f6-8084-61ffaad19ef2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d8dc28bd-881b-44e2-8541-566f339ce021">
+      <statement statement-id="ps-5_stmt.c" uuid="2edb4391-b20b-4637-b5cb-ecc09df29a6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b78e8a0-9ddd-4594-8dc7-9199f89e3683">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6256,8 +6256,8 @@ or transfer are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="0f3faa9c-7015-4d8c-854a-6d3f9b45f18f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ece818ee-f803-4d9b-a515-d788d6b4ade3">
+      <statement statement-id="ps-5_stmt.d" uuid="b8690aa2-ea61-46c1-b1cb-4dc2a85cf21d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aff56077-e3ec-4b21-a408-01fea0a64369">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6266,10 +6266,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbd89db5-eaf2-44a1-b6d6-1831e0d82743" control-id="ps-6">
+    <implemented-requirement uuid="dea9ff31-8a0b-47d3-a11c-99433ef1b31e" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="515ca4b7-838e-4692-a72d-77f1cc2fe2f3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a13d6ae1-50f5-4c2e-9db8-31c98c0d7805">
+      <statement statement-id="ps-6_stmt.a" uuid="2f66e87b-349f-4248-8a43-0c731a10769a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2b39e55-bede-4885-bb55-ba1da248bd38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -6277,8 +6277,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="4fff015c-bbcf-432b-a48c-d9c7696b5d16">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bca931eb-1346-4ef8-a0cd-75da45e2b1f9">
+      <statement statement-id="ps-6_stmt.b" uuid="eb94419d-f820-407e-9bfd-315a92e12daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cec67604-4082-4efa-bb6a-5ee320b38b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -6286,8 +6286,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="87cd915b-c851-4d91-b9fb-d2dc463d85c7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="07c710ea-f627-4bc3-a07c-3480b1ca35bd">
+      <statement statement-id="ps-6_stmt.c" uuid="e800e662-52e1-456a-a977-23a39e42a5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6295,8 +6295,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="06f7c5eb-8c6a-432c-be4e-cf554e653e70">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f43e1de5-c106-4f2b-8d29-25a8052de3f1">
+      <statement statement-id="ps-6_stmt.c.1" uuid="dc15c108-e2d3-4f89-b89e-54e49db92a44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6304,8 +6304,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="04071078-f5f8-4a5b-b246-a776124dc59d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5b64b45c-8fe4-4feb-8b09-1c8682efb5f0">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d4818871-64ec-4b32-8214-b515d02e8320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6314,10 +6314,10 @@ access agreements are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a466c37-657e-4869-87be-99895069418e" control-id="ps-7">
+    <implemented-requirement uuid="3bf37c4a-021f-4b34-af32-d7b9fd6a2c4a" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="e8b48940-d48a-44ba-b1b7-b0f2452e8866">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="27595409-34db-4013-8ea1-37cfd2405b2c">
+      <statement statement-id="ps-7_stmt.a" uuid="2945bdc9-ddf4-41d2-844e-dc72062bdf86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cacae972-7d2e-4057-b8bb-eb041b623dc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -6325,8 +6325,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="cbbf4be3-3637-42cf-bbfb-e4216a7f5801">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="54399874-d465-42b8-8ac8-7798abb6e0d3">
+      <statement statement-id="ps-7_stmt.b" uuid="af9686d3-b729-4b9f-844f-16786efadcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1213e2d5-2797-4ce0-9f11-caaae82fa258">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -6334,16 +6334,16 @@ the organization are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="4114dcfb-c60d-4b5d-b2af-f6625f4db14e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1bae16f0-ac4a-4fd3-b85c-9ba984ec5427">
+      <statement statement-id="ps-7_stmt.c" uuid="c79914aa-3a49-4dbe-8922-c1c5c1e6f87c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c4267dc-3818-42d8-a671-cf44ca7e0d67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="e944b675-451f-4338-83d8-0cace33c030b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8e812cbb-ecc3-4e34-9aa7-88665a47fdb1">
+      <statement statement-id="ps-7_stmt.d" uuid="2d9b350a-8f2f-41f8-be37-43e1f31a92dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9aa191c-a620-4f1a-9d6e-14795465a4f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -6354,8 +6354,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="2b62e1be-8ac6-47b0-9598-9618166e9820">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="50ee78c9-bff5-4a3b-8196-26cd62d19920">
+      <statement statement-id="ps-7_stmt.e" uuid="dcd75ff6-34de-4d8e-afb0-24b21c914f89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="524c0b4d-63df-4619-9803-b2d1e87578ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of CoreOS configuration.
@@ -6363,10 +6363,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb7cb3fa-eead-4fb7-aa86-93f886ca825b" control-id="ps-8">
+    <implemented-requirement uuid="144d6958-d305-481e-93ba-1855414237a9" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="d01ccddd-d36a-4ff5-b7c3-986b2462ebbc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="de0e5e9f-59bd-44c6-bca0-7ce609ebb62d">
+      <statement statement-id="ps-8_stmt.a" uuid="47324678-8588-405b-828f-6836cef02800">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7d7c773-0c79-43d4-afba-87dcde0f451d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -6374,8 +6374,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="9c47faa8-0007-4888-b4ba-f19a2875c752">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e4457feb-85bf-460a-8299-ce4b944f9bb7">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -6385,10 +6385,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58b333ab-0bd7-4072-9e66-6ce0203cb29e" control-id="ra-1">
+    <implemented-requirement uuid="cbd41f9b-3395-449f-aabb-11982cf4072c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="18bc519e-dee4-4bb0-802b-9c67f8a5879d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2e79fd05-ce9a-4933-a21f-ae29780c9d13">
+      <statement statement-id="ra-1_stmt.a" uuid="b9ec47cd-c79e-4fec-b740-d0633a43b066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6396,8 +6396,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="20cf6b9d-119d-44fb-8097-09b4a6b82ee6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="49d4e4ec-e3cd-44f0-b488-6e1998cc9a26">
+      <statement statement-id="ra-1_stmt.a.1" uuid="093b0873-cee2-4731-9145-4c5f9403b681">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6405,8 +6405,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="d72d89ce-75c3-4db1-95e2-70eca6cd5dc5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5b60d342-335c-4e54-9fb6-706427f6874d">
+      <statement statement-id="ra-1_stmt.a.2" uuid="f4ac6d2c-45c5-458b-8dda-9b152e215b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6414,8 +6414,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="93fe2f8b-fbfa-4aaf-8679-714ded11772c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8f7ce3f4-8920-44bd-baac-2b9419708ded">
+      <statement statement-id="ra-1_stmt.b" uuid="18a2c73d-bd73-4bad-8a65-5327e87af997">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6423,8 +6423,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="54079fc1-78af-4f29-b3bc-91ece0790199">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a19ccf40-17bf-4301-84a7-152dd8f3f670">
+      <statement statement-id="ra-1_stmt.b.1" uuid="8ca1a04b-1ce8-4d10-86dc-998980760beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6432,8 +6432,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="b68778bf-5837-4a20-86a8-dc44415ee169">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3284a30d-ae9f-420b-b588-6ff01b0a7f60">
+      <statement statement-id="ra-1_stmt.b.2" uuid="73006780-8601-4739-9bf4-5f9a34cf6373">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6442,10 +6442,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8eb1ce74-4708-458d-98b2-4d59b5e4067f" control-id="ra-2">
+    <implemented-requirement uuid="dd4d32ed-c9ee-4c8d-983a-8519b85d93fb" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="c83b1373-0156-42d6-ad34-1323d3ed49dc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ba3a9133-5410-4014-ad33-709984c7b23f">
+      <statement statement-id="ra-2_stmt.a" uuid="bd55c578-2e02-43dc-8d2c-dae6909ff532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38e8d6ad-482d-41e8-a9dc-077244810b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -6454,8 +6454,8 @@ guidance, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="435fda68-57b0-49f4-9809-5d70f8167505">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="96a7a8b8-6f18-4b58-8e39-76d72e0d587f">
+      <statement statement-id="ra-2_stmt.b" uuid="02c243d3-21db-4500-a429-f6a93169cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="827fbbd0-994f-4551-b04c-4839494e133d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -6464,8 +6464,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="8cf2ca32-6981-4943-861a-c1bc98e85a1a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="23cebe6c-e6d1-442f-b824-09990c850b9a">
+      <statement statement-id="ra-2_stmt.c" uuid="a761f6b6-b88c-427b-b219-9b6133c05196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="222b3d51-4fb8-42c4-8b2b-00b40d003325">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -6475,10 +6475,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8166a312-0bea-45d4-b384-f6c104c2d926" control-id="ra-3">
+    <implemented-requirement uuid="a91d978d-76fc-4f91-996a-ec3bd70d2f20" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="78e14650-419a-4780-bc80-99c0dbe14ee8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c9c789b4-db14-4525-aed3-8731fdd70469">
+      <statement statement-id="ra-3_stmt.a" uuid="8f28b273-d3d2-4733-9cce-28a43c6f8790">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="440515ac-07ee-4423-94e2-1dac61f0149a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -6488,8 +6488,8 @@ transmits, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="a53bd3e5-803a-4fc1-a02c-792d0f86f622">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5c1a2b0a-7278-4dca-a774-0b7144138418">
+      <statement statement-id="ra-3_stmt.b" uuid="8e0a280d-8df4-43f8-ae7c-69fa52679253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d896e942-2f5a-468b-bfa7-69b07720a268">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -6497,8 +6497,8 @@ documents, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="b998486e-48b4-4998-810f-b409d24f4561">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2d7c991c-04a3-4fc2-961f-c6ffe4e6ed19">
+      <statement statement-id="ra-3_stmt.c" uuid="a4c416cc-7372-4332-9954-f385e2e4a62f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06648176-8f20-4d8c-8dce-9fb6bab40ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -6506,8 +6506,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="470c6883-eed0-41a4-87a3-b730b359d7e6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b07ddf5d-eb7f-4ade-8104-2aa8976f97d2">
+      <statement statement-id="ra-3_stmt.d" uuid="60b70e92-5e62-45b9-bd5d-51b8d4a533be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1ea9294-5af3-4ef0-9f29-5442a87dfb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -6515,8 +6515,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="f2e0702f-5ab8-4913-be26-8ac4669d2965">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e6865f95-b84e-4ac7-884b-5349703a6616">
+      <statement statement-id="ra-3_stmt.e" uuid="4725522d-a508-48c1-a3e9-5928b73d4124">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2f6371a-788f-4180-b531-392900117b2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -6528,18 +6528,18 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ce5a880-070a-4a24-a68c-b6ca9f28a0a9" control-id="ra-5">
+    <implemented-requirement uuid="faba4d3b-a229-4ef4-92a7-51930564432c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="b70ce172-f46c-4276-8feb-14533b25cd20">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0df4e2c5-2a4d-4742-b58a-bec83f38321d">
+      <statement statement-id="ra-5_stmt.a" uuid="ac517196-6214-4d51-9acb-fabac78e0911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="377f8ba4-a65c-42b7-baf0-f5a8387330cc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d62689c4-7a94-468b-a14f-a0de2b3b3ae8">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6547,16 +6547,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="9b7ed201-6c2e-4f73-88d6-151ffff318e2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="29af2d33-aeea-41c2-a7ed-140016eeff46">
+      <statement statement-id="ra-5_stmt.c" uuid="eb2ceef6-2632-41ab-bd7f-bd9fafd3d08c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="7156a727-7377-402c-adfa-b31224d8b36f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d6de49c3-4e2d-4ce0-ba05-5cd359780cb7">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6564,8 +6564,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="f953abcd-a66b-4eaf-8f65-d603c81fe3c1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2208195a-dcac-4fb6-9b3a-28405e415d0d">
+      <statement statement-id="ra-5_stmt.e" uuid="1ff6a01d-7430-40af-9732-808c455f1558">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad407a82-f2e6-46f4-9029-f9fcbe5b785b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -6577,10 +6577,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b055c19-3538-456c-8b9d-734bc2ea4ed7" control-id="ra-5.1">
+    <implemented-requirement uuid="99bfb322-3894-4141-babf-b99bfe1d7692" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="9d92bfe8-c08c-4475-842e-7ae916e08b99">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d4a8e064-8691-4a75-8b51-764801882ab9">
+      <statement statement-id="ra-5.1_stmt" uuid="c78f080b-6d2c-4038-830f-eb3c7e1ae855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e39b5519-8ce6-44bf-b85b-37b0f2295593">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6589,10 +6589,10 @@ https://issues.redhat.com/browse/CMP-353
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="693e0f10-485e-41c5-831f-85f631f1647f" control-id="ra-5.2">
+    <implemented-requirement uuid="4943ba18-45e4-4e49-a170-d37ebb1ced85" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="1a819435-2103-4fc8-bcd9-9e381614388f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a54773e3-9bd6-425c-8129-86c6504ee7bc">
+      <statement statement-id="ra-5.2_stmt" uuid="de799794-299e-494b-a3b4-c26fc280ba0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -6600,10 +6600,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5950f9e1-ab84-4363-881e-a56af883ab09" control-id="ra-5.3">
+    <implemented-requirement uuid="810d5edd-d21a-451e-b7b3-67d6f714aeb7" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="3b553f52-a6ea-49f7-9128-2a3dc1b690cb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="81a82447-4678-4f35-b3ad-d0fb03864d5f">
+      <statement statement-id="ra-5.3_stmt" uuid="cf5fa76d-4097-486e-932d-6ffc633e724f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -6611,10 +6611,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ff7b352-5553-432d-821c-6077dca073a7" control-id="ra-5.4">
+    <implemented-requirement uuid="d194d2af-b539-434b-86c4-c330c1e61adb" control-id="ra-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.4_stmt" uuid="a9cddf2d-acab-49b0-8a35-31f2d5f04480">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="653e9bc9-4a08-40ec-a72b-d5d5badabd6c">
+      <statement statement-id="ra-5.4_stmt" uuid="62a12a26-4c85-4031-8ec1-ca06cefc7b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2eca7b45-5942-4994-b711-b525128ca9a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6623,10 +6623,10 @@ https://issues.redhat.com/browse/CMP-354
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55bfef22-6f38-4cab-99f3-df0b4256a4c8" control-id="ra-5.5">
+    <implemented-requirement uuid="9c800aef-8511-49ed-bfe2-d907ee7f61ce" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="17925361-a0e0-428b-ac43-cfcd02abad87">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c5222e3c-25c8-4769-bbb2-522ce79d6188">
+      <statement statement-id="ra-5.5_stmt" uuid="ccca2fc9-70b2-4cab-a980-33d198bb8e93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10028990-75a4-41c2-9cf7-a75f6f72870c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For the purpose of conducting a vulnerability scan of CoreOS, the CoreOS nodes
 should be scanned using the OpenShift Compliance Operator. OpenShift supports
@@ -6637,10 +6637,10 @@ Cluster Administators are able to access and run the operator for compliance and
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f532a7c6-f4ec-4be7-be1c-cc17b215d801" control-id="ra-5.6">
+    <implemented-requirement uuid="3a66b623-7a77-4166-9bc8-fe36369d6a66" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="26de51ff-4ee7-44db-aeac-7e0968372f73">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7f92d850-eda4-460e-80f8-218d8c547434">
+      <statement statement-id="ra-5.6_stmt" uuid="42e81289-d5c0-4fb6-a470-ca1b979a6f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65f278f2-f1de-4fc4-a2a8-625d8839df42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6649,10 +6649,10 @@ https://issues.redhat.com/browse/CMP-356
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92f6eef1-7f6b-4293-807d-cc0d3db18e18" control-id="ra-5.8">
+    <implemented-requirement uuid="52cd9967-b86b-41e2-948a-b60259fe9638" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="96a0a93f-68e9-48de-b041-4b011e073cdf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="900234da-a22d-435e-b9c6-44f21326c346">
+      <statement statement-id="ra-5.8_stmt" uuid="d08bc80c-4429-4531-9ec7-df30f390bdf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0e99da8-613f-4e82-b02e-b47289fae021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -6662,10 +6662,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff6a55b8-3577-4e89-bfe9-d05bea25542c" control-id="ra-5.10">
+    <implemented-requirement uuid="eb23ca80-f976-4e4a-968f-d339a330a577" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="b3503e59-c0bd-4f17-b586-245ada15eda9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="87858a38-186a-489a-a323-36c4f07397c9">
+      <statement statement-id="ra-5.10_stmt" uuid="943c0961-716c-4ba5-823f-53e793ca0811">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47ee21c2-e28e-49a2-ac5d-b56011c725ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to correlate the output from vulnerability
 scanning tools to determine the presence of
@@ -6675,10 +6675,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f59fc5c-9f8b-4ee1-bbc8-5c485b5b83e7" control-id="sa-1">
+    <implemented-requirement uuid="0c0652aa-7057-4f72-b1e0-ee4437f43f32" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="60ef788c-190d-4b31-a16b-0379286ccc19">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ee72ccc7-6bcd-45c7-a196-14df7a47213a">
+      <statement statement-id="sa-1_stmt.a" uuid="3d66e025-98f3-4642-b709-8ad2d8f3d5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6687,8 +6687,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="5f741590-1c55-466c-96f3-a30393bca628">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8eae1d03-2185-4c0d-bb2f-b8f1fa44b884">
+      <statement statement-id="sa-1_stmt.a.1" uuid="cd61765c-36f5-4066-b631-f184bb57d5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6697,8 +6697,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="e2f7b087-e613-4a62-be93-2f93e5b75743">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6f31e4db-06f7-4ddd-a6a4-033ec61a22ac">
+      <statement statement-id="sa-1_stmt.a.2" uuid="7b92ddc0-42b3-4bc7-b148-475ab42bf48d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6707,8 +6707,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="26d996e5-90e5-4598-8334-7a67c128e230">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="25b61fe7-5f46-4d91-bdc1-91eb155f5588">
+      <statement statement-id="sa-1_stmt.b" uuid="82acdcc6-8d2d-4ac2-b6b5-fa56906034f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6716,8 +6716,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="f3cf7e90-4c3e-41b3-9dde-69c26e7dd649">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1d55dc05-e817-4b88-95c5-4f316389775a">
+      <statement statement-id="sa-1_stmt.b.1" uuid="10ddd67f-0dad-4c07-a52f-e9a411a81590">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6725,8 +6725,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="a1ac1852-cef8-4dd9-a20f-559930e36ad4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc7c3e87-ba90-4623-9029-1e46899e3aee">
+      <statement statement-id="sa-1_stmt.b.2" uuid="8c40d9e9-f309-4d84-bbd6-8330b7deae55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6735,10 +6735,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2498855f-560f-452c-a4b4-db6602e585af" control-id="sa-2">
+    <implemented-requirement uuid="7145a51b-2ff7-4828-b118-57aca991d868" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="06fa0696-ad08-4e39-9783-c30d7d291a90">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="92e5fbc6-8b47-4e46-ad25-1bd8e6243831">
+      <statement statement-id="sa-2_stmt.a" uuid="2755cb68-25bd-40a2-ad83-1998ddbe4b8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b5d2b15-1d23-4308-91b6-81520a9e5d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -6747,8 +6747,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="08c9e82b-e833-4dcd-9361-d96f34790ee6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7016a39b-87ec-45aa-b5c8-1174a17ed553">
+      <statement statement-id="sa-2_stmt.b" uuid="c861f1a6-b97d-40b5-bb1c-c7534589144e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bde7c5a-d48d-4ffe-84ce-49d33dca8cc0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -6758,8 +6758,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="350a13e7-6002-423f-ada2-b700e60b33fe">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5460f3d7-dcec-4544-8707-f51d43f40e80">
+      <statement statement-id="sa-2_stmt.c" uuid="16c673ff-ca9d-4e39-9506-2448605a41dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4173a7c3-70d3-4f66-af32-b1d257a4a434">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -6768,10 +6768,10 @@ documentation are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c8683e9-82d4-48b8-bc75-6c12cb1aa84b" control-id="sa-3">
+    <implemented-requirement uuid="f5854499-3850-4041-8163-2098e8ce66f9" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="2e0fb4c8-0608-4206-bfb9-8eec5278d1e9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1cfea61a-4193-4a32-a92f-2781c26f454a">
+      <statement statement-id="sa-3_stmt.a" uuid="ab1f9419-2d17-407a-9899-d198c6784c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8091825e-84d7-4e98-b2e5-39a43ff6fd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -6780,8 +6780,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="165eec12-2468-49d2-b335-0f8781153541">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="29922501-d9d9-422e-9764-156d88be69ec">
+      <statement statement-id="sa-3_stmt.b" uuid="f0f0c199-51ed-4b15-aadb-3b2287f0219c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574de2a9-b6ac-4180-9f66-faf08af1494a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -6789,8 +6789,8 @@ life cycle are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="dde31aaf-cfc9-4d73-a09d-f01aea2414f7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6e20fda2-0f20-4ed8-98fa-292eaa8b957b">
+      <statement statement-id="sa-3_stmt.c" uuid="ba979c87-fd05-4bbc-8c25-bf77aa504bbd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ace7cb98-3cba-441b-a31a-14917d2f9701">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -6798,8 +6798,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="c42b2e62-4f43-49a2-b6c1-e0ad40786960">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fde58a0a-c413-4f41-a87d-235c3db1c4f5">
+      <statement statement-id="sa-3_stmt.d" uuid="81798b33-2475-461c-bb95-0423f44a2427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a9cb6d6-2615-4dd6-a2fd-739442455a56">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -6808,10 +6808,10 @@ activities are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a21211da-d9ac-431b-9123-c4fee73fc887" control-id="sa-4">
+    <implemented-requirement uuid="a6127496-fcee-476c-93ac-985866a01330" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="914936b8-8f61-44ce-b9cd-2d4e410f97d8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a4731e15-9684-49e3-8726-4bbe352f3226">
+      <statement statement-id="sa-4_stmt.a" uuid="66e9e982-66c4-4d53-873c-67972cae950d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="572f10ee-08b1-45ff-9ba6-67c5e27bd949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -6819,8 +6819,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="dc6b098f-685b-49ce-bf2b-b9409942e79d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="28056438-e4ed-4c27-8404-2c85658a3bf4">
+      <statement statement-id="sa-4_stmt.b" uuid="5acbbc04-7c5b-46c5-bbbf-1b989d32260c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c001268c-4565-4dc9-a033-258fb2d1aab3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -6828,8 +6828,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="bb01cdfc-3055-485a-bd18-bf813db6eae9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="eedb1f97-be74-4671-a2d5-eec0c1fc9fc3">
+      <statement statement-id="sa-4_stmt.c" uuid="ebc06327-df41-4050-8545-c31078c78658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4b17de1-8bcc-44ba-9c0a-9c64b04d39ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -6837,8 +6837,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="b2412737-6cab-43b3-a2c4-39b99609d8a8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bdc578b6-168d-4d18-8adc-454b0a971a3a">
+      <statement statement-id="sa-4_stmt.d" uuid="bfcde3f9-7df8-4058-b708-7076656c4aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a023e396-23d4-4da2-b88a-a82810b4b941">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -6846,8 +6846,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="044b1ce0-eea8-430f-b56c-9e9c820c8e47">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c754b3d2-19f5-4c8e-a0cd-53abf24c1536">
+      <statement statement-id="sa-4_stmt.e" uuid="d209b23e-a57c-45fb-aa56-5d61c0ab647c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64203fc3-95f8-4b3d-8ddc-04cde85cbb81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -6855,8 +6855,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="58badbdf-22aa-4e8a-ac6b-817790512ed7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e7683aed-b67e-4bc5-9168-dadaf2886838">
+      <statement statement-id="sa-4_stmt.f" uuid="1521bbdf-33b5-44c7-bd64-372014b03655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a13a456-f7e8-4774-90ac-3bf599dda9cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -6865,8 +6865,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="a02f88e9-0643-4879-be41-70ce000f8697">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aa489b2c-f38f-491b-a62c-57bb601649ed">
+      <statement statement-id="sa-4_stmt.g" uuid="e77d9d21-6ff6-4e11-a420-5d1ff9410008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06b0ef7c-0b8e-4b73-921f-ce2b48a7c710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of CoreOS
@@ -6875,10 +6875,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e20e41c-0b44-428f-8394-4556d5c854da" control-id="sa-4.1">
+    <implemented-requirement uuid="5304b0c8-226c-4b93-8016-3c5d124f854b" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="7c168a19-5584-434e-916f-b536dea53d93">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2a791940-daca-4757-9993-d40dfca5feb8">
+      <statement statement-id="sa-4.1_stmt" uuid="64169bbc-e536-4a43-a859-591743b4b950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d3defd9-e7ba-4864-8474-4487cbcaf84e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -6888,10 +6888,10 @@ https://issues.redhat.com/browse/CMP-360
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="208325a6-cbbe-4f4f-9900-483f91da758d" control-id="sa-4.2">
+    <implemented-requirement uuid="44c7e4b7-6adc-4f5b-9dc5-e761001d8982" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="3baaad05-a522-49f7-a0c7-d470bd9487ef">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="53e4771a-4226-4dce-ab19-716c918e9299">
+      <statement statement-id="sa-4.2_stmt" uuid="59c5a200-46b7-48ab-bc21-d6932d43a016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6535c33-0142-4714-8f10-09335fc6dc79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -6901,10 +6901,10 @@ https://issues.redhat.com/browse/CMP-361
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a70fd988-2fb7-4317-869d-c0adb38c5c0d" control-id="sa-4.8">
+    <implemented-requirement uuid="11659e90-59b5-4173-b43b-1812ae1883b6" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="33a867b8-bb06-4280-9367-4fdefc5ba97e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1a7868bc-9998-4c92-b885-8853eb44bf5e">
+      <statement statement-id="sa-4.8_stmt" uuid="4b9d4eea-be9d-4f5f-9a67-ce7e25a48f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597f1282-83d4-49ec-8766-9be0dbbd2f16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -6914,10 +6914,10 @@ https://issues.redhat.com/browse/CMP-365
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="248b3b5b-48af-47a9-bbb2-4a55e3255d20" control-id="sa-4.9">
+    <implemented-requirement uuid="9ff8b64a-8a54-4e48-ad70-1fdaea27c11e" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="2ffbde60-deb6-4f70-ab26-cc225b4ae7da">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e3d80b80-1e46-4a2b-91e5-f37248bfe088">
+      <statement statement-id="sa-4.9_stmt" uuid="267db06e-5550-47ff-9734-f9d2e6f704f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d42c837f-2526-4ac8-8d24-1add8af53ab1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -6927,10 +6927,10 @@ https://issues.redhat.com/browse/CMP-366
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89c654df-4a39-41b4-a045-c3ae535c83cd" control-id="sa-4.10">
+    <implemented-requirement uuid="383fd5dd-44f2-4e63-a8a3-045c1fb9f635" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="b07e6f32-5bba-4fc6-acbb-e739f10cba30">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c2f89786-7a95-4663-a292-c838328ba02e">
+      <statement statement-id="sa-4.10_stmt" uuid="0bd66465-3009-4bf6-aaa0-8bd6a2cf2a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6938,10 +6938,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8140f95a-9cf7-4c28-9938-5dd455d50bd7" control-id="sa-5">
+    <implemented-requirement uuid="f78f691a-653a-4df7-bc18-65ff8336c199" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="e0cc4acc-98eb-46a5-9c5a-8903001a23fe">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2d0e9443-6610-4de5-b322-4ae76942b165">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -6950,8 +6950,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="7da235b6-0cea-43a8-9c93-0aa90f59805d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="49c78b4b-c7a6-4814-a6bc-42f488b4b2ad">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -6960,8 +6960,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="6cbdeb48-a346-4f15-a931-c538adfba9a3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2a0de985-9921-47fa-8b44-ceaa5f0a2b98">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -6970,8 +6970,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="4c3c1967-772d-46b0-bb69-2c634262f3b8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ffeeb514-353d-473b-9fec-cb811adfdf43">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -6980,8 +6980,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="af326ed9-462e-4675-baa7-0e47ee549f62">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9951cf08-29a8-4769-a7fd-a4315e1bdba4">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -6990,8 +6990,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="2f166742-8271-4066-af8a-be99a9516b4f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="50302aba-dfd2-442d-8d9e-ddd4da75f675">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -7000,8 +7000,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="0e1d6e6a-4f5e-4521-9b13-c6ccf8a3d93e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="15d746b5-a221-45eb-bab8-8bd69b949c1a">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -7010,32 +7010,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="359af43e-8649-429a-b972-caa5113d54ba">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8e5bfa24-d5c1-4b36-b22b-c0f7e75ec2dc">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2988f5e3-bd2e-47ab-8b2a-0961b58a6667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="dab5317c-bccd-4cfb-bbc3-94fec8e69532">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f9210c21-8971-4496-96db-a508b53194b8">
+      <statement statement-id="sa-5_stmt.c" uuid="35fb7c42-07a3-43e8-ba7e-ea762fba9f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="2a916b60-a8f8-4534-b1aa-9188ec01a94f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="28487184-fafe-4b45-9aad-49927eaec721">
+      <statement statement-id="sa-5_stmt.d" uuid="4ce14cc1-b29c-4334-b59c-02ef744b5bfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="acfb504a-862d-4bac-9712-a71e6b53373b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b84e9796-0761-455e-b687-f98b04576af0">
+      <statement statement-id="sa-5_stmt.e" uuid="10a7f065-0e7f-4660-b464-b66f5f383362">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7043,10 +7043,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0e95c0b-40c0-405d-945c-6f27d8169b81" control-id="sa-8">
+    <implemented-requirement uuid="31b3cb6f-5fd9-40de-b1d9-bea329ea7719" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="9b665fe2-f16c-43f9-87b0-cfd31e4a1849">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="85fe1a89-8d0b-4e1c-aabe-5499b53e0f9e">
+      <statement statement-id="sa-8_stmt" uuid="fa213582-083b-4260-be33-7b25b07bc6cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7054,26 +7054,26 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1113a4b-3873-4b18-a513-e02549a758d7" control-id="sa-9">
+    <implemented-requirement uuid="8e537434-01f1-4324-bf80-6f36a6ea38df" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="85707ede-ab78-429e-b4ef-2768a864780a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="224e5fe8-70ce-4002-89f7-ebe4578502e4">
+      <statement statement-id="sa-9_stmt.a" uuid="13c765df-6a58-4792-b3cf-26d28b151fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="52a10026-d76e-4a46-bd00-868f0e268afa">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e3c297c6-1806-4705-b0a8-855bbaefe8d2">
+      <statement statement-id="sa-9_stmt.b" uuid="da1eaec2-07be-47be-a90f-2f93fad86c6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="bb1e523b-5e97-41b1-b4b2-a92c99d494e5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ae4b1b9c-8fed-4181-b107-7d5800d4b704">
+      <statement statement-id="sa-9_stmt.c" uuid="6b75bd8a-ffcb-4b13-8346-a4d8670d7587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7081,18 +7081,18 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30e4a6f0-ed18-45e0-8abe-96db9e39ad84" control-id="sa-9.1">
+    <implemented-requirement uuid="44070922-c066-48ee-98bc-d1bfddeb98e8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="b68460f2-33dd-4eff-bbd8-28e097c9115b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6ea04996-e7b7-4bbf-8ae7-49bcc845ec3b">
+      <statement statement-id="sa-9.1_stmt.a" uuid="8e49af8e-4872-4dee-9c8a-83ab82569e30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="f53aedc2-e4b8-4739-9961-ea891cf206af">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1c3775e2-3b41-4a94-905b-b6dc3f771aba">
+      <statement statement-id="sa-9.1_stmt.b" uuid="0a3cd44c-a6ee-43d2-9675-763f3eb540d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7100,10 +7100,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0bedb75-fa12-4c0d-8d86-618a9d067a6a" control-id="sa-9.2">
+    <implemented-requirement uuid="4b7c9524-7b84-4608-9f20-9256082760f7" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="1b48c7bf-3f18-41e7-94f8-be9419de1aa8">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ad20be87-35f5-4c60-b598-8009ed02e4f1">
+      <statement statement-id="sa-9.2_stmt" uuid="6c48daf0-dd90-4212-8ecd-3dda8a0301a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7111,10 +7111,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="feccc6ae-bff1-4ea1-b995-2f5987b532c7" control-id="sa-9.4">
+    <implemented-requirement uuid="8e99cd10-f93b-4302-9fc8-507a69e3ae2a" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="a69d3da2-96d1-49b1-9840-aa646eb4bdf5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7a863024-f299-4ff2-b81f-3eed9ea15c36">
+      <statement statement-id="sa-9.4_stmt" uuid="294c5b35-62e8-4c8b-b519-59a34102449e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -7122,10 +7122,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73a1afdc-6014-4129-9339-6d5b7d2369b5" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="4816d0ba-efc7-4251-ac02-801a36e03742">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="53a4fbda-2e92-46a5-b911-942736eaff78">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -7135,10 +7135,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="241d0d7f-6563-49d6-b108-81fa1999d170" control-id="sa-10">
+    <implemented-requirement uuid="23e70356-2035-4233-a7f4-8370b3d60157" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="e35d8941-479f-4139-8a38-a383286317eb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2507bd21-493d-41eb-9c7a-32fda908dbf1">
+      <statement statement-id="sa-10_stmt.a" uuid="95684487-9444-4195-8dbb-962f685d5bd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ac6e51-7ce3-4f56-bc71-b6ee264973d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -7147,8 +7147,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="0d76a95d-541c-48b8-864e-1263c98ab2b6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4f2f62ed-b8d2-4361-aea2-07d0cc48037d">
+      <statement statement-id="sa-10_stmt.b" uuid="3f0d837b-9027-4ba8-ac9e-9b4f1b9544a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa90dca2-ea44-4706-8cb9-2280b5d5f2d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -7157,8 +7157,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="4b27cf2c-e9f5-4056-b227-f251ec79e6c9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="55c50bb7-d1d4-4d28-a353-00e8672a5a5d">
+      <statement statement-id="sa-10_stmt.c" uuid="40f2740d-7c38-4a52-aff6-f09b9240678b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe37bd74-209c-4b2f-acfe-3da20c65069b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -7167,8 +7167,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="3c557c84-7579-4862-a098-041ff538f0bf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f2d06ebd-1f3e-4ac3-87c8-eb5f2b835936">
+      <statement statement-id="sa-10_stmt.d" uuid="a1e3cfe6-bafd-4bcf-add0-e2df6c385eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51149b43-7746-4674-81e0-9343b6556130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -7177,8 +7177,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="12f3b54b-acd9-4f09-b16f-1a761c1f67f2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5375e924-342c-4d72-a5dd-c994a66fcf56">
+      <statement statement-id="sa-10_stmt.e" uuid="1d119dee-e436-41b2-ab4d-2dbd8a87a222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b6d4be-f2c6-43b7-9f49-133379f30817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -7188,10 +7188,10 @@ https://issues.redhat.com/browse/CMP-369
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7c3bee8-7b48-4eef-ace6-8dbb60d8692e" control-id="sa-10.1">
+    <implemented-requirement uuid="4c64a19c-d9a6-4f5f-8362-95028e8a5a27" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="d36d9d3f-39ae-4729-955e-7bdd835ced23">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7356d701-6860-4c1e-8dae-1a891e2717e3">
+      <statement statement-id="sa-10.1_stmt" uuid="3893e7a9-f701-4695-bb10-3c715ec900de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5a26a-f4da-4af3-97c9-1b9cd4601ff9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -7201,10 +7201,10 @@ https://issues.redhat.com/browse/CMP-373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fd073ab-d7de-4e95-914c-22b846192c36" control-id="sa-11">
+    <implemented-requirement uuid="a86926a5-e735-4a73-83bc-60bc088ce819" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="18fbbdc9-45c3-4852-b421-9d3cf71bd961">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2e5f4ee9-519a-477c-ad84-7fe8f0fca03f">
+      <statement statement-id="sa-11_stmt.a" uuid="46fc688a-6a7a-491d-8c9d-f3ca597d33eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f34b6662-ab38-41e3-ac72-b08cb8675a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -7213,8 +7213,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="eb8f8c87-6096-4080-9500-94ae512a2052">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f373d55c-8639-436f-bc5a-cd137aecde85">
+      <statement statement-id="sa-11_stmt.b" uuid="3c6b0a07-19e1-4b56-8978-84f78e5d41b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c00fc148-bd08-4f25-aee0-9ad9d3760062">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -7223,8 +7223,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="8f57c118-9dc5-4ca4-b04f-2da160719fd4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="35078ebc-3ed3-4d96-805e-ab1fdc316cb8">
+      <statement statement-id="sa-11_stmt.c" uuid="95db2f92-ab21-4cdb-bf9b-41002f9858be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c0e9f2-6558-4dd6-b14e-9a254d3cd9c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -7233,8 +7233,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="895dfc33-0c98-40d5-930c-74a69b6296b6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ce7d88b5-f0fe-4715-b60d-dc80adcef9d7">
+      <statement statement-id="sa-11_stmt.d" uuid="efebb503-1b64-4ce9-832c-3be4e01cc4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b2f4dcf-5965-417a-8706-e9e23c034690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -7243,8 +7243,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="a10c5ed9-dcce-4b98-ba82-fff1c6155246">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dbf553e0-942a-431f-9621-41cdd65a8e4b">
+      <statement statement-id="sa-11_stmt.e" uuid="fcf54721-40fd-49b0-af2d-7c710acfa862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="528f9b93-35a6-4d13-8a0f-acb56b90303c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7254,10 +7254,10 @@ https://issues.redhat.com/browse/CMP-374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a7ac22b-77b1-454a-9720-e4175fcac825" control-id="sa-11.1">
+    <implemented-requirement uuid="390d4359-e23c-4ea7-a03e-33ab0f771c89" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="6fd61999-957e-4d00-849d-2afe2a20db26">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="07fa173c-dd7c-49d7-b214-c1905bdb1ea3">
+      <statement statement-id="sa-11.1_stmt" uuid="78fa5d63-08f1-40f8-aa7f-302d689735df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3953a8df-4a05-4b03-811c-eecbc5b1115f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7267,10 +7267,10 @@ https://issues.redhat.com/browse/CMP-375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7cf6c0c-2889-48a0-bea7-3d364f2dc280" control-id="sa-11.2">
+    <implemented-requirement uuid="f6a79121-574a-4870-8fd6-f0b7f8e8264b" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="035aa3d7-42fa-4a13-8eba-a35ae7eed2ae">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7ee161dd-fa7f-4ea7-8172-6140e2ca492d">
+      <statement statement-id="sa-11.2_stmt" uuid="bc1c0016-a06c-4757-af0f-2bebb94fb87b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a25713a-4531-486b-bb1d-534a8fd9065e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7280,10 +7280,10 @@ https://issues.redhat.com/browse/CMP-376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f5add5c-f6dd-4a0a-838f-b4172d99e04e" control-id="sa-11.8">
+    <implemented-requirement uuid="b2c4d52c-2d22-410b-91fd-6adcafe27600" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="dca53e70-52c2-4028-a69f-8c277b54ec11">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f2cd5c0f-1b53-4e36-b7c4-3def86024be0">
+      <statement statement-id="sa-11.8_stmt" uuid="6bb50194-184f-4669-9484-5e251888ba63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5626f4d-3991-4663-8a15-b4c106696880">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7293,10 +7293,10 @@ https://issues.redhat.com/browse/CMP-381
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="180a6ebf-73c5-43a7-b270-b7b78c18bd6d" control-id="sa-12">
+    <implemented-requirement uuid="f99a1cbb-dede-4f71-85e7-ec6dea75bbd0" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="de749c60-4dee-45fe-8fb1-b7e3a172cfed">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ad4d1475-f2a0-495b-ae12-040a5fcee97b">
+      <statement statement-id="sa-12_stmt" uuid="c563269f-4c41-4a77-8ebc-ec51acb22f6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bc51b63-9523-4031-8845-df80783e280f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-12 is planned. Progress
 can be tracked at:
@@ -7306,10 +7306,10 @@ https://issues.redhat.com/browse/CMP-382
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c5f581f-bbe2-4e89-862b-77f40c9e4894" control-id="sa-15">
+    <implemented-requirement uuid="0f371a25-e91f-4885-9f0f-943e04eead02" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="caa4a96e-8d32-4a34-85a9-ffd897f85a79">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="36731f64-299e-4eaa-af5d-76d730eb40b5">
+      <statement statement-id="sa-15_stmt.a" uuid="b66fd6cb-383b-4281-8109-92b4966ce76f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f74d490-81a7-4297-b413-71ae4a1015f2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a) is planned. Progress
 can be tracked at:
@@ -7318,8 +7318,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.1" uuid="2150fddf-93cc-483f-9423-a092db6ad919">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3bbd5f61-e867-4474-89ad-1501d8178e50">
+      <statement statement-id="sa-15_stmt.a.1" uuid="bd3166ec-9fe3-45cf-aa6f-14651b1e28d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb23a2a8-de80-47aa-9881-041ee04a669a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(1) is planned. Progress
 can be tracked at:
@@ -7328,8 +7328,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.2" uuid="da45b99d-96c9-4334-a5da-d03dcc0dac82">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="896a659c-443d-482e-87a1-505ed8a36e87">
+      <statement statement-id="sa-15_stmt.a.2" uuid="1f93b263-b721-4673-acdd-ed89b320f6f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ee92eff-1182-4982-bf5a-ffe29b3679e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(2) is planned. Progress
 can be tracked at:
@@ -7338,8 +7338,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.3" uuid="d3b6f96c-5144-4be7-b962-b6ea4f2af29a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="91118e13-c932-4a10-bf1b-700d9e7f8e6e">
+      <statement statement-id="sa-15_stmt.a.3" uuid="ac6d04eb-d23f-4686-841d-0ac6d4f58e00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d6c1033-2542-4eb8-b24d-79dd2ab5bb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(3) is planned. Progress
 can be tracked at:
@@ -7348,8 +7348,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.4" uuid="dd1f6eaf-1331-448c-b4d0-7fd65c50c817">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="18e27b4d-4cb1-405d-aa2e-ecf710f170b0">
+      <statement statement-id="sa-15_stmt.a.4" uuid="0a6afb90-82b2-423e-aa27-f03cf47f5e9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7063db13-5c35-4b99-87b8-ef5e3ad15fa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(4) is planned. Progress
 can be tracked at:
@@ -7358,8 +7358,8 @@ https://issues.redhat.com/browse/CMP-382
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="667766e0-adfe-4af8-9daa-f908eb0444b1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1145e318-3a92-46a1-8994-f468117293de">
+      <statement statement-id="sa-15_stmt.b" uuid="f3c3d6b5-025b-41d2-82fc-91318fa4d074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fff64b6c-e115-40bc-b9c1-32ef0891faa9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(b) is planned. Progress
 can be tracked at:
@@ -7369,20 +7369,20 @@ https://issues.redhat.com/browse/CMP-382
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="def1dcb3-b384-4d0c-a9b2-3d75e02c0407" control-id="sa-16">
+    <implemented-requirement uuid="9bb3c0cb-a2a8-46a7-9ca4-b2a4e6f1ef91" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="417e01d7-7c20-4eb4-8eb3-fa745679b71b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ef41ac2-4d64-48a4-95ac-4428d92ed692">
+      <statement statement-id="sa-16_stmt" uuid="1b44cb72-6d8a-4a8d-8437-288906e1ddc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90480eb2-7f20-4b67-b557-b325700907b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-16 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da3ef6db-9dca-4928-a2fc-e175dc96aa12" control-id="sa-17">
+    <implemented-requirement uuid="bc6ced25-c598-4c02-a447-25960226df22" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="38964919-e714-407b-9aee-43df6a562417">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b8f4f128-8e94-4c99-995a-4f5cdf5a6fba">
+      <statement statement-id="sa-17_stmt.a" uuid="3d8ff4e8-11a7-4163-95af-7fc49f9848c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="699e84a8-2766-46eb-ad5a-484eb4c9c3a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(a) is planned. Progress
 can be tracked at:
@@ -7391,8 +7391,8 @@ https://issues.redhat.com/browse/CMP-389
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="94ddbcf4-8b8f-4caa-b38b-875c3fa263dc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="672a0918-f3a6-4f54-a258-538576b77002">
+      <statement statement-id="sa-17_stmt.b" uuid="11528158-c617-414b-80e5-81b5bf49a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af3ab2ae-ebd4-4242-ae94-c54c59a8e8a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(b) is planned. Progress
 can be tracked at:
@@ -7401,8 +7401,8 @@ https://issues.redhat.com/browse/CMP-389
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.c" uuid="e64e44d3-341c-443b-9209-3feb77d6de7c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ae6676c1-e30c-4f4e-b903-04861443d4b9">
+      <statement statement-id="sa-17_stmt.c" uuid="23942290-6e90-4392-9c34-0a2649fa4335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3378fc76-522a-41f2-a73a-0d670a84dfd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(c) is planned. Progress
 can be tracked at:
@@ -7412,18 +7412,18 @@ https://issues.redhat.com/browse/CMP-389
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="597f7043-840a-462d-8bd3-89ddcfbce3d6" control-id="sc-1">
+    <implemented-requirement uuid="54e9360d-eae0-47f4-a92a-894f7a8ceb12" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="fe9c69d3-dae7-43e2-a063-8f661cc6beb0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="827495d9-f6f7-425e-bfa7-cbc975619a33">
+      <statement statement-id="sc-1_stmt.a" uuid="354dc18e-1012-45fc-a30f-c1a9fabd2b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="d6064cd3-a2c1-44ee-b4f8-24f6e5df0c46">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8af86ccc-27f8-4ac6-8c29-437d9f583a27">
+      <statement statement-id="sc-1_stmt.b" uuid="ac80bea9-adb9-4bc1-8c4a-528f150bf852">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -7431,10 +7431,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d287235-b432-47a9-90a9-02c3949067ae" control-id="sc-2">
+    <implemented-requirement uuid="591ef3b8-6fee-4e3f-a241-82278e96a4e7" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="3036ffaf-7546-4e13-821a-e6dbf7fa93de">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="290e9bd9-b69d-4c45-8d4b-d2b5568a9b61">
+      <statement statement-id="sc-2_stmt" uuid="143cf0ca-c117-4586-a1cd-91947e3f1a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa072737-5175-4d0d-a2ab-e535883b1181">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -7449,10 +7449,10 @@ https://issues.redhat.com/browse/CMP-429
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5121bcc-aa2f-4c24-9aed-57adc5a470cd" control-id="sc-3">
+    <implemented-requirement uuid="4585b1a9-f2b6-47c5-9ea1-fe85860e03b5" control-id="sc-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-3_stmt" uuid="96684e4a-4cf6-40f3-adcd-68b4607e0e1e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ef1b8602-d378-462e-b917-a6ee6c851363">
+      <statement statement-id="sc-3_stmt" uuid="47370f6d-b791-4508-9f02-15d432b516ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49b6197f-11f4-40fb-b3fb-0086caf4bae7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for deployment utilizing namespaces,
 host roles and other features as well as policies and procedures
@@ -7467,10 +7467,10 @@ https://issues.redhat.com/browse/CMP-467
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f84a7f8e-5ee9-485d-a6d1-cb3ff8390d94" control-id="sc-4">
+    <implemented-requirement uuid="96f7fae4-b1c4-4625-92ac-3353f07bb6ca" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="3479b8af-97ef-449a-9432-5862459c3217">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6e8ddfe6-92c9-4e5a-a98d-b1749f0c3b4e">
+      <statement statement-id="sc-4_stmt" uuid="deb25b8f-b7c0-4ffc-87c3-ddb3e0e9e98b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="617b39ae-8abc-4fb0-9c00-c50746b0d781">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -7484,10 +7484,10 @@ https://issues.redhat.com/browse/CMP-428
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="961eb7cb-964b-4fcc-bcca-ee2a6bec4f60" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="a5c5e88e-60cc-4697-bf03-5fa0bb25a564">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8be8b37a-f02d-499d-81a6-d6423b4ecf51">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7497,10 +7497,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e5fe7ee-f3ae-4248-9e46-de58ada6c346" control-id="sc-6">
+    <implemented-requirement uuid="2ecd1aa4-1ec5-424c-8299-2f1847c78d2d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="af81f1b7-7802-4b27-a79e-0584f5384ff0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e54d1e6c-b3a5-4e07-b4eb-45e1fba73bef">
+      <statement statement-id="sc-6_stmt" uuid="1c65ffd6-790a-45be-9f96-dae549f63731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb086507-2e55-4213-b420-2f757534f30d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -7515,10 +7515,10 @@ https://issues.redhat.com/browse/CMP-476
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="397b5039-8d9f-4bb4-8324-ca404a4ff771" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="44cfe7ff-3871-4c47-ab3f-13625f617229">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dfd8ef40-8f54-4df7-8d50-b376c08d380a">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7527,8 +7527,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="f3a0059f-3f57-44ff-8ca0-519343103590">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ee24aedc-8603-4d8d-87b4-9d2cdbe10458">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7537,8 +7537,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="1a443003-9395-48ed-96ff-ce7430b7ac6a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1c146068-a47b-4008-9fe4-8d6e57c4147c">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7548,10 +7548,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="199f7360-651c-4748-9009-bac04dd6e6f3" control-id="sc-7.3">
+    <implemented-requirement uuid="186b2385-1f1a-4a9f-87cb-fa9ba58408bc" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="587aa91c-7e6d-4dd3-97a4-9f421b1d4862">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dd7c6ba7-929b-4493-acc5-7bcbf7068447">
+      <statement statement-id="sc-7.3_stmt" uuid="34c09b45-a0e3-4736-b446-a55a9b2a919e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c23c58f-8d5c-4070-a9c0-8ae34f8b5eb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -7561,10 +7561,10 @@ enforcement.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1a02590-0b8f-4612-a450-252824a064a3" control-id="sc-7.4">
+    <implemented-requirement uuid="036fedec-6866-4c42-a4cb-78e19368a3bb" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="97997e15-f51d-4092-b269-daa351a387af">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e88d2e40-0c38-4080-9cbd-85534c6183d3">
+      <statement statement-id="sc-7.4_stmt.a" uuid="ffaa818d-a56a-406d-8534-d92aa505b945">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64b1aee9-3772-4cb1-baa5-8343ba144412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication service
 is addressed at the network infrastructure layer and is an organizational
@@ -7572,8 +7572,8 @@ control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="46f28d84-6d3f-4d8a-ae5a-49799ed06378">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f4623464-4869-4efb-8074-6b146a1760b8">
+      <statement statement-id="sc-7.4_stmt.b" uuid="1bfeefff-ab02-427e-8770-5df42cf390d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5054f3d-48a7-4136-90fd-58c0e36c0c59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside the
@@ -7582,8 +7582,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="2b9cc79a-8924-4b58-9dca-9bdfd3953d02">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="64c95c7a-c785-4437-952f-017b9d8de044">
+      <statement statement-id="sc-7.4_stmt.c" uuid="1af6eb6a-5c7b-4f09-862c-45b20f777565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79d1d101-b3e4-4324-9904-c33c064ac238">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being transmitted
 across each interface is an organizational control outside the
@@ -7592,8 +7592,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="adb1d946-755c-4955-8322-9e44104f4bc3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8ae518c4-95cd-4eac-9484-d348786a6f53">
+      <statement statement-id="sc-7.4_stmt.d" uuid="c4cbae4e-54d0-402e-9967-5882609908ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2065dfc0-f7e6-4e9b-b625-82ace606cce2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational control outside the
@@ -7602,8 +7602,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="070ed637-d773-49cb-86d2-75de5e0034c1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="99d5cb4d-9fe9-41ac-9b14-5fbf8480f9b0">
+      <statement statement-id="sc-7.4_stmt.e" uuid="2e9f316c-441e-4e99-8bc8-edc888c8a30c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98709f04-2185-4da4-8735-f97137a7376d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally defined frequency
 and removing exceptions that are no longer supported by an explicit mission/business need
@@ -7613,10 +7613,10 @@ handled at the network infrastructure layer.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83a832eb-9f05-4a8f-acf1-d56106822208" control-id="sc-7.5">
+    <implemented-requirement uuid="299dcdaf-d2bd-44b1-9f34-7a83c829a2b4" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="e1d4c74c-279d-49a4-8c4d-1ebfbc911ef7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d8cac09f-cd8c-4a29-bb30-9dcea314f5aa">
+      <statement statement-id="sc-7.5_stmt" uuid="796764c4-2388-42ab-99f8-bdf5a00fb0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b15b06f-d5dc-4fb0-af24-596c93208d35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -7630,10 +7630,10 @@ https://issues.redhat.com/browse/CMP-424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42867b7a-a2fa-4d19-b6bb-8035cd218872" control-id="sc-7.7">
+    <implemented-requirement uuid="0af997e5-f97f-4d13-91e7-e9c5a864df45" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="e9cabfc8-327d-49fe-b276-c45fbf91e04e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="db08b020-8319-4623-93bb-cc1296aaae5b">
+      <statement statement-id="sc-7.7_stmt" uuid="cb78b303-47eb-4ac0-abd7-7b7c81060c99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94db18fa-a069-48ec-8c67-6bd51db07d70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing split tunneling is an organizational responsibility
 and not the responsibility of the CoreOS Container Linux operating system.
@@ -7641,10 +7641,10 @@ and not the responsibility of the CoreOS Container Linux operating system.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0502f3b0-4ac5-4170-a239-b3cf384f270b" control-id="sc-7.8">
+    <implemented-requirement uuid="7decfaf2-b8e3-498b-ae55-671b24506ec9" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="dd794263-b491-4afa-b872-5207068b1c4c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="87552419-7b1b-4432-a862-8d19f691368e">
+      <statement statement-id="sc-7.8_stmt" uuid="833f91c1-8eb3-4422-8059-f8d05cfe7237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adba8470-6219-47a4-aeb4-ba166c6b610a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7654,10 +7654,10 @@ https://issues.redhat.com/browse/CMP-477
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa9e34f7-0986-426f-9c53-823f955e28e4" control-id="sc-7.10">
+    <implemented-requirement uuid="679c2de8-d087-4463-8622-1b5cdd1ff547" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="b7214c9d-a1f9-444d-93a1-cae1620f6736">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="25515acf-bed7-42bc-9cf9-37e6568e2a7e">
+      <statement statement-id="sc-7.10_stmt" uuid="d73cea55-f22c-4ba1-a9a5-02dd9fafbe04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82aa1ba8-6968-43b2-8c19-cbe7df2a6ffc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7667,10 +7667,10 @@ https://issues.redhat.com/browse/CMP-482
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d7607ef-0d27-4ae8-98c8-4425b9c5f852" control-id="sc-7.12">
+    <implemented-requirement uuid="7bcc9d61-0924-4650-a79c-d2bcf6e0bfde" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="4f99ea07-31d2-4a6f-aba3-d5b1b573e4a4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3f525445-beed-45fb-bdff-5a9b5d5010e1">
+      <statement statement-id="sc-7.12_stmt" uuid="04b972b1-e2d5-4deb-868d-b1a1bb971393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c721f916-ebf5-44d2-930a-0f52d3887fec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -7684,10 +7684,10 @@ https://issues.redhat.com/browse/CMP-483
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7659d51f-e4b0-4fba-bc8b-fc70c5e6fc12" control-id="sc-7.13">
+    <implemented-requirement uuid="541d239e-bcdf-4fb7-a5bb-0b3f1a90c476" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="52af08d1-19ef-45ae-b09e-06735ccbb0fc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c90b186c-d7d2-410b-9d94-9302894078a8">
+      <statement statement-id="sc-7.13_stmt" uuid="4ba0efb2-52e0-4f15-863b-f089605a50b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa550ac-3fea-41e0-bb2e-2fa546c17355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that CoreOS is
 isolated from other internal information system components by
@@ -7704,10 +7704,10 @@ https://issues.redhat.com/browse/CMP-484
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a85008fb-1d34-4aba-ad1f-2961ad028a6c" control-id="sc-7.18">
+    <implemented-requirement uuid="7e0070ef-c09f-48d1-9579-efebc49bb27b" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="483ba82f-8b4b-497a-9b63-32fb3eb7105d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7f9ce1e0-c64b-4c57-91a6-e810f2c5035b">
+      <statement statement-id="sc-7.18_stmt" uuid="6bc5981d-371a-4efe-91bb-23f0994ae97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f446eca6-5b4d-47c8-815d-301752b4d6ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7717,10 +7717,10 @@ https://issues.redhat.com/browse/CMP-488
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0420db7e-ee16-4962-982d-bf4ddde68e6c" control-id="sc-7.20">
+    <implemented-requirement uuid="9b22263a-6581-43bd-9229-7c6c2e20bc77" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="9e63bb0f-7bae-486c-b1f0-261b8671cfc5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="61639c65-0c94-4510-ad44-cb87c4d2b84e">
+      <statement statement-id="sc-7.20_stmt" uuid="d56944e9-176b-469f-9616-3f55ab9f86ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f635877-5d6e-4ea7-a1bb-a73604c5fa9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met when SELinux is enabled and configured properly
 with namespaces being used as well.
@@ -7728,10 +7728,10 @@ with namespaces being used as well.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4af50116-61b5-4ff3-a80e-f1c486110a4f" control-id="sc-7.21">
+    <implemented-requirement uuid="64438902-f29d-4aa4-8a62-4853674b24e2" control-id="sc-7.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.21_stmt" uuid="e35fa139-632e-4c69-8aba-8eeff0422093">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2efc8d92-b1c4-47dd-b956-07caef9f6864">
+      <statement statement-id="sc-7.21_stmt" uuid="5983e354-e073-4af8-8f42-ae69e1bd7b14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="143bf9a5-3bbb-47ff-a892-bce11a26ef04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7741,10 +7741,10 @@ https://issues.redhat.com/browse/CMP-489
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90407114-74f7-4687-b168-1a60fc2e55ac" control-id="sc-8">
+    <implemented-requirement uuid="5204cabf-dbf5-4d92-9cd1-804354d80d7a" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="7314d2c0-4ba1-4f1f-a68b-549aa47a53a1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a317133b-c25f-4ae7-a08f-def8f81f3a78">
+      <statement statement-id="sc-8_stmt" uuid="10ab3b1d-fa32-4dfb-b7f0-c5c4f924b33c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fee56b6-5600-43e3-9132-b328cd2e17aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -7752,10 +7752,10 @@ information.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e358ad9f-9e45-492e-913e-6baa1d6fc797" control-id="sc-8.1">
+    <implemented-requirement uuid="d79b39ec-b75a-4d9d-b839-2f28d69d9e98" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="2e0e19dd-057a-484f-b8db-f21e631e48ee">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="82b630ae-90d1-4b14-9f9f-0a4965558074">
+      <statement statement-id="sc-8.1_stmt" uuid="84d59cbe-40c4-4f22-8df4-1246640eef00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acd8d90a-0f39-4844-acf7-6a4ed7f9b815">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -7766,10 +7766,10 @@ network communications that carry customer data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de0c9d9f-55ad-4a6c-aabf-e270aa2a5b38" control-id="sc-10">
+    <implemented-requirement uuid="df5e51eb-966c-402f-98c6-1bc7cb654de8" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="826ad7de-d8fe-4b1a-9cff-2db338c6fd0a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="5a759721-2ae9-40aa-a63b-ed3942014ed2">
+      <statement statement-id="sc-10_stmt" uuid="49fd79b3-99f8-474f-82f2-797e2fcb4835">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fcef049-edaf-49f1-ae92-34545047b7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -7784,10 +7784,10 @@ https://issues.redhat.com/browse/CMP-422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e679fbb8-636a-40fc-8c49-a10218f1d69a" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="2ea5e9fd-0bfe-4026-8017-d653163c569b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bec73fc0-e018-4182-9619-80f8a94cb113">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7797,10 +7797,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbb08cd6-015b-4435-91ae-f7ae0e18db12" control-id="sc-12.1">
+    <implemented-requirement uuid="63ab894b-cf8f-4a84-9833-1d270552f36b" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="0ee32da9-ea58-4e54-bd52-c94ff107ca26">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1005554c-5057-417e-af01-5c2744705055">
+      <statement statement-id="sc-12.1_stmt" uuid="212fc07b-7b23-44fb-9faa-e66e524fbe4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a4db13e-65b6-4b6a-9f33-5d4e6c86902d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7810,10 +7810,10 @@ https://issues.redhat.com/browse/CMP-497
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fefbe3e0-70dd-4d5c-b118-359af382b671" control-id="sc-12.2">
+    <implemented-requirement uuid="f654668f-472a-4fbf-a522-57b6eecda6b0" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="46004d06-e39f-46be-86e2-840d74501640">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7c2a4c47-035a-4722-a4bf-01ad077427f3">
+      <statement statement-id="sc-12.2_stmt" uuid="67ed0c07-b5b2-435c-bf22-d186feeafb91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7cd35cb-8dd1-4c8c-be3a-46ce4c45892f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7823,10 +7823,10 @@ https://issues.redhat.com/browse/CMP-498
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91d66f61-3b50-400a-a0d5-699dd82dd95d" control-id="sc-12.3">
+    <implemented-requirement uuid="573937d5-283f-457f-8b61-cf35b660c70a" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="ce0f9b19-d435-43a6-a302-cce228cefe18">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="70f2fe19-9d0c-4b3f-b0a0-15cc4af2b130">
+      <statement statement-id="sc-12.3_stmt" uuid="a440cef9-784e-4366-a8cb-6d94f9df94bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90872c45-14ad-48c2-8509-c00f5833d23f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7836,10 +7836,10 @@ https://issues.redhat.com/browse/CMP-499
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="387e7ef3-c531-46e7-8e8a-b7cae2a89ed4" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="f1bdf305-b4f2-48d5-a566-1ba5cd77f61f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d5872e03-8b92-49bb-b7c0-50cbd3a737b6">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7849,10 +7849,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3ea711a-1b98-4992-890f-d378402392db" control-id="sc-15">
+    <implemented-requirement uuid="d4373dc0-0592-44a3-b8ac-19c15a277ed6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="febfbc8a-deb4-423e-8f95-4b0823a55915">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0a114d0d-2c99-462a-830e-27f2ce352d10">
+      <statement statement-id="sc-15_stmt.a" uuid="c399b25a-6449-4871-bff6-daf5ff8efbb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7861,8 +7861,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="9920ee75-a8da-4aa5-b7c9-884fe8b93e13">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fd09601b-9aef-4233-8cb7-0661f0dcb35e">
+      <statement statement-id="sc-15_stmt.b" uuid="c6c7c1ab-cbde-4eee-8df3-ad2e347204ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7872,10 +7872,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7542cf7-4b9e-4c61-bb83-ca4b993f0289" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="9f3f9bb4-7397-42ac-9ded-b6d2701a7dfb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8713a9b7-64cd-4f61-9f74-1b1a1c7da5c7">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7885,18 +7885,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51ee8161-29dc-4853-90dc-435986d5830a" control-id="sc-18">
+    <implemented-requirement uuid="e66da199-3ae9-4df6-83ae-8f99d17875fa" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="aea0d633-928c-4a6b-95c7-60d857e520af">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2dcb22f6-2d17-4d49-a975-5f497b7a0d84">
+      <statement statement-id="sc-18_stmt.a" uuid="35d7a6e6-8a08-4344-a7e1-192048af3423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1cf039a6-1ab9-4aee-baea-b15765600d67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining acceptable and unacceptable mobile code and mobile code technologies
 are organizational policies/procedures outside the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="de89223e-4da8-4c01-9563-0f7461bc5e9a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="76430826-c297-48d0-bdad-94d533990cce">
+      <statement statement-id="sc-18_stmt.b" uuid="f729f833-67a2-4e17-b454-f166291d36a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30838b6d-1a89-4eb2-a5d0-70d2e52b9a56">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing usage restrictions and implementation guidance for acceptable
 mobile code and mobile code technologies are organizational policies/procedures
@@ -7904,8 +7904,8 @@ outside the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="4d1855a1-d786-4bde-8f07-d298373750a9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="71d538c7-9236-4405-9a93-54ddecdb52e5">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -7914,18 +7914,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0602dd32-faa8-46a4-8e2c-815905e0a02c" control-id="sc-19">
+    <implemented-requirement uuid="4d25e2ca-02fe-4fb1-a448-051ff7235e89" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="e786afd9-0802-41bf-860a-e8883f0dc50f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="76bb5f13-f671-4358-9503-0d8be587cc8a">
+      <statement statement-id="sc-19_stmt.a" uuid="411582be-7102-4247-9f51-a999d1798bde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="2ec04686-168e-4396-9b18-30ae3dab4a65">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="683c3525-baed-4e40-99b6-fdd6ef061f1f">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -7934,10 +7934,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4593325-19d3-45fd-95c4-ae54a4f337f0" control-id="sc-20">
+    <implemented-requirement uuid="c77113e5-0a1a-4df8-a7b0-5847ff7b267a" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="91fd06c7-1314-4183-bfc4-868a6dc6e06c">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4f889ea5-02a6-4434-93fa-1315af68025d">
+      <statement statement-id="sc-20_stmt.a" uuid="a38a366e-a171-4825-81ec-29464e4f2441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7946,8 +7946,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="56d22921-f060-4d8a-8852-dfe2e520e407">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1e090425-9237-4fe7-8335-1d8edfc2e5a6">
+      <statement statement-id="sc-20_stmt.b" uuid="c5749db4-3e0f-4e6f-b7e7-fc8496731ca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7957,10 +7957,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f37b4664-891a-44dd-a753-3ae119a2f475" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="0d32352f-8ec8-4258-8b65-101861e70cd4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="dffaca02-4c2d-4a93-a7aa-d79330ce84b5">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7970,10 +7970,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4b775c6-a45a-4342-bb32-99abb03e71c1" control-id="sc-22">
+    <implemented-requirement uuid="8b7be659-58fc-4f8e-b6ba-fcdc3111e4fa" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="9dbec206-68ac-4e2b-aab3-018ba842e128">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0b22ef9d-3d35-4125-bbbe-926562f13d23">
+      <statement statement-id="sc-22_stmt" uuid="5525a272-a750-4ba0-aade-c3c0660b21db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d75e9d7-2b91-4d97-9af5-2efbfc6c5d6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that name/address resolution service is fault-tolerant and
 internal/external role separation is implemented is not accomplished on the CoreOS
@@ -7982,10 +7982,10 @@ node level in an OpenShift cluster. This is done at the OpenShift cluster level.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea0115fd-1c19-450f-be37-95152b5779ef" control-id="sc-23">
+    <implemented-requirement uuid="f56a5648-30ff-447d-94d5-438189034ff6" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="a738d4e3-ff33-4623-a5eb-ecbc205ecb79">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d472ed26-dea3-4d93-b02b-dea21cd16474">
+      <statement statement-id="sc-23_stmt" uuid="aecd3395-ce0c-4a78-81b5-4b3567af9f5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00370ad4-7c53-40e9-9ed3-16f8ba73ce27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -8005,10 +8005,10 @@ https://issues.redhat.com/browse/CMP-408
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="146e0bea-9222-40f4-a363-d9c986e0db74" control-id="sc-23.1">
+    <implemented-requirement uuid="b985a08c-0c77-45bf-aee6-6f338f66844c" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="1740bf18-55b4-4fd6-a862-675187f27399">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9a28e02a-45c2-4eec-9c80-80a6d0340a95">
+      <statement statement-id="sc-23.1_stmt" uuid="cd72eb89-b726-49e1-9c75-43eaa350ceed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="680c783f-957d-497c-ad0a-b7b30e965b29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8018,10 +8018,10 @@ https://issues.redhat.com/browse/CMP-503
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90d7378b-d163-47c6-847f-5e04facc69cb" control-id="sc-24">
+    <implemented-requirement uuid="760dc535-35d5-4aaa-a424-d6f48867e4c5" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="8543b835-f59e-4735-b70f-81f234a7acca">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4eafb039-54a6-45dd-bb9e-189ebeb8e34b">
+      <statement statement-id="sc-24_stmt" uuid="420dd762-6c23-49b2-b672-06fb5d6978fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c361032-37ec-4037-9c35-181d6eab1e82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8031,10 +8031,10 @@ https://issues.redhat.com/browse/CMP-506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5daaf21a-0ba6-4671-82ee-0b280d019fa6" control-id="sc-28">
+    <implemented-requirement uuid="2f992720-6db0-4356-8634-6339b0d6cda8" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="1ad0ecb2-17bd-44b8-a077-f06d485e7b95">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="54964c2e-a937-4932-a90f-5c9112607d2a">
+      <statement statement-id="sc-28_stmt" uuid="8ef6d238-c643-47a9-852d-368fa7d3e931">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32649326-f922-49d4-bd77-0b13901bf763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8044,10 +8044,10 @@ https://issues.redhat.com/browse/CMP-407
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5163e672-95d7-4b9f-ad09-583b72641fd1" control-id="sc-28.1">
+    <implemented-requirement uuid="44963431-b6cc-4330-b19b-8116a31596f7" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="4e57da0d-1890-471a-b7ea-3ced09fd5fe9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3cb95dc0-ee5b-45e1-8fb7-1c0937e658e0">
+      <statement statement-id="sc-28.1_stmt" uuid="4e2915fd-e293-42e0-b8bb-1e13f4275ce8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60860935-2e75-41f3-899d-77b295e6650c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -8068,60 +8068,60 @@ https://issues.redhat.com/browse/CMP-509
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f37b95c-ec6f-4699-a19e-95147fe362ee" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="d1155374-775c-4237-9535-7f97248a1257">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e5ac0728-a76a-4667-961f-a1ebccc10d6e">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cb8c34f-618b-4024-b090-afb121d328ae" control-id="si-1">
+    <implemented-requirement uuid="939ad644-f843-44d6-9827-c800985ba52f" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="e21429f2-3ef8-41bd-8d8a-4d3fb8bdd440">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3f129c3d-d834-4c68-a61b-f573473ee372">
+      <statement statement-id="si-1_stmt.a" uuid="faf77839-500b-4190-9d2c-bb124cdfe49f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="a2891a37-418f-4e90-8e68-4972286292b9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="026ed2a1-9ae8-4de7-b531-39da53138db8">
+      <statement statement-id="si-1_stmt.a.1" uuid="8a14bbab-9059-4b95-afed-e159522f38be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="862e6fa9-99cb-45e4-bb6f-560e7c2ca41b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2a01aa10-3bf8-4279-8ed1-741387129ab5">
+      <statement statement-id="si-1_stmt.a.2" uuid="0f66fa58-3e16-483e-8717-de494858c173">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="27b389ba-36a4-4fe5-9409-cb7d08a8ada1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="810115cf-8ab4-41e9-8aed-3dc93f5cd785">
+      <statement statement-id="si-1_stmt.b" uuid="80f86133-24b3-46f0-972f-781d6cc87d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="7d4260c6-02ed-40cd-9238-fa260c301296">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b79cb856-24fb-463f-98c4-223b824a1c8e">
+      <statement statement-id="si-1_stmt.b.1" uuid="e8d3dccd-bd75-4eb7-ac9a-70d5cd1e26ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="b447dc87-2665-49f4-be59-addcbcd9d0c5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2112f510-3f01-45e8-a9a6-21464524b355">
+      <statement statement-id="si-1_stmt.b.2" uuid="d5091781-e22a-453f-bfd9-da12a3cffbeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8129,10 +8129,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3bb9448-2b1a-4e98-a0a0-945eebf95c5b" control-id="si-2">
+    <implemented-requirement uuid="4ee1f2dc-9abf-4af2-a0e6-68fc08d98380" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="52400c81-4bae-4029-bcfe-da3b498122e1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ba18789c-bb16-4105-bdfe-fcee4a0711de">
+      <statement statement-id="si-2_stmt.a" uuid="9720e20d-3df6-4f50-8ae3-a4ef5f8ca8fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dff4e8f-9e35-4256-b12a-0de5fc01866d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their CoreOS deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -8142,8 +8142,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="a780af8e-23a4-4ad0-a39b-9df08ebdfb63">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="efc8991c-6e46-4028-80c0-5dec34ccfda5">
+      <statement statement-id="si-2_stmt.b" uuid="d89d296d-55a1-4bed-aa91-66c08067c4a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b6d6495-2347-4f30-8e10-9044b74463de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing CoreOS updates
 related to flaw remediation prior to installation. A successful
@@ -8153,16 +8153,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="541a3b87-2260-49bb-96a7-ac5bb903c107">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9b0f8c2a-0596-4a67-bb38-02306abc2ca1">
+      <statement statement-id="si-2_stmt.c" uuid="e194c214-36bf-47a9-b578-186ef5c68da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="a99adc1e-1cda-4317-b3f7-5a3f2f5b51cf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e1f7b624-ee04-4df3-87ca-c5292fdd002c">
+      <statement statement-id="si-2_stmt.d" uuid="9cd61549-ae3a-494d-8793-2a0eed029bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8170,10 +8170,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25bec244-7f49-4175-916d-d3007c9d2ee5" control-id="si-2.1">
+    <implemented-requirement uuid="215e150b-3030-414c-abb0-d250f8d5e88c" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="7ddd8b35-738f-47c8-947a-3c49ddb5db3b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2b5048c7-a7a3-4946-ad36-e5e10932ed05">
+      <statement statement-id="si-2.1_stmt" uuid="5a8ec765-bc42-4136-b844-0322400dc658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="236427d0-9b5c-4fa0-9296-8eaf8c701c8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-2(1) is planned. Engineering progress can be
 tracked via:
@@ -8183,10 +8183,10 @@ https://issues.redhat.com/browse/CMP-526
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82c91354-5300-4b13-b8a0-44f8700fb0b0" control-id="si-2.2">
+    <implemented-requirement uuid="25e6bb3e-56cc-4987-892a-3e681e6f3441" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="8838382f-fd47-4103-bf60-37360b14c27d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aad9edea-cbc6-48dc-b14b-290c7093b8f1">
+      <statement statement-id="si-2.2_stmt" uuid="166767a9-51b0-49a0-a1bf-86af3fa2e962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d5517-24f7-404a-ba5b-c641b36f0d73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -8204,10 +8204,10 @@ https://issues.redhat.com/browse/CMP-405
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="425c6969-e7ae-4529-a1f9-7ab4944d1cdc" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="04846abd-07d3-4297-a270-a7093dcd1e29">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e1d166d2-f36d-4c30-a94d-a0e59712f094">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -8218,8 +8218,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="0bfcbbd4-a0d2-4f18-8958-49a1632ef591">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e07b34f3-8472-4525-81af-f8afdd377183">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -8231,10 +8231,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da9dd136-ab06-4548-93d4-3483b73e45c9" control-id="si-3">
+    <implemented-requirement uuid="4a1a1387-0d1c-435b-a997-6cf4182f0d3e" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="4d9a3b2f-b876-4287-bcc5-1f8e55236bfa">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="02f94825-956c-4b72-94d7-0e7bb53600bd">
+      <statement statement-id="si-3_stmt.a" uuid="2cedad34-820d-4c19-8351-320d162dd000">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b9c31cc-1e94-44c8-b9e7-79474eb422be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -8246,8 +8246,8 @@ the use third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="6c99432d-8228-40e9-83b6-a78b143eacf7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d7d16229-9012-4992-8138-2b178b5ab5c3">
+      <statement statement-id="si-3_stmt.b" uuid="f0a8a2c2-9853-40ad-82a3-71d35d099093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acaa67b5-6168-4bb9-a0c4-6520f323328f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -8256,16 +8256,16 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="1f14a318-7fc2-470a-8f96-628ab2903939">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0d49c76f-6e23-421d-b751-f50a6adb656a">
+      <statement statement-id="si-3_stmt.c" uuid="950f012d-7938-4cd0-8513-ad982ac3bb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68db3553-e877-4ae3-b0de-9027603a9df9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="7c1a9d34-0e46-4e3d-9749-c0d71eff7133">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0b7b182e-4bfc-4a6a-bb1d-d1e7ba770a5c">
+      <statement statement-id="si-3_stmt.c.1" uuid="7b6729a1-c4b8-4647-924f-6563d03e0605">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eff97d30-28a8-498b-98bc-2e77dc7868d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -8275,8 +8275,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="99337b1c-a521-4656-81a5-6b0eee8b71bc">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1b80fd02-c932-492f-b77b-569cab616616">
+      <statement statement-id="si-3_stmt.c.2" uuid="a8c51912-153a-4da5-9705-c24ddc805862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c27f453-80c0-4206-8086-8033410bb8dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -8284,8 +8284,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="cf514ada-20a8-4251-ba14-00bd4071ab95">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="fe3cf712-ef93-49d7-833c-db721d341533">
+      <statement statement-id="si-3_stmt.d" uuid="f1faaa16-6cbf-41e9-900b-c0b780d64182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="369435a4-8044-471e-9a54-6d5457f0e4e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -8294,10 +8294,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01769204-0606-4b2f-a0fc-15c77676e273" control-id="si-3.1">
+    <implemented-requirement uuid="1cb9ce8c-a065-4e29-8ce4-cf2326fb5635" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="33ed5e64-cd17-47b4-b295-4b0e0a9ed48e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f1f7914e-3eeb-4d6a-8264-43d6a6afbb1d">
+      <statement statement-id="si-3.1_stmt" uuid="eb659309-6941-4e3f-b759-e9650d65d7f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3e4d451-1297-4cb9-948a-5c981fa69b20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -8308,10 +8308,10 @@ protection mechanism is centered in one location.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3493e400-fdd3-48b8-8ace-75eb5a5d1da5" control-id="si-3.2">
+    <implemented-requirement uuid="18ccdba5-ad8c-4be5-bc88-3d1aa521f7fc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="d33f1ae2-8d29-4489-9eab-78344d0ae50f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3c53e7d8-1671-4a13-9dbe-243a17f9a660">
+      <statement statement-id="si-3.2_stmt" uuid="f025634a-0829-43ea-a63b-43512c51068b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9640d91-db08-4e76-86bd-d5f90fb4fe43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -8322,10 +8322,10 @@ mechanisms definitions are configured to be updated automatically.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba1662e7-0c06-40b0-8197-bcb7cdb05bd5" control-id="si-3.7">
+    <implemented-requirement uuid="cf3810d4-c2f2-4aae-9d19-8a62dc9eff70" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="731c5a74-a802-42ce-8ed2-0dc02f4f884e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6ac8d8a1-5d48-400a-be04-11a3392a79ff">
+      <statement statement-id="si-3.7_stmt" uuid="c8f35cf2-5a10-456f-ae5d-d11ebbb2e481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cee870d-007c-4f0a-a265-2c7467b1ffd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -8338,26 +8338,26 @@ do not yet exist.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5d9e17a-9fef-46a9-b205-a610e0dcef80" control-id="si-4">
+    <implemented-requirement uuid="bdbbd04b-e0f0-49e6-bbbf-acd8c686f8a7" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="3fcf4c59-94d0-49be-b0e1-89ae21997ace">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="59d210d8-f09a-41c8-9bc2-582761c32f19">
+      <statement statement-id="si-4_stmt.a" uuid="0677e3a7-bf35-4378-a1fc-1be2f318baba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="b6eddff0-801b-4081-a9c5-be55c7aaaa05">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="da1400e9-cfcd-4aee-8f6f-ab178f2af5cf">
+      <statement statement-id="si-4_stmt.a.1" uuid="546c286e-e1be-43f8-b843-7adf97ebb7ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="d4d73e38-90c8-4770-a9a8-f90f528611df">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a3db1f11-a5ab-41cb-b2a7-1d6228297d89">
+      <statement statement-id="si-4_stmt.a.2" uuid="8a3f7de4-ddf7-40bd-993a-c29b1409bd64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9bb5b42-c476-4aa5-985d-e9ba02c5d707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of CoreOS configuration.
@@ -8365,8 +8365,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="93f52c45-8712-4c2e-91b4-aca555fd7b62">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f8379eb0-7bba-48c0-aae3-ab09c32f004f">
+      <statement statement-id="si-4_stmt.b" uuid="680ade86-4b9e-4f2d-8628-4e8d97dfa690">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="148f2e3f-ddb3-4874-b4c5-81e95e745305">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -8374,16 +8374,16 @@ of CoreOS configuration. Functionality to meet this control can be provided by a
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="4da33a93-f1b3-4cf8-bddf-a6949159622a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="a8e772d3-e552-424c-92a7-4e5df3b6f5b7">
+      <statement statement-id="si-4_stmt.c" uuid="110eef98-891f-49ff-85a7-15bc1df2df7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9c75a2d-2eef-43c3-8c81-b2d9811bdc9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of CoreOS configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="21b8113b-61d7-4370-b2a9-834e6e965174">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2b95ee1b-5ff5-4f0b-aa88-a3126e6fe6d2">
+      <statement statement-id="si-4_stmt.c.1" uuid="1ddbf432-1d71-4f0d-8899-52c86d4877c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="391a4025-aa3a-4916-a7b6-2675a890739b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of CoreOS configuration.
@@ -8391,8 +8391,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="764dae57-65a4-4e45-bd03-78d144667dd1">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b5c3ba9f-7ffa-41af-8742-893c8cb9dbf0">
+      <statement statement-id="si-4_stmt.c.2" uuid="07f80a66-1645-4f90-981b-ea7e4f5a704a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ef0e67d-380c-4cb9-a718-3f53e99d2f54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of CoreOS configuration.
@@ -8400,8 +8400,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="66331c94-8b29-4f6b-832e-0e1cd7d2c504">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0c0e6fc6-6ce1-4d63-9807-0dc838c20e4d">
+      <statement statement-id="si-4_stmt.d" uuid="23254b38-9177-4e7e-9b4a-640411ae6e56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66c58a1a-589c-4f34-b1d0-7a68570d650e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of CoreOS configuration.
@@ -8409,24 +8409,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="f1dbec33-9fa2-4d81-9f9d-23ca48065403">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="371870ab-3d52-4ecf-a201-ba344874247c">
+      <statement statement-id="si-4_stmt.e" uuid="4ca3ca63-8647-4bb8-ac72-4b879fdf361b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="f7beb0ec-f058-44b0-845b-ab9e4b75e495">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e7d8028f-dead-4afa-a2fe-e6887a283732">
+      <statement statement-id="si-4_stmt.f" uuid="dcd5cc24-40a1-44c4-8e1e-8596ba232473">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="6d35a715-a9c2-46e2-b62a-4097ca16cc55">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aa943e35-1e32-4323-abd4-43c727264c02">
+      <statement statement-id="si-4_stmt.g" uuid="8fb28cd1-0afe-4a0d-984b-946420b5dfdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8434,10 +8434,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42894270-92f2-4f9e-b21e-077ad57be3ab" control-id="si-4.1">
+    <implemented-requirement uuid="75d89090-a9f0-454b-89e9-ae96313bdb54" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="b36470fd-be2e-4ba6-9f36-c1b3f3aaedf2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="1e179b65-0c91-456f-8328-d2db3bcb285f">
+      <statement statement-id="si-4.1_stmt" uuid="8ffb6de2-8cfb-4c4d-b919-95476ce9b019">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14256b5d-c5ac-4897-b77f-6022a1d7b073">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the CoreOS environment, and documenting how this
@@ -8449,10 +8449,10 @@ systems.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad8a2cc3-224c-44d1-a472-6b1058874a5f" control-id="si-4.2">
+    <implemented-requirement uuid="a466564a-c24e-44f5-a371-0d118c5aad09" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="6a77e570-130d-44ae-bcd5-aea0dc8a225d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="16b7fbad-699b-43f0-9c9f-13ac168494bf">
+      <statement statement-id="si-4.2_stmt" uuid="bfec4448-35cc-4e5b-95c3-e12ba645a0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="158a60d2-2cb0-4c25-87b6-2a893330343c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -8466,10 +8466,10 @@ analysis of events.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d778d5f5-c41c-4e2b-a549-7a4f3a15452e" control-id="si-4.4">
+    <implemented-requirement uuid="7b2489d5-2f6f-4d1f-b59f-dca4ae41798a" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="3381733f-63ff-4dca-8381-b6e2586e4c3b">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="256d0a6d-6dfe-4ee2-9d67-2e01d2de225f">
+      <statement statement-id="si-4.4_stmt" uuid="ad0d0571-b244-4c86-9d3d-b043dda2a718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e96419b-1e8a-4449-84f4-3d330c160a20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -8481,10 +8481,10 @@ not, how network traffic is continuously monitored.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f331e0f-25d1-43c7-9079-7495ca37aecf" control-id="si-4.5">
+    <implemented-requirement uuid="9ed28fbd-039e-4879-824c-5fb5fa40ada4" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="65ca6c83-60af-43da-8edb-09fc22008302">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="49cc0ff9-41ee-46e9-8c1b-5e74fcaa7f3a">
+      <statement statement-id="si-4.5_stmt" uuid="7d9d1d38-f847-436f-80f1-5f2040122816">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae281442-f332-407e-959e-52cb7a2dd9df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -8496,10 +8496,10 @@ the notification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08077f17-6bd5-40fd-bc2c-3e84431b81fe" control-id="si-4.11">
+    <implemented-requirement uuid="c4241cc6-c63e-4549-9c96-415c3387cb75" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="5571e4b6-a995-4029-97e3-2c978cb88165">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b886104b-0172-4628-810b-77c418986cb3">
+      <statement statement-id="si-4.11_stmt" uuid="a1458ce7-eee4-4928-9e3b-268ad50c90ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8507,20 +8507,20 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c823cd0f-cbce-4362-8437-2ee3e1a5adff" control-id="si-4.14">
+    <implemented-requirement uuid="a7ebf79a-ce66-45f3-8fc6-f565302c29c1" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="eeeb0ff9-018b-41b8-858e-52b966fb8e59">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="aa53e0c4-70cf-4ee8-932c-07127b50a066">
+      <statement statement-id="si-4.14_stmt" uuid="5e1e10e1-5136-4c37-a9f0-c2ecad6147ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5eca404-095e-4b2b-86e6-72099fb623ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An CoreOS infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cce6d661-3598-4d47-bc4b-d6542b196b8a" control-id="si-4.16">
+    <implemented-requirement uuid="07d7972f-8d1d-4f42-ad1a-42cede0f3a4c" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="b59c121b-91a5-41c2-a550-676023cdc4d6">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="19ef8d91-1257-46ae-9a08-33edd3e384b1">
+      <statement statement-id="si-4.16_stmt" uuid="816c1b9b-678c-4cd0-9101-99a2ad18fea9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9202c5d-7097-4f4d-95f1-5de0b334241b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -8535,10 +8535,10 @@ https://issues.redhat.com/browse/CMP-536
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d478f2bc-09e2-4ac0-a4c4-e5a926a572ab" control-id="si-4.18">
+    <implemented-requirement uuid="d2cbb742-daaa-4125-9ee3-dbd658af64cf" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="d4db1c65-fb7c-4ecc-ada1-def2ccfa0ce3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="213b5df6-38a5-4446-bcee-ce4c124358e3">
+      <statement statement-id="si-4.18_stmt" uuid="cf285747-2532-438c-9878-d8429e3dc8ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e1eb355-99c5-490f-b12e-117555710770">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(18) is planned. Engineering progress can be
 tracked via:
@@ -8548,10 +8548,10 @@ https://issues.redhat.com/browse/CMP-537
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="516c99dd-1dd4-43a8-b6fa-72a2a56867e6" control-id="si-4.19">
+    <implemented-requirement uuid="0ccd511d-1b2b-4881-80cb-5f22ace5a168" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="e0f43e4d-e069-44e5-96ce-bbfb4cb61a8d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="b025932b-b69f-423d-ad4c-3c491d4d30b5">
+      <statement statement-id="si-4.19_stmt" uuid="1f43da2d-d9aa-4241-866c-73f910f18f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8559,10 +8559,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8eea5425-5a28-4000-b88e-c781d75c1d83" control-id="si-4.20">
+    <implemented-requirement uuid="f16c7058-e89e-432e-8074-212ed7efe6d4" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="6a85bf36-c5a6-4af3-99f9-bdb5d1e4d5f2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="0f683f09-f342-4090-8c10-f45a9c7678e7">
+      <statement statement-id="si-4.20_stmt" uuid="9871f713-8749-4cdc-88de-3485f7f23fde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da2241b7-a23b-4049-98f2-1c78a7285774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8572,10 +8572,10 @@ https://issues.redhat.com/browse/CMP-538
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ca0c0e0-b94a-4138-93bb-0098741c9bf6" control-id="si-4.22">
+    <implemented-requirement uuid="a7fd1508-2b77-4f5c-b286-dc3d3f76ee1b" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="398af240-3729-4631-a662-03580fcf7d20">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="3f464afb-b62d-4efd-a9f0-2b18063cce34">
+      <statement statement-id="si-4.22_stmt" uuid="07a995c2-3bc5-4012-9c79-8cd666cf90d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2fd10c0d-6887-46e1-8445-2236ca57468b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8585,10 +8585,10 @@ https://issues.redhat.com/browse/CMP-539
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f36af870-5fb4-4569-bb63-0254c3981952" control-id="si-4.23">
+    <implemented-requirement uuid="27c9177e-deb2-4a15-ba81-b36494cb9ef4" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="35c65a8c-ed2c-4f0d-ab10-7683ed0af2d7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="ae8ca645-9b34-488b-b726-b11fd85d6213">
+      <statement statement-id="si-4.23_stmt" uuid="090e454d-d7c6-477f-99cd-ef028901620e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac1be603-ec65-4c92-9980-6ba048488476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -8602,10 +8602,10 @@ https://issues.redhat.com/browse/CMP-540
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8694a34d-09ab-4eb1-af21-c53cb4cd5037" control-id="si-4.24">
+    <implemented-requirement uuid="772e7b5f-a085-4dbd-83c6-5b8ac9eab8e6" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="da2f81ff-c9bc-4ecb-88f7-7c0e81a869c3">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6b8ba26a-60ba-4706-95f7-f6ca25319768">
+      <statement statement-id="si-4.24_stmt" uuid="c3b3fd35-3364-472b-bf7c-783221a95a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f28d76d9-f570-4cd7-962b-5587092f4b5d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8615,10 +8615,10 @@ https://issues.redhat.com/browse/CMP-541
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6470639-9257-4d15-8ae1-2f015691d539" control-id="si-5">
+    <implemented-requirement uuid="751c1382-670d-4e79-82f3-417934a90459" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="db09ca7f-3b78-4bc7-94cb-c4f4de55ec31">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="c29f35ea-9184-48dd-be99-e8fc3e495e44">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -8627,8 +8627,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="4b6228c4-740f-49b3-9946-fd3d0e6bf32a">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="94077c67-b377-4904-b300-b65a29844bec">
+      <statement statement-id="si-5_stmt.b" uuid="2d6f3fd6-5ceb-42a5-861d-ed9429db50d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ffb574f-1429-4a3c-b34e-3661754291ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -8641,8 +8641,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="6c0a223c-c9fd-4b79-b678-c2c6e2649fcb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6b732af9-9a8a-4354-9b64-55a4d687311d">
+      <statement statement-id="si-5_stmt.c" uuid="5337086f-8de7-49ad-9a55-b5fb48cda4ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1611a1fa-24be-4608-b7f0-19ba0e92a895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -8651,8 +8651,8 @@ procedures/policies outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="764dc045-af10-4c2e-a8b0-79bcf1611c96">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cbef7f34-d8cf-4142-8e7a-df4578ec939d">
+      <statement statement-id="si-5_stmt.d" uuid="d102557b-2f6f-4ccf-80b8-75fa13defc64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fb1fbdc-e1c6-4d94-8fc8-900c172936b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -8661,10 +8661,10 @@ procedures/policies outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fed1a0b-3041-4554-8bd9-0c0c94994418" control-id="si-5.1">
+    <implemented-requirement uuid="f8df7deb-976d-4fe2-8929-26fd08f27cd6" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="cdef7ace-b81a-42ac-9b6b-322976d955f5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="2cb3fc38-c133-4151-86be-32670651e129">
+      <statement statement-id="si-5.1_stmt" uuid="56e382ed-3dbf-4037-a110-c55672e2b7fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8672,10 +8672,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="644e1358-b9a9-4a77-afbb-066717325149" control-id="si-6">
+    <implemented-requirement uuid="db734672-4491-4bc0-83df-6e1c367064c4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="9943822d-39c3-4d71-a0cd-6a1804c59121">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="655835e5-9325-46bc-ae26-d13227ff5226">
+      <statement statement-id="si-6_stmt.a" uuid="705d5b25-1cc4-4a17-a467-dcba7f7eb858">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1be72547-09fa-4e5d-97b8-90d5d6f5c3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -8690,8 +8690,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="577f3fec-addb-4f48-b99e-7887aef4933d">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bef09eb4-7ef6-471c-8096-420677ced7e2">
+      <statement statement-id="si-6_stmt.b" uuid="c8938a79-90df-4705-8f84-0851a5571634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df99302-8afa-42b5-ad64-d171a878c25c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -8707,8 +8707,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="38408dfd-ae35-44a0-8fab-73b8091ff777">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="6683fd38-9103-4a8a-81d1-9510f78cb1c0">
+      <statement statement-id="si-6_stmt.c" uuid="644fd87b-44c6-4637-a737-837a44d925ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0edc2e83-d6aa-4a31-9980-0091fa7f777d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -8722,8 +8722,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="dfed4680-dfc5-4dfb-b364-1871b32d0776">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="18cd13bf-68db-446c-9470-9ee91a3862d0">
+      <statement statement-id="si-6_stmt.d" uuid="ea6a903d-35f5-4cb6-9fb6-1b881404cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="474dceb6-7148-4aa4-92c1-2489caded95b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -8740,10 +8740,10 @@ https://issues.redhat.com/browse/CMP-542
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7cfa1eb-a459-4727-832a-fd4a073d831d" control-id="si-7">
+    <implemented-requirement uuid="75b37a46-3c5d-4af3-b138-3dd476964635" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="cb9215d1-f0ea-4035-979a-e70dd5ccbee7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="60ae6057-16fe-4445-9f87-77cfb4a5edec">
+      <statement statement-id="si-7_stmt" uuid="8f7edc4b-595d-481e-95ef-290b4ef632cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c1d92f-ecb2-4ea3-a509-a65151878115">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -8758,10 +8758,10 @@ https://issues.redhat.com/browse/CMP-394
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2af3489c-feff-4067-bb86-dc8647cb1032" control-id="si-7.1">
+    <implemented-requirement uuid="ca455f35-8815-4603-b38f-dbd91fcb6a79" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="5032ca64-fc90-49bb-8580-32467544929e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4a6af95b-a6fc-4440-b847-e5645c34e667">
+      <statement statement-id="si-7.1_stmt" uuid="b9e27bf9-5e74-407b-bc19-f1ee19c96e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a3da903-2950-443c-ba74-bffeec06af44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -8778,10 +8778,10 @@ https://issues.redhat.com/browse/CMP-395
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ee8ab0-9bce-4aa1-a423-69eb81f3d926" control-id="si-7.2">
+    <implemented-requirement uuid="acb16927-d2fc-4225-a852-db8327ab867a" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="ef8a7b55-bb84-47f8-a9cc-02f3b4e58cdf">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cfb574bc-0141-4fcc-ae71-76468ece7a2b">
+      <statement statement-id="si-7.2_stmt" uuid="d5bc44ab-8cc9-492c-82a6-822e33ec89be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe84e8d0-f2df-4ab8-ae9d-e9941839979e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(2) is planned. Engineering progress can be
 tracked via:
@@ -8791,10 +8791,10 @@ https://issues.redhat.com/browse/CMP-545
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60e8c78c-a9ff-4014-9b51-a9efc7ae744b" control-id="si-7.5">
+    <implemented-requirement uuid="f0149f2e-d5c6-4d98-b81f-c8113b528173" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="a2bb803e-64f5-42d9-b443-252a14c8b7c9">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="464a8268-0789-4681-837d-09a4f895e7d6">
+      <statement statement-id="si-7.5_stmt" uuid="77115b5d-35ea-4f75-b0fc-b65825e7950b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1f9e992-9496-4294-b9cd-0cdc1fdb827f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(5) is planned. Engineering progress can be
 tracked via:
@@ -8804,10 +8804,10 @@ https://issues.redhat.com/browse/CMP-547
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1954c75e-d2e8-4aec-a08f-d8e599a128d5" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="cd477545-7766-4772-80a6-80492531f829">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="cc2d98c1-4412-478f-8408-651ee6f0ad30">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -8819,18 +8819,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="135a7cc7-0e31-4945-8ca7-2e87cd488b91" control-id="si-7.14">
+    <implemented-requirement uuid="5e7caed4-7390-45d8-9361-959bd75fed2d" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="7800a20f-bbf4-4238-a463-2705906b87e0">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="bca7f79d-9756-47d4-8b5b-cde7dc80d0bf">
+      <statement statement-id="si-7.14_stmt.a" uuid="27ce3933-f62a-46b5-85fa-4002c75a560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="27260bde-8bd5-4678-97d5-3ba4eb9a3ef7">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="9b4e449b-4350-419f-9b5b-b29393451f57">
+      <statement statement-id="si-7.14_stmt.b" uuid="9a4febb3-6059-4e61-9b94-45a7e313a454">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -8838,18 +8838,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0582c78f-ea3b-4376-9ceb-18143fdcbdf7" control-id="si-8">
+    <implemented-requirement uuid="da2b38c9-d54a-49ac-84bb-3a53a9d94df0" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="2bfabbcd-dcfb-4ebc-9106-3130d7cdc377">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="8afebde5-88dd-4f1a-a9d1-c5dad0d3dc3c">
+      <statement statement-id="si-8_stmt.a" uuid="fca0fa64-910b-4e7a-9dbf-1d6824384be5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="517dca7c-4ecd-46af-8b3e-df1225e51940">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="f5dcf120-26c1-4f5c-8aef-bcf1f39e4e1f">
+      <statement statement-id="si-8_stmt.b" uuid="a75e2a00-e4ca-497f-9875-bb4d092eb7d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -8857,10 +8857,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d3cf7c7-e3f8-40ca-8fca-4e6f9f3eff15" control-id="si-8.1">
+    <implemented-requirement uuid="4a971b76-f4e0-4345-8f13-67b67665137d" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="486aeb9c-a65f-4df1-9985-3d9d60420bb4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="50bb1f99-08e4-4407-996d-4b12cdfc3edf">
+      <statement statement-id="si-8.1_stmt" uuid="99f9a6c9-4955-4725-8c5f-5413abb882e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -8868,10 +8868,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e54bf4d5-d53d-418d-997b-70d81028d9c7" control-id="si-8.2">
+    <implemented-requirement uuid="b4378b5e-99ae-407f-aeba-de3e38aa1332" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="2d377c5a-a923-495e-868e-58651aae3aa5">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="7db1897e-3738-4895-9672-ccf5db57bbfb">
+      <statement statement-id="si-8.2_stmt" uuid="8ed3cb71-7439-40a6-bc69-68c2c6e8d40e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -8879,10 +8879,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98570ce2-1baa-481a-96b6-0f1f5862e13f" control-id="si-10">
+    <implemented-requirement uuid="5637a065-2c41-4b1c-8392-b5ffc146062e" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="e6dd83a3-c64a-4467-8258-c2fb5020c43f">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="d7c517af-d865-4c9f-bab2-0261c872455b">
+      <statement statement-id="si-10_stmt" uuid="ed487876-7061-4778-96a1-04a08a800007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="230d9846-c77c-44ce-970a-06f688716e92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -8899,10 +8899,10 @@ https://issues.redhat.com/browse/CMP-393
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49b478c7-7b67-4512-85f6-4b76e883a20d" control-id="si-11">
+    <implemented-requirement uuid="e6cb6628-1177-4d93-a4a6-1a0510d6328b" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="24d20506-22b6-486f-90d2-f17500bee7d4">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="390059e7-9d1e-43cf-835e-b509e2b21ee0">
+      <statement statement-id="si-11_stmt.a" uuid="13df6b6e-0fac-48ec-906e-3b7eb8dd6700">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a8dcc90-b783-49bd-9457-39a78c8ca167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In OpenShift, the logs depend greatly on the component. Some
 components would just write messages to stdout that the cluster
@@ -8921,8 +8921,8 @@ security information, account information, etc.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="2c471eeb-529b-4077-a1b6-08c810370a0e">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="e3ee68f7-f6fb-4888-acec-e281a6ae84f6">
+      <statement statement-id="si-11_stmt.b" uuid="0e20cfd6-f6a6-484f-9b51-643953bd0ce2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06c151a0-f34d-4bf1-a89b-fd089b157b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the API server logs are protected by UNIX permissions and
 only cluster administrators are allowed access to logs.
@@ -8930,10 +8930,10 @@ only cluster administrators are allowed access to logs.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d58b1ae9-f110-47d4-83de-71bb0a63a170" control-id="si-12">
+    <implemented-requirement uuid="1ce07b9b-8700-4477-9e3f-e78da30e83ce" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="d03f065e-e7de-4463-af0c-3ac551d3b0c2">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="692d963b-5825-4dfd-8c1b-91e395507eb3">
+      <statement statement-id="si-12_stmt" uuid="24c68931-27c0-4e74-b69b-64db342d38f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dd9058d-69a0-415e-a099-63f6b05f4622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, CoreOS in
@@ -8947,10 +8947,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="370eb59b-5fc9-42bb-8172-2590fe5f24ec" control-id="si-16">
+    <implemented-requirement uuid="3680fa8c-408e-4624-8c74-8e70a35e49a8" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-16_stmt" uuid="118f7e85-9085-434c-8619-33bfe9640aeb">
-        <by-component component-uuid="8aa09ed4-ec6e-44e0-9f97-b2e6d21289de" uuid="4ce05d94-ee25-40d9-bdc7-06594e846c65">
+      <statement statement-id="si-16_stmt" uuid="f2f8f447-3b48-4547-8d3d-3fd2d6070ec4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7710e88f-bcc8-4c4b-bd62-e807ba8526e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/coreos-4-fedramp-Low.xml
+++ b/xml/coreos-4-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="442b6889-bec0-44ce-bf79-a262ab81e828">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="a9078384-069a-4dd7-8b40-a6e5b08a7735">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.28+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.51+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="94ac40c3-a557-4448-bd2c-822b61272dbf">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="29607fdf-1f26-461c-b493-28204f082d17" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,117 +484,117 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="bc2e77ec-2576-4f0a-9b19-65b11945d850" control-id="ac-1">
+    <implemented-requirement uuid="6f8fc8e9-f526-43ff-9aa0-8ffc41f2b51d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="e78a3e9e-558e-4289-b3b1-06a3c9e09a0e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fb9f2692-c157-4406-b3ca-a0d648ab7ced">
+      <statement statement-id="ac-1_stmt.a" uuid="1ec2691e-ff83-4ff5-b27d-605ba12af54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7be8eab-6fe9-4b04-b51b-bab9d86e5655">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="77744a40-0e68-4476-bcc9-2325747e980d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fa38451a-66bd-444a-b075-b9bac91d975d">
+      <statement statement-id="ac-1_stmt.b" uuid="879eb157-d51a-4028-8e7a-0080b30a15fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edf524ea-5b3f-4612-8aea-a3b5a9e48d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5942be71-66e4-4ad8-9a84-7d81b1e317fd" control-id="ac-2">
+    <implemented-requirement uuid="1e499a5f-dbf8-452d-927a-cfa2859f5e75" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="e93cacab-3482-4b0d-bfc3-14f9f74c56e7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3bf9f889-9453-4a0f-be9b-083f832ad3fe">
+      <statement statement-id="ac-2_stmt.a" uuid="8f9b18d3-1fc4-40e7-b8ca-3052a4c9430e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57c1db98-8a0b-425b-a0a6-b9f027bcb747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="070b9c87-02e4-4a44-8ebb-37dc23391a1b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="27addb1e-b4fe-4d80-9198-dcc1ec19cb44">
+      <statement statement-id="ac-2_stmt.b" uuid="b62b8180-4d99-48b7-afb4-d8265f4c35d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe059028-d2df-4472-8f55-6c037617da7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="30f5ea20-81ca-4423-bb97-ba003899aa20">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a7024dd5-464e-4b64-917c-4dcdb90e1c96">
+      <statement statement-id="ac-2_stmt.c" uuid="f21b17fa-1e6e-4859-a43f-6d5001f70932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c3a878b-68b4-4a62-b0d5-b589f4f394fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="58d5e75f-1a35-4d32-b2ce-86498e95fb31">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d09e8443-d3df-4384-8e15-0213da9767c0">
+      <statement statement-id="ac-2_stmt.d" uuid="737ed433-52f6-4cfe-90fe-a6097ea1591e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48e0ab4b-ee61-4b1f-b427-1fa022ae556b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="41f98ae6-91a6-46ef-816c-ad83b19c05c4">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="89f22f00-5967-4aca-b264-2463b942c7e2">
+      <statement statement-id="ac-2_stmt.e" uuid="6eb2a353-e46e-4216-922b-a33c499caa02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2761bff2-9aa8-4b6b-8e27-ce9fe156d502">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="e2087707-ab54-4569-876d-30ac55b73070">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dd4f73c3-3d9e-4439-9d11-cd3d6e651c3a">
+      <statement statement-id="ac-2_stmt.f" uuid="5604aab6-740d-41c6-b081-957f0b162b5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd7eb988-149e-46d4-8511-9558e63c5edb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="706d174d-5765-4a97-9651-d7e9cc0e91cb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f05b91bf-0d26-43e1-a9af-4c68ebc74080">
+      <statement statement-id="ac-2_stmt.g" uuid="e0e395c4-bd90-4852-9c75-6239fe7e1a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0a08956-265e-4f35-8e96-87c56c9d6157">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="9758d0a6-b1f0-4174-aec6-20709ee3e2e2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a4d2bb83-7152-47d4-9611-b59c026f3241">
+      <statement statement-id="ac-2_stmt.h" uuid="2e96297d-49dd-4413-9e03-f82c946876b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd502b78-27e0-4b0b-852f-5bc209d708a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="b358646a-3656-41e1-b2fa-0341d0e762f1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6ce19696-16ba-49bd-a86d-2c444b014be4">
+      <statement statement-id="ac-2_stmt.i" uuid="fbc7d733-8e39-4339-9fe5-89ab0050e7f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f499a8ed-a851-4a30-9a5f-16ca6ae97ecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="85dd48aa-0967-41e2-95f8-fae66312e796">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5c0f8640-39b5-4880-9d0e-94ec62ea90db">
+      <statement statement-id="ac-2_stmt.j" uuid="76ac689d-66dc-4e51-805b-902263860091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b90c24-fb80-44e0-bd9f-64cc4f9d530d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="09b3dcc1-cfc9-40dd-b42d-554f5d240f5d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="00406106-b903-42a5-903b-370b46a6b1b2">
+      <statement statement-id="ac-2_stmt.k" uuid="2a7fd158-28ce-45ff-9d4b-7a0e4644d4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e90a2ff-91a8-4ea8-89a3-7b606be091db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3890994-356a-4cb7-8af9-752cde07db81" control-id="ac-3">
+    <implemented-requirement uuid="54eaf0e8-a603-4de6-957c-02d360dff060" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="16d0d0d0-a060-4691-abec-9fbb32e86cfc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="aa050b5d-582f-40ab-890d-b86d9de4f6a2">
+      <statement statement-id="ac-3_stmt" uuid="77b67dec-bc0d-4dad-ad78-bb20120e4c7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e678ff1e-eba1-4013-82f4-03456ae8554b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met by CoreOS when SELinux is in Enforcing mode
 and configured against the SELinux Targeted policy.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="142e4569-9af2-4f26-960b-5931cbabb31c" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="30c591d9-7778-48df-bd13-d3ce2383a908">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cae66fa4-cae1-4116-ad2a-27c9f6715afe">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -605,8 +605,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="1a828509-77d1-4e06-9df4-c20ad484a0a2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="bb5e25c2-81b7-432e-a305-941141fb7cb4">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -618,10 +618,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d2e202c-8a89-42b0-9d58-363f409008f1" control-id="ac-8">
+    <implemented-requirement uuid="b364dab2-3da7-492e-8c0b-744c78232918" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="b20ed4cf-406c-4067-b9a6-76e8f7b7be4e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ee20948c-02bf-4047-b11f-d0bf238c3d31">
+      <statement statement-id="ac-8_stmt.a" uuid="32e61082-a341-4794-b630-59a2e468e8de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713a10e8-f5ee-47f8-90ea-bba9658cfd59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -641,8 +641,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="483f88b0-3c1e-4d79-81b7-db60367f7b65">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="187788d6-af17-41c2-83ff-7427f6ebb267">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -657,8 +657,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="f891d277-13b1-4ad3-bd6e-9e9b15c0b9aa">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6901d0be-6255-4c62-9175-15fbf1015631">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -676,8 +676,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="5540490c-8fd9-4226-9acb-de948587d2b1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="38eab275-8d33-4b31-9376-f10c28b4bd05">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -690,8 +690,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="b13a51b8-2540-4fdd-906d-6840ac593006">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3d42b05b-32bd-4533-84bb-641e3bc12a99">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -705,8 +705,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="639efecd-97ee-4a3d-987b-a26b063e7c6b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b553eec4-4171-49ef-a5ef-e50e471c87fb">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -722,10 +722,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="459e98d3-0e60-4bcd-933e-975227a43688" control-id="ac-14">
+    <implemented-requirement uuid="74aedd6e-0b78-4029-9487-224f5fa1a3c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="190e25f4-63c3-4db6-bdf3-cd027db4a3bc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="141484d1-1df7-4916-8173-6ee2dbd39492">
+      <statement statement-id="ac-14_stmt" uuid="85ab16ac-f3b6-4835-ba7b-f80b13e2880f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caef0d25-057d-44f7-b0e3-b578d96b11e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the CoreOS Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -735,18 +735,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc52cc5a-6893-45f8-a357-50f44b9a407a" control-id="ac-17">
+    <implemented-requirement uuid="52338ece-b04e-4a7e-baf1-32ab40979a4d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="99863119-911e-4f3c-bd66-a12340b87cfb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="79da0027-7dcd-4c6f-a943-7b14c64d9289">
+      <statement statement-id="ac-17_stmt.a" uuid="6f5015e4-d2de-4ac4-8679-471fc4d1b336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="b42894ee-74a5-415e-b73a-e19688dfec3e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="882ab78c-b34d-4d69-a12d-c37c37fe499b">
+      <statement statement-id="ac-17_stmt.b" uuid="28a3c8cc-80b9-47fd-840a-75943f6d4a93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -754,18 +754,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d505e1f9-8085-400f-b7c2-434390ce7659" control-id="ac-18">
+    <implemented-requirement uuid="5d4b56aa-8e14-491a-9b7e-52f4a3dc6e89" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="bccc9da3-e8f6-404e-9085-b5c6bc668b3a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="af155bac-faf4-40f1-a38b-2db2d0694279">
+      <statement statement-id="ac-18_stmt.a" uuid="1b94291c-4f38-4d22-8161-79d388d32758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf9153f9-1db6-4e2e-88a7-634b9cbef1f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="1dfb8e46-59c4-4471-8128-bfacd4a152d5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ee44be1a-4a2f-4433-aff2-37491c3e70de">
+      <statement statement-id="ac-18_stmt.b" uuid="eb73f1fc-c8c8-4fbe-8b48-4fc3ad09a3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18432f18-2002-42e0-abcc-b0131b443d64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of CoreOS configuration.
@@ -773,18 +773,18 @@ system are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2fc6540-e3aa-4818-9a13-d5e464cfd0ef" control-id="ac-19">
+    <implemented-requirement uuid="2eaa2377-e027-48eb-b623-9707bc43ed8e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="149f1527-0157-4add-8418-9a4d2d7a227b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9f37a22d-4208-406f-96f7-5d1f912da133">
+      <statement statement-id="ac-19_stmt.a" uuid="5beee672-d457-41f9-8b66-7129b0ef1e2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14640741-0e7b-446d-ab60-c038a9c67acc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="6307ed24-316f-41fc-b880-a9d592c5ac55">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dfd029c4-96ca-4af4-99cc-1b650a2f28c9">
+      <statement statement-id="ac-19_stmt.b" uuid="1489caf3-35df-42d0-99ac-34ee9fe939a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daea7828-b48f-4e2f-8838-95871dfdf677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of CoreOS
 configuration.
@@ -792,10 +792,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26cae22a-92fd-4b95-a946-a766f4def19f" control-id="ac-20">
+    <implemented-requirement uuid="8da17d11-aaff-4b42-a8ef-239c2f037ed5" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="90d32a2f-b075-4eb6-83cb-487ae8392b21">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e7f24c02-fdd2-46d8-bb64-ca56904b6f10">
+      <statement statement-id="ac-20_stmt.a" uuid="9016e096-ae1d-4e6c-b0b0-715631291e3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e863569c-9595-42c1-bc0c-eb2b2ba883d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -803,8 +803,8 @@ systems is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="2d87a28c-a469-46c9-bc51-6c50af097064">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="eba7a0a4-a33d-4091-9961-61b8d8be7659">
+      <statement statement-id="ac-20_stmt.b" uuid="de1dade3-ce08-4dab-831c-fea500622d95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83299231-fa17-4a90-a250-282ce6fd5114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -814,10 +814,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ff3caa9-3759-40ff-87dd-deae817989bc" control-id="ac-22">
+    <implemented-requirement uuid="15e4e849-3ea8-4bf6-b2f9-fc35f51e78b4" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="7c47f50f-4523-4116-b312-b4a688241899">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2fd26978-a368-431e-9acf-f323368bea12">
+      <statement statement-id="ac-22_stmt.a" uuid="3f7fe930-3993-44d8-aed5-145487858da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c8349a-1b72-4922-98a2-f679ae0e98e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -825,8 +825,8 @@ system is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="0b38d01b-f2bc-4b9f-a5d3-bfd415e03a29">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="58f21e1a-4723-4886-b280-5a20da41cafc">
+      <statement statement-id="ac-22_stmt.b" uuid="dc5d118c-ae8d-49b6-bfcd-e7de78038687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9618069e-d920-41de-a880-e10126de5e64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -834,8 +834,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="c5c46d99-e138-44f8-995e-3765f92b558e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="03855565-c0cc-42af-b1d0-2eef1a7a88b7">
+      <statement statement-id="ac-22_stmt.c" uuid="daf95474-b47d-4768-8927-8a8f7423d930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5244ca92-85c0-41d8-a9ab-7751eb4989be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -844,8 +844,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="c5338601-d3ae-4cc5-9a52-c0e20e311702">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="83b90c88-bf19-498a-a26e-9e35a6659408">
+      <statement statement-id="ac-22_stmt.d" uuid="eb208ca0-9b96-43a9-93fb-c381c7a6eca8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ff72021-3f80-4705-aaef-9766c09ab9f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -855,18 +855,18 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8ef91fd-f7e2-40e2-bb3f-2f65c6338104" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="432171cf-b132-4f34-b928-a19dc14d6bb8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="22c4b661-0041-414c-ad3e-48bfb8187dd1">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="6bde6c20-ded1-4eef-acd4-2d19591b8c8b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="db830183-c16d-434c-b0d0-5f40363daf0d">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -874,26 +874,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35973772-bdf3-4793-a8fa-6cd30c0eccfd" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="fa79ba65-d3e0-48ff-a009-f9192a49e22b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f914936d-e0b2-42bb-bad5-21bc8c9c985f">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="075f9db5-f064-4495-a283-b19914529f4b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="470b245e-1a54-4c27-8603-6834fbb9cb88">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="786dbe13-f6c5-43cf-aa09-404e90c95a81">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d1471bb7-e9f2-4917-bb9d-e9b6494bfec2">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -901,26 +901,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8692b7d8-5f95-499d-bdf4-ba044d8f9ab9" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="14c1fe3b-3eff-4fd2-9d86-aa72a640a5bd">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="da6b4462-d1d8-4265-89ee-8ee8d6be1095">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="4847b0e5-98fd-40b1-8e06-0ac46e83d0fe">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f30fedc3-1e0d-401b-9b10-20b45af7366b">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="0028a2db-27d3-49cb-9fe6-17c293ed3f3e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="00373490-6b96-47d6-88a2-f9fee7d8774f">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -928,18 +928,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3041ed0f-5225-4f08-b015-1c35e23308ee" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="c04763c4-e156-49f6-a1cf-0863b1ac3921">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="881de769-3421-4147-b0ad-6255da5a0fd1">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="6bb71543-3828-4c0b-ad1b-a959a9567b7c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3c707b56-9eec-4831-b129-fd236b9ee68f">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -947,10 +947,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8aa8226a-73ca-414a-bf5f-8d913d52f7e2" control-id="au-1">
+    <implemented-requirement uuid="4d9e7955-92c6-499d-ad77-1afaa84b2c5a" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="28ad1d4c-9a3a-48ca-8aca-96b8b0b3c4ff">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6ac6aedd-2d2b-4d1a-8a49-e0cd41e03dec">
+      <statement statement-id="au-1_stmt.a" uuid="b9675a53-dc16-4ace-915a-7ee6e1961c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92243957-9a7a-4469-9b0c-758387037f88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organization-level
 audit and accountability policy is outside the scope of CoreOS
@@ -958,8 +958,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="a3c93c13-71cd-4c28-96b4-81693710e66a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fd1bfbe0-1fb4-4af1-a009-5bf9adb4bdac">
+      <statement statement-id="au-1_stmt.b" uuid="997ea394-2e91-4991-b19b-b18e33273887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ee0a85e-a540-4050-945f-06eef494c233">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of CoreOS
@@ -968,10 +968,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1dd63ae3-1926-4076-bf2e-b355d7a88093" control-id="au-2">
+    <implemented-requirement uuid="287ece19-bf2a-4a48-b52b-45898307cbbe" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="5a7b3a12-e68d-4bb5-a522-1117c176c220">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="78d9a9c3-2a8c-4a09-8a7e-5c72c7ff89fa">
+      <statement statement-id="au-2_stmt.a" uuid="3291559f-d71c-4339-879f-b59cfe1b654a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5595f04-f8b8-4e30-9a87-86e8f3760141">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS was designed to satisfy the audit requirements outlined
 in the Configuration Annex to the Protection Profile for General
@@ -1024,8 +1024,8 @@ Selected audit events from ICS 500-27 include:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="8c173fa5-9221-45f3-9da3-bbc6e540c5eb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5cd68202-0eff-4628-a0bb-c81374a19445">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1033,8 +1033,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="312d2c79-c945-4787-8f0c-48da64a601ce">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="0e9762ef-3727-4e75-96e3-dde06b0582dd">
+      <statement statement-id="au-2_stmt.c" uuid="b615cc45-8590-44a1-af90-f91621e87e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f806b1ca-cbbd-403a-902e-8a3ecb18a518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat did not express judgement in the rationale for why auditable
 events are deemed to be adequate to support after-the-fact
@@ -1049,8 +1049,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="dcf5ca66-b747-42d9-93a2-7538ba0d6242">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7328c1f6-11b9-4856-b5db-9b4683458aa6">
+      <statement statement-id="au-2_stmt.d" uuid="7998da4f-89c7-42f0-89d7-9c844cf8b189">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1641516-0f4f-40cc-a25b-79b30da4ac14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Determination of which events are to be audited within CoreOS from
 the subset of auditable events defined in AU-2(a) is an organizational
@@ -1068,10 +1068,10 @@ realtime (e.g. immediately upon an audited event occurring).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e099a2e-6d22-4b1b-8aca-ffa605ab679c" control-id="au-3">
+    <implemented-requirement uuid="0e32b747-e74b-4dc8-90cc-8dc694f485a9" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="84dd526d-6b0f-4665-b13a-bfb08a28cb74">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9200325c-ecbe-4b54-b990-c175109ff697">
+      <statement statement-id="au-3_stmt" uuid="7c00bbc5-bed3-4987-9b1b-401a96763521">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="822d2d2d-9e81-4bae-8f7c-37f141b9fb7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AU-3 is satisfied when the following configuration checks have been
 implemented:
@@ -1083,10 +1083,10 @@ for OpenShift 4.x.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fb49953-00ab-42c2-b6f3-d7098f0d3503" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="b2e5b4cc-d88c-4d30-8bd7-1f45834520a3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="979a8652-bec5-4bc5-9959-32fd2a1ecaad">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1095,10 +1095,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92d39877-545a-439d-8f55-c116320048b3" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="832b4204-6b42-43e8-95ce-95c9f2bf1213">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2fe43080-52f3-4b51-a1e3-0a5d48826b26">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1106,8 +1106,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="c3676bab-7649-4f2f-80c8-909eff5b11be">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3c3b8908-04ae-452b-8845-bc3f647548a3">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1116,10 +1116,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f758098-3a37-491b-93c1-6086e100e709" control-id="au-6">
+    <implemented-requirement uuid="d6a49803-12f0-427c-aaef-b980628e3a93" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="f9a428cf-d5ce-4a89-a9ad-6311d9a9f676">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ba6fd076-2a87-4046-a529-57bf9b39a03c">
+      <statement statement-id="au-6_stmt.a" uuid="4605a12f-fc92-465a-8048-b224db829c2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b183e222-7171-4f1d-88ab-fbd547eb99d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1128,8 +1128,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="3d618ba3-5a54-43d6-89ed-083b567260b1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="df9a0114-a11b-46b3-aa02-ab3d6438359e">
+      <statement statement-id="au-6_stmt.b" uuid="ffd8c14a-413e-415d-8e38-d50aabd5420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdf2e4d8-f1bf-4822-a619-d759550ae3a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1138,10 +1138,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9ef37e1-e5b1-4c1e-b4d8-949ec67ea026" control-id="au-8">
+    <implemented-requirement uuid="cfa63b2f-753a-4c92-9cee-f8e5ce20299e" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="4c2fbd7a-89f9-4432-ac81-30a8e9234f61">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a578bc70-e583-4701-b3f0-3673b76ec2d8">
+      <statement statement-id="au-8_stmt.a" uuid="3c14208a-a876-4029-87de-5036e4a2969e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dea8b84e-ea73-455b-b435-b4fa13787d7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, CoreOS auditing uses the internal system clocks to generate
 time stamps for audit records. At the code level, this is accomplished
@@ -1149,8 +1149,8 @@ through the use of the C programming language time.h which is part of the
 C Standard Library.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="2812cdf0-c1ba-47de-a317-ecdb17de822e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cef372bc-59ee-459f-b591-3e22549e4e84">
+      <statement statement-id="au-8_stmt.b" uuid="55eb61ed-02b8-49fc-a370-e76892d9fce6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1016d760-97fb-4c10-9011-6d9b1c99a5d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the CoreOS auditing records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -1171,10 +1171,10 @@ for more example and explanation of auditing.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="649ad008-b861-46eb-b9bc-270f06742e36" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="619c51b0-75f9-498e-b97d-2b28e7f8509c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5829933f-8db6-4fda-8113-13b8728e98e6">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1183,10 +1183,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1e55548-2920-49a7-b83d-a945b38ec13e" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="52f22708-58d0-48e4-b81f-406447b4bda3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ee568d5e-db9a-4292-8cef-044b199fb64a">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1195,10 +1195,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c72ec9b-a4f3-4ffe-8ba3-34c686080132" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="1d95b453-4647-43cf-a198-41663cd73257">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a89241a3-6811-48ca-a063-b2cf0533d783">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1206,8 +1206,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="a9d2eb8b-dedf-431b-9a98-171eb1865065">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="21d98d4f-f027-4ce2-bb34-09c9642e8139">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1215,8 +1215,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="25749bdd-83b5-4bc9-a998-f0247ee12851">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ff9fce5e-508e-45b8-b8ff-6bf941f14b65">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1225,10 +1225,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18bb011f-cd69-4619-a422-283b523905c6" control-id="ca-1">
+    <implemented-requirement uuid="99daba6d-133e-4957-b69e-abb25b8978cc" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="6b84c1a2-d9e2-4ccf-8109-e1884c9221e6">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f441f3d7-a087-4d30-9365-4e51d8020355">
+      <statement statement-id="ca-1_stmt.a" uuid="c6d6d9cd-b8b5-4f2e-957d-f57dd1ae55c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1236,8 +1236,8 @@ the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="641a70c4-dc7d-4d60-b040-6b4127d8843d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f38429fb-bd17-4231-affd-74a18d8257d5">
+      <statement statement-id="ca-1_stmt.b" uuid="d910896e-a8ef-4e87-85ea-661516ea4969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1246,34 +1246,34 @@ the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fc0e01d-1271-40f5-ad1d-be3214815674" control-id="ca-2">
+    <implemented-requirement uuid="13cc8da5-63b9-4ad7-8027-2dc6a4f82694" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="ab9cdb1f-cb22-4e45-a4ec-02510b54b46c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9e491ece-8b28-4020-8c2e-a8344633404f">
+      <statement statement-id="ca-2_stmt.a" uuid="dd41448d-5fae-4cc9-a688-7852824d178e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="eeb77291-3667-4988-b9a6-6c319aa1d23a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="13b04239-39b7-4625-bf8d-317bac03fcda">
+      <statement statement-id="ca-2_stmt.b" uuid="bf74b610-4372-4e81-ab09-173a1640dd60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="820cc3b6-3cfa-4edb-8688-7abc644057eb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="64899c8c-c1c0-4210-9dd6-0319c18f0dba">
+      <statement statement-id="ca-2_stmt.c" uuid="473814f0-520e-4b66-af54-dfbb6e18368a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="72a7f5c2-9f14-442f-8dcb-9a7509a005de">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7a10b456-90c9-4644-9f1c-aad6804b2089">
+      <statement statement-id="ca-2_stmt.d" uuid="bb1f6262-9d2d-42e8-b22f-523d3449139d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
@@ -1281,10 +1281,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9556f546-b39e-48fc-9d2d-722b88c16c19" control-id="ca-2.1">
+    <implemented-requirement uuid="38874da0-214c-4491-a3a1-bbb1ed6840ec" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="a15106df-22ee-4b5d-8e94-1c2770e82808">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ce1a542f-1907-4500-9ea8-8b77b5e92d96">
+      <statement statement-id="ca-2.1_stmt" uuid="db6413d3-b953-4ccd-958a-d009b9723385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dc6837b-8db9-4350-a142-d836a51793a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of CoreOS configuration guidance.
@@ -1292,10 +1292,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e30b675-b215-4111-9644-44a976f5e52c" control-id="ca-3">
+    <implemented-requirement uuid="c8f891db-8b24-4efe-939b-56da63f73605" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="73ef192b-ee3f-40d3-8493-da36b84443e6">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4c473b39-91e2-4be0-98ab-694ab937d3a1">
+      <statement statement-id="ca-3_stmt.a" uuid="60cc31b1-571e-4c25-93bb-2ce12b41c657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -1303,8 +1303,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="4f5b6cb1-bdf8-4c28-9b64-df783c38511d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="db226be8-eeb1-4a5d-9f51-68e22a3e9101">
+      <statement statement-id="ca-3_stmt.b" uuid="d181dd2f-df60-4e59-b08d-0e353d957d07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -1312,8 +1312,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="24cb7729-a260-4951-9275-21a0f86596ec">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="77902514-00cb-4cf7-ac2f-0dc6d40e7c33">
+      <statement statement-id="ca-3_stmt.c" uuid="77478ec5-5cf4-47ac-b9e2-73ba4fbfaeae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -1322,10 +1322,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cf866fc-3cb1-4929-9c96-0dc55d89fa2c" control-id="ca-5">
+    <implemented-requirement uuid="04cf2e93-8e53-4c29-a789-31dae68b1f8d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="7610dd75-7029-4e69-9993-e7ef8158e780">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="89aca1df-d8eb-4235-b887-5d78ab92b181">
+      <statement statement-id="ca-5_stmt.a" uuid="395a7806-3504-4444-8b1f-14bee13b1d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f244e5d7-c63c-4700-85ea-5e38983a62bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of CoreOS
@@ -1342,8 +1342,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="479180fa-bb73-47a7-a9a5-13d71d5f679c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2db24ab9-50b5-429f-b08b-cb82dae29d57">
+      <statement statement-id="ca-5_stmt.b" uuid="e29dae32-0560-4ad0-b328-14dd6e89d073">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="614d44f5-285d-4cee-8d2b-4c90cbf4325b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -1357,26 +1357,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7648ff82-bfd3-470b-879c-a73b204ba03b" control-id="ca-6">
+    <implemented-requirement uuid="607608f2-fde2-4334-a6f3-4e9027c959d0" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="b24495d3-7e86-4b92-9f9d-38a7e9dd2341">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6d2bd55f-50e3-417e-891f-9e69094ce621">
+      <statement statement-id="ca-6_stmt.a" uuid="511137db-c306-44a7-b081-11ce5a8a0be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="cf2e1703-b19b-4223-8f28-a7259ba19e7d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6e58665a-a5d8-43d0-8405-9b6ea01706bb">
+      <statement statement-id="ca-6_stmt.b" uuid="68ee121f-2444-42f2-8269-8779a2b68269">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="b4a58bea-8050-409f-b03c-9ec4db8c09af">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b28bb3f9-761b-4b2d-a594-b4120beb4cbf">
+      <statement statement-id="ca-6_stmt.c" uuid="590e46e4-2052-40e9-ad70-c1116fc37a51">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -1384,10 +1384,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce916435-d443-49d9-a137-b4e83878fc3d" control-id="ca-7">
+    <implemented-requirement uuid="066ece2d-9278-43bd-9aa0-abbb1e9ad96b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="59d30d1f-4c5e-4e37-bf1a-d66e804ad7b5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2e760f7a-43bc-42f5-9d2a-9508d31029bc">
+      <statement statement-id="ca-7_stmt.a" uuid="1455a053-6e81-4928-89a7-b1ee8dabbaad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5ddd44f-3d95-4ca2-bf11-bdc4a2e5deb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -1396,8 +1396,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="077921f7-d64e-47eb-8267-414511e3a2db">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b0114a1c-1ec0-4efb-8dd6-6644b9386c2f">
+      <statement statement-id="ca-7_stmt.b" uuid="b3f7a7fe-e740-4842-add2-0515352403e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa91273-e3a4-49d1-9b4d-8947af8ec22e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -1406,8 +1406,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="565d8510-8a54-4253-9314-792ad2bf9c90">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e0f8bab5-f6ce-4d11-a35c-42bf91b0d088">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1415,8 +1415,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="82f1f4d1-ab85-4709-8b43-bb5b31f4e76d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="17d4f9c8-5fd0-4d78-808a-0a03931b99af">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1424,8 +1424,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="3be51be8-464f-4b74-ab2d-024ca57e351f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="72a88bfe-52a9-4959-90c9-4f2ecdb8ab22">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1433,8 +1433,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="2d423bc4-8249-4f7d-a818-d637220d7f8a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ecfeb5d9-5b34-4740-8fe0-740972c1e70a">
+      <statement statement-id="ca-7_stmt.f" uuid="f3822d6e-2a18-4228-8299-967d9f1ca26b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a396b00e-1a45-4eff-bb9d-bcf705d7e2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of CoreOS
@@ -1442,8 +1442,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="af2b0698-9d13-43a0-a634-4e3fb3bbfbf1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="bd54ec18-dda6-48ee-98f2-19ca9abab67c">
+      <statement statement-id="ca-7_stmt.g" uuid="004d1a1c-403c-4be9-ba6d-54b91176e631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8a4b2a0-f735-4371-a45f-2726c489d9e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -1452,10 +1452,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0fbaadd-94ed-4141-9ba3-e91e9b5d20d0" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="a9112f4c-03d0-499f-84d4-0b53354d49bd">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="db4d78be-439c-49be-bc4a-fe24958c876e">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1463,8 +1463,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="d2add1b9-ecfd-4c62-bebe-7a141aa9800f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8fec3c96-33e1-4b9d-b1d6-a00eea8382f1">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1473,18 +1473,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3bfcf4c-5dba-4e6b-bc7e-8e4f9b2d5634" control-id="cm-1">
+    <implemented-requirement uuid="115e2333-0921-4c67-a4b5-12379b2478a5" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="abd762a5-8dd9-4ef9-be9f-ced6b4b9e222">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d3e130b1-4a5b-4518-8bae-7422b86346b4">
+      <statement statement-id="cm-1_stmt.a" uuid="9d54d106-6d17-47ea-93c8-c84ce10158b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c65750c-dcc8-43ff-82ab-4ad8ea4da2e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="b3408fa7-1b3e-4a47-90ed-f70b84a12e2f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cb1a227e-2907-40e7-a2b4-bdb329ae838e">
+      <statement statement-id="cm-1_stmt.b" uuid="7e95f0dc-7904-4a82-ac38-1d526f64de65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="129d3029-87cd-4b0a-b766-282cef0783bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of CoreOS configuration.
@@ -1492,10 +1492,10 @@ management policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="508cee57-8154-4f8c-8773-d3460a9b71ff" control-id="cm-2">
+    <implemented-requirement uuid="d4e8ab39-ad10-43cb-92c9-b282ec92e657" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="846c1a64-3fbc-4c5d-bccc-9811140dca7b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="86094a94-0e5b-4071-86dd-efb4a3f72276">
+      <statement statement-id="cm-2_stmt" uuid="1af42b2a-18c8-49a3-894b-b9f2139c9340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce35a501-1e1e-4e7b-9f14-187b04fc37fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration management is enforced through Ignition configurations
 and Operators.
@@ -1524,10 +1524,10 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="067a87bb-5793-4d57-a2a3-d8f0947e0648" control-id="cm-4">
+    <implemented-requirement uuid="0c074561-38c6-4f50-9c76-d1f298a8f245" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="66888c31-4814-4c2b-a281-d956a2a5350e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b5f6980e-4a8d-4d8a-80cb-912be43f82ef">
+      <statement statement-id="cm-4_stmt" uuid="ceb5d10c-effb-41fb-9f4a-feb7759b4c2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7133f40-2f37-4417-97b3-de7e200ce50c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -1536,10 +1536,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8cedc9f8-de47-4c17-a415-d3220d4d3c60" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="4f45318a-2ca9-4dcb-95b1-fb3a887d7d36">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="054fa992-1a53-4581-ad2d-1af7a12a6e34">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1548,8 +1548,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="c1ea2143-97f1-49f6-b78a-b8b84f2532f8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="42cc1401-025c-4f54-9d43-79c95df08067">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1558,8 +1558,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="75174ca0-8c74-422c-991c-7bb18ce19898">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4cd7d0af-9d7c-4e97-a057-9e72d2566023">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1568,8 +1568,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="6a34c66f-0962-4330-9d9f-d06f704096bc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e136de0e-01cd-4499-a690-0a441796391f">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1579,10 +1579,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5a735a1-9a2f-466c-8b9e-00c4c064aa2b" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="f4f733f0-baf8-432b-b0f9-f364822b3765">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="322b71ba-a8b1-43f6-8414-104587d5466b">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1591,8 +1591,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="c9df845c-b185-44b0-8e83-beb5f87436b0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dc415af3-001f-4b0d-a8c5-4f0aceec7ebf">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1602,10 +1602,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e43eafc7-8b2f-45c7-854c-c93dc47fd181" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="17c79a25-6efa-4907-85a2-87d4e9e70970">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cf07956b-a811-42e0-94b2-801ea8bea685">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1614,8 +1614,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="ba0237a9-8e5d-49a5-a11b-7d9bde2a829d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ecf12203-21e4-4a74-8f4a-4bbc7272077e">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1625,10 +1625,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07aa94a4-fdbe-48ba-8aa8-fa0414f0928a" control-id="cm-10">
+    <implemented-requirement uuid="9c12e422-ddf6-49cd-bf9b-a80f8c950df9" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="7e903089-bda5-4d00-a0f5-83c01408733a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7cf50ab8-c9a6-40b2-a147-b166706bfc17">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -1640,8 +1640,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="24ca57fc-f51b-48c3-9071-f176ff799c27">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c1a1e7ea-1117-4e6f-bcce-eb79247f0c27">
+      <statement statement-id="cm-10_stmt.b" uuid="c8349289-6521-426d-844c-0e559e03346a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1d08f7f-119c-402c-abdd-e35d81e70bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -1661,8 +1661,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="f938ee98-b1b5-4b67-b249-8d8dcc1c18ba">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e87c4f1a-6eed-4ee0-ace6-56fcee07cb12">
+      <statement statement-id="cm-10_stmt.c" uuid="6022e056-feb9-4aac-9ec7-aba2b09afb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33326b1d-2e3a-4939-b0d0-a6e9450910cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -1673,10 +1673,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7f4b5ae-7bd9-4adc-a6dd-3e5b80db5037" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="9b09eb86-d7d8-411e-98dc-e905cfb6ff5b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5009de1e-4b7b-409b-87f9-7c6d34aebd6f">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1685,8 +1685,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="14a70f94-0ec7-4db1-b50c-a14d4e7a93ca">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2319a770-7ec7-4173-9d6c-87e4f84fe37d">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1695,8 +1695,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="c508db99-f5cb-4f12-9ea1-af5f82c1f9aa">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="941f43dc-a97e-47e0-acd9-c98fc4c9ad67">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1706,18 +1706,18 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b26a04a6-2fa2-471b-a28e-10431d7b3574" control-id="cp-1">
+    <implemented-requirement uuid="6b7cbaac-f4e5-4b5d-b8da-9ff2bb76b9bf" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="4fc29f49-204c-4681-ba4c-b13210b4b079">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="380f9c70-a883-480f-aa80-cc15f9bed4d0">
+      <statement statement-id="cp-1_stmt.a" uuid="736c1891-f977-46c2-9091-bab9684d3048">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e140afe-57d2-4aac-88d4-79901b4a865f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="92920284-23c6-4a08-9d66-8827e3df4fbe">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="68aaae5e-59ed-4bab-a5a5-0e7987a52ae1">
+      <statement statement-id="cp-1_stmt.b" uuid="dd8d1fb9-bab2-4fde-861e-72841defd393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f5be2e8-3159-42d9-bc1e-55f082d78b6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
@@ -1725,10 +1725,10 @@ policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7308c86-d021-46e5-b7bb-dec933f7f132" control-id="cp-2">
+    <implemented-requirement uuid="d034a012-6d34-4314-ab52-aceb05eaf925" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="c8aae605-8011-40e9-b27e-a84fd042a422">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="755509cd-89b9-4728-abba-c3fcc250a0ba">
+      <statement statement-id="cp-2_stmt.a" uuid="fdf0a5ab-f5a6-400b-b075-28f6c336363e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6311f816-aacb-4ae0-b282-e50434f1c4fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
@@ -1741,24 +1741,24 @@ recover/restore the CoreOS environment.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="886e4a31-abd3-4af2-888d-1138458f8f2a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="008386c3-e5e8-4319-9c58-8ee07fcb74aa">
+      <statement statement-id="cp-2_stmt.b" uuid="c59e57a0-cbea-4411-99d9-1aa73b612ae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89ac414a-5381-45ef-b0cc-cc44765ddd35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="92827ed5-af1d-41e9-899d-edcfc99624f1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e67d43db-ecf3-45a7-bda8-f8841dc4b490">
+      <statement statement-id="cp-2_stmt.c" uuid="fddaa849-3a2e-44ea-9f56-6e4cb58d821e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3dfed86-0354-4cee-bd64-c9e95efb53b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="427512a9-d095-4cbf-80f7-e7a26ac49c3e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fb9e81d1-2baa-4e6a-9e22-5892b1f6a268">
+      <statement statement-id="cp-2_stmt.d" uuid="3f374816-464e-4d92-8abd-a5dd6f749d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="894ea615-37b9-491b-9931-d15976f6699a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -1766,24 +1766,24 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="e99354ae-d160-4b1f-933b-f7cf3c424711">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="bd25d40c-4994-470d-ad79-279e873523b7">
+      <statement statement-id="cp-2_stmt.e" uuid="0bf3cbd7-d938-4884-b955-a7b633590246">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713bcfda-0b2b-4126-8f25-2af62d934d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="0aa288fc-eb2b-4e9e-bc73-6419efc83b7f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3320485f-3659-46f9-b15b-e4dfccfb535a">
+      <statement statement-id="cp-2_stmt.f" uuid="fb61d8de-1066-4bc5-b73e-8525be8784db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bc60506-ba79-48f9-9435-3be7baf7c1f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="de1af936-2b1f-4113-a723-80fe4be30dfc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5d9572a8-fdb9-49b6-93b0-61e0bf19c390">
+      <statement statement-id="cp-2_stmt.g" uuid="ac2fd90c-1cd4-426a-98d9-2676d772c4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a59dad64-7bd4-4dae-8bf1-aae9e7c99213">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of CoreOS configuration.
@@ -1791,10 +1791,10 @@ modification is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df9db7e4-7461-4ff0-b923-be00eb996fbe" control-id="cp-3">
+    <implemented-requirement uuid="488f88e1-c977-4f8e-8141-c5a836717ece" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="ffd52da5-83d1-43d2-b5b7-2db221fbb20e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4c6c2824-6131-41a6-93fb-7c8dc976db21">
+      <statement statement-id="cp-3_stmt.a" uuid="2c42ff0e-d889-483a-b2d2-4397ce93462d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a78089aa-ea53-42d2-a550-c26f9fcc8430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -1803,8 +1803,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="75e93650-4476-4bdb-b2a9-8c2b0857c41b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="226304b5-e212-4cdf-957c-8a4910529a79">
+      <statement statement-id="cp-3_stmt.b" uuid="29caf479-ac35-4419-9258-542e1c304f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa849a2e-44d3-47e6-9c09-782b20ba7b55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -1812,8 +1812,8 @@ system changes is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="c040ed84-f901-4456-b467-f93a4bfeb58b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="38429145-8829-486b-9a05-2a602c23b07c">
+      <statement statement-id="cp-3_stmt.c" uuid="df7614a3-07f1-41fa-8fd1-5180452355c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95f14aad-9eb2-4303-9431-064dea10fe80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -1822,10 +1822,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b02944c8-a6f8-468a-99e7-482586377911" control-id="cp-4">
+    <implemented-requirement uuid="517d445e-c3d4-4768-b44d-58ca4bd6a85e" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="1f41f05a-4bc2-46b1-b148-1ec30ef244b9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4cebed8e-0672-4c54-a527-ab45c62dea57">
+      <statement statement-id="cp-4_stmt.a" uuid="0f2d92d3-09ba-4cec-b823-860292845602">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ebb990c-8eec-43b6-9a6f-aedd77f38b03">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -1835,16 +1835,16 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="10f1fda8-616a-4557-8df5-9d40f9645693">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3b410dc7-1d42-458b-bcfa-78f57bae946c">
+      <statement statement-id="cp-4_stmt.b" uuid="8adaf079-4ea5-4b02-b78c-e7ea33003a26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f81e51-fc2e-4416-b64a-1acdb36b3955">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="be9e891c-0716-43e5-8307-dfdcd612c193">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f363d22b-1825-4a25-bb23-50f7ff1fc1ba">
+      <statement statement-id="cp-4_stmt.c" uuid="875c27c1-f0ac-4098-8a7e-4004d3628197">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8c5099-a674-4a51-ae0a-c966d42b5eb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of CoreOS configuration.
@@ -1852,10 +1852,10 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46d4d0e4-74c6-4e9e-9b90-e2e21acfcc5d" control-id="cp-9">
+    <implemented-requirement uuid="d9ebf0a0-b779-4d30-93f6-19808ebc103d" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="67f9044b-7f30-4962-a803-efd285556750">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a4264b9b-5f11-41e8-8300-379264383f9e">
+      <statement statement-id="cp-9_stmt.a" uuid="e21640a8-ee15-4f40-8389-e389acc1d61f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd4b3b4f-ae69-4660-a361-fd28a230152b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1887,8 +1887,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="746305db-4fb9-49c2-bfd6-63501a8d9347">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8d1e876d-f07b-43c8-9202-65b00cd80561">
+      <statement statement-id="cp-9_stmt.b" uuid="cb59ca89-0a5e-48fd-9854-0a9a0146025d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac97c356-cb33-4444-a30a-6c8fe49e99e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1919,8 +1919,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="0c7c7659-4e7d-45bf-9bcc-8eeae7b2d018">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cfe3767c-2996-4fbf-bece-58af56b8d5c9">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1931,8 +1931,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="37495cc2-c558-4a77-80b4-377318615028">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c4b92cf4-1d5a-4a7e-9277-9ca45525ffa2">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1949,10 +1949,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34d29695-1c76-4782-abb5-75b50d94064c" control-id="cp-10">
+    <implemented-requirement uuid="18c26625-857f-42e0-8fb0-0f7bb56e24c3" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="7ee4b354-bb27-4435-a7a9-17d1f5347829">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="91018a41-ce8e-4b2f-bdae-7ad0ea191707">
+      <statement statement-id="cp-10_stmt" uuid="62aa28e1-61f6-45e3-97f8-a43ab7567c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="745a7e2b-3a65-4b5a-a6d0-712de9382982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their CoreOS environment. A successful control response will detail
@@ -1976,18 +1976,18 @@ https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-workin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5984b5cd-a273-4c7c-b3cd-26e5e6318d4e" control-id="ia-1">
+    <implemented-requirement uuid="9f4f8d15-4472-43c6-b214-95cc5a6d146d" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="d9c023a0-0aee-40d9-b075-0921ef80ed21">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cf01ce96-7d66-4a23-a0cb-2943dcd677ad">
+      <statement statement-id="ia-1_stmt.a" uuid="f7f6f54f-eff4-4350-83f4-3e39ae53dbde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31dd12f9-2bcf-4a34-8cf1-fb8174f72c65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="941b96bf-17d7-4aaa-8aa8-cc666dac9172">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e11033f7-9fb2-4fdd-8f35-49ddad029607">
+      <statement statement-id="ia-1_stmt.b" uuid="f8a8eb5a-6754-4d09-8a0f-776340c6a57c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91e2d7c9-6f39-4976-a809-edf8fc802309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
@@ -1995,10 +1995,10 @@ policy and procedures are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02b7939e-b281-4845-91ec-16bb634a4a32" control-id="ia-2">
+    <implemented-requirement uuid="6b49cd9e-d1de-4845-b766-89344094f9eb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="bad5feff-e521-4ea4-8416-6f3ec60f9648">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b0e29932-197b-4b6c-94de-3948e0afa2fb">
+      <statement statement-id="ia-2_stmt" uuid="3ec41b83-c748-459f-a660-40c1a281aa5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb02e477-a99c-4084-9775-6f3863a4788d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2007,10 +2007,10 @@ https://issues.redhat.com/browse/CMP-299
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c0d5188-38d8-476e-b1bd-9a9b2e3ee8d5" control-id="ia-2.1">
+    <implemented-requirement uuid="06fe78c5-0865-49a2-a9b3-3aa2aea4b826" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="37a88535-6e9e-4aa9-9ae8-2745ec52897c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7b704685-76a1-40f0-82d3-10cb4cb36239">
+      <statement statement-id="ia-2.1_stmt" uuid="715ccb15-6d68-4238-8949-8c78c50da9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d315b66-3eba-4daa-854c-b40d92188be4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2019,10 +2019,10 @@ https://issues.redhat.com/browse/CMP-300
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e837a99-a386-44c7-82aa-ea4676f5c0e3" control-id="ia-2.12">
+    <implemented-requirement uuid="45d37aeb-8b02-455d-8ef9-95144b4575cd" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="46ef7069-fe56-452e-8c36-3a15f754aa91">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="bed7e018-1b3f-44dc-b90f-10abf7507d35">
+      <statement statement-id="ia-2.12_stmt" uuid="539ceb70-a71b-4d6a-979b-85e42826c873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af00b192-2944-40f8-853a-96d85d52bfff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2031,34 +2031,34 @@ https://issues.redhat.com/browse/CMP-317
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0b1346b-d1d6-4f33-bb13-7c2de6a35586" control-id="ia-4">
+    <implemented-requirement uuid="87aeed69-4e40-46a2-bb66-84611a0189a5" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="0c8ab959-9edf-49ca-a470-932d05f79277">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="24ff74c6-38c4-4e84-944f-a0062e365e27">
+      <statement statement-id="ia-4_stmt.a" uuid="952ac5db-5177-457b-85a8-9d9982249390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="7903f310-91aa-4a51-9260-dd414dd2e979">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="165c7314-cd81-4520-9ec8-ea5b94892ade">
+      <statement statement-id="ia-4_stmt.b" uuid="3c0fee9c-0979-428d-b941-b161dc588fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="d77f2603-ffbe-4535-b488-9200213c690d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2c5256cc-7ffc-42ec-ad19-b8f0c9aa48bc">
+      <statement statement-id="ia-4_stmt.c" uuid="d9d158ca-544c-455a-9f9e-ff5c6016cf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="cf9dee80-2374-476c-b8c2-b71e2a0a99ec">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b7b2ff75-fc5e-452b-b678-a8b0d19d58d2">
+      <statement statement-id="ia-4_stmt.d" uuid="b6dcd342-64d6-47ec-84fc-4204e11b1969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2066,8 +2066,8 @@ https://issues.redhat.com/browse/CMP-321
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="b5585fad-6817-4c00-8829-975df54aab51">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ccfb6e20-5d0b-445a-80a6-c730968a890e">
+      <statement statement-id="ia-4_stmt.e" uuid="6b0b3383-d354-418a-8882-a91c23fc4ee3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2076,18 +2076,18 @@ https://issues.redhat.com/browse/CMP-321
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96b1e0e6-d57d-4ab7-915e-d9a11549720c" control-id="ia-5">
+    <implemented-requirement uuid="625b4fbf-2c0f-40de-8a20-b0552f64ade7" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="0182ebbe-a0b6-4f5f-901c-56bead3b0916">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2e862b47-021d-4d15-aae1-3a0032848cb8">
+      <statement statement-id="ia-5_stmt.a" uuid="aa62b80a-2651-45e6-8edb-28d1a6f3a48a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="9f7b268d-3c2e-44e0-8997-c1b7b3ef52bb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a0fd03dc-c094-4551-88e7-9fa5b17b7414">
+      <statement statement-id="ia-5_stmt.b" uuid="7675e20f-4a79-4710-8f04-6679de7375fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2095,8 +2095,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="0fc77fd9-8fff-4e92-985a-202f6a48f024">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="07871350-bb5a-4e0c-9ca0-92fe76573477">
+      <statement statement-id="ia-5_stmt.c" uuid="07ba01f2-7389-4b79-84a5-9c40775876ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2104,16 +2104,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="9b2a54ca-cb13-4754-8a78-373ba3fdc01d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6c4c4e0b-9eee-4c58-af46-63acb37f2688">
+      <statement statement-id="ia-5_stmt.d" uuid="542ddcdb-4ae8-45c3-8989-df62a727aa1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="aafbbf0f-cda4-4d89-83f7-77a9e3fc9c50">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="00df2e6b-1749-4b71-8d51-44d9e55ccf6a">
+      <statement statement-id="ia-5_stmt.e" uuid="f68df002-5ba4-4afa-aff2-dfc5685ad985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2121,8 +2121,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="2e3928ff-cace-495a-b32e-ce622c8a1afe">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1ecda6f3-09a0-406f-929b-0af502510e02">
+      <statement statement-id="ia-5_stmt.f" uuid="f7a5edc3-8789-42db-851c-f426f31a409a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2130,8 +2130,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="51e3c3e4-69dd-42dc-914d-d17461e35fac">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1242b860-9252-43c7-9030-d9ff4fc92887">
+      <statement statement-id="ia-5_stmt.g" uuid="b3872af9-fcee-4b75-9358-556a7d9ce2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2139,8 +2139,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="79bc73be-2fb7-45ce-bc3c-2e1c321abd1f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="61303dce-0c53-421b-8249-75d5550d1324">
+      <statement statement-id="ia-5_stmt.h" uuid="1dcef40a-162d-48a1-98f0-53af0391fea3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2148,16 +2148,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="c81c891c-aedb-4123-b349-9dd9e2fac5ba">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d26a634d-1130-4d3c-986e-bce3e89ac337">
+      <statement statement-id="ia-5_stmt.i" uuid="61a23821-f7a5-4c42-a8cc-0757408fc66d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="970e3b81-586e-490f-a370-1f68b4273e6f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9b80263f-d741-4a97-a6a1-47c191667179">
+      <statement statement-id="ia-5_stmt.j" uuid="b92999f4-4612-44aa-9fb5-c2ce1df52918">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -2165,18 +2165,18 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0e9fca6-9561-40ec-84b5-49c2f8dacf5a" control-id="ia-5.1">
+    <implemented-requirement uuid="267b5f9e-f797-48e4-bcf1-5a7368856bca" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="8d226c58-0773-4e20-83ac-1cbc072314d2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ab3ef132-6339-4fc9-84b7-c0c83ec5fa57">
+      <statement statement-id="ia-5.1_stmt.a" uuid="a4b2d0a8-7ae3-4118-a638-349e3d20bc05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="bda7e400-ae41-4bd7-b919-3286b840e33a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="829692f2-3e01-4372-ab46-addc2797bc3e">
+      <statement statement-id="ia-5.1_stmt.b" uuid="b0da37b6-5cc5-4d12-be5e-d0ce97842b1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2184,8 +2184,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="0bb8f1de-bef9-46ef-969d-a0a45c835348">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7ba5c342-13b4-461c-b4bd-48a8a757a3b7">
+      <statement statement-id="ia-5.1_stmt.c" uuid="6a4f689c-b3e4-4faf-92e3-0de9d5ea204c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2193,8 +2193,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="d41d5d6c-5892-4bcc-b794-7a3772e45885">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d21bb167-fd39-4338-a65d-c46589353ac5">
+      <statement statement-id="ia-5.1_stmt.d" uuid="57231353-874d-455f-b0bd-1505e1e147f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2202,8 +2202,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="4c8039fc-c322-458a-b9de-a04deea728af">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="aa308ae8-5ca9-4bf0-8b11-75d89f370b9f">
+      <statement statement-id="ia-5.1_stmt.e" uuid="ce80d2f9-98ff-4216-bfcf-b6166252988c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2211,8 +2211,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="9f900a91-2dde-4a77-867d-69120e819747">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dc22f691-5207-4cb4-85c8-7948e49b47a9">
+      <statement statement-id="ia-5.1_stmt.f" uuid="661295ca-7fe0-430f-9037-d877834d4d69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2221,10 +2221,10 @@ https://issues.redhat.com/browse/CMP-326
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7914114e-e21c-47a4-90ca-3b669eaa8eb3" control-id="ia-5.11">
+    <implemented-requirement uuid="8ab48681-5092-4b20-aa14-10f1981f3818" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="376b5883-3585-49ac-ba70-eb3f1613d311">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4bf3fe25-8c6d-4698-8d54-3748c4a0eb4e">
+      <statement statement-id="ia-5.11_stmt" uuid="15842798-f01a-4905-b300-8cb508bd629f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a8092a5-66b2-4abb-b930-0f30f40f8ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -2233,10 +2233,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="702649a7-fa09-4e4a-9672-68be0f67b37d" control-id="ia-6">
+    <implemented-requirement uuid="865eebb3-b85c-4e9c-b0cd-dc5ce446cecf" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="d442ef0d-0717-4c85-8d7c-3660c422b51e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4264ccb0-1abf-4681-8b44-e788759a9ef3">
+      <statement statement-id="ia-6_stmt" uuid="a6a61e98-b7e3-49ce-bf87-b19048f9bbb7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dfbef3f-9d21-43cf-ab83-b1fe5d6125fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2245,10 +2245,10 @@ https://issues.redhat.com/browse/CMP-333
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="533fd131-2e22-4f0c-aee1-46aeb602b834" control-id="ia-7">
+    <implemented-requirement uuid="50b7752b-5f00-4d46-9cf1-1fc7adddbd8c" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="fc322a45-e205-41e6-beeb-094a24be7095">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ab10be68-10d7-4481-98fd-5cb63a8ee87e">
+      <statement statement-id="ia-7_stmt" uuid="23d94d20-a397-4a53-8400-4d64686e6e26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4a15e2d-8d2b-46d0-a90b-6286705fe5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2257,20 +2257,20 @@ https://issues.redhat.com/browse/CMP-334
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8245a303-1b0a-4a0a-a690-d91276d2e43b" control-id="ia-8">
+    <implemented-requirement uuid="ca731b60-3d8e-4540-94a0-027098462df6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="8ddcac98-f20a-4ee2-a498-73773aad28bf">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dcbaf5b0-6e3d-4696-b6c3-ce561b9a9f3e">
+      <statement statement-id="ia-8_stmt" uuid="5dc8de3c-c093-46eb-9727-918ffb8a4603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5e23088-66e5-4637-ac25-c63231140c55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bcb6c23-dabe-4dc8-8b3a-fc9f29a11f52" control-id="ia-8.1">
+    <implemented-requirement uuid="9eba357a-02ce-4bca-b506-982efb5fb335" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="8a22b693-314b-4b27-866e-afed5970e52e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fb3cce45-d167-44ea-a8dd-73a36f821525">
+      <statement statement-id="ia-8.1_stmt" uuid="93bfaa19-1dd4-423d-ad9a-b73eb1b6e5f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9c5c9c5-e5d8-405a-b968-467718cf284c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2279,10 +2279,10 @@ https://issues.redhat.com/browse/CMP-370
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33429a17-dd7a-4d79-b19d-01e4e256aeb6" control-id="ia-8.2">
+    <implemented-requirement uuid="8f0564cd-efeb-4326-a6e3-67066fdd2952" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="1e24b1bd-67df-42c5-8c03-ce65e48be78c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d2a854ab-73ae-4488-86c7-6827f51afbdd">
+      <statement statement-id="ia-8.2_stmt" uuid="6ad10106-b7fc-4ac3-99df-8664987a7afd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9e23f93-3c11-4119-b8fe-87a54aaa2f57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of CoreOS configuration.
@@ -2290,10 +2290,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc7e238f-37fe-482a-b91b-e9e0b71c9d5b" control-id="ia-8.3">
+    <implemented-requirement uuid="f95af47a-ef4a-4f5a-8b74-330c4063104c" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="4161137c-d326-4289-bdf9-163d105f873e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d2210c98-480a-4f11-bab1-f7a508fcbc64">
+      <statement statement-id="ia-8.3_stmt" uuid="3b8e8f20-e66b-46da-88d0-dea35b8f96ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fd1c869-9bf2-46d3-b6e7-ac4179f9757a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -2304,10 +2304,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff42f18a-75ce-40e0-a80b-deb32ca13ecb" control-id="ia-8.4">
+    <implemented-requirement uuid="75184568-9d36-4b85-93da-89bd20786246" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="5aa5c4b1-24ca-42ab-ba78-b126b9c42c11">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7d31281c-54cb-43cd-a221-3942394b63f2">
+      <statement statement-id="ia-8.4_stmt" uuid="8b9a54e4-f379-4f74-9cbf-291acd9b7af7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75876a5b-6071-4a72-9c51-a8304a1ca69b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2316,10 +2316,10 @@ https://issues.redhat.com/browse/CMP-335
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85391237-2391-4f23-8fac-4b378010d535" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="dfc979ae-3941-4183-b281-9461b65b55a5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e30c5835-2195-48e4-a26d-f33900e1afbd">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2327,10 +2327,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60f4b3c5-2257-4fae-9ac6-252dd4df120b" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="5fc8c9b3-5774-4805-abe2-29141fd3a1ed">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="0bf4f9c9-7b0b-4dcb-91ef-c7cee5b0c6c3">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2338,10 +2338,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6717371-1921-4d55-bbcd-29ebdea5ed6c" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="83deebc1-ef81-4922-b1eb-0f11bd700968">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="580836a5-6502-4836-8397-4a4323154008">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2349,10 +2349,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b392035-4f67-4aae-aa99-668c706c939f" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="23c78e46-01c8-42a7-a817-dc2f88cca29c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a81605b5-4afe-48e6-b751-0f4f098ad467">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2360,10 +2360,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f6f837d-0aee-4e6e-8adf-ff90596e6206" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="469cff77-b5d0-426d-9999-ce4e5a170ca8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d3448f9b-4e95-422f-8354-0f5c9ff37108">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2371,10 +2371,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bc91224-da36-47d7-83ad-ac1141e0e6ab" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="24134287-1db2-40fb-9d9c-56d91fb34cc5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b92453c8-adfb-4641-833c-3d5d837b52d8">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2382,10 +2382,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48565237-4662-45cf-8a18-d2896852253c" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="67bb3caf-397a-4738-a0bf-f397323da5b5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="660fbb10-dff0-48dd-90db-c5f8832accc8">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2393,18 +2393,18 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2fa68a0-9d88-4b4d-9647-80d882c5d3ba" control-id="ma-1">
+    <implemented-requirement uuid="50b14c60-c01d-4085-a382-fa457b35fd61" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="cb493a65-b3dd-4b51-8761-f5c7c3fa9e8d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d7cb99c9-26f9-42cb-a771-874d62037ea5">
+      <statement statement-id="ma-1_stmt.a" uuid="b6f304cf-f3d9-47d0-8518-a57d506847f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="6294a03b-1e61-4e49-b65d-1c043c8f081f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="07b64bdc-91cf-46c4-b3ba-2a4bf1e0da23">
+      <statement statement-id="ma-1_stmt.b" uuid="71cbcfa2-f0dd-4327-9039-3bed09db8ad7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -2412,50 +2412,50 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="412032a6-791a-45b5-851c-3e08baa44583" control-id="ma-2">
+    <implemented-requirement uuid="7f9d8c44-fd37-4b6e-b97f-73ad22f8bbf1" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="b8aae4fc-6f73-4059-9179-41a39b0e2b2f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="840ea3f6-6707-47ab-abb0-3abefe77ca0e">
+      <statement statement-id="ma-2_stmt.a" uuid="9126811a-76df-449c-abf7-e0430a8b6464">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="6440cb8d-db89-40e5-8a21-d0d1d0811e34">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2b10c78a-03ca-4a46-94fc-a09abe20fe84">
+      <statement statement-id="ma-2_stmt.b" uuid="11e3771e-3161-49c6-b9e7-b28e08121dae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="7071f7a3-6296-41b4-a120-e82aed01a3c7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8adebe20-e8e1-4999-bc67-a3ee4b805f8b">
+      <statement statement-id="ma-2_stmt.c" uuid="789faac6-28dd-454f-9f45-f4fd86906164">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="98a5246a-d508-4b20-b7d6-67d413acd406">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5ab19822-9f95-4332-ae32-f12838b6bd63">
+      <statement statement-id="ma-2_stmt.d" uuid="50d4caae-391a-4c9a-be44-1f7740100c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="00bf374b-a412-4cc2-b66a-78c549c829ec">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7de0a605-e031-4e08-8110-414a6a4a5104">
+      <statement statement-id="ma-2_stmt.e" uuid="d6374385-f18e-494f-9c78-5b28c007825f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="67504108-717b-44be-8342-7caca42592e5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e50f0634-7b47-463a-99b3-c6151465ba77">
+      <statement statement-id="ma-2_stmt.f" uuid="98d0fbb6-3723-4fbf-9375-d4060f218d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -2463,18 +2463,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b9e894b-43bb-49d9-bdf5-a6d659002039" control-id="ma-4">
+    <implemented-requirement uuid="e38aef0b-901e-4933-b193-830da092e215" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="7ddb276d-52ad-462d-9ded-a64c2a285562">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cccc4dcc-89ff-4f8b-9460-4f3bae7e252f">
+      <statement statement-id="ma-4_stmt.a" uuid="9b4fa041-4366-499f-9dbe-aca03562a942">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70acaca1-c029-4a48-b6c6-a29275ac6879">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="1d51d61d-fe4e-4dfb-9d5b-aae60ad48529">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e2d90163-0b6d-4a48-a2d1-ff6fccbaaed6">
+      <statement statement-id="ma-4_stmt.b" uuid="68f4a8bd-5e99-4f80-9089-45a252290af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e635f2e0-b395-48f6-832b-d60922bbc7a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -2482,8 +2482,8 @@ orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="dc9de951-82c9-4354-90c5-d954aba3075d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="584a1f00-7d07-4272-af9e-65d338b6ea07">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2491,16 +2491,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="72ca3c23-1bcc-4987-b577-d0e31c2fa495">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7f393606-ed05-4b1d-ad82-11ac13bb8778">
+      <statement statement-id="ma-4_stmt.d" uuid="ef043a60-760f-4c9e-864c-01dcea2b9f93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18daba6d-0a0e-4309-846f-cbc8a83b60fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="e55480b3-b186-4ace-b264-13a4ddced5c0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="738d0bd6-9f83-458b-9867-780e5758c601">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2509,10 +2509,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c1883dd-016b-449c-882d-b9198b7ac90a" control-id="ma-5">
+    <implemented-requirement uuid="60cf192b-4c54-49e4-9491-0ba3a68e05cb" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="905047e7-a3b4-42cc-8bc5-2445b83fea59">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9737c4fa-3a7d-480b-9711-3fc899a5cd8f">
+      <statement statement-id="ma-5_stmt.a" uuid="2aeae088-c7e3-41c5-87da-95515fbf80c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4643d896-4c18-4a1f-8e5f-2fc5e15b8728">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -2520,8 +2520,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="55c0aca4-4b33-4b8f-ab16-4715c2799fde">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="66458680-63bc-4fd3-808e-3464c2ed9b55">
+      <statement statement-id="ma-5_stmt.b" uuid="fc9cdbb1-004e-4786-8dab-904941239160">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fd5cf2e-d52c-4bab-afb4-912b678f8e60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -2529,8 +2529,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="e4b4873e-04f5-4d50-85ae-0f4303ff589c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="eddf6e81-3731-4dc3-9092-eaae310560f2">
+      <statement statement-id="ma-5_stmt.c" uuid="1bc8381b-03f5-4434-9f66-8a0d45a42c2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31a876f0-3b3b-446b-800b-b65e77a928e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -2541,18 +2541,18 @@ scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ede12417-f12c-42b8-bbcd-059947022bf1" control-id="mp-1">
+    <implemented-requirement uuid="db6de972-7474-4a78-928c-103473959819" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="7c206467-f45f-4e03-ab68-7919df037579">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f56ac1af-8c13-4374-9dbc-6774ad6b569d">
+      <statement statement-id="mp-1_stmt.a" uuid="323ea68c-9123-4ded-865b-111d13e5bc8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="41a63b74-e38d-4aca-ad52-deff2ca79280">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="85204db1-4461-48f6-bb32-5cc1ea59030f">
+      <statement statement-id="mp-1_stmt.b" uuid="0097f982-adc9-42f4-a94f-7ad598d57f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -2560,28 +2560,28 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ff8333b-c47c-4b41-961f-15d2b504e6ff" control-id="mp-2">
+    <implemented-requirement uuid="98250c5d-4122-4fae-8c8e-5a991dfb578c" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="0af0221d-4253-45a5-8e6b-a0418856a63c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7390d013-cc07-4b94-9022-511912f72223">
+      <statement statement-id="mp-2_stmt" uuid="0e13fba7-27c8-4803-9ec4-8677e06d9587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="850b3516-0b0d-4c3d-85ea-c8132f0e2711" control-id="mp-6">
+    <implemented-requirement uuid="c7724dcc-1780-4c27-ab8a-4948baa96830" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="c7ddc541-cbf8-4d97-a03d-ea610e8e09de">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8a4907c5-ce22-49cf-9700-219a0da72ea7">
+      <statement statement-id="mp-6_stmt.a" uuid="bf44b130-318c-4ea9-8b11-917cc390dde0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="a7bc07c8-1776-4dbf-876d-249259793a78">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ac95a56c-ff91-4d82-950a-efd194563154">
+      <statement statement-id="mp-6_stmt.b" uuid="065997b5-c670-4635-ae8b-c011cf223764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -2589,10 +2589,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7078670e-f1a2-42e3-88a0-080a83b73e44" control-id="mp-7">
+    <implemented-requirement uuid="6ac60336-91b5-4c2b-97e8-4fc19d3f4d01" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="0fc01224-3d94-4573-b615-d2074f2a2a55">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d72584c4-6c75-4acf-84a0-5a0af9ac47cd">
+      <statement statement-id="mp-7_stmt" uuid="53a598db-cd5c-4596-83c8-a23ab639973e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9b28071-a891-4e8a-b0ab-da77b0872c8e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to CoreOS configuration through such
 actions as kernel module blacklisting. A full control
@@ -2604,10 +2604,10 @@ https://issues.redhat.com/browse/CMP-351</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33f75f18-2004-42d1-b893-75ba61de6490" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="ecb76225-d4b7-494b-acbe-388af70f9d67">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6cdce5f0-c3f4-456e-98a3-6376c959095b">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -2616,8 +2616,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="da1c3ce9-5829-4578-9f34-a7e180807b86">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a29ff5d8-cde2-4c10-95cc-a8245a3284d3">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -2627,10 +2627,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67b30fd0-298b-48a5-be18-ff1beb8c2e4d" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="fdb7dd1f-28c7-48f9-96d1-4b74a736f39c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5528cb90-205a-4824-a924-3ee9e67d17bd">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -2640,8 +2640,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="9cf76245-eef9-4cab-877c-cc3f65d4094f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="969ea1ff-1262-41af-9d62-995ecd78082d">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -2649,8 +2649,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="f959c94c-7c56-4972-9dca-61288e87b383">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4e20c98d-74cf-4862-9bb2-528b15cd34fb">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -2659,8 +2659,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="722ed12d-8a0d-46c3-911f-fec523798959">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d3ce7df9-402b-4396-9990-76f73207dde9">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -2669,10 +2669,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06c50aff-000c-47a4-a55e-fe1d2b2743bd" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="2951fca6-2ba8-406c-8bce-c1c9d3d1742c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8d172fa1-7739-4ed7-9aee-e224d2d29feb">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -2681,8 +2681,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="6fe6c0c5-8960-4877-b0d1-e5abcacf365c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8cfdf74b-86e2-4e3c-acc0-20336fa8fbec">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -2690,8 +2690,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="2bd2c6f7-b6bb-4c99-8197-961f85a84d7b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9a324dd9-5d25-43a1-b3e7-ee8072bc5465">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -2700,8 +2700,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="bc969760-9386-4a63-ae6f-71c6018054ed">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1e7ac058-c61e-4c95-930b-8c04b620c3e0">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -2710,8 +2710,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="a977948a-1c60-4ce5-8aac-d55f10637888">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f9f7bc45-5ab9-40a3-8b36-a47c63620965">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -2719,8 +2719,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="30a5d2d8-6b4e-4318-ac37-d75bf531e2df">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a1806796-ff21-496c-bb62-87d7ab55b973">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -2729,8 +2729,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="4423616d-8927-41d1-afc4-4cc9a96ccbe4">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="33531eea-cf36-4174-96ed-bce94fea7658">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -2740,10 +2740,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd067593-f86b-4e17-96e1-10cbe35c25ad" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="7f5d2016-e7c2-467d-8040-b21a5625b4ae">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="35fe958b-b372-4ec8-b615-3ad3a11ad7c7">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -2752,8 +2752,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="01b0d33a-8eb8-4ae5-a913-37bf0097fd8d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a6f3f05a-1513-4446-982b-9fecd5738729">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -2763,8 +2763,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="f0a49174-a734-447d-8b3a-7bd3ea3b4d68">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2dbd59bd-5ab1-4ba0-8e21-a60348c925bd">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -2774,64 +2774,64 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8a88e74-b67b-4e74-aa62-62cd815b9769" control-id="pe-8">
+    <implemented-requirement uuid="b9f38e4a-2e80-4aa0-ac02-213d63b5f964" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="2acdd114-5425-455d-9066-f35296ca8f9d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6b310825-c340-490c-bfc4-31182434b089">
+      <statement statement-id="pe-8_stmt" uuid="3dbccc27-b1fb-4181-b57c-6c97616584b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4958933-ad6a-4b6e-8d86-de08e49867ad" control-id="pe-12">
+    <implemented-requirement uuid="bf2148cd-725d-4d33-bca9-e6059f48ae69" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="07add041-3ed1-4aec-9540-ad657d9146ec">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="66359220-547b-4ab3-967f-8e2d78c44416">
+      <statement statement-id="pe-12_stmt" uuid="1ba7c150-e414-4755-acbb-b677abb04a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a2565f5-91a8-4af7-bbec-ef5f01d7921b" control-id="pe-13">
+    <implemented-requirement uuid="67ab882c-0e48-47d6-ae34-e14e8eed800e" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="0050cf39-a4e3-40fa-8d5a-17e94f78008b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="86f40091-6e5a-4176-b78e-309b6cf695cd">
+      <statement statement-id="pe-13_stmt" uuid="cd19567e-4199-4191-88dc-f8a79f7fe5b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63f9fdf6-e6e0-452a-b8f7-1e522b21ab47" control-id="pe-14">
+    <implemented-requirement uuid="98fb3296-437a-496d-853b-92c71a0b01c9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="b7f68b1b-e06c-4083-9cae-fc0503f5c2d8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="28d28cbe-a867-4c43-99f5-3f4fb9aae036">
+      <statement statement-id="pe-14_stmt" uuid="f410cb6f-ecea-42da-89f1-16544b34d9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dc14fd9-35dc-4556-896f-9037cf51b979" control-id="pe-15">
+    <implemented-requirement uuid="3b494e54-817a-4771-a20c-62d7508a39c7" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="418b7d58-e898-4609-89f3-0fc1a3025577">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="142493cf-ee65-48bf-b629-bc64a19e3036">
+      <statement statement-id="pe-15_stmt" uuid="91e060ce-e238-4e32-a2e3-2c485523f69f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da87cb7b-2628-4c53-8e58-c62cc60910a8" control-id="pe-16">
+    <implemented-requirement uuid="a3e84d2f-1ed6-4c19-8c72-25e6cdde0d46" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="98bab659-ff26-4e57-b6e0-e13dbcd9f182">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3e8e03a9-4e41-4346-be23-b0fd32b2a891">
+      <statement statement-id="pe-16_stmt" uuid="acde645c-992b-490d-b159-d6d5576e2bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9fcb481-674f-4a24-aa33-17be23b361cc" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="4b04417d-9662-46d1-bebc-7575de4080a1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="31e7a4a0-7ac2-47f2-9516-a82443243051">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2839,10 +2839,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69a1f9f3-039b-42e2-ab93-8880ea71d74d" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="94ea963d-d597-4f1f-8b08-ff749e4af68b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8196e590-ad1f-4723-ab80-f41430c80a96">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2850,10 +2850,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e27b6e25-9646-479a-9058-31a214cb3873" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="f54c0add-6b80-4ca9-bf9b-59e84e17a073">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6b40130b-f328-4e15-8e42-99312e442177">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2861,10 +2861,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c70aa3c-6f6a-4440-9cff-a58490014e76" control-id="ps-1">
+    <implemented-requirement uuid="0d6fc93b-9959-43e7-ae1b-0fab7ac39726" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="e84ab9ab-2d34-4930-ace5-f4dc9f2481cc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c533023f-a30f-49d6-a1bf-ea92ebd6d323">
+      <statement statement-id="ps-1_stmt.a" uuid="484243d3-184b-4b25-98c7-ce076f11694f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -2872,8 +2872,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="4eba7faa-bed4-4d76-aec5-f7e802088c1e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="57b532e9-e7f8-49a8-9251-e04485cb7b00">
+      <statement statement-id="ps-1_stmt.a.1" uuid="e90c6c0d-1a1d-4b71-a894-3f62807bd565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -2881,8 +2881,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="32abbc3f-2f7a-4399-8395-026cd741c494">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4f090f69-3990-412a-82f4-9c7d8f3f13fd">
+      <statement statement-id="ps-1_stmt.a.2" uuid="ad2e7acc-28f3-403f-ac8b-3d73a4738beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -2890,8 +2890,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="50cb7999-0aed-43b9-8d8b-15a2f010f2e5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="52a020de-f51b-4aef-b0a9-2a7a5a49d6a2">
+      <statement statement-id="ps-1_stmt.b" uuid="fae8b684-9938-4b25-bb6d-8b44b03bb116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1fab7a44-4e0c-4a4a-b0d4-f65722d402fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -2899,8 +2899,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="a82b4bd1-a9fa-44fc-a4b6-8f064aa668a5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="25d77de1-1890-41db-89fd-dba0b3fc35fb">
+      <statement statement-id="ps-1_stmt.b.1" uuid="388bd160-ca4f-4ecd-adb6-8d9b11e76c5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -2908,8 +2908,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="d2cf06dd-5c13-4fae-b702-cfff3d55d77f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ce8425d1-4b88-4a52-9421-0a6ffd91d5be">
+      <statement statement-id="ps-1_stmt.b.2" uuid="9aba6ad7-81c7-4531-b797-ea7ab09eb431">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -2918,18 +2918,18 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7f728fe-58ad-4870-83fd-991bd4b9451d" control-id="ps-2">
+    <implemented-requirement uuid="2063b7cf-d7c9-4a47-820f-192605a7c815" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="5d278779-eeb2-4388-b841-cfede905793b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="de3f96d1-a89e-4e34-8bf1-680374cae965">
+      <statement statement-id="ps-2_stmt.a" uuid="04f38777-f10d-4327-a851-9b634b75d3d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5470435-d97b-42f1-9cb8-e8ee2e6a3e93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="9ac8ccea-4e07-4609-810e-b9962e9067f3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f57afbba-727d-45a4-877f-8c5c3703e6de">
+      <statement statement-id="ps-2_stmt.b" uuid="1cc918ee-67b2-4d62-8c94-ecdb6bb8bfef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc2e4b27-069f-455f-ba9d-b60e392f2594">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of CoreOS
@@ -2937,8 +2937,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="23fc17cd-befd-467f-bfea-91483cfe0096">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d7668367-22e3-4019-b97a-fc4d123ae2ac">
+      <statement statement-id="ps-2_stmt.c" uuid="042591b6-eed4-4da1-a24c-7244deea296c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68978f4e-23a3-4f5d-8f7c-f2b83b063eb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -2947,10 +2947,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ae2c022-e079-4563-89b3-cb597856cb6d" control-id="ps-3">
+    <implemented-requirement uuid="60c3c056-17d1-483f-9781-99b6bf925ce1" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="f020b346-58d9-465d-a615-1a179f09c135">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9e24f00b-7402-47d6-b1aa-a7f034f906c5">
+      <statement statement-id="ps-3_stmt.a" uuid="9ea78d95-7f29-4f79-8867-d329d8d22877">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5499886-17eb-4843-960f-88b0489759fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of CoreOS
@@ -2958,8 +2958,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="baeabfe3-e1fd-4555-b663-d3d9906e8ae4">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="99105fd9-8386-4099-8115-de4ec5c10f55">
+      <statement statement-id="ps-3_stmt.b" uuid="eac234db-81b5-4efd-9a8a-6c1bf5d205a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04005097-2b0e-4353-b3d5-9bce89a97bd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -2970,10 +2970,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="634e1be8-75ea-4db7-99d3-f04fc0b4ced7" control-id="ps-4">
+    <implemented-requirement uuid="da10f8fb-cc1a-4199-97c4-ee86b21da08c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="614fe2d7-c4e3-4928-9ada-4b45a65c3c2c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a424da73-e661-4b8e-8b8d-b67e47379927">
+      <statement statement-id="ps-4_stmt.a" uuid="d7a444d7-a380-4f01-8cfa-3ed8c6d65386">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f5127ab-95d5-44b2-ba3d-9623d6a768f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -2982,8 +2982,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="a1f406ff-e157-40ec-8455-8645b6125d0c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cf36bc44-c0f4-442a-9b61-718174f7d59f">
+      <statement statement-id="ps-4_stmt.b" uuid="e1088a65-d6a1-4170-891f-afd60daa1151">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de39dddc-4466-41f5-8b59-20a8fbc7090c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -2992,8 +2992,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="d6b3efd5-ae31-4310-9323-a20108894cf5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f66f07b9-e611-4342-aa6d-8a02c5b25425">
+      <statement statement-id="ps-4_stmt.c" uuid="c2914a86-37a2-48df-9651-f2d4fb21af3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71b8f8b2-f052-456d-9504-39e0c6e226f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -3002,8 +3002,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="1819d46c-ab2a-4573-a601-aa36799b79b7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="13e7bb01-4e97-4e31-aa88-87be9fab1153">
+      <statement statement-id="ps-4_stmt.d" uuid="be7521aa-782f-497c-a2a3-327a5aa1f541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a8c3238-643a-45a0-a54e-3cedf8269e87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -3012,8 +3012,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="9b523427-976c-4392-a972-15ad639f1fad">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6287afc9-6cab-478a-ab6b-48255d57ff6c">
+      <statement statement-id="ps-4_stmt.e" uuid="d68f408f-28d5-43a4-88c8-ece7c6985979">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c74c79b5-8455-4a63-b3f8-e95436fdb805">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -3022,8 +3022,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="526908d9-c6ab-48fd-b65f-0ffba0c31984">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c8e40c57-66c3-4661-a738-a3ab714cd58a">
+      <statement statement-id="ps-4_stmt.f" uuid="84630747-db8d-4b27-8d27-2a95b929881b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f54285a1-8b65-49f0-8a67-e3eb9f3344d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -3033,10 +3033,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="353460f9-0c23-4a8f-b714-8ffd1de7b505" control-id="ps-5">
+    <implemented-requirement uuid="b6f0483b-9352-4587-8500-bc8cd994e8b2" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="f8dc4b28-182d-415f-acde-37b7fc6ddd0e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8cb4804a-4bfe-4ee4-beb0-15acbfe292a1">
+      <statement statement-id="ps-5_stmt.a" uuid="0aa3e87c-188f-43ef-9d7c-8ae9239ee640">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e279f94f-02ff-4a52-8b68-9e4cfab9c79e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -3046,8 +3046,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="dc7d3fa9-d8dd-4628-ac4d-b314158de83a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="87004439-3cc1-47cf-aee0-9d6b6ffb24a3">
+      <statement statement-id="ps-5_stmt.b" uuid="515c35fe-d4fc-4ca1-bd8f-6d5c45605427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d517900-4646-457e-87ca-8ab4718cb546">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -3056,8 +3056,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="90ed87fe-4888-4cc0-9ca4-c942d8d0d5ef">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="585e577b-6e5e-46f7-8167-fcc3b0634e73">
+      <statement statement-id="ps-5_stmt.c" uuid="2edb4391-b20b-4637-b5cb-ecc09df29a6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b78e8a0-9ddd-4594-8dc7-9199f89e3683">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -3065,8 +3065,8 @@ or transfer are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="647478be-96a7-4e8a-a242-c9f3ef8eabe8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="67833230-1143-4464-bcde-6e97b7700efa">
+      <statement statement-id="ps-5_stmt.d" uuid="b8690aa2-ea61-46c1-b1cb-4dc2a85cf21d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aff56077-e3ec-4b21-a408-01fea0a64369">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -3075,10 +3075,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9743ff86-ae6d-4c35-b1f1-6971ddb3b244" control-id="ps-6">
+    <implemented-requirement uuid="dea9ff31-8a0b-47d3-a11c-99433ef1b31e" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="94a9ff18-7fe1-49a8-9813-550889154263">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e9d37af7-c2c5-4cdd-9cd3-c3abb40b65e5">
+      <statement statement-id="ps-6_stmt.a" uuid="2f66e87b-349f-4248-8a43-0c731a10769a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2b39e55-bede-4885-bb55-ba1da248bd38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -3086,8 +3086,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="3e94cd36-e12e-42ef-8661-68473c0650ce">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9b0b7033-4b2a-478f-9735-8badca88247e">
+      <statement statement-id="ps-6_stmt.b" uuid="eb94419d-f820-407e-9bfd-315a92e12daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cec67604-4082-4efa-bb6a-5ee320b38b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -3095,8 +3095,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="e96fd5ac-c168-4ffc-9ecd-0b7bd9b3c1e9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="edacbe68-a03c-468e-b530-f3fec0b766e9">
+      <statement statement-id="ps-6_stmt.c" uuid="e800e662-52e1-456a-a977-23a39e42a5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3104,8 +3104,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="10697f13-3319-4038-8a7d-592f9f5d0855">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f26d52cb-b290-49c0-a0e9-95a223d5abc0">
+      <statement statement-id="ps-6_stmt.c.1" uuid="dc15c108-e2d3-4f89-b89e-54e49db92a44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3113,8 +3113,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="7d3de238-88de-4617-ab10-c3f60a1691b5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d725dbd6-8f91-4c86-b22c-7aab9e3e744a">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d4818871-64ec-4b32-8214-b515d02e8320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3123,10 +3123,10 @@ access agreements are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0dc54087-451d-4625-b363-10884ac6d97c" control-id="ps-7">
+    <implemented-requirement uuid="3bf37c4a-021f-4b34-af32-d7b9fd6a2c4a" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="94000538-c82b-4851-9c63-242a9ebc2421">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6ebdc0f5-1a80-4656-b525-806f276a671f">
+      <statement statement-id="ps-7_stmt.a" uuid="2945bdc9-ddf4-41d2-844e-dc72062bdf86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cacae972-7d2e-4057-b8bb-eb041b623dc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -3134,8 +3134,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="77763867-980a-447e-8b9c-2d35f9fa77b1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="0571585b-290e-4efc-bf99-f4c4120f29e8">
+      <statement statement-id="ps-7_stmt.b" uuid="af9686d3-b729-4b9f-844f-16786efadcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1213e2d5-2797-4ce0-9f11-caaae82fa258">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -3143,16 +3143,16 @@ the organization are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="062ba006-a30b-48d9-a577-c48a0183b57b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="58d97df4-7294-4774-bc77-3c84d31765f8">
+      <statement statement-id="ps-7_stmt.c" uuid="c79914aa-3a49-4dbe-8922-c1c5c1e6f87c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c4267dc-3818-42d8-a671-cf44ca7e0d67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="c5af9cc2-9468-4603-88df-ba4053cec4ac">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ea8c2ca8-853e-41c4-8b16-143661456eab">
+      <statement statement-id="ps-7_stmt.d" uuid="2d9b350a-8f2f-41f8-be37-43e1f31a92dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9aa191c-a620-4f1a-9d6e-14795465a4f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -3163,8 +3163,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="d221d32e-b761-4789-b16b-290eb142acde">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e2d436ea-f330-4380-82a9-16eb242486e1">
+      <statement statement-id="ps-7_stmt.e" uuid="dcd75ff6-34de-4d8e-afb0-24b21c914f89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="524c0b4d-63df-4619-9803-b2d1e87578ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of CoreOS configuration.
@@ -3172,10 +3172,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b07ceae2-66cc-49ed-90fc-116f740380fd" control-id="ps-8">
+    <implemented-requirement uuid="144d6958-d305-481e-93ba-1855414237a9" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="3675f951-59b7-4e46-8370-3b9e9a227671">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="0272b802-d033-4e26-bb63-36c9b06eca31">
+      <statement statement-id="ps-8_stmt.a" uuid="47324678-8588-405b-828f-6836cef02800">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7d7c773-0c79-43d4-afba-87dcde0f451d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -3183,8 +3183,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="ffd2d338-b45c-49df-be5a-679603890ea3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d07f9c64-d323-4d2e-ae3a-0816db781ed0">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -3194,10 +3194,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="208a7cb6-2d38-4b2a-ab45-9d984a34cd26" control-id="ra-1">
+    <implemented-requirement uuid="cbd41f9b-3395-449f-aabb-11982cf4072c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="7ac27e9a-9043-4269-acf7-f934cb124ca6">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="397787f1-5082-46fa-a238-2b3148a997d2">
+      <statement statement-id="ra-1_stmt.a" uuid="b9ec47cd-c79e-4fec-b740-d0633a43b066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3205,8 +3205,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="5352348e-e7b8-44a5-93e4-9913997aa228">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7963d90c-363e-4672-ae41-cc17aa67ef7e">
+      <statement statement-id="ra-1_stmt.a.1" uuid="093b0873-cee2-4731-9145-4c5f9403b681">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3214,8 +3214,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="20f4c238-0f25-41a6-abbb-09ee97b02b12">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fb29bddb-0995-4c7c-a9ea-6c134a6df74f">
+      <statement statement-id="ra-1_stmt.a.2" uuid="f4ac6d2c-45c5-458b-8dda-9b152e215b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3223,8 +3223,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="db8137d3-3060-47d8-8773-b63491c6c843">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="14a624ca-f45e-48d2-be02-ba5584f1652b">
+      <statement statement-id="ra-1_stmt.b" uuid="18a2c73d-bd73-4bad-8a65-5327e87af997">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3232,8 +3232,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="42c52633-2c93-4bb0-9ff6-37715cd91ed5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="491920fa-29ba-4458-bcde-edd2f32ae63f">
+      <statement statement-id="ra-1_stmt.b.1" uuid="8ca1a04b-1ce8-4d10-86dc-998980760beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3241,8 +3241,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="2ee1e346-5eab-41cc-97b6-ad084bcbccf7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="3bcab747-d717-466c-b7ec-8dbbdb6cf79d">
+      <statement statement-id="ra-1_stmt.b.2" uuid="73006780-8601-4739-9bf4-5f9a34cf6373">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3251,10 +3251,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2c7f9d9-77be-4cc9-a86b-afbaace9b125" control-id="ra-2">
+    <implemented-requirement uuid="dd4d32ed-c9ee-4c8d-983a-8519b85d93fb" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="f28415b6-b5a5-439a-a7f5-545621b3b104">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1a2f23f2-53e0-4a8b-9e77-09647bc83bd4">
+      <statement statement-id="ra-2_stmt.a" uuid="bd55c578-2e02-43dc-8d2c-dae6909ff532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38e8d6ad-482d-41e8-a9dc-077244810b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -3263,8 +3263,8 @@ guidance, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="ef6caea7-debd-4d1b-a3b5-77868249fb71">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a044f7f9-70c7-40df-8696-9b4ed2c9be70">
+      <statement statement-id="ra-2_stmt.b" uuid="02c243d3-21db-4500-a429-f6a93169cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="827fbbd0-994f-4551-b04c-4839494e133d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -3273,8 +3273,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="addbbbd0-a2b6-4404-bc2e-c0b5423ded07">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e6144bad-899e-4e8e-a8fa-8e6d599b51c0">
+      <statement statement-id="ra-2_stmt.c" uuid="a761f6b6-b88c-427b-b219-9b6133c05196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="222b3d51-4fb8-42c4-8b2b-00b40d003325">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -3284,10 +3284,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8613d796-032d-4a5a-9fd7-d23685056d43" control-id="ra-3">
+    <implemented-requirement uuid="a91d978d-76fc-4f91-996a-ec3bd70d2f20" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="5ae3a952-dc0f-4c77-9b3a-68383ce7da27">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="34919f31-c1bc-4210-9afc-6fa9598b59d0">
+      <statement statement-id="ra-3_stmt.a" uuid="8f28b273-d3d2-4733-9cce-28a43c6f8790">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="440515ac-07ee-4423-94e2-1dac61f0149a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -3297,8 +3297,8 @@ transmits, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="0dc07323-04d6-4c97-aae2-9f0afce5ae14">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="5520d360-a095-4251-a541-fe8e44a1990f">
+      <statement statement-id="ra-3_stmt.b" uuid="8e0a280d-8df4-43f8-ae7c-69fa52679253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d896e942-2f5a-468b-bfa7-69b07720a268">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -3306,8 +3306,8 @@ documents, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="1a08ab05-fc91-4653-89a9-e75c84e69dfc">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="19ffe796-a2e0-4586-b4f7-458b0783208d">
+      <statement statement-id="ra-3_stmt.c" uuid="a4c416cc-7372-4332-9954-f385e2e4a62f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06648176-8f20-4d8c-8dce-9fb6bab40ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -3315,8 +3315,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="69e9b99e-20fa-45e6-a70e-01b4f99e31b9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6a84d440-c367-438c-9ac3-392eb98163ce">
+      <statement statement-id="ra-3_stmt.d" uuid="60b70e92-5e62-45b9-bd5d-51b8d4a533be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1ea9294-5af3-4ef0-9f29-5442a87dfb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -3324,8 +3324,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="170d5f78-a88b-47dd-9849-724a00b25859">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="6cc7acf9-be31-423c-be0b-2603e1e3edc9">
+      <statement statement-id="ra-3_stmt.e" uuid="4725522d-a508-48c1-a3e9-5928b73d4124">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2f6371a-788f-4180-b531-392900117b2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -3337,18 +3337,18 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34385485-3e07-491e-be1c-e49552f8f13e" control-id="ra-5">
+    <implemented-requirement uuid="faba4d3b-a229-4ef4-92a7-51930564432c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="78999d32-79f3-4378-852d-5a847610745d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2bbeaf65-848c-46f5-a907-ffe7e1e12f71">
+      <statement statement-id="ra-5_stmt.a" uuid="ac517196-6214-4d51-9acb-fabac78e0911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="9eb0cdb4-0f22-4a96-9e31-66a7ccff34eb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7b7aa0bb-aecc-4b07-b57b-b539c1f94a24">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3356,16 +3356,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="855333a4-32a2-4b88-8adc-81da3bb5a757">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c859b1b4-2573-477f-a882-536a05475ec2">
+      <statement statement-id="ra-5_stmt.c" uuid="eb2ceef6-2632-41ab-bd7f-bd9fafd3d08c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="c2a81482-92ce-45bd-a74e-792fcfb3cf9b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="34136cf1-b858-4535-8a56-00569e480ed3">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3373,8 +3373,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="efc128ad-8c45-40ff-a8c9-8da7d18173b8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="764c01ee-bd9b-4407-a636-3d1be9c3d444">
+      <statement statement-id="ra-5_stmt.e" uuid="1ff6a01d-7430-40af-9732-808c455f1558">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad407a82-f2e6-46f4-9029-f9fcbe5b785b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -3386,10 +3386,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="159873e7-da19-42c6-ae99-2fc95bee7041" control-id="sa-1">
+    <implemented-requirement uuid="0c0652aa-7057-4f72-b1e0-ee4437f43f32" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="ca61b720-dcb4-4b35-8b3b-2cfa8f18249e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fa71d75a-a1e7-4450-ae34-794cdd64bc5d">
+      <statement statement-id="sa-1_stmt.a" uuid="3d66e025-98f3-4642-b709-8ad2d8f3d5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3398,8 +3398,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="3b538303-d70a-44cd-abd0-df1a5f9f74d7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4ef67adf-9018-402d-a737-db19d4456651">
+      <statement statement-id="sa-1_stmt.a.1" uuid="cd61765c-36f5-4066-b631-f184bb57d5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3408,8 +3408,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="d894139f-2dc2-40f3-ac69-d72280f81666">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="865e2185-9962-4b3c-95e8-0290efcb9f0b">
+      <statement statement-id="sa-1_stmt.a.2" uuid="7b92ddc0-42b3-4bc7-b148-475ab42bf48d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3418,8 +3418,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="b21039aa-7949-435f-9ec0-da58e05a4cb9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d53847fd-8cb0-4d5b-adeb-f2eeb8c01493">
+      <statement statement-id="sa-1_stmt.b" uuid="82acdcc6-8d2d-4ac2-b6b5-fa56906034f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3427,8 +3427,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="553ba379-2ecf-40be-aacb-99c8f4c3f56d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b005727c-f0d9-4679-8576-c7b564951a01">
+      <statement statement-id="sa-1_stmt.b.1" uuid="10ddd67f-0dad-4c07-a52f-e9a411a81590">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3436,8 +3436,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="29028ccd-09d7-4b9b-8485-aef4bf92029a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="73c644e1-4725-4aa9-a6d6-54adf1369ff3">
+      <statement statement-id="sa-1_stmt.b.2" uuid="8c40d9e9-f309-4d84-bbd6-8330b7deae55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3446,10 +3446,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26158d96-2141-4f36-a956-dea5367e846e" control-id="sa-2">
+    <implemented-requirement uuid="7145a51b-2ff7-4828-b118-57aca991d868" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="983eb038-2923-44bc-9f42-242fd7294521">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b5e6cf9a-b9e0-4a4f-9f85-e244e1ff10d7">
+      <statement statement-id="sa-2_stmt.a" uuid="2755cb68-25bd-40a2-ad83-1998ddbe4b8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b5d2b15-1d23-4308-91b6-81520a9e5d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -3458,8 +3458,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="e666d3b8-871b-4321-8b35-933e3ab0927f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fee194f1-99ae-481b-9fb7-122faa63ff87">
+      <statement statement-id="sa-2_stmt.b" uuid="c861f1a6-b97d-40b5-bb1c-c7534589144e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bde7c5a-d48d-4ffe-84ce-49d33dca8cc0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -3469,8 +3469,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="0fd544f3-716a-48b3-a547-3b979a79e9d2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c2b2cbfa-fd9f-4a67-8fb8-535fd20a795e">
+      <statement statement-id="sa-2_stmt.c" uuid="16c673ff-ca9d-4e39-9506-2448605a41dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4173a7c3-70d3-4f66-af32-b1d257a4a434">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -3479,10 +3479,10 @@ documentation are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70eae11e-1744-4fa3-be81-563b48b8ba69" control-id="sa-3">
+    <implemented-requirement uuid="f5854499-3850-4041-8163-2098e8ce66f9" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="1ab5aa49-1ea5-4ddb-9b9e-4469c92890c2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="41089ad5-d294-4c6c-b5c5-4bfb7fd03907">
+      <statement statement-id="sa-3_stmt.a" uuid="ab1f9419-2d17-407a-9899-d198c6784c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8091825e-84d7-4e98-b2e5-39a43ff6fd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -3491,8 +3491,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="e6bcea42-d40a-4c9e-bfa6-a795ac62c217">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a9ff192f-8cd8-4848-a88b-eb7a737d8513">
+      <statement statement-id="sa-3_stmt.b" uuid="f0f0c199-51ed-4b15-aadb-3b2287f0219c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574de2a9-b6ac-4180-9f66-faf08af1494a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -3500,8 +3500,8 @@ life cycle are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="29d6fdac-1ee9-41f5-adea-f7b1601c58e3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7068f0b1-8801-4f0f-8036-3ecebeea5409">
+      <statement statement-id="sa-3_stmt.c" uuid="ba979c87-fd05-4bbc-8c25-bf77aa504bbd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ace7cb98-3cba-441b-a31a-14917d2f9701">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -3509,8 +3509,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="176312c0-a175-4182-bf29-f3ca9e0c09e3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a27b2255-f082-4de2-91d2-9d839f6e95d0">
+      <statement statement-id="sa-3_stmt.d" uuid="81798b33-2475-461c-bb95-0423f44a2427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a9cb6d6-2615-4dd6-a2fd-739442455a56">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -3519,10 +3519,10 @@ activities are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="046f6698-de1b-44e9-9570-aaf22ee1dc9c" control-id="sa-4">
+    <implemented-requirement uuid="a6127496-fcee-476c-93ac-985866a01330" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="add0e63b-6e8a-4265-946d-368849aefc69">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7cd43126-81d1-4c75-84f5-a7ced8319fc7">
+      <statement statement-id="sa-4_stmt.a" uuid="66e9e982-66c4-4d53-873c-67972cae950d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="572f10ee-08b1-45ff-9ba6-67c5e27bd949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -3530,8 +3530,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="8dce1c46-add7-411e-80a2-ef1337828d28">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4e3a4d7d-6764-46ad-aaed-c86f1e337abd">
+      <statement statement-id="sa-4_stmt.b" uuid="5acbbc04-7c5b-46c5-bbbf-1b989d32260c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c001268c-4565-4dc9-a033-258fb2d1aab3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -3539,8 +3539,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="6d04273c-43fc-41f6-b678-7f6264f45ff8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b34cc54d-3a99-4bd4-b510-5f1a91883cb8">
+      <statement statement-id="sa-4_stmt.c" uuid="ebc06327-df41-4050-8545-c31078c78658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4b17de1-8bcc-44ba-9c0a-9c64b04d39ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -3548,8 +3548,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="2ea21a06-91d0-49d2-82b6-acc985d48eb1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d07f35fe-4c0b-4e2d-9e1e-f64bd9ac39a4">
+      <statement statement-id="sa-4_stmt.d" uuid="bfcde3f9-7df8-4058-b708-7076656c4aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a023e396-23d4-4da2-b88a-a82810b4b941">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -3557,8 +3557,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="2c809236-ee17-4f7b-b745-a1d6553331b0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7f5ee0d9-de3e-4c30-a398-a1eeb2717272">
+      <statement statement-id="sa-4_stmt.e" uuid="d209b23e-a57c-45fb-aa56-5d61c0ab647c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64203fc3-95f8-4b3d-8ddc-04cde85cbb81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -3566,8 +3566,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="1d5faa28-1037-4dbc-ad33-eaf15d5fd442">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fa18300d-08d4-4c96-89dd-2cebaacf9301">
+      <statement statement-id="sa-4_stmt.f" uuid="1521bbdf-33b5-44c7-bd64-372014b03655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a13a456-f7e8-4774-90ac-3bf599dda9cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -3576,8 +3576,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="283e0f7c-ec81-4178-a8db-ed3d5c2eb014">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="09a754ec-5d54-4631-bac5-aa9fb2162393">
+      <statement statement-id="sa-4_stmt.g" uuid="e77d9d21-6ff6-4e11-a420-5d1ff9410008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06b0ef7c-0b8e-4b73-921f-ce2b48a7c710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of CoreOS
@@ -3586,10 +3586,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c9a8d67-9a1b-4233-a13e-44553a729a98" control-id="sa-5">
+    <implemented-requirement uuid="f78f691a-653a-4df7-bc18-65ff8336c199" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="5982065b-6c0c-44c7-aa33-aa75c89f2d72">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="585713d6-2e15-4de1-86aa-9e91a1590fd8">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -3598,8 +3598,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="c8c68088-9b76-4f36-9e7c-d77c0ffd207c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c96a0a6f-bd7f-453c-bb3c-c6f52701d75e">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -3608,8 +3608,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="5b14b995-4d51-438c-be69-23997dff85ac">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f12bee8b-3a81-49e4-be58-d4dda7783064">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -3618,8 +3618,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="58ac4a8c-420e-4e7a-b498-22247786e252">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a9eeed24-232d-41be-810e-c18b88a0ea24">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -3628,8 +3628,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="4d2a587e-0aec-478e-b967-3f91e10b1202">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="90f76eea-bf22-4c6f-ac51-28fc7f277c29">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -3638,8 +3638,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="214281ba-4841-43f8-b5b7-31c75db51a1c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4ab8e076-e6f5-45e4-ae81-8c9a375bc73e">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -3648,8 +3648,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="f7871e4a-6251-4365-ac9f-8ecca1a4a9e5">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="db7880c1-691f-4404-81f9-750f0b5d7a85">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -3658,59 +3658,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="b1c38b2a-6da8-4a22-b241-d7ac27fa2499">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="24545520-e648-46cd-b7b1-00a1edb0c02f">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2988f5e3-bd2e-47ab-8b2a-0961b58a6667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="5939668f-05a9-44b8-8190-5c52427c44f2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b9538653-6245-4c96-8099-f50741dbb125">
+      <statement statement-id="sa-5_stmt.c" uuid="35fb7c42-07a3-43e8-ba7e-ea762fba9f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="f507ab09-ff4a-42b4-afe4-d05f003e4357">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b4b5c583-0f2b-4e61-8de5-485802684309">
+      <statement statement-id="sa-5_stmt.d" uuid="4ce14cc1-b29c-4334-b59c-02ef744b5bfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="6ab5beda-dae3-4dd3-a883-57cff5d489a0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="05dbff02-dc72-43a1-b042-088942521553">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to CoreOS configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fccb390e-4797-4506-ae42-75de017849fd" control-id="sa-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="2dd82a52-2931-4ef1-abc4-01de44603b84">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dc39fe95-c2fa-407a-b322-78a584777dc5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to CoreOS configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="5d0b3e32-2cd8-42aa-8fff-cd01daa7aa9f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="0a292d58-0baf-4fd4-89cf-49302ee75695">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to CoreOS configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="bb42881d-2f2e-47e5-8a8c-fee5f7cb042e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="4a73672c-dcca-4fe9-bbe6-2aec67bb3a65">
+      <statement statement-id="sa-5_stmt.e" uuid="10a7f065-0e7f-4660-b464-b66f5f383362">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -3718,18 +3691,45 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3214ed69-01ad-4a25-b088-280f14f1da9d" control-id="sc-1">
+    <implemented-requirement uuid="8e537434-01f1-4324-bf80-6f36a6ea38df" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="6dda5aab-fe6a-422c-81b6-da64c594c3e9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="be5bf753-278c-419f-9339-56938ece07c7">
+      <statement statement-id="sa-9_stmt.a" uuid="13c765df-6a58-4792-b3cf-26d28b151fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to CoreOS configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.b" uuid="da1eaec2-07be-47be-a90f-2f93fad86c6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to CoreOS configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.c" uuid="6b75bd8a-ffcb-4b13-8346-a4d8670d7587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to CoreOS configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="54e9360d-eae0-47f4-a92a-894f7a8ceb12" control-id="sc-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="sc-1_stmt.a" uuid="354dc18e-1012-45fc-a30f-c1a9fabd2b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="1b9614d3-2087-4b43-b2cd-103e1bda048d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="89659c17-29e1-43b1-91c0-8b6c972028c9">
+      <statement statement-id="sc-1_stmt.b" uuid="ac80bea9-adb9-4bc1-8c4a-528f150bf852">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3737,10 +3737,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63729204-5495-4ebe-a87a-008378a702a2" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="a5bd2d24-8240-468b-88a6-106bdd130201">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="21d1029e-7c3a-45eb-8528-d619baa6bcc2">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3750,10 +3750,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f489c2b-944a-45f8-8b04-f2078babb346" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="5361642a-2deb-49ba-b27f-613d84277fb8">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="358aff32-555c-4413-918d-a608935cc12e">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3762,8 +3762,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="caa770b3-9e42-4eb2-8e6e-31fcf943cf91">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a66a1e70-4978-494d-8ca1-0ed3ccebe2ba">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3772,8 +3772,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="e88d25d0-b320-472d-85f1-98b8e2daf0e9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7d20fda1-e295-47c0-8153-5e0d07e61a0e">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3783,10 +3783,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a69cc0f2-402f-4988-b149-3d60a9e792e5" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="335e6fc9-795e-49d5-92e2-f1a342fea019">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="88696e70-6b51-408b-acac-b6e13059a1c1">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3796,10 +3796,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa695e70-d390-4d63-86dd-451a10aa085f" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="1049a25e-dc1f-4688-9072-4a1d181952c7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2b1f3193-dc69-4f22-ac45-7ae61a44d752">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3809,10 +3809,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8714fdba-ae2e-47a0-8853-a15aba3b804c" control-id="sc-15">
+    <implemented-requirement uuid="d4373dc0-0592-44a3-b8ac-19c15a277ed6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="ea6be59a-c2ff-421e-ae45-c6eef6cd28fb">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="c04db6d1-e3b9-4623-b3e3-4582f2818f5b">
+      <statement statement-id="sc-15_stmt.a" uuid="c399b25a-6449-4871-bff6-daf5ff8efbb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -3821,8 +3821,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="c830f711-1f67-49c6-998f-0c9e8a8992a0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="46063ea7-c6f7-4fc2-82bc-ec29f4aab179">
+      <statement statement-id="sc-15_stmt.b" uuid="c6c7c1ab-cbde-4eee-8df3-ad2e347204ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -3832,10 +3832,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7c89f0c-63fa-4835-bf73-10320020c6aa" control-id="sc-20">
+    <implemented-requirement uuid="c77113e5-0a1a-4df8-a7b0-5847ff7b267a" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="efb9d093-fa03-46f8-a931-eb076e9c9863">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="2fc47de4-8bc3-41f0-911e-ee227b31ff3e">
+      <statement statement-id="sc-20_stmt.a" uuid="a38a366e-a171-4825-81ec-29464e4f2441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3844,8 +3844,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="a00838ef-2259-414b-9960-0092714c4917">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a9022359-3b09-4147-970d-faef7e8b46df">
+      <statement statement-id="sc-20_stmt.b" uuid="c5749db4-3e0f-4e6f-b7e7-fc8496731ca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3855,10 +3855,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="486dbc67-eea1-4210-b89e-602dac929065" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="6a38289a-14f6-4a0d-89a6-61a0cbac71bd">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="e9b109be-0c3a-499b-aef8-9fb64de48803">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3868,10 +3868,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bd2c3c1-776b-4ffd-baa4-0d50d49b7f79" control-id="sc-22">
+    <implemented-requirement uuid="8b7be659-58fc-4f8e-b6ba-fcdc3111e4fa" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="da1f67c1-8293-45a2-867f-6429f3e4887d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="7e1d30f1-72bd-4d54-9bf0-5247f5735753">
+      <statement statement-id="sc-22_stmt" uuid="5525a272-a750-4ba0-aade-c3c0660b21db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d75e9d7-2b91-4d97-9af5-2efbfc6c5d6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that name/address resolution service is fault-tolerant and
 internal/external role separation is implemented is not accomplished on the CoreOS
@@ -3880,60 +3880,60 @@ node level in an OpenShift cluster. This is done at the OpenShift cluster level.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc118ce2-2eda-4d34-bf03-0b7ddcfdefe1" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="bb529046-1c71-40e3-b4c4-af6dc3286866">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="14a1ff0f-364c-4f75-ae18-6b1823f85f05">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="445d3897-2ff3-44c9-85b8-1e119f5cd21f" control-id="si-1">
+    <implemented-requirement uuid="939ad644-f843-44d6-9827-c800985ba52f" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="f6371e67-eef8-44ad-80a2-986de62537e0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="36fa4abc-b8e0-4d3f-b8da-cea93811ea41">
+      <statement statement-id="si-1_stmt.a" uuid="faf77839-500b-4190-9d2c-bb124cdfe49f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="a42e693e-dc00-42a9-9141-1611b0205d4f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="398bde1b-59ff-4d83-bf75-9185f9cf0157">
+      <statement statement-id="si-1_stmt.a.1" uuid="8a14bbab-9059-4b95-afed-e159522f38be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="96769858-e8fd-4b7e-bd5d-72803b0b0425">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f1bc0091-c73d-495c-9e32-fe8ea31d0baa">
+      <statement statement-id="si-1_stmt.a.2" uuid="0f66fa58-3e16-483e-8717-de494858c173">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="e38f3c07-7261-4b06-9a17-2f0061afe225">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b5376b15-2bcf-47ea-b395-bc5e851a77e8">
+      <statement statement-id="si-1_stmt.b" uuid="80f86133-24b3-46f0-972f-781d6cc87d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="c80bcb8c-b4a2-4a45-b5bd-b38a219811e2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a4f6bee7-651d-49f3-9483-c2914b87c080">
+      <statement statement-id="si-1_stmt.b.1" uuid="e8d3dccd-bd75-4eb7-ac9a-70d5cd1e26ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="1d00f691-afdf-40e2-bd09-277ad8f825b7">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ef6a3650-68fa-49b9-88c3-a5cb69f3ac99">
+      <statement statement-id="si-1_stmt.b.2" uuid="d5091781-e22a-453f-bfd9-da12a3cffbeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3941,10 +3941,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08005228-fad3-465b-9efc-e99445c2f8d7" control-id="si-2">
+    <implemented-requirement uuid="4ee1f2dc-9abf-4af2-a0e6-68fc08d98380" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="22d41d25-70e7-4e2c-83f1-9fe77391d80f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b2051b72-68e2-4da8-be87-e2c6d8dd84e7">
+      <statement statement-id="si-2_stmt.a" uuid="9720e20d-3df6-4f50-8ae3-a4ef5f8ca8fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dff4e8f-9e35-4256-b12a-0de5fc01866d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their CoreOS deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -3954,8 +3954,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="bd88b19e-cc2c-483f-9b8c-b1375e68ea7c">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cd112ae0-b521-4a19-b969-1950a4110a98">
+      <statement statement-id="si-2_stmt.b" uuid="d89d296d-55a1-4bed-aa91-66c08067c4a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b6d6495-2347-4f30-8e10-9044b74463de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing CoreOS updates
 related to flaw remediation prior to installation. A successful
@@ -3965,16 +3965,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="5373aac4-ed3a-4450-9146-00cf517b751a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8494dfe6-c5e7-49fd-94dc-2955663141b2">
+      <statement statement-id="si-2_stmt.c" uuid="e194c214-36bf-47a9-b578-186ef5c68da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="fa94f837-6949-4213-9266-2fb9ed2fd4d9">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="df79dde6-e91d-4b27-b718-690b19642d4c">
+      <statement statement-id="si-2_stmt.d" uuid="9cd61549-ae3a-494d-8793-2a0eed029bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3982,10 +3982,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6451a1b2-93da-41b5-a8f5-e16bcde2928f" control-id="si-3">
+    <implemented-requirement uuid="4a1a1387-0d1c-435b-a997-6cf4182f0d3e" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="11de6be1-1827-4599-91f3-eca59d121b17">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="99ef3ba5-2448-42d7-a48b-afca751654a4">
+      <statement statement-id="si-3_stmt.a" uuid="2cedad34-820d-4c19-8351-320d162dd000">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b9c31cc-1e94-44c8-b9e7-79474eb422be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -3997,8 +3997,8 @@ the use third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="355f102c-baf4-481b-bb2b-a3f5011e964a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="815cebbb-ae82-4424-98ba-3754cccb171d">
+      <statement statement-id="si-3_stmt.b" uuid="f0a8a2c2-9853-40ad-82a3-71d35d099093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acaa67b5-6168-4bb9-a0c4-6520f323328f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -4007,16 +4007,16 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="1f07a01d-6e70-4a4f-9455-afd620e88d32">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="90bb7d07-4199-4b80-be64-0f277edf3e32">
+      <statement statement-id="si-3_stmt.c" uuid="950f012d-7938-4cd0-8513-ad982ac3bb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68db3553-e877-4ae3-b0de-9027603a9df9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="3c291306-3c6c-44b6-ac06-0ecc8b2b9031">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="22fe039f-89b5-4d70-bed5-8a076b50f8e8">
+      <statement statement-id="si-3_stmt.c.1" uuid="7b6729a1-c4b8-4647-924f-6563d03e0605">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eff97d30-28a8-498b-98bc-2e77dc7868d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -4026,8 +4026,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="301f6cf2-a5fc-4b81-a1f1-fbca63d14b96">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a2004832-776a-429a-b18a-bd6921e7ba38">
+      <statement statement-id="si-3_stmt.c.2" uuid="a8c51912-153a-4da5-9705-c24ddc805862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c27f453-80c0-4206-8086-8033410bb8dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -4035,8 +4035,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="cd3f97b2-5db0-4cea-9604-11fbf80f6ca3">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="787c7e96-b5ac-4ab8-b59e-da02ac37cf2e">
+      <statement statement-id="si-3_stmt.d" uuid="f1faaa16-6cbf-41e9-900b-c0b780d64182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="369435a4-8044-471e-9a54-6d5457f0e4e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -4045,26 +4045,26 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b91a0769-538e-425d-9417-81466fff6d2d" control-id="si-4">
+    <implemented-requirement uuid="bdbbd04b-e0f0-49e6-bbbf-acd8c686f8a7" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="40056b6e-ee6b-49fa-8bee-fcb9b01eec7e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1d16347f-4761-4366-bed0-6f44632bd595">
+      <statement statement-id="si-4_stmt.a" uuid="0677e3a7-bf35-4378-a1fc-1be2f318baba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="02ffcc86-92f3-4bf7-8d34-9d940f506a52">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cd5abcc8-ae6e-4182-b55e-27f58616e413">
+      <statement statement-id="si-4_stmt.a.1" uuid="546c286e-e1be-43f8-b843-7adf97ebb7ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="d4ebcd38-1bff-4b71-90c6-78123cb06d7a">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="ebed82f0-f107-445a-8ce7-9a3116610d43">
+      <statement statement-id="si-4_stmt.a.2" uuid="8a3f7de4-ddf7-40bd-993a-c29b1409bd64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9bb5b42-c476-4aa5-985d-e9ba02c5d707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of CoreOS configuration.
@@ -4072,8 +4072,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="9dddaf21-7b55-4a6d-9813-211f8bc7a3ea">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="dba3fc14-a3de-4812-a23f-d6fbdbd14b5b">
+      <statement statement-id="si-4_stmt.b" uuid="680ade86-4b9e-4f2d-8628-4e8d97dfa690">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="148f2e3f-ddb3-4874-b4c5-81e95e745305">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -4081,16 +4081,16 @@ of CoreOS configuration. Functionality to meet this control can be provided by a
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="84eb5ab7-4aa1-44df-a4df-062f1418963e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8cb02f29-2902-4850-9d8b-776cf9dab6dd">
+      <statement statement-id="si-4_stmt.c" uuid="110eef98-891f-49ff-85a7-15bc1df2df7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9c75a2d-2eef-43c3-8c81-b2d9811bdc9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of CoreOS configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="0d0ef389-14b4-4de8-93bc-5f7162e88ce4">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="b2b16388-1e69-41d8-aafd-147e3643ea50">
+      <statement statement-id="si-4_stmt.c.1" uuid="1ddbf432-1d71-4f0d-8899-52c86d4877c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="391a4025-aa3a-4916-a7b6-2675a890739b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of CoreOS configuration.
@@ -4098,8 +4098,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="86cbb7fe-1e07-4f3a-a571-3ec6befe459f">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="1cf12951-900d-4990-9975-24502ed434be">
+      <statement statement-id="si-4_stmt.c.2" uuid="07f80a66-1645-4f90-981b-ea7e4f5a704a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ef0e67d-380c-4cb9-a718-3f53e99d2f54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of CoreOS configuration.
@@ -4107,8 +4107,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="cb2e289b-b7d9-405b-ab03-199589edc7c0">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="f70d9edd-5c41-4b0b-b640-8198bef223e4">
+      <statement statement-id="si-4_stmt.d" uuid="23254b38-9177-4e7e-9b4a-640411ae6e56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66c58a1a-589c-4f34-b1d0-7a68570d650e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of CoreOS configuration.
@@ -4116,24 +4116,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="272c2de0-d2a1-4975-a947-3b477549994d">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="9f25b593-e931-4761-9167-adb444392d8f">
+      <statement statement-id="si-4_stmt.e" uuid="4ca3ca63-8647-4bb8-ac72-4b879fdf361b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="dca27e99-919a-490f-9014-21243b310ed2">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8cf5d978-2381-40ea-8726-c72fa9abd046">
+      <statement statement-id="si-4_stmt.f" uuid="dcd5cc24-40a1-44c4-8e1e-8596ba232473">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="093a0344-c11b-4ad8-b50a-acbf36b91eed">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="cd02dfd4-a970-4373-80ae-bf81a6f6a20c">
+      <statement statement-id="si-4_stmt.g" uuid="8fb28cd1-0afe-4a0d-984b-946420b5dfdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4141,10 +4141,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df13f127-6a18-45e1-b488-8a6e34e185ef" control-id="si-5">
+    <implemented-requirement uuid="751c1382-670d-4e79-82f3-417934a90459" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="f9484666-bea3-40c6-8c55-4e458350ae61">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="fcc5f864-47f6-4f6b-a168-c2b38ddc01ef">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -4153,8 +4153,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="eecb00c4-9dd4-4153-892f-b2b41304e433">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="8eb1f6df-ae63-4a5b-b59d-0b7d7f2c753d">
+      <statement statement-id="si-5_stmt.b" uuid="2d6f3fd6-5ceb-42a5-861d-ed9429db50d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ffb574f-1429-4a3c-b34e-3661754291ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -4167,8 +4167,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="f62a87c5-e554-4cb0-b321-48c2e7199af1">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="67f15dcf-580c-4184-b481-508b804d4eb8">
+      <statement statement-id="si-5_stmt.c" uuid="5337086f-8de7-49ad-9a55-b5fb48cda4ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1611a1fa-24be-4608-b7f0-19ba0e92a895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -4177,8 +4177,8 @@ procedures/policies outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="b327e3bc-dadf-4562-a668-a6621e1d8f4b">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="eccc0757-22ab-418c-9c29-f5e19d87e18c">
+      <statement statement-id="si-5_stmt.d" uuid="d102557b-2f6f-4ccf-80b8-75fa13defc64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fb1fbdc-e1c6-4d94-8fc8-900c172936b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -4187,10 +4187,10 @@ procedures/policies outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23fdd1ad-49d9-4620-94fb-95b6a4019751" control-id="si-12">
+    <implemented-requirement uuid="1ce07b9b-8700-4477-9e3f-e78da30e83ce" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="dae4547d-6dfd-4082-b0e8-06d0a54f613e">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="a0cd7ff8-e7ab-44d1-8b67-05296ecd133e">
+      <statement statement-id="si-12_stmt" uuid="24c68931-27c0-4e74-b69b-64db342d38f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dd9058d-69a0-415e-a099-63f6b05f4622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, CoreOS in
@@ -4204,10 +4204,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32319cbb-6c96-4388-be76-1ddc843e2c96" control-id="si-16">
+    <implemented-requirement uuid="3680fa8c-408e-4624-8c74-8e70a35e49a8" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-16_stmt" uuid="5576fbfa-9fd0-452d-9586-973b5ba27705">
-        <by-component component-uuid="29607fdf-1f26-461c-b493-28204f082d17" uuid="d9430ddb-8830-4849-818d-9b074ae5e9a5">
+      <statement statement-id="si-16_stmt" uuid="f2f8f447-3b48-4547-8d3d-3fd2d6070ec4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7710e88f-bcc8-4c4b-bd62-e807ba8526e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/coreos-4-fedramp-Moderate.xml
+++ b/xml/coreos-4-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="77d4719e-ca97-43ef-be95-fdf506523341">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="a3436e85-d9b0-47da-b020-dac23b56b93f">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.33+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.59+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="0d462bc1-447b-45b6-99e3-61f55df0f166">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="b399cd32-f245-4838-abfa-df2b264bb3b9" control-id="ac-1">
+    <implemented-requirement uuid="6f8fc8e9-f526-43ff-9aa0-8ffc41f2b51d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="ac30ca5b-9d65-4937-9413-cc455cb27cbf">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="27d0e8ab-4871-4f70-a9a2-1405c1df5b1d">
+      <statement statement-id="ac-1_stmt.a" uuid="1ec2691e-ff83-4ff5-b27d-605ba12af54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7be8eab-6fe9-4b04-b51b-bab9d86e5655">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="9d6b0ad9-d7f2-440d-b9d9-9c42c1b4faed">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c3201a60-c508-4919-ac70-40012aa7c171">
+      <statement statement-id="ac-1_stmt.b" uuid="879eb157-d51a-4028-8e7a-0080b30a15fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edf524ea-5b3f-4612-8aea-a3b5a9e48d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d7cfe30-63a2-4028-84e9-7781677b7cd9" control-id="ac-2">
+    <implemented-requirement uuid="1e499a5f-dbf8-452d-927a-cfa2859f5e75" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="8cdbcfd0-14dc-4959-bcfb-046268e84b6d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="83cab937-e7d4-42fb-88a9-a612a08b4fe2">
+      <statement statement-id="ac-2_stmt.a" uuid="8f9b18d3-1fc4-40e7-b8ca-3052a4c9430e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57c1db98-8a0b-425b-a0a6-b9f027bcb747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="617f1d5a-18da-4dd8-9db4-ce72b8c154b9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f1e49308-5fd2-46af-b0b7-f7dc555d2362">
+      <statement statement-id="ac-2_stmt.b" uuid="b62b8180-4d99-48b7-afb4-d8265f4c35d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe059028-d2df-4472-8f55-6c037617da7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="c9ba3158-3941-44a7-85bc-c3deededda27">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6311bbdb-d33b-49be-9ad5-244bc09ef79d">
+      <statement statement-id="ac-2_stmt.c" uuid="f21b17fa-1e6e-4859-a43f-6d5001f70932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c3a878b-68b4-4a62-b0d5-b589f4f394fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="8990d970-6a0f-4a35-b9bb-fec744ec716c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="db5bd581-298a-4dca-b1d7-a703eebf8886">
+      <statement statement-id="ac-2_stmt.d" uuid="737ed433-52f6-4cfe-90fe-a6097ea1591e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48e0ab4b-ee61-4b1f-b427-1fa022ae556b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="6975df61-c1f3-41e6-9de6-f49278f06d25">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1398b9e5-cd3c-4998-bfae-1cebcd9be07f">
+      <statement statement-id="ac-2_stmt.e" uuid="6eb2a353-e46e-4216-922b-a33c499caa02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2761bff2-9aa8-4b6b-8e27-ce9fe156d502">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="dd492dd6-7a6b-4c02-8db8-e93dd6d5c71f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d4c5facc-d1d0-4708-8cac-a9bb9049e6d4">
+      <statement statement-id="ac-2_stmt.f" uuid="5604aab6-740d-41c6-b081-957f0b162b5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd7eb988-149e-46d4-8511-9558e63c5edb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="b438bd55-ced4-4ccd-aba9-461312c02a08">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="89d78cbf-36ff-4857-b877-e9f039be5cef">
+      <statement statement-id="ac-2_stmt.g" uuid="e0e395c4-bd90-4852-9c75-6239fe7e1a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0a08956-265e-4f35-8e96-87c56c9d6157">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="e5470e52-9d4f-4df3-ae6b-72a6213aa6f5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bbe9e979-1fd3-40da-b18d-85bb7b0aa77f">
+      <statement statement-id="ac-2_stmt.h" uuid="2e96297d-49dd-4413-9e03-f82c946876b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd502b78-27e0-4b0b-852f-5bc209d708a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="06d127be-7f03-492c-a707-5d205a4da8ea">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cdd9783f-5170-4a17-a836-5511ad1013e4">
+      <statement statement-id="ac-2_stmt.i" uuid="fbc7d733-8e39-4339-9fe5-89ab0050e7f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f499a8ed-a851-4a30-9a5f-16ca6ae97ecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="3cb3ba19-cd1e-4fb7-8b71-5aaee43c545e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a3ea0c77-7433-48fc-84b6-9096c8cd6f07">
+      <statement statement-id="ac-2_stmt.j" uuid="76ac689d-66dc-4e51-805b-902263860091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b90c24-fb80-44e0-bd9f-64cc4f9d530d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="364a6a36-f616-4b92-a132-ae2d94870def">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a5cb9e05-087c-45aa-8c3c-cb483fd8734c">
+      <statement statement-id="ac-2_stmt.k" uuid="2a7fd158-28ce-45ff-9d4b-7a0e4644d4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e90a2ff-91a8-4ea8-89a3-7b606be091db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eabeafc0-c52f-419c-8e63-9fb8e15ace8d" control-id="ac-2.1">
+    <implemented-requirement uuid="eded554a-0682-479c-9d98-920bfd758dc1" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="3f82cd28-354a-451a-bf09-70ec14227b4e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cfc6263f-f1da-40cd-9ef1-3d10a3aa6d42">
+      <statement statement-id="ac-2.1_stmt" uuid="8d8f505d-70a9-4f50-8be9-d9f685f8c0be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f77043-43a9-4191-a8d0-6780af8b2ae4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS components of the system support automated
 management through monitoring of accounts and system
@@ -608,10 +608,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a9c7824-4691-4048-8388-d4223e31d3be" control-id="ac-2.2">
+    <implemented-requirement uuid="02dcf8d8-7b09-4c1b-a9ea-0f84310e7796" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="5b5faed5-b4dc-4c13-91b0-1f144dbe5ac3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="596e93bc-0ba5-4d91-b544-adbe2d2e3976">
+      <statement statement-id="ac-2.2_stmt" uuid="04c1bd25-a2ac-43f4-a380-a64057715737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c73414c-c967-46d4-9b37-96f486afe5bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS does not have the capability to create
 guest/anonymous accounts or temporary accounts. Any
@@ -628,10 +628,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a4fab5c-1761-4a09-a978-d3aa748c9337" control-id="ac-2.3">
+    <implemented-requirement uuid="07264740-0867-4c9f-99a2-a6d8d25f7e5c" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="040270e3-4e5c-4f7e-ba8a-6aaf9160cfc0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="27a343c4-af1a-46d9-981e-9637aff6d3d7">
+      <statement statement-id="ac-2.3_stmt" uuid="4da09b35-f7f6-4a40-a9dc-a5c679cf080b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08bb0b0c-e8e4-4d59-8a06-47a9ab070aa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS end-user account management is inherited from
 the hosting environment. Automatic disabling of these
@@ -648,10 +648,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="199680d8-93a5-46df-b4e6-aa27f134b98d" control-id="ac-2.4">
+    <implemented-requirement uuid="e2531160-6221-4052-9b48-c36af2ca9524" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="3db249d7-31f7-47f6-8f37-f1c3ef7c722f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e0c43e5b-d5e4-4d46-8788-a3836ab1fcf5">
+      <statement statement-id="ac-2.4_stmt" uuid="39f02a55-6bfb-49b8-abf3-defa200d7329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcbe4ca0-2deb-4e83-8b88-237dd2dee6bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To meet FISMA requirements, CoreOS must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -671,10 +671,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c1d0ece-3c67-44a5-9e97-1d365e89b1a0" control-id="ac-2.5">
+    <implemented-requirement uuid="b2009884-8e3f-43a1-92b2-92b5729f2d7c" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="868ddb1a-c0d6-4235-a66e-8ab9cf189f57">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5e40504c-114b-48ac-a10d-bec394182858">
+      <statement statement-id="ac-2.5_stmt" uuid="04fd2aa3-2ba8-4604-80e6-5200b2843c27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="688b06a0-687e-4f23-be5e-764580e26c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2 (5) is planned. Engineering
 progress can be tracked via:
@@ -690,10 +690,10 @@ user account handling in CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb84ece6-f4dd-451b-91e2-fe2f40f086ec" control-id="ac-2.7">
+    <implemented-requirement uuid="b0f186b5-4f1d-478b-b03f-0b2e9b3c83c8" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="6f3add85-6528-4f80-af81-ffd426f694e5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8d58dde9-c3a9-4828-83ca-a3332762805c">
+      <statement statement-id="ac-2.7_stmt.a" uuid="cb087f11-2c7b-4215-9494-6f2d577fbafa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21350fe2-0e01-4b99-894d-c42aa132f9d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -717,35 +717,35 @@ More information for SCC can be viewed at:
 https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="9b23541f-81cf-4db7-a5ca-e7f6625c4ef2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4f717f63-2632-4f12-a6c3-172c8bd167bc">
+      <statement statement-id="ac-2.7_stmt.b" uuid="7155eb11-bbed-4961-9759-d086ef297059">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="148a8d31-28fe-466b-a8dd-a280cecc3e6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of CoreOS.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="6ab0bb4e-6ef5-48dd-b227-299d0c1c7b1c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ae76963b-ee5d-49aa-9f90-57188e5478b1">
+      <statement statement-id="ac-2.7_stmt.c" uuid="d47b55e2-35b2-4740-9d80-1b64f23a788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93749a3-34bf-4d6b-bb6f-757c0efcc2d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c7e3a82-5803-4b56-842f-657e05fb745d" control-id="ac-2.9">
+    <implemented-requirement uuid="2ba66307-7d4d-4eda-9a77-0a936daacc6a" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="889f98a9-d0ed-4fb7-a503-08e79460a5a1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="dee0d21c-a473-4bd2-a1c6-70b0f4451e78">
+      <statement statement-id="ac-2.9_stmt" uuid="46153aa5-fdd3-4c8e-8320-ebe418c40e82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23a2eb0d-d4b8-4296-9e57-2122fcce503a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9081c961-467c-4008-b7b5-1bcd7a80f4cf" control-id="ac-2.10">
+    <implemented-requirement uuid="3eb43f24-e00a-4031-96d3-0c9777739c0e" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="5e18615b-1c77-488c-a47a-8075a0da1511">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b8363ee1-268c-4914-b801-2f786f476683">
+      <statement statement-id="ac-2.10_stmt" uuid="133c97ae-85ef-4436-b81f-289f0ac278a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="753a3224-6163-4eba-b69f-8a67ffcb371b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS does not have the concept of group accounts.
 
@@ -755,10 +755,10 @@ responsibility of the shared identity service and not CoreOS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="913ef1af-8ba0-4100-b207-1a6c94dbc893" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="0aa02c25-a9d4-4da1-a078-84ba7b3b330f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="84489c0e-53cf-4f68-be1a-77953fad97d3">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -766,8 +766,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="dbc56c91-2f94-46ab-a8d1-4dbfd88fe157">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="66c5ca5b-2249-4c0f-b8f2-0ff0dbf4fbcd">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -776,20 +776,20 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29a12045-e41c-4aea-a007-e42ce61deec0" control-id="ac-3">
+    <implemented-requirement uuid="54eaf0e8-a603-4de6-957c-02d360dff060" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="333fac77-630a-4584-a68d-aecac93f044c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="25c7bf1a-7a8b-4eca-944b-1614637a8ce3">
+      <statement statement-id="ac-3_stmt" uuid="77b67dec-bc0d-4dad-ad78-bb20120e4c7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e678ff1e-eba1-4013-82f4-03456ae8554b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met by CoreOS when SELinux is in Enforcing mode
 and configured against the SELinux Targeted policy.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dcf41c4-1c60-4088-8520-18e53bb84386" control-id="ac-4">
+    <implemented-requirement uuid="52d4a6ad-af88-4e7d-92f8-effe11d5f363" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="85fca24a-7ffe-4abf-a0da-0172de245c5a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9d007ecb-9bd9-4f08-9bd6-111d171ddd7b">
+      <statement statement-id="ac-4_stmt" uuid="d22b8559-ef87-40a0-96c1-9b10c8adb3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6345764-c22c-4e76-b06a-f8c1d20537d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -797,10 +797,10 @@ https://issues.redhat.com/browse/CMP-98</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27c30f68-20d9-4bf0-97f2-c7a84cfa1169" control-id="ac-4.21">
+    <implemented-requirement uuid="013bf472-055f-4057-a9a7-67e12094efbf" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="4fa8fe8b-870c-4376-bbd8-14dce0b6ab33">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c3b10ea1-3426-44d4-9a24-10cdb696cff2">
+      <statement statement-id="ac-4.21_stmt" uuid="726b5013-677d-483e-8063-362924525d43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58c793a2-66e5-488b-bdd8-eb09cd4d03c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -814,18 +814,18 @@ https://issues.redhat.com/browse/CMP-113</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a16c5c4-9f67-43fa-a0f6-91dbc30acee0" control-id="ac-5">
+    <implemented-requirement uuid="fe3ba54c-031d-4f59-9a38-348ed2d37035" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="7f392489-0e55-44b3-9d0a-54df14f5f5dd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d1f3447d-792a-49d5-ace3-369df986a788">
+      <statement statement-id="ac-5_stmt.a" uuid="56ad1915-7c59-42b9-a31d-895b127a3c47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0269de03-f278-4bbc-8ce7-70c126f74b7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="d2872197-8902-4a68-b909-01df726e4a9e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c8549dde-5936-4d12-a8ad-51386663dbd2">
+      <statement statement-id="ac-5_stmt.b" uuid="3e9015ea-1dde-437c-bea5-3fa7cbbb9173">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65c3671f-e596-4721-b594-0472fd051355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of CoreOS
@@ -833,8 +833,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="928c0704-280e-47f1-bc8e-ae866d90b403">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="14876374-4f6a-41e7-ad36-2f5c12cc08df">
+      <statement statement-id="ac-5_stmt.c" uuid="c00b6896-4456-4a1b-809b-4a0725de246b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a99707ea-72cc-408f-abac-0f35e7dfeddb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -843,10 +843,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89d48d1f-024d-4f8c-93a5-805c84305178" control-id="ac-6">
+    <implemented-requirement uuid="88abbdda-8e98-4645-80b9-5595e5f7d2c3" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="f3b4e809-57d3-44ea-abf9-388740a4393c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5af7acd4-84f6-488f-a929-2265a18999cf">
+      <statement statement-id="ac-6_stmt" uuid="2919dd72-8813-440e-95aa-eb4a48e9292a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f513ea4-777c-4021-88e1-d944a78e84d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -855,10 +855,10 @@ https://issues.redhat.com/browse/CMP-115
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4f58309-469c-43e1-9cd1-bde7fb48047f" control-id="ac-6.1">
+    <implemented-requirement uuid="be17b2e2-832e-40b8-8b3f-ecfca434f4cb" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="0334e2d4-dded-4ee6-b9f4-8bd00c60ac78">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="29bb4011-f0c5-4158-960a-7728414a04e7">
+      <statement statement-id="ac-6.1_stmt" uuid="3d1ce575-6e16-4e36-a4ba-c376990f21c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d844c0-1c7c-4fb3-a161-cf80cdee6df3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -867,10 +867,10 @@ https://issues.redhat.com/browse/CMP-219
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b4e7390-9e67-4201-8683-ef23828ee1d9" control-id="ac-6.2">
+    <implemented-requirement uuid="e1235cf2-448b-486e-89d4-1cec7e1ef3e9" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="6bf1c3e0-dde3-4af9-b761-50e00d38022a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8df2aa4b-293e-44cb-9866-7dda2120d525">
+      <statement statement-id="ac-6.2_stmt" uuid="104cb488-67a2-4d16-9ada-134be0de1a0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11abbae2-3fb9-445c-8e8e-ae1fdc534cb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 CoreOS configuration.
@@ -886,10 +886,10 @@ https://issues.redhat.com/browse/CMP-220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a359f71-1884-4788-ab7a-b09c6da21c62" control-id="ac-6.5">
+    <implemented-requirement uuid="e3e3efab-5461-4dd0-8720-65773f2e5379" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="4f2645ab-9b1c-48c3-908a-5d77a0106e2e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d803c436-850a-4f48-95f9-a720d65eb0a0">
+      <statement statement-id="ac-6.5_stmt" uuid="6582b7a1-0f0e-4d84-98f3-ebe259e0b29d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626ddc47-b7c5-417f-9610-19c21a97cfcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -898,10 +898,10 @@ https://issues.redhat.com/browse/CMP-118
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9aab533b-0fca-4421-aa99-8994bce27936" control-id="ac-6.9">
+    <implemented-requirement uuid="a46cc993-69c0-40a9-b1c7-3b51a8170ecc" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="06016bba-97c5-43a7-ba2c-c9409345e043">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9da28ef2-bfaf-4f83-aa6b-0a0e41a16258">
+      <statement statement-id="ac-6.9_stmt" uuid="1b950782-4ef9-4f2f-aa12-d01c6885456e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7754724-50c8-4d11-b4a0-d4235cb8ef81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -915,10 +915,10 @@ https://issues.redhat.com/browse/CMP-122
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da25919f-0f36-42c0-a533-b93e72dd5806" control-id="ac-6.10">
+    <implemented-requirement uuid="3e6efe21-9357-46fb-9506-c930ed1c9bd1" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="d9eeaa0a-1795-4528-ac1c-fb74f669f719">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3a1e923f-80d7-482f-9ff0-7571a6878c4b">
+      <statement statement-id="ac-6.10_stmt" uuid="fcec7506-27c3-45a4-abc8-25e198fd2ca7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f817e29-325b-449e-9120-08bf8dc62dca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -933,10 +933,10 @@ https://issues.redhat.com/browse/CMP-123
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f900b143-15c4-489b-921b-5005fe5f2638" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="550c723e-6eb4-422d-998d-06ff1e10e83b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="04f66721-04fe-4e83-ae02-092414408074">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -947,8 +947,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="89b03bfd-b0c1-489e-80aa-2baa4ce3d119">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="27d85f07-62db-44b4-b6e7-7c741bcb15ce">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -960,10 +960,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2be61976-c20f-46de-a3ce-252589185749" control-id="ac-8">
+    <implemented-requirement uuid="b364dab2-3da7-492e-8c0b-744c78232918" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="7f1d341c-a8ea-4d18-b43d-b2b4d9f557fa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fe86283e-1828-4858-a825-73fff718d409">
+      <statement statement-id="ac-8_stmt.a" uuid="32e61082-a341-4794-b630-59a2e468e8de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713a10e8-f5ee-47f8-90ea-bba9658cfd59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -983,8 +983,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="f8a30532-9362-4ee2-a1c6-9ba1d61731c2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e35a049c-7e0f-4422-b977-68927a60ded6">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -999,8 +999,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="ef387d49-10ef-4d47-9517-26a7e3dccf45">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="05799143-af16-425a-9dd5-fe96ec412aec">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1018,8 +1018,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="4cb92fb1-af6d-4893-8baa-128d66e1c3ab">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="dc7e4719-2e52-4216-b62e-079938778520">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1032,8 +1032,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="ca8451bc-a1e3-4e27-97d4-e05d539c93e5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="585be05c-599e-4202-bddd-c2838811b488">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1047,8 +1047,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="5142d853-f684-4458-a335-160aefb6dcc4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6ddfb6c8-5660-4884-a79b-81316fbb4262">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1064,10 +1064,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4166becf-b374-46c6-aaa1-1092a654625a" control-id="ac-10">
+    <implemented-requirement uuid="317d48f2-c463-4fd9-a033-49c4ef0fa7d0" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="a46ea8b2-d008-4f43-a2e4-3e8260ae5040">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8320f621-4aff-4919-8488-daee53052062">
+      <statement statement-id="ac-10_stmt" uuid="3f970970-cbef-4fb6-a9b4-26b91e499a28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aed70d9-b8b8-4e83-89c0-337f33551afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1081,10 +1081,10 @@ https://issues.redhat.com/browse/CMP-131
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3828c167-2713-4041-a8f9-da7b156fa5b4" control-id="ac-11">
+    <implemented-requirement uuid="e915b154-d306-4240-b477-551192bcedc5" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="4014a0ac-3e45-47e6-87d0-7c81d5984099">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ca789f59-35b5-4293-a1bf-388ab61bfae4">
+      <statement statement-id="ac-11_stmt.a" uuid="ddde43f0-56b3-481b-96dc-95b0befdff3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1092,8 +1092,8 @@ https://issues.redhat.com/browse/CMP-222
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="50f42936-ad28-4e5a-8198-7c11a4b30353">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6fdee1ef-68b5-4922-9439-016f6e7b9229">
+      <statement statement-id="ac-11_stmt.b" uuid="9cfa0153-ccc7-4fad-baac-e5e5beee1046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1102,10 +1102,10 @@ https://issues.redhat.com/browse/CMP-222
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22f27ae0-d074-4b01-9782-83594a6108ce" control-id="ac-11.1">
+    <implemented-requirement uuid="ab6903c4-8a5b-4507-ad07-184780da55aa" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="84c10e44-358f-4e5e-bc72-465542eccbd2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8b49e23e-9068-4d8e-b54e-72b8af7bec33">
+      <statement statement-id="ac-11.1_stmt" uuid="e16650c5-8d95-4e15-bc8e-5d3e7457ba56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09896195-8492-4293-a137-628ef9ab4ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1114,10 +1114,10 @@ https://issues.redhat.com/browse/CMP-221
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4952d480-1db1-4999-9e11-2ae81e29075f" control-id="ac-12">
+    <implemented-requirement uuid="80d9fe3f-ec91-44e1-8c30-69b9aaf4e472" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="cb7e0afb-94a3-42bb-b407-2c83feb7e855">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="afda4644-11cd-4fbc-93e0-093da036da36">
+      <statement statement-id="ac-12_stmt" uuid="fc0fc943-da69-4c4e-946a-4d377389240b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="292db0d7-a6a2-4127-a9b1-4efb2359e579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1132,10 +1132,10 @@ https://issues.redhat.com/browse/CMP-132
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db66ff3c-790b-485c-9741-404af28e3f0c" control-id="ac-14">
+    <implemented-requirement uuid="74aedd6e-0b78-4029-9487-224f5fa1a3c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="0e2fc0fd-6792-4060-a7ce-9c9cb520ec38">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7cc9f72e-18e3-4c44-9fcf-4322029acf17">
+      <statement statement-id="ac-14_stmt" uuid="85ab16ac-f3b6-4835-ba7b-f80b13e2880f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caef0d25-057d-44f7-b0e3-b578d96b11e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the CoreOS Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -1145,18 +1145,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ca9662-291c-4fa3-b8cb-2d4a5735c143" control-id="ac-17">
+    <implemented-requirement uuid="52338ece-b04e-4a7e-baf1-32ab40979a4d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="f9a4b4c8-17ce-4125-9681-d3e8e88ee7d3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bb9ebb99-fc23-4c7e-b176-8b53fd63bf18">
+      <statement statement-id="ac-17_stmt.a" uuid="6f5015e4-d2de-4ac4-8679-471fc4d1b336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="8039bb1e-5302-470f-8a87-b1f873646f7e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5a7a0d12-f3c3-4506-b1d6-e00527c7f391">
+      <statement statement-id="ac-17_stmt.b" uuid="28a3c8cc-80b9-47fd-840a-75943f6d4a93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -1164,20 +1164,20 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5f918e8-e9c7-4ba8-a405-061f2a8f1e7e" control-id="ac-17.1">
+    <implemented-requirement uuid="42fa24ee-797d-405f-aa57-199244f3d3d9" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="bda91d4b-d898-456b-9c3c-f51fec025e7c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="76f0cc17-c926-4d89-9888-427241c7d728">
+      <statement statement-id="ac-17.1_stmt" uuid="7ba47ef0-ad23-4dc4-a755-5b6c0c59954c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de20252c-d63e-4210-92f7-be1a133f519a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63cea7d2-bfd3-43ef-9096-8b0533a8d5d4" control-id="ac-17.2">
+    <implemented-requirement uuid="dc19e26a-01b7-4749-9e63-cf54f8dc6294" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="0d675631-258a-4953-88a4-0b5e9f5f12e4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5cce0426-4152-4e7c-8ada-a6ce9a0c1611">
+      <statement statement-id="ac-17.2_stmt" uuid="fd7194bb-d878-4f49-a85e-66269e4d4031">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44885b26-7c16-4c6e-89a1-29fac2a242f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1186,10 +1186,10 @@ https://issues.redhat.com/browse/CMP-144
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25da4080-b77e-4dc6-aaf1-f3b2afaa45e6" control-id="ac-17.3">
+    <implemented-requirement uuid="39d48f16-1d4f-47cd-a477-ddb3574cdf02" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="215f4cba-db24-4e53-9793-9552f0152f8a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="16831460-7fba-40d0-8a6f-88bf5fa3f50b">
+      <statement statement-id="ac-17.3_stmt" uuid="7967ae9c-1cd4-42ae-bdcf-f84c036ae938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09af0121-32d6-4b5b-8587-b4c4adeea806">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1216,10 +1216,10 @@ https://docs.openshift.com/container-platform/latest/networking/routes/route-con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ceb9271-69fd-45bb-b93d-48e206e6e1bb" control-id="ac-17.4">
+    <implemented-requirement uuid="89b3ebb2-f648-40b4-afe0-830e5931e47c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="b026b74d-e890-4ecf-9465-3ab2d501c0d3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c315a024-7609-46b1-9aae-9e3ba8f6eeb6">
+      <statement statement-id="ac-17.4_stmt.a" uuid="c2a6bbb0-2fb8-4c48-82f6-8d8601699e90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f8f0216-6223-4f9e-b182-623eab4fe16c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to security-relevant
 information via remote access only for organizational defined needs is an
@@ -1227,8 +1227,8 @@ organizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="f4e9f4aa-4737-496d-8882-cf4f7dc98284">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6e514ad3-713d-40fa-be35-6d62ab07097e">
+      <statement statement-id="ac-17.4_stmt.b" uuid="37dbf564-e7b2-4adb-be21-a8b879a9a69f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c50f7adf-4044-419b-b0e6-194b17399e55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and access to
 security-relevant information via remote access in the security plan for the
@@ -1238,10 +1238,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37e2219e-6047-4b35-b96e-4a3a5bcaa56d" control-id="ac-17.9">
+    <implemented-requirement uuid="66bab541-40ec-44f3-83e3-11c5057f4513" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="9ee2e1e4-4e90-47ed-9cb2-69314ac36050">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3fd16785-ad04-42d0-97de-40f302e4aff0">
+      <statement statement-id="ac-17.9_stmt" uuid="dc1fa1c7-7c80-49bf-8494-05e250cb03d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fdf9daa-52fc-4d4e-81b6-068aa076e3ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS utilizes the firewall technology embedded into the
 distribution. This technology, named firewalld, allows a system
@@ -1260,18 +1260,18 @@ for tenant applications immediately.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="198045e0-2fda-41ff-9a51-7d30d700c8dd" control-id="ac-18">
+    <implemented-requirement uuid="5d4b56aa-8e14-491a-9b7e-52f4a3dc6e89" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="6a10389b-16ec-42e6-adf3-2bef385f894b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fac0d979-4efe-46fa-b735-38b7758eb63b">
+      <statement statement-id="ac-18_stmt.a" uuid="1b94291c-4f38-4d22-8161-79d388d32758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf9153f9-1db6-4e2e-88a7-634b9cbef1f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="c0fe2aaf-f33c-458e-b109-5b476a9ab208">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3c2668ce-d18f-445e-8851-a59b7772136e">
+      <statement statement-id="ac-18_stmt.b" uuid="eb73f1fc-c8c8-4fbe-8b48-4fc3ad09a3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18432f18-2002-42e0-abcc-b0131b443d64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of CoreOS configuration.
@@ -1279,10 +1279,10 @@ system are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fc972ab-99d6-414c-b3cc-1b88dd455943" control-id="ac-18.1">
+    <implemented-requirement uuid="3ee98bff-7810-479b-9e0a-8c18917a14aa" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="788e61c7-b4f5-4bc3-85ff-a647fc4ff1c1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e8193d4a-6dae-487b-99a9-ccfb4023692c">
+      <statement statement-id="ac-18.1_stmt" uuid="47d60365-f0c4-4573-b060-9d548acc2678">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f3a6d1e-4d81-4dca-99a2-d586ddd6211b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 CoreOS configuration.
@@ -1290,18 +1290,18 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd2b5799-294b-4dfc-8c38-708cf450e670" control-id="ac-19">
+    <implemented-requirement uuid="2eaa2377-e027-48eb-b623-9707bc43ed8e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="42e22878-5827-4dfc-89d4-f1b2c001978c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1bfa627b-b821-46ef-b53e-d403fae57e3f">
+      <statement statement-id="ac-19_stmt.a" uuid="5beee672-d457-41f9-8b66-7129b0ef1e2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14640741-0e7b-446d-ab60-c038a9c67acc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="fcb377e1-ef7d-478b-b5c5-7285f8589649">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f369e743-2bed-4940-9c01-6eb779cfc356">
+      <statement statement-id="ac-19_stmt.b" uuid="1489caf3-35df-42d0-99ac-34ee9fe939a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daea7828-b48f-4e2f-8838-95871dfdf677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of CoreOS
 configuration.
@@ -1309,10 +1309,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d772226-475c-4307-a025-c7f7442d7ad7" control-id="ac-19.5">
+    <implemented-requirement uuid="83b2e6c9-d5d5-4911-84c8-f0ba757e66f3" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="dad14ff1-a61d-4214-b6ff-9fcb7f67f5c3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9d4ebb70-2db7-436a-abb5-1c45ef812d60">
+      <statement statement-id="ac-19.5_stmt" uuid="886ba590-18d0-467e-921e-68f6d5f4102d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cdf081c-4c50-49b0-b3a9-2c87299ff572">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of CoreOS configuration.
@@ -1320,10 +1320,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44ca686f-7382-4fb0-b813-beaa8a671ba1" control-id="ac-20">
+    <implemented-requirement uuid="8da17d11-aaff-4b42-a8ef-239c2f037ed5" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="abba5a29-d6d3-44b9-b57e-bf1a492d22c6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2573d993-160e-4469-8cf3-8f0b3bb3352a">
+      <statement statement-id="ac-20_stmt.a" uuid="9016e096-ae1d-4e6c-b0b0-715631291e3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e863569c-9595-42c1-bc0c-eb2b2ba883d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1331,8 +1331,8 @@ systems is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="cfcf123a-5b53-4353-9d94-8f7e64e42ef6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d0d7ba7b-d9d2-4ad5-8dfb-b4d602672ef6">
+      <statement statement-id="ac-20_stmt.b" uuid="de1dade3-ce08-4dab-831c-fea500622d95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83299231-fa17-4a90-a250-282ce6fd5114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1342,18 +1342,18 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c192a39f-d78e-43c2-92b9-75645a0c5cf8" control-id="ac-20.1">
+    <implemented-requirement uuid="13ac6de4-c191-4e06-9ad1-ac7b96b9b9a5" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="827970a6-92d1-4e80-a3f2-fe40462d4e37">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3092859d-1e9a-40f4-a1e6-2abee99e8c11">
+      <statement statement-id="ac-20.1_stmt.a" uuid="17b58b51-88ec-4f3d-9f52-6f3d9c0263c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7037104a-af44-4aad-9582-199502cc1fe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="e891d54e-c068-4d7a-acd9-2b6da39ad28c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="12f14a38-db2f-4150-af63-17158e73b1cc">
+      <statement statement-id="ac-20.1_stmt.b" uuid="90a525db-451e-4b3c-9183-07bc9e1a8c88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8617a61e-cddd-467a-87b6-57d35da9d52e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1362,10 +1362,10 @@ information system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83921b11-846f-4979-b1d6-a109430d6db6" control-id="ac-20.2">
+    <implemented-requirement uuid="9c66575e-1b8d-4489-8b18-2138b50a75f0" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="43877acc-3018-4c8f-a850-bbebc2ed7967">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="29d0388b-ceea-449a-8d02-75532a5b1f88">
+      <statement statement-id="ac-20.2_stmt" uuid="40db944c-5c88-469b-a39f-a57862cdadc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9991679-ce94-45f2-aff3-c6d262722b4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1375,18 +1375,18 @@ systems is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9969372-e0a1-4d4b-8d44-7ccc8388978f" control-id="ac-21">
+    <implemented-requirement uuid="e37f4554-c00d-4133-ad4a-bed4a4c8bede" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="7b845683-7807-4378-9d79-5c7f95e8ca46">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1ecc2411-f6f0-4ae7-a584-4ddcf10fcc5d">
+      <statement statement-id="ac-21_stmt.a" uuid="2a8e00ea-f586-4055-bc92-7efaed1ea197">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e9791f5-4e25-4c22-a192-c04489d0a8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="2e6596a9-563b-490a-a8da-2c209ea73923">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="89126145-1647-4858-ba24-0281730007f5">
+      <statement statement-id="ac-21_stmt.b" uuid="5c844891-296a-4448-b939-4e5f7e6588d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bea71ff-4fda-4995-9f37-27e7df7be6ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1395,10 +1395,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e18f3545-eee0-4c0b-be08-84fc8ee73458" control-id="ac-22">
+    <implemented-requirement uuid="15e4e849-3ea8-4bf6-b2f9-fc35f51e78b4" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="b77bf71e-1319-4327-8308-26b4d9de8c89">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3e8bda35-120c-4b0d-8e85-ea7245e17cdc">
+      <statement statement-id="ac-22_stmt.a" uuid="3f7fe930-3993-44d8-aed5-145487858da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c8349a-1b72-4922-98a2-f679ae0e98e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1406,8 +1406,8 @@ system is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="4e9d8621-074b-4220-a048-217fffe60992">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b2e70147-0253-4fa4-a91a-fd827ebe2bfc">
+      <statement statement-id="ac-22_stmt.b" uuid="dc5d118c-ae8d-49b6-bfcd-e7de78038687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9618069e-d920-41de-a880-e10126de5e64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1415,8 +1415,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="d272b38d-cac8-472b-b9bf-8913ca0adcc2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2660a7dd-00ef-49c9-bf4f-d979c6e0fe18">
+      <statement statement-id="ac-22_stmt.c" uuid="daf95474-b47d-4768-8927-8a8f7423d930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5244ca92-85c0-41d8-a9ab-7751eb4989be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1425,8 +1425,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="ad0bce9d-d561-47e2-a0a9-6c5146db3a76">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a34901e6-d1cf-4d85-87cf-dd774160782f">
+      <statement statement-id="ac-22_stmt.d" uuid="eb208ca0-9b96-43a9-93fb-c381c7a6eca8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ff72021-3f80-4705-aaef-9766c09ab9f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1436,18 +1436,18 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26d38a00-fcee-4ba4-8d6d-1fb6c6666bd4" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="b7dcf60e-bb03-4cd0-bce5-9ae1bec97c5d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e6074bd4-d97e-4c16-803c-cc4dbc82e6ad">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="e1ed3f33-cf03-48c7-903f-4bd8e266d9a4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2cdfd129-ddab-4a20-8422-4933f993b1bb">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1455,26 +1455,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29a3d31b-1a70-49e9-b977-414cfcd7b640" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="375aae30-6745-4f93-b8cd-c74dce112151">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f7e3664c-462a-44f6-83ce-b877b3a97a65">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="e93fe326-88df-4fae-a0a0-929e083a03b7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="772bc88c-eb7e-48b2-a21d-39facaf7651c">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="72479cd6-17ab-4c15-8dd7-01f8019771b8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f3ef8a19-6b76-4731-bfc9-ca5820c94aff">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1482,10 +1482,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b182a65-f364-4005-b51a-6420003d51e0" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="dd2aee01-efaf-4725-9eb3-db29ebf75b84">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c848c01a-8144-4133-b44f-1d964959b44e">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1493,26 +1493,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e4ed69b-3495-4dc4-8baa-7e50dd81127e" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="1014a2c7-4a1d-4bac-902e-2289bfd9dda5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7a8a99c9-61bc-4b43-9c41-d6a386ec7ea0">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="4dd498ea-98e4-4657-a703-093801512a0e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="97af5760-d2da-4a95-b712-2247e4586bce">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="47cde88c-1077-413a-b23b-ded442fb9ada">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="45aeffd3-6b73-4ae2-b29f-08b12343fa82">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1520,18 +1520,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e43b52de-5a36-4362-918f-4ae531810aad" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="4327d9a5-7ded-402c-9561-c0e722bacf69">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d1626587-2c49-46d2-b32a-8a61f48f7a95">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="bcdf1c6b-5602-4a60-ba54-9004bfbb2cfa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b8748b18-ea2e-49f0-8555-05ee04d9c8ac">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1539,10 +1539,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3bd4acc-f4e6-4a85-9ef7-a0520f915e89" control-id="au-1">
+    <implemented-requirement uuid="4d9e7955-92c6-499d-ad77-1afaa84b2c5a" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="7d8ee635-f7af-494f-882e-d840ddcd20a8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fa305ad4-58a3-4044-bd93-95bbe0457aa2">
+      <statement statement-id="au-1_stmt.a" uuid="b9675a53-dc16-4ace-915a-7ee6e1961c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92243957-9a7a-4469-9b0c-758387037f88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organization-level
 audit and accountability policy is outside the scope of CoreOS
@@ -1550,8 +1550,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="0a6176eb-5007-45ba-9094-b0f05615aa8d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f6123826-8eb6-469e-822b-df47240bf2fd">
+      <statement statement-id="au-1_stmt.b" uuid="997ea394-2e91-4991-b19b-b18e33273887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ee0a85e-a540-4050-945f-06eef494c233">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of CoreOS
@@ -1560,10 +1560,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5949f9ff-2141-43b4-a6b4-450929bd7fa8" control-id="au-2">
+    <implemented-requirement uuid="287ece19-bf2a-4a48-b52b-45898307cbbe" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="3792ff74-6529-4ad0-99b8-ad0703138cd9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4eff859f-1a75-4414-8249-b6d1e37c6bc6">
+      <statement statement-id="au-2_stmt.a" uuid="3291559f-d71c-4339-879f-b59cfe1b654a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5595f04-f8b8-4e30-9a87-86e8f3760141">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS was designed to satisfy the audit requirements outlined
 in the Configuration Annex to the Protection Profile for General
@@ -1616,8 +1616,8 @@ Selected audit events from ICS 500-27 include:
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="8ef38c3e-18d1-4906-9e2b-181cb8a84a95">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="566fa1cb-9a2e-4e01-bff9-9ccfd1a94560">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1625,8 +1625,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="0b7cf74b-3dec-4abe-b842-7b34edd8f290">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cdb01475-ede5-44a6-99e5-5c29502d51cc">
+      <statement statement-id="au-2_stmt.c" uuid="b615cc45-8590-44a1-af90-f91621e87e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f806b1ca-cbbd-403a-902e-8a3ecb18a518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat did not express judgement in the rationale for why auditable
 events are deemed to be adequate to support after-the-fact
@@ -1641,8 +1641,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="5eb0a110-e45d-4e42-a8ae-2b87162dd410">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cf135201-76d5-4906-99ea-53174d48b4b3">
+      <statement statement-id="au-2_stmt.d" uuid="7998da4f-89c7-42f0-89d7-9c844cf8b189">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1641516-0f4f-40cc-a25b-79b30da4ac14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Determination of which events are to be audited within CoreOS from
 the subset of auditable events defined in AU-2(a) is an organizational
@@ -1660,10 +1660,10 @@ realtime (e.g. immediately upon an audited event occurring).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="484a3297-4383-4714-b384-d72477ae55d3" control-id="au-2.3">
+    <implemented-requirement uuid="bead2ab1-53ea-48a1-a6fe-f5a9faad6647" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="4241b128-1a44-4f7c-9c1c-38d7b3f60078">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fed91f40-0485-4f4e-a749-e8d69b7ff600">
+      <statement statement-id="au-2.3_stmt" uuid="e63869d3-e5d9-4713-8ae8-91fe070dcae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="053a6ee7-85b1-499d-821f-931f13924619">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of CoreOS configuration.
@@ -1671,10 +1671,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b6ab6e8-0f32-45e1-8c1f-d88b612ecf94" control-id="au-3">
+    <implemented-requirement uuid="0e32b747-e74b-4dc8-90cc-8dc694f485a9" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="cf303547-185b-488d-82f8-24bf1bcebd54">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="aad5848c-f736-41f9-ba52-a8b5d07502e5">
+      <statement statement-id="au-3_stmt" uuid="7c00bbc5-bed3-4987-9b1b-401a96763521">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="822d2d2d-9e81-4bae-8f7c-37f141b9fb7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AU-3 is satisfied when the following configuration checks have been
 implemented:
@@ -1686,10 +1686,10 @@ for OpenShift 4.x.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6920ab48-9691-4ce1-b335-9a0d6eb5aa3e" control-id="au-3.1">
+    <implemented-requirement uuid="c1e0e21f-dcd1-496e-8035-c390c79d8ee5" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="01963d82-e9f3-4336-a871-be88ed965c5f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c2f04035-854d-4d76-b314-afe4cc0cc9b2">
+      <statement statement-id="au-3.1_stmt" uuid="75fb7866-11a8-41b8-bad1-b9155c8ffcc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dc50397-62c3-4794-9b21-da85086bc5ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1698,10 +1698,10 @@ https://issues.redhat.com/browse/CMP-157
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2b07a3b-7ab1-4ee6-a33e-f0c2e286aa8e" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="406cb592-318c-4df0-9fd0-7693ae6400eb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d2effd3f-b586-4548-8ffc-094e840540fe">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1710,10 +1710,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6005d152-db94-4ccb-9256-e62115c26b80" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="a7bba5f9-f088-44b0-9b55-4cc20ba891ca">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4340c7fa-efb2-45ef-bb63-1aac40a72f8e">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1721,8 +1721,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="9f0e8a58-97fb-424f-8019-904f303fc15a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6eb60774-d6b6-49be-9f27-177e788d78dc">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1731,10 +1731,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="563caffd-c7eb-4281-9c42-bf3ab75bb9eb" control-id="au-6">
+    <implemented-requirement uuid="d6a49803-12f0-427c-aaef-b980628e3a93" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="4f95cb7e-2968-428b-a7e6-fcbd2a94e000">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e50fc753-8b9d-48a4-87a9-a179cb73bb08">
+      <statement statement-id="au-6_stmt.a" uuid="4605a12f-fc92-465a-8048-b224db829c2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b183e222-7171-4f1d-88ab-fbd547eb99d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1743,8 +1743,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="25038162-0a33-4233-86b2-8da69231d38c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b67150f8-0e10-4694-9686-3303af3ca652">
+      <statement statement-id="au-6_stmt.b" uuid="ffd8c14a-413e-415d-8e38-d50aabd5420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdf2e4d8-f1bf-4822-a619-d759550ae3a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1753,10 +1753,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86387017-7b32-40b9-86e1-613f6ceaf3f9" control-id="au-6.1">
+    <implemented-requirement uuid="8aabc505-f7bb-41a3-a480-ac1a395dfa19" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="00a57d66-9c1c-4122-b618-99f4a1bd8438">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e5706c77-5380-4fb4-8bc4-cb83bb8d1a8c">
+      <statement statement-id="au-6.1_stmt" uuid="28329b18-d848-42f2-993d-46e449954e92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7fd9b2f-a136-4ce4-b51e-0bb00545754e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1765,10 +1765,10 @@ https://issues.redhat.com/browse/CMP-167
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da4c6b57-8c07-47c7-b485-5ac90854d563" control-id="au-6.3">
+    <implemented-requirement uuid="0c9ca6a7-8388-4dfa-bdcd-d00bdaafd3b3" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="cd2e3033-f779-4d5c-a7f5-25456830a86f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c75e5360-825b-4dc3-a8a3-13a41810e640">
+      <statement statement-id="au-6.3_stmt" uuid="e8c748d6-7e7a-48a3-8cba-07d91a13fd3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4bfb747-ce68-4d58-8864-bd47dbfbe264">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1789,10 +1789,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5766597-dece-45d2-89df-3b5a9e8bb1e7" control-id="au-7">
+    <implemented-requirement uuid="fcee1857-8555-4629-8bba-af53fa98fdd8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="61e2233c-1f88-41f4-95cd-5c3f18a3d148">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="34102ee0-cf5c-4dcf-a01e-d343b52c2daa">
+      <statement statement-id="au-7_stmt.a" uuid="b3dd1b17-9bce-4dbd-902c-298b68b5f6de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac2c4991-8f4e-4055-b74a-079501969db3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -1811,8 +1811,8 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="1abaa7ac-df76-46fe-83b0-8b6625f2057d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7d673aca-103a-4da9-a963-c3eecf2e7006">
+      <statement statement-id="au-7_stmt.b" uuid="c748f2fc-cf92-44c9-9806-ba1248fe7e40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a54018e-66bb-4e1b-9b2d-38a087c60965">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When OpenShift's Cluster Logging Operator sends CoreOS node logs to a remote log store,
 the operator does not alter the original content or time ordering of audit records.
@@ -1820,10 +1820,10 @@ the operator does not alter the original content or time ordering of audit recor
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef0fc2e1-71d0-4cff-aa32-fc8664d85a9a" control-id="au-7.1">
+    <implemented-requirement uuid="99511d4a-09fc-4a44-ace9-52945e8cad80" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="5cd0a1be-ca08-4030-a965-6826e638364e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d8b52411-7769-47a3-a70e-917ebf38fae5">
+      <statement statement-id="au-7.1_stmt" uuid="846a5d5d-db26-40a1-b86f-0177b6a36baf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a6a566-1a42-4583-9a4c-681d5318b419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>CoreOS supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -1843,10 +1843,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12eca5fc-09b7-4b9f-a02e-6e46316b0127" control-id="au-8">
+    <implemented-requirement uuid="cfa63b2f-753a-4c92-9cee-f8e5ce20299e" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="4bbe6dbe-00df-4c98-af05-2090ea74aaf1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="611849ed-2e95-47b9-8f57-3654a2d3814d">
+      <statement statement-id="au-8_stmt.a" uuid="3c14208a-a876-4029-87de-5036e4a2969e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dea8b84e-ea73-455b-b435-b4fa13787d7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, CoreOS auditing uses the internal system clocks to generate
 time stamps for audit records. At the code level, this is accomplished
@@ -1854,8 +1854,8 @@ through the use of the C programming language time.h which is part of the
 C Standard Library.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="dbb432ea-90de-43a8-9c42-cfd78229a334">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0e8a89ef-ece7-40b5-a901-591651c853ae">
+      <statement statement-id="au-8_stmt.b" uuid="55eb61ed-02b8-49fc-a370-e76892d9fce6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1016d760-97fb-4c10-9011-6d9b1c99a5d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the CoreOS auditing records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -1876,10 +1876,10 @@ for more example and explanation of auditing.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c22d8d1e-2307-42a4-8639-b5b63920880d" control-id="au-8.1">
+    <implemented-requirement uuid="0070376d-7fc5-4aca-a10d-a9240b6d6818" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="46dd9ea7-af68-43ff-853a-a81361d25315">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7b4f4545-aa9c-4097-b9ef-343eba70cd40">
+      <statement statement-id="au-8.1_stmt.a" uuid="dde13b89-d5ff-40fa-af21-a4954e1c9be4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1887,8 +1887,8 @@ https://issues.redhat.com/browse/CMP-232
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="96ccdd6e-9774-42fd-b0ec-a950987d7a3e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bb1d2dd0-d1a9-4226-acbf-35fa6f96b59e">
+      <statement statement-id="au-8.1_stmt.b" uuid="7a8ebdb0-51bd-4f15-b55b-a6393dc71d94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1897,10 +1897,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e98fc4fa-6d8b-427c-961f-651391c9e374" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="8b72e3cc-3f97-47c8-b783-14dcfaaf2763">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="afa49f57-0a1e-4673-99cc-3d8f4144d633">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1909,10 +1909,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe54b4ff-f11a-4c8d-b6c7-4521a7c82bca" control-id="au-9.2">
+    <implemented-requirement uuid="8da0c910-0bf8-4170-9672-83b82d2e48ef" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="dd821a1a-91a8-4707-b272-9d2b9e0199e2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2b81a398-a500-4927-a909-95e48af683f6">
+      <statement statement-id="au-9.2_stmt" uuid="2ea89db4-c679-45f3-96b0-402c5b837cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8937265-8b0a-4436-b148-4083efa33711">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -1923,10 +1923,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1209542-8459-4af2-81ac-6be283e1b51c" control-id="au-9.4">
+    <implemented-requirement uuid="2e936dfa-c426-4c14-b9bf-b4a2585f877c" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="7c4bbbf6-2e37-4bb1-b08e-409138f1f86b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a56a99df-f922-4619-8dac-6c4c52317f20">
+      <statement statement-id="au-9.4_stmt" uuid="67384918-d292-4ecf-907c-a9a006bd813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c316f2ae-f82d-4182-a625-9ce6bf288afb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be tracked
 via:
@@ -1936,10 +1936,10 @@ https://github.com/ComplianceAsCode/redhat/issues/863
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f84b21d-e149-40f5-84bb-1167330a9e14" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="a7a55b19-7cc4-4f7f-9e8e-2d19c3be7e08">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0e17f252-749c-4e8c-aa1d-3bb822af5d3e">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1948,10 +1948,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f28b3ec1-cae8-4f3b-af27-08995ecf750e" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="805b3d57-9a74-46ff-9293-f9d518c25e08">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="98e4f119-9a0d-4ad1-89a9-fe30f04f799e">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1959,8 +1959,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="ba280bd3-f4b7-44e6-87b5-3f58596d6fa9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d3a76f42-b7b5-4a31-9f4f-95818cf34673">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1968,8 +1968,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="4bbeed65-4261-43bc-aefa-b875a5d87fce">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b2c934e2-1129-425e-bbea-d1d525f71076">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1978,10 +1978,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb13180f-3e77-4226-a23f-45a7e818d785" control-id="ca-1">
+    <implemented-requirement uuid="99daba6d-133e-4957-b69e-abb25b8978cc" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="c814be0a-bf81-46b2-99e2-28588cfaac0e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b4ffa494-804b-4d54-bb6c-95c6937859d4">
+      <statement statement-id="ca-1_stmt.a" uuid="c6d6d9cd-b8b5-4f2e-957d-f57dd1ae55c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1989,8 +1989,8 @@ the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="7244efd3-fa2b-4604-9370-0e551c36bb9a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d23e9de3-b3f0-4596-93f2-e85a0d6d466c">
+      <statement statement-id="ca-1_stmt.b" uuid="d910896e-a8ef-4e87-85ea-661516ea4969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="417aaead-5519-474e-9951-273568ef9221">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1999,34 +1999,34 @@ the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8456947-a153-4611-b43c-18d6010f003b" control-id="ca-2">
+    <implemented-requirement uuid="13cc8da5-63b9-4ad7-8027-2dc6a4f82694" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="526a9892-5108-4ac0-9263-a98b45833214">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="da5712e4-6acd-4286-ab2e-7fe6cab42f65">
+      <statement statement-id="ca-2_stmt.a" uuid="dd41448d-5fae-4cc9-a688-7852824d178e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="03f051d4-9353-4723-9d23-6ec4a9362e7b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7ec9d9b6-02c9-491d-a976-470ce7ef0f13">
+      <statement statement-id="ca-2_stmt.b" uuid="bf74b610-4372-4e81-ab09-173a1640dd60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="88239256-fade-4ee9-a5ba-d7c97739171a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f9d05e8e-cf5b-48e7-9420-359e5d4cd98f">
+      <statement statement-id="ca-2_stmt.c" uuid="473814f0-520e-4b66-af54-dfbb6e18368a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="3552ab43-fb04-48e9-aa40-507298545de3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4296d92c-f4b7-4f44-9240-e7fd59500203">
+      <statement statement-id="ca-2_stmt.d" uuid="bb1f6262-9d2d-42e8-b22f-523d3449139d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7bf8a10-6d06-474d-ac76-c59a81788852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of CoreOS configuration guidance.
@@ -2034,10 +2034,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20a6a529-c3ce-4134-8abb-47b8742a4e15" control-id="ca-2.1">
+    <implemented-requirement uuid="38874da0-214c-4491-a3a1-bbb1ed6840ec" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="2593e007-eb22-4010-8b18-60cce31c0642">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="55590441-42d5-48ea-bc5b-253d0d894c95">
+      <statement statement-id="ca-2.1_stmt" uuid="db6413d3-b953-4ccd-958a-d009b9723385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dc6837b-8db9-4350-a142-d836a51793a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of CoreOS configuration guidance.
@@ -2045,10 +2045,10 @@ is outside the scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61fb2534-4b54-46ac-98a7-38867e7d34ce" control-id="ca-2.2">
+    <implemented-requirement uuid="7337b6d7-4a42-4730-9349-d8ff84c44e89" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="c0c5ad23-f158-4ff8-b121-9b73350d2861">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9c576896-1a7e-475c-ade3-21f1d4a5df46">
+      <statement statement-id="ca-2.2_stmt" uuid="d4081db8-7aa1-48cd-86ec-1283251fc33a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7a98cd5-d563-4698-9551-ee5f0ec8118b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of CoreOS configuration guidance.
@@ -2056,10 +2056,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f8c4ccc-75e2-4174-9204-2e6b72580002" control-id="ca-2.3">
+    <implemented-requirement uuid="cc67f3b4-fa28-46d0-a4db-c33507f2e15b" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="9bd5e3d3-97f0-4c76-b256-f2e47f8b4d3d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cda921ea-e10d-4bc8-9959-06545cac464e">
+      <statement statement-id="ca-2.3_stmt" uuid="14883387-097b-466e-a9e9-8b8e628b5068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f442262-dc3e-46f5-a6e3-41717cad4434">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of CoreOS configuration.
@@ -2067,10 +2067,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4b94983-85b5-4611-a057-b355a29c9eb3" control-id="ca-3">
+    <implemented-requirement uuid="c8f891db-8b24-4efe-939b-56da63f73605" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="0a6c1b65-c2d9-40ca-8ccd-d08f3f26669a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e285725a-b6fe-466b-9c38-fee8a1d51b51">
+      <statement statement-id="ca-3_stmt.a" uuid="60cc31b1-571e-4c25-93bb-2ce12b41c657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2078,8 +2078,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="aeb8d854-c256-44ec-ab64-e28789666c75">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ce597f24-44c7-4c91-87dc-94b16d7b8d74">
+      <statement statement-id="ca-3_stmt.b" uuid="d181dd2f-df60-4e59-b08d-0e353d957d07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2087,8 +2087,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="8fbd2a21-f133-49c7-a6bd-2a5dadcb08f8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="efb36137-b3ba-4150-b6bf-3ca477a03f40">
+      <statement statement-id="ca-3_stmt.c" uuid="77478ec5-5cf4-47ac-b9e2-73ba4fbfaeae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcb3c21-5416-4807-81e8-1a227fa0a7d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of CoreOS configuration
@@ -2097,10 +2097,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a972a2e4-7863-4d2f-8d43-50379cf17155" control-id="ca-3.3">
+    <implemented-requirement uuid="5c2a70ef-ee18-49ca-9c70-afed8c3a37c5" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="3d3d1f3d-b666-4a8e-864a-ca5aaca8fff7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b0fc1d4b-3ec1-44e0-85ae-7e232f5f2f64">
+      <statement statement-id="ca-3.3_stmt" uuid="bcd681a2-4cdc-47fc-b568-37617c3ae9e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5715310c-9830-4454-a30a-ae328e97a06b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 CoreOS configuration guidance.
@@ -2108,10 +2108,10 @@ CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd2195ef-6aab-4ff7-b8ff-821fc442ccb6" control-id="ca-3.5">
+    <implemented-requirement uuid="877f2a7b-35fb-4332-833a-e20c1d9a75b4" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="5a51ae56-e806-49a2-882a-678325a681ae">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="32be7b9c-7cd7-4425-b6eb-d28d5ce068aa">
+      <statement statement-id="ca-3.5_stmt" uuid="681aa9a0-07c2-4c6e-aea2-b51a79fe2e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dd3477e-6236-457c-950c-104b6f8579af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to CoreOS and applicable
 through host-level firewall rules.
@@ -2123,10 +2123,10 @@ https://issues.redhat.com/browse/CMP-253
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a65e1501-c808-4863-9af5-5a7449c26d1a" control-id="ca-5">
+    <implemented-requirement uuid="04cf2e93-8e53-4c29-a789-31dae68b1f8d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="fcecd300-dedb-4ed6-80bd-809c0421d82f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b32ff4fe-9770-46bf-97d7-5bef64f2384f">
+      <statement statement-id="ca-5_stmt.a" uuid="395a7806-3504-4444-8b1f-14bee13b1d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f244e5d7-c63c-4700-85ea-5e38983a62bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of CoreOS
@@ -2143,8 +2143,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="e99b39e1-aa62-479a-a920-5f6e2f76ae93">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a336c95b-0717-4e6f-aa5b-006b6fea935b">
+      <statement statement-id="ca-5_stmt.b" uuid="e29dae32-0560-4ad0-b328-14dd6e89d073">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="614d44f5-285d-4cee-8d2b-4c90cbf4325b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2158,26 +2158,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e70dcfe6-4c39-4a08-ba4a-299d288219b6" control-id="ca-6">
+    <implemented-requirement uuid="607608f2-fde2-4334-a6f3-4e9027c959d0" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="04125b84-2f5e-4630-9724-34a4d80b8f95">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="930cba5b-374e-4163-9b24-eb31badcc7b9">
+      <statement statement-id="ca-6_stmt.a" uuid="511137db-c306-44a7-b081-11ce5a8a0be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="f1d53fa9-a2c0-4d77-8eb8-8d7d151d5969">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f9bddb28-83ee-4b8d-b6aa-500459d68d61">
+      <statement statement-id="ca-6_stmt.b" uuid="68ee121f-2444-42f2-8269-8779a2b68269">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="5e801242-1bfd-482a-963d-c6c31271f219">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6512f5d4-3589-4c09-87d7-dd4f59774663">
+      <statement statement-id="ca-6_stmt.c" uuid="590e46e4-2052-40e9-ad70-c1116fc37a51">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2185,10 +2185,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ffa1ca2-27f3-48e4-b3ee-a557da4fae77" control-id="ca-7">
+    <implemented-requirement uuid="066ece2d-9278-43bd-9aa0-abbb1e9ad96b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="ac4ed6bd-f187-4a29-a30e-1ffa71232c86">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="00adef33-2352-4c79-a784-0afbd16f5568">
+      <statement statement-id="ca-7_stmt.a" uuid="1455a053-6e81-4928-89a7-b1ee8dabbaad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5ddd44f-3d95-4ca2-bf11-bdc4a2e5deb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2197,8 +2197,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="5010b251-c5c3-464a-9c28-ccbe934f55eb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5b512c66-8738-4d3b-82b5-5b0dfb7de9b1">
+      <statement statement-id="ca-7_stmt.b" uuid="b3f7a7fe-e740-4842-add2-0515352403e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa91273-e3a4-49d1-9b4d-8947af8ec22e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2207,8 +2207,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="4fa65797-b867-45ae-b6b0-13714adec0d9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="46dfabb0-846f-4dbd-883c-27b8645e50dd">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2216,8 +2216,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="18840822-de55-4ab3-a5e1-9cb0184331d1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fb93b13d-4ece-4a4a-8cc2-a5ef1e948ac4">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2225,8 +2225,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="be17631f-e3c2-40fb-b28d-b87a526e6333">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ac5f2e59-4057-40ca-851c-a47cc5dda351">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2234,8 +2234,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="478745ea-2a33-460e-8233-23c833281be8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3e265f5b-528f-4e14-8997-a3a0e7a09d03">
+      <statement statement-id="ca-7_stmt.f" uuid="f3822d6e-2a18-4228-8299-967d9f1ca26b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a396b00e-1a45-4eff-bb9d-bcf705d7e2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of CoreOS
@@ -2243,8 +2243,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="4fdcdf5b-8474-44d8-b603-225f53e93b4a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0fccbe7f-ebc9-4ddf-a4db-2d4e92dfdf44">
+      <statement statement-id="ca-7_stmt.g" uuid="004d1a1c-403c-4be9-ba6d-54b91176e631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8a4b2a0-f735-4371-a45f-2726c489d9e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2253,10 +2253,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc065cf1-12a6-4c59-9864-258dfc0f3f09" control-id="ca-7.1">
+    <implemented-requirement uuid="52512572-aadf-4f6d-be4f-61114e6e457a" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="c9b265bd-a1d0-4188-8b83-19cbf4d256cc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c533d451-c078-476b-af0b-a32c5938016c">
+      <statement statement-id="ca-7.1_stmt" uuid="f29d7e91-df3f-483c-a086-70171bb44dbc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5583a506-0008-4d23-b513-a671b314fea7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of CoreOS configuration guidance.
@@ -2264,10 +2264,10 @@ scope of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="331ff0e4-671b-46ec-aa1d-9556585d12ed" control-id="ca-8">
+    <implemented-requirement uuid="ea97dbf6-8b81-4f9d-83fc-fdc5a538295e" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="c69cba35-8c21-4fa0-9775-463ba9b771ac">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ef4d6884-f90a-4f8a-8c8e-4a99d9ecfffc">
+      <statement statement-id="ca-8_stmt" uuid="db987961-b72d-41d0-abef-19306d8d7da9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="605ab3e1-23b6-486f-a5a2-eb5e4feb881a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 CoreOS configuration guidance.
@@ -2275,10 +2275,10 @@ CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29d88671-e8b0-4bf3-a5d9-379dddb7b277" control-id="ca-8.1">
+    <implemented-requirement uuid="ad132af0-ff44-4e60-8a23-f450b92915eb" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="23b40194-a52a-4ec9-a946-994afa53fa83">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="eebea5f9-0bf2-4b84-8322-b7e420f077ea">
+      <statement statement-id="ca-8.1_stmt" uuid="3d5b02a0-89c2-482a-a4ad-7acabea48da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16a0e298-9e53-4860-94f5-3bc9aac29dce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for CoreOS configuration
@@ -2287,10 +2287,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27892247-2bb5-41e2-9584-6c989e0aaa88" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="f0f62a5d-ae8e-498e-8ea4-abc5a9a70a27">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7eae9320-399f-40e6-8ed5-4cbfb6b71c9d">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2298,8 +2298,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="327ccd30-764d-4bd9-9b81-53f25e5577e1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f2918aac-9aac-4a77-a209-d2f25793aa9a">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2308,18 +2308,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a9eef1c-ef88-4a4e-9a00-71f9984d2201" control-id="cm-1">
+    <implemented-requirement uuid="115e2333-0921-4c67-a4b5-12379b2478a5" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="b647bf8a-a8d2-442a-b3d3-7831cfd5dada">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7e885d61-cfa0-4798-a4b7-155532d18865">
+      <statement statement-id="cm-1_stmt.a" uuid="9d54d106-6d17-47ea-93c8-c84ce10158b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c65750c-dcc8-43ff-82ab-4ad8ea4da2e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="1a11bea1-a5b7-489f-aa4e-682379a5242a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="77a0c1fb-f844-4ea0-868c-7ccf73bb8e13">
+      <statement statement-id="cm-1_stmt.b" uuid="7e95f0dc-7904-4a82-ac38-1d526f64de65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="129d3029-87cd-4b0a-b766-282cef0783bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of CoreOS configuration.
@@ -2327,10 +2327,10 @@ management policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6391379-2ed0-4bd9-a81e-720e7ace7ecf" control-id="cm-2">
+    <implemented-requirement uuid="d4e8ab39-ad10-43cb-92c9-b282ec92e657" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="a380d41a-849a-4eef-b572-43a706d2b185">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f208024c-bdd2-46d9-9023-1268e16f1dc4">
+      <statement statement-id="cm-2_stmt" uuid="1af42b2a-18c8-49a3-894b-b9f2139c9340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce35a501-1e1e-4e7b-9f14-187b04fc37fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration management is enforced through Ignition configurations
 and Operators.
@@ -2359,10 +2359,10 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b813bf2-0c07-46a2-a34d-11c0515a73c8" control-id="cm-2.1">
+    <implemented-requirement uuid="c08ed4b6-dce7-40d8-b0f8-b38e7a3d0383" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="902aa230-9114-48e5-83bb-5c23246d0d4e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b1519247-6925-474c-9a18-07a7b4de03f2">
+      <statement statement-id="cm-2.1_stmt.a" uuid="9e8c7ec0-ed37-454d-a4dc-42980335e634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f220af3e-2912-4338-905f-3f5fb7aa0ff0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS per an organization-defined frequency is outside the scope of
@@ -2377,8 +2377,8 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="23ef55bf-533d-4a6a-9c31-2cae9d5789d3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="29951c7d-265b-4839-8c92-18bd1f30d24e">
+      <statement statement-id="cm-2.1_stmt.b" uuid="344cae84-267a-4f72-b976-6de9c9acc251">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9480c18-43e5-4d83-8002-becc7e8f069e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS when required due to organization-defined circumstances is outside the scope of
@@ -2393,8 +2393,8 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="ca111deb-4150-46f1-ada5-e25dac227515">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f74e75a3-6c66-4c69-a1b0-5b8f23f9dacf">
+      <statement statement-id="cm-2.1_stmt.c" uuid="912ec445-1b02-4ef8-a13e-7b031b4e705f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f445927c-ccfc-479a-bf06-5dd2c7a8da0a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 CoreOS as an integral part of CoreOS component installations and upgrades
@@ -2412,10 +2412,10 @@ https://docs.openshift.com/container-platform/latest/installing/install_config/i
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09653f14-59e4-4def-8076-9ca4634d4009" control-id="cm-2.2">
+    <implemented-requirement uuid="9811f427-cb9f-4959-839e-c1ad0e3b1f69" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="5f72610b-3e8f-4bef-8d61-5f45d7291e83">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a19590b3-3f01-43e3-b830-80d0457d84d1">
+      <statement statement-id="cm-2.2_stmt" uuid="1a85e226-7846-458e-87aa-daabb3024acb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbf585d-7073-4272-9b00-0e9a10603a48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2425,10 +2425,10 @@ https://issues.redhat.com/browse/CMP-262
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30885539-5069-449e-84de-1ebd991831ec" control-id="cm-2.3">
+    <implemented-requirement uuid="61c72c52-9e74-443f-a3e2-1e2ab6294b48" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="63eb148f-0159-477f-97d0-951d273b6e3f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b63c53c0-a6a0-4771-8192-9c6b2549f1f4">
+      <statement statement-id="cm-2.3_stmt" uuid="5defd3a0-8190-424f-9d7f-e744e1a156ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="463ccdde-031c-4459-8680-3d60772598e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2454,10 +2454,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="741fa765-9b5c-4f82-8918-5a2b96f1e4cc" control-id="cm-2.7">
+    <implemented-requirement uuid="d3915c81-b498-4570-ba51-ff42853ce066" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="d10507c5-68e6-4075-ac30-c7953de8eeb8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cbf61e06-6ac7-485f-b690-49801f55f5be">
+      <statement statement-id="cm-2.7_stmt.a" uuid="177987a4-6352-4c14-a47c-cb0c21c216ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="522d40e7-e47c-445b-aedf-355f153eb239">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2467,8 +2467,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="ca7208d6-7553-4125-9d0f-a6595086905b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1247c1c3-ff6b-4e09-b7d3-5122f5b42e50">
+      <statement statement-id="cm-2.7_stmt.b" uuid="9bb1f72f-1b3c-4c1e-85dc-95c6ed48e00a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5829f28d-b726-4e28-b648-991a5f24cf63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2477,10 +2477,10 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c649086-4c16-4001-9cb5-e0d99b8b0423" control-id="cm-3">
+    <implemented-requirement uuid="a541cf41-be0d-4f16-9682-4c25f54441d9" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="a90c581a-fa56-4730-afa5-7ba88aa87c94">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="45c9a9c6-0b58-4a20-ac75-9e30c941982d">
+      <statement statement-id="cm-3_stmt.a" uuid="cd86af9e-b2c4-42f9-bd08-622642ee246a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2489,8 +2489,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="e6c0177c-e499-4f61-961e-1ca10598f418">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d3dce0e0-3d2d-454b-ab14-8584893ec2d2">
+      <statement statement-id="cm-3_stmt.b" uuid="55b2e92c-81f2-4fad-b3dd-456c93a1fbac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2499,8 +2499,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="428ee968-2949-4785-a37c-7ec5aaf29d6e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d27faef7-76ec-47d9-86b4-77fbeb3712e4">
+      <statement statement-id="cm-3_stmt.c" uuid="684a0521-4ea2-4b94-b6b7-7b7a50b3f2aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2509,8 +2509,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="4e0824cc-e3dd-437e-a3eb-f79ed421be87">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b86223a6-dffd-4ce0-9a57-06534bb2eff3">
+      <statement statement-id="cm-3_stmt.d" uuid="b1245fb4-2e87-497b-9ad1-8332e3854425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2519,8 +2519,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="78dd97d5-26e4-41f3-b29e-30dd780df4b6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c8cb22dd-c747-44fd-a031-9586ac648924">
+      <statement statement-id="cm-3_stmt.e" uuid="2a387d15-e1e8-4940-bce5-98bf905dd8d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2529,8 +2529,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="6a6fe777-bd65-4eed-91c0-a8ad2419d425">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="50e816c8-bc46-40ac-a210-ef2128ecb9f7">
+      <statement statement-id="cm-3_stmt.f" uuid="dfaa0f29-9d3f-4979-97ec-a7128d6afa16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2539,8 +2539,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="86759e90-1503-49b0-a06a-0ef784d67658">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c250dc38-e778-492c-9677-a44e8bd3ab45">
+      <statement statement-id="cm-3_stmt.g" uuid="e40bb466-a8d8-4b85-a5f8-656ff4eb52d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2548,10 +2548,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b728401-e66f-4f46-aa43-af3ffebf09b1" control-id="cm-4">
+    <implemented-requirement uuid="0c074561-38c6-4f50-9c76-d1f298a8f245" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="69521223-3a26-48c4-8cab-f31d87f1d513">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fa6f5842-24a3-4ea2-bb72-d233567e31ad">
+      <statement statement-id="cm-4_stmt" uuid="ceb5d10c-effb-41fb-9f4a-feb7759b4c2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7133f40-2f37-4417-97b3-de7e200ce50c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2560,10 +2560,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1220baf-62cf-4eeb-a404-13a90509615a" control-id="cm-5">
+    <implemented-requirement uuid="b4f990ea-f8ec-443c-9b4b-72dcfcc1cfea" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="4c1fc83b-a331-4daf-9a16-f77a43c79b2c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9af59236-d76a-42cb-87b8-022ea91982f2">
+      <statement statement-id="cm-5_stmt" uuid="bfab5f89-6a89-49ff-aee8-747b7cab7422">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5617b51f-189e-46b5-9afb-239398c61146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining, documenting, approving, and enforcing physical and logical access restrictions
 associated with changes to the information system is an organizational control outside
@@ -2582,10 +2582,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ba642f5-2e6d-4ff3-96d8-b3fa9a08a745" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="f2a7eb74-337e-4f7c-99e3-30934677c08f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b44e626e-badb-44f6-b616-f86de5dfc461">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2595,10 +2595,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5df1e47b-d2a1-4a89-b2c7-a5b55ffb3310" control-id="cm-5.3">
+    <implemented-requirement uuid="49523066-b7d9-4d77-a2c7-59366937787a" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="e7b27464-711b-4193-932a-ba4251756ad4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9e7ba9c2-ea48-4c22-b3b9-b2a745a7747e">
+      <statement statement-id="cm-5.3_stmt" uuid="84764f58-0c4a-4051-bc47-08d6a39f7317">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca577a36-3847-4240-9bff-912466fccf24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2608,10 +2608,10 @@ https://issues.redhat.com/browse/CMP-187
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7347989-1e6c-437e-b739-18ac985a9ae5" control-id="cm-5.5">
+    <implemented-requirement uuid="767160ac-33c3-44d1-9df1-e2f139f5e8a5" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="5ce34356-6c0c-46b5-b429-1119597b0486">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="10a88535-5d1f-42f1-843d-e90ce7e46e19">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3dae2524-5241-4fdd-978d-beb381490964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d823359b-250c-49fe-954d-f6be6ba9d33a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2620,8 +2620,8 @@ https://github.com/ComplianceAsCode/redhat/issues/901
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="f75d3dd1-a102-4d8f-aabf-79e9fc5aaa26">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="74060501-6b52-4f8d-8f2e-35acdb373f60">
+      <statement statement-id="cm-5.5_stmt.b" uuid="25979d90-68e7-4bcd-a7bd-c80ba1eeac1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2629,10 +2629,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b92f3f3b-939a-496c-b7ad-dda8f1baaa15" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="4ce68123-464a-4eac-a9db-b4ce064cc1b3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6eef4a2b-9edf-41ff-b6b1-fb56dc61e1ce">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2641,8 +2641,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="6b642a25-7b16-40ea-b973-0e0358615c48">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bc0c1594-d4b7-497b-9ab9-61d088bf74a0">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2651,8 +2651,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="be2da539-9b9b-4493-be2e-97f14820b189">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="94a7fa67-d94c-4990-a2d1-9cdae62acf32">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2661,8 +2661,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="0264e977-6f37-43c3-8cea-353a79120e99">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e19881ac-742d-45b1-8df3-adbafc42ce44">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2672,10 +2672,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95935379-dfbc-4c4d-a377-053fc7a45c35" control-id="cm-6.1">
+    <implemented-requirement uuid="23adbbfd-9d1e-417f-934e-fedba07890ae" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="60663799-40a5-48f2-94fd-f3353d5754a5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="92ba2dd1-824b-49ae-a3aa-f4f5d2c3280a">
+      <statement statement-id="cm-6.1_stmt" uuid="2f1e18cc-ae8a-42f4-b1af-e6941dd5209c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4551de61-8db5-440c-bfab-68c6bcb8968e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2685,10 +2685,10 @@ https://issues.redhat.com/browse/CMP-272
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e986d1-8b0d-4a60-9d63-97f38a8d5f28" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="8c6029d8-44bf-478d-92dc-05766905c42a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e414b59c-9f73-467e-b1de-82e11e3bc80d">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2697,8 +2697,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="f9eabd6d-0405-4147-810b-55ca309a96c3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8eeb86cd-a1b2-4292-843c-7bdc164a4c6a">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2708,10 +2708,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a39039b-bdfb-4017-977a-4cd53ea41394" control-id="cm-7.1">
+    <implemented-requirement uuid="681bbf04-881f-448a-b207-3183b7066a64" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="137c8ef2-9378-49db-a2b2-c6c8f499d9e2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0ea41797-032f-47f4-998e-905fc971f96a">
+      <statement statement-id="cm-7.1_stmt.a" uuid="712afed5-3de9-4f0b-a3cd-93267d37b136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2720,8 +2720,8 @@ https://issues.redhat.com/browse/CMP-274
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="9a7209ae-5f53-4547-8610-23db087aac9c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="adf4b938-34a1-480c-ba57-910668a35135">
+      <statement statement-id="cm-7.1_stmt.b" uuid="ec980658-104c-4e52-8631-2d923aff4c85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2731,10 +2731,10 @@ https://issues.redhat.com/browse/CMP-274
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c544872e-e1d4-4571-9875-d292131e91a3" control-id="cm-7.2">
+    <implemented-requirement uuid="2045f042-6725-4305-b4d5-dfab9f16e180" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="67bae709-5852-4446-82ab-09e94132859c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="281bb57f-14e1-47cf-8e14-66d5067df0ff">
+      <statement statement-id="cm-7.2_stmt" uuid="70ab7b0c-c1db-4c82-b9b6-f464a23a1371">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76bedc11-066b-41c5-b5b0-8b40dc36c3c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2744,10 +2744,10 @@ https://issues.redhat.com/browse/CMP-275
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8cba63ea-f63b-4a24-93af-8ffae4d799e8" control-id="cm-7.5">
+    <implemented-requirement uuid="afeb82d5-0753-4ca1-90fd-3866f47e1b51" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="0babdb62-eebd-4b75-bfce-05f99fb498e5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6bcafa6a-4858-4a4f-bdf7-f9cbc07515f6">
+      <statement statement-id="cm-7.5_stmt.a" uuid="664d44d4-5274-4bcf-b887-31cd4a5ac1d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2756,8 +2756,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="5c88475e-ba91-4352-8a9c-912953098631">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="637df3e2-2f8c-488c-ad8b-a6f07c4bf232">
+      <statement statement-id="cm-7.5_stmt.b" uuid="76448ea7-3d83-415c-add0-9cb8a842af1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2766,8 +2766,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="d30ae23c-7fbd-4c63-837e-170c66f26f31">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e5958841-a5ef-4730-a686-22e583377125">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3b3a6030-4ee2-4050-95a8-c28aaaa8e862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2777,10 +2777,10 @@ https://issues.redhat.com/browse/CMP-205
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="983ede29-610b-4cbe-9fa6-8a72077c92fd" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="d5072b99-f37e-4ddc-bc10-4127f67b0f10">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fd091866-eff9-47b3-a5b5-3532d4398ce0">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2789,8 +2789,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="633f1ca6-d36f-4579-afc8-8fe6e1ca66ab">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2a7a0771-27b9-483e-8933-1ee797df16a9">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2800,10 +2800,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f3f66c0-3ef7-4f31-93b4-6d662c771fbe" control-id="cm-8.1">
+    <implemented-requirement uuid="a2d7594d-e346-4274-9265-d46540911822" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="caf9bbf7-bdc6-4e3c-8352-dfe35ff45e8f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d413c8df-ca71-46bf-b8b6-d7fc98c35eaf">
+      <statement statement-id="cm-8.1_stmt" uuid="e8f890bc-f312-4f4a-b859-d8ae6b11b6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8df6da4e-b135-43b9-86fe-b966c8589097">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -2819,10 +2819,10 @@ https://docs.openshift.com/container-platform/latest/updating/updating-cluster-b
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6141b81-f9d1-4711-abf3-ba9f0037ebca" control-id="cm-8.3">
+    <implemented-requirement uuid="9f65e091-76eb-4b8b-a90d-01dfcf2d492c" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="24954712-4055-4145-ab75-890b9c972d83">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7a4ea996-9a80-4c23-9600-4dbf74cffc6c">
+      <statement statement-id="cm-8.3_stmt.a" uuid="23171812-48fa-443e-9266-3902cb35ff08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2831,8 +2831,8 @@ https://issues.redhat.com/browse/CMP-280
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="97efb07b-e76a-4c0c-92bd-ea09b5954240">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="79a3b0ad-292b-41d1-9a6f-6dc65aef3d51">
+      <statement statement-id="cm-8.3_stmt.b" uuid="7af95e64-9f75-464f-86de-26378e862fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2842,10 +2842,10 @@ https://issues.redhat.com/browse/CMP-280
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7182bc2-b94c-4a29-8bd8-581e54424378" control-id="cm-8.5">
+    <implemented-requirement uuid="780e7ba5-4a78-4965-81d8-9c71e29ebf78" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="a00a8469-f1d5-4da7-bf35-d8b1e8387074">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a32ac6c8-9d89-4e9f-ae6b-b7585c57e706">
+      <statement statement-id="cm-8.5_stmt" uuid="6eeac808-579a-44c3-9352-f27062cf6e8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a48448e-2c01-444b-a600-69b4b418e96b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -2855,34 +2855,34 @@ inventories is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d241eba-0a11-45f0-8b52-3ec81d0b750e" control-id="cm-9">
+    <implemented-requirement uuid="d7a00663-3e5e-4e8b-8877-0fb65a72caf8" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="7e5e5af1-10d2-41d4-910d-ef933106773d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e389817f-f765-4620-ba66-e7b85e362f62">
+      <statement statement-id="cm-9_stmt.a" uuid="c8d7bf32-bf20-4b42-825e-34ad1f8bc208">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="9697d1ee-b5c9-4797-875e-26b44ac33949">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ee39a368-9049-461f-8644-f7c249f4c1a0">
+      <statement statement-id="cm-9_stmt.b" uuid="c6a2b555-5b87-43e5-8651-921942b9802c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="fb53a2c5-581d-4f0e-a089-2ed8d2adadae">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bc4934ce-62b4-4741-afd4-2f85ef6d6d1e">
+      <statement statement-id="cm-9_stmt.c" uuid="dc022556-0ab1-49ea-96e0-a3154d2782ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="a4035b95-acbb-4f10-b6bd-d3508ea519d1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3eb8286e-8cc1-432a-b7e8-e430b5ad834f">
+      <statement statement-id="cm-9_stmt.d" uuid="65b2fc13-4a24-4ba9-9a60-56836e7aab0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ddc4dc6-288f-4a71-9119-73c2192588d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of CoreOS configuration guidance.
@@ -2890,10 +2890,10 @@ of CoreOS configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f074e11e-c3e5-4f93-adaf-b8a716f47c57" control-id="cm-10">
+    <implemented-requirement uuid="9c12e422-ddf6-49cd-bf9b-a80f8c950df9" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="4d1fae04-8c98-408a-9cd2-381ee00ffb14">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="29090012-d1e0-4a1d-b4d4-4cd60d25a304">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -2905,8 +2905,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="2f85c681-701d-446b-b396-28a9d8d9d834">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="022db317-db07-42d8-a3a9-1e6e3ca7ec27">
+      <statement statement-id="cm-10_stmt.b" uuid="c8349289-6521-426d-844c-0e559e03346a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1d08f7f-119c-402c-abdd-e35d81e70bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -2926,8 +2926,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="2ccd28b8-d58e-4b22-b864-153c2b354a80">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="712a89e0-b33a-4c13-b965-4cc2f8682d77">
+      <statement statement-id="cm-10_stmt.c" uuid="6022e056-feb9-4aac-9ec7-aba2b09afb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33326b1d-2e3a-4939-b0d0-a6e9450910cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -2938,10 +2938,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6958075-bcb1-44a8-b375-ebb39299cb8b" control-id="cm-10.1">
+    <implemented-requirement uuid="c173a71e-b386-443e-9366-e07f879eddd6" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="873bc00b-bc4f-47cd-9af9-53ca1b0f0714">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6cf4f173-a90a-45c3-9ec8-b965450f324d">
+      <statement statement-id="cm-10.1_stmt" uuid="081e3c31-2f63-42c8-bc82-d6a7f4ab4c40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="715d4079-67d7-4b59-bbdd-787d84c23cbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of CoreOS configuration.
@@ -2949,10 +2949,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4c6899e-f625-48d0-905b-e57ca76e4e42" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="526572ba-ebca-4d2c-8398-1750606345a0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="62c52ab6-1715-41c7-8658-89ffcbe7289f">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2961,8 +2961,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="b165ac58-d73b-41d3-8d1b-b55b1e2cc449">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c91b1c2f-9c7d-443a-a7ac-6b8c048c0c53">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2971,8 +2971,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="ff486135-f8af-4ea2-ba20-998a4c2e538b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0cbd9dcd-8765-4412-9b8d-a290271b60a4">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2982,18 +2982,18 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="905e8763-ef73-49bc-9c57-32cdb0396e2c" control-id="cp-1">
+    <implemented-requirement uuid="6b7cbaac-f4e5-4b5d-b8da-9ff2bb76b9bf" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="dac0ce61-8f26-4974-975c-2d9ef3db3330">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="eba7d760-abe1-48d3-af39-8801888f9fb5">
+      <statement statement-id="cp-1_stmt.a" uuid="736c1891-f977-46c2-9091-bab9684d3048">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e140afe-57d2-4aac-88d4-79901b4a865f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="eb8a894c-98ec-4e52-bb42-0d7c60087dbc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5baae9ee-6513-4795-b385-a649837c5f5e">
+      <statement statement-id="cp-1_stmt.b" uuid="dd8d1fb9-bab2-4fde-861e-72841defd393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f5be2e8-3159-42d9-bc1e-55f082d78b6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
@@ -3001,10 +3001,10 @@ policy is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3c881f0-d278-4c22-8912-be81dc3d9af4" control-id="cp-2">
+    <implemented-requirement uuid="d034a012-6d34-4314-ab52-aceb05eaf925" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="a3b2a2fe-de3f-4442-bbd3-26fafecf572b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6252102a-1718-4ecf-aa6e-d54349ec9de4">
+      <statement statement-id="cp-2_stmt.a" uuid="fdf0a5ab-f5a6-400b-b075-28f6c336363e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6311f816-aacb-4ae0-b282-e50434f1c4fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of CoreOS configuration.
@@ -3017,24 +3017,24 @@ recover/restore the CoreOS environment.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="2cb721db-52c7-49a8-a2b3-5264aa0b14fc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="085ca103-1e2a-4386-b290-afb7c112770b">
+      <statement statement-id="cp-2_stmt.b" uuid="c59e57a0-cbea-4411-99d9-1aa73b612ae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89ac414a-5381-45ef-b0cc-cc44765ddd35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="302a2d39-64a8-45f8-b59d-1b65e3bbc93b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e169fa91-7622-4248-bc4c-f914f942d545">
+      <statement statement-id="cp-2_stmt.c" uuid="fddaa849-3a2e-44ea-9f56-6e4cb58d821e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3dfed86-0354-4cee-bd64-c9e95efb53b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="d48cb40a-9347-454c-9f1c-b446e7fc318d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d31e5712-49ae-4d2c-9b0c-9fd6380eeaf9">
+      <statement statement-id="cp-2_stmt.d" uuid="3f374816-464e-4d92-8abd-a5dd6f749d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="894ea615-37b9-491b-9931-d15976f6699a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3042,24 +3042,24 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="1c5fcd55-cc55-491d-bb57-66f100f0819f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0087a82d-0c7a-4201-8127-3c7d8ba66af1">
+      <statement statement-id="cp-2_stmt.e" uuid="0bf3cbd7-d938-4884-b955-a7b633590246">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="713bcfda-0b2b-4126-8f25-2af62d934d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="28f57efb-ee6e-472e-887f-5c9f18cf9cd6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2b5c37b0-6ca8-48a4-ab60-80b4ffe7451c">
+      <statement statement-id="cp-2_stmt.f" uuid="fb61d8de-1066-4bc5-b73e-8525be8784db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bc60506-ba79-48f9-9435-3be7baf7c1f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="c9d475c4-54c6-45ea-8be3-f69080573981">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d944f6be-59f5-49b5-b5ca-35c3b51fa2f4">
+      <statement statement-id="cp-2_stmt.g" uuid="ac2fd90c-1cd4-426a-98d9-2676d772c4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a59dad64-7bd4-4dae-8bf1-aae9e7c99213">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of CoreOS configuration.
@@ -3067,10 +3067,10 @@ modification is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53d1f44a-e62a-497f-af79-58ece667b8fc" control-id="cp-2.1">
+    <implemented-requirement uuid="76e31b3e-422b-4b82-b9d2-f4a67f9d600a" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="13d7c6e0-510d-4ea0-985e-2f78e5cfbaef">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="724501bd-8786-45b3-bdad-51b4047cc15e">
+      <statement statement-id="cp-2.1_stmt" uuid="89e94a31-2510-44d5-83ed-4dc2b10bada1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31507ba5-fe31-49ed-9ab6-c2df14e19b9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of CoreOS
@@ -3079,10 +3079,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a7066ef-a574-4260-80a3-d33f4a033e80" control-id="cp-2.2">
+    <implemented-requirement uuid="3ed2435a-49e6-4337-a5b9-a29b86b28a6f" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="94064d5f-9703-4e45-86a6-3b728632366a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="82293a93-4f39-4203-b856-eb69728c7b6f">
+      <statement statement-id="cp-2.2_stmt" uuid="6b6067de-bacf-4e09-a9b7-500366be488d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3090,10 +3090,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fb8c981-d6af-47f5-a11a-ccd71c7da121" control-id="cp-2.3">
+    <implemented-requirement uuid="fb91b490-7180-4457-bdcc-09647f14c2f1" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="7a7c176b-60b2-4651-95fc-9385c9221c25">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1815f74b-32fe-4ddb-9201-4492749340f5">
+      <statement statement-id="cp-2.3_stmt" uuid="f769faaf-5cac-4531-bdbb-0da941e084d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fd71d48-660e-4564-882f-a078daf7c212">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3102,10 +3102,10 @@ plan activation is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00e08f2c-9d07-4a3e-b6e0-be0b772b03f9" control-id="cp-2.8">
+    <implemented-requirement uuid="f326c1f7-fa6b-4276-b603-8e748d76da35" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="499fb08c-9dad-467d-893b-3525e2b46466">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d9d78ce6-5a3d-46da-8fe1-1ac558958976">
+      <statement statement-id="cp-2.8_stmt" uuid="74972022-00ba-47b5-bd04-600889ca564e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3113,10 +3113,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efd23c65-e9c3-4396-9db7-281114258870" control-id="cp-3">
+    <implemented-requirement uuid="488f88e1-c977-4f8e-8141-c5a836717ece" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="0246d03c-4026-410a-91cc-28bfb287faa3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="20adb42d-4fd5-4391-944e-fe7c70469de5">
+      <statement statement-id="cp-3_stmt.a" uuid="2c42ff0e-d889-483a-b2d2-4397ce93462d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a78089aa-ea53-42d2-a550-c26f9fcc8430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3125,8 +3125,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="2c42b6ef-596f-4cf8-8b42-7e64bbb574de">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c7dc3bec-6125-46be-a8af-0ea584315648">
+      <statement statement-id="cp-3_stmt.b" uuid="29caf479-ac35-4419-9258-542e1c304f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa849a2e-44d3-47e6-9c09-782b20ba7b55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3134,8 +3134,8 @@ system changes is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="ceac203b-6921-4f39-b45a-c74688b8f532">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b8468a28-f3f0-4584-82a8-9a86dd8b66c5">
+      <statement statement-id="cp-3_stmt.c" uuid="df7614a3-07f1-41fa-8fd1-5180452355c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95f14aad-9eb2-4303-9431-064dea10fe80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3144,10 +3144,10 @@ frequency is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95cf4777-0e30-417d-ad7a-871db50b3dea" control-id="cp-4">
+    <implemented-requirement uuid="517d445e-c3d4-4768-b44d-58ca4bd6a85e" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="284087b8-0d52-44c4-80e6-7fb256aeddb7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4a25e0db-5d54-4594-8b3b-df6ddc2891ee">
+      <statement statement-id="cp-4_stmt.a" uuid="0f2d92d3-09ba-4cec-b823-860292845602">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ebb990c-8eec-43b6-9a6f-aedd77f38b03">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3157,16 +3157,16 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="fc94e07a-d0a2-456a-94cf-4e114c909c5f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="31b026cd-73ac-4c42-a16d-0167a6f1c27d">
+      <statement statement-id="cp-4_stmt.b" uuid="8adaf079-4ea5-4b02-b78c-e7ea33003a26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f81e51-fc2e-4416-b64a-1acdb36b3955">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="d4e27cc4-8215-459c-8971-198b28f32f8e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="586c22f6-8315-4d8a-a998-516cf91ced8f">
+      <statement statement-id="cp-4_stmt.c" uuid="875c27c1-f0ac-4098-8a7e-4004d3628197">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8c5099-a674-4a51-ae0a-c966d42b5eb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of CoreOS configuration.
@@ -3174,10 +3174,10 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e2d621b-c6bc-4ccf-8d42-8344981920fe" control-id="cp-4.1">
+    <implemented-requirement uuid="416b0954-8258-45cc-82c9-8fc43691803b" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="2b1bde67-7234-4936-b299-0163494673a2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fe8dc8f4-1217-43a2-9ef4-836f250f4741">
+      <statement statement-id="cp-4.1_stmt" uuid="25d8cd0e-5be4-4500-8de6-c79e71455802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca3f0332-70cc-435f-893b-09434e67e3e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3186,10 +3186,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c48efbff-501c-464d-916c-740943e3b840" control-id="cp-6">
+    <implemented-requirement uuid="33297ac0-084f-40a3-b153-ce70354c7a92" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="678bcb51-73ec-480b-a548-ff04e17f257f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7bd12bcb-1a9d-4efe-8f61-4403f7d22aa6">
+      <statement statement-id="cp-6_stmt.a" uuid="dd11cfe1-d254-4ec6-83d4-8048405ff6a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a60899ec-f25d-4d3a-af83-9f8087f3e0ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3198,8 +3198,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="99f2d102-8ade-4c92-9b49-c88d176cd519">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f9f885cc-2f73-4905-a357-443e5b373d06">
+      <statement statement-id="cp-6_stmt.b" uuid="4b3437e7-e571-4257-b64c-0ce829cce5a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b71d2c2-5537-432b-9e36-9777dcd03a81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3208,10 +3208,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae27185b-641d-4672-9d52-5c9435bd03f0" control-id="cp-6.1">
+    <implemented-requirement uuid="df0ab68d-d846-459a-b7ac-4a88cb89505c" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="28699544-e675-414b-a655-f87e755ff112">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4600dc71-b895-449a-9dab-5b6e114db401">
+      <statement statement-id="cp-6.1_stmt" uuid="d752dcd3-b144-4d5e-ac35-4a74910e9611">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec272e5d-cab0-457f-90c4-d7165704150f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3221,10 +3221,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2415f14-df7f-476b-89c1-82a2280793c2" control-id="cp-6.3">
+    <implemented-requirement uuid="38ebc2e3-1b08-4426-ae2d-656753d8ab8f" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="af3c53b6-3f33-4dd5-bcf0-26e75e44930d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7c1c7dad-422f-4dac-94ee-11e745dda653">
+      <statement statement-id="cp-6.3_stmt" uuid="dccbb24c-4283-4d45-9e2b-5e298773f298">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80398667-5529-4b3a-8b47-ee83d9b36a06">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3234,18 +3234,18 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7efc45e5-3ccb-41f8-98a7-b09e30dee127" control-id="cp-7">
+    <implemented-requirement uuid="f3533d94-0f44-4e77-93c8-262555d091f8" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="1e76b559-f577-4d17-bd7e-63f47be56ca0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5f39b2b7-fb56-4131-8d12-31771f894940">
+      <statement statement-id="cp-7_stmt.a" uuid="5e4fc735-6102-4035-8fde-65efe795d832">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="e7ce1adf-8008-4c6b-8d68-833b915cb0fc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="396c780a-2543-4a01-8f7b-a7182b99270a">
+      <statement statement-id="cp-7_stmt.b" uuid="23fa3af5-5217-4981-a4e4-c8757382338d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="796b4ab7-7086-44bd-91c4-71f84ff2dbb1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3259,8 +3259,8 @@ at the cluster layer and not the individual node layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="356afc58-3e0c-465d-957f-288bdfb95c6a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5c86d56f-14d8-4e1c-b67e-ca4dbcecc60a">
+      <statement statement-id="cp-7_stmt.c" uuid="5535ed3f-0ec9-4d7f-a266-c6f0e703dfce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -3268,10 +3268,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74f22b3e-e996-478a-9396-9ed7aa74b84b" control-id="cp-7.1">
+    <implemented-requirement uuid="89a4466f-b3f9-44eb-9817-c61e81a20f0b" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="0542798c-06ec-4177-9467-0095867fb8a4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4a0ac3b2-550d-4b5d-a55c-674425a776fc">
+      <statement statement-id="cp-7.1_stmt" uuid="8cd8e19a-4ef5-4350-a97f-50b514d399af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92fa3087-2e66-40f7-9e85-be1aebe5593d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3281,10 +3281,10 @@ scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f2ce161-a25c-4637-bbad-b2c2e2480f08" control-id="cp-7.2">
+    <implemented-requirement uuid="31982630-30ec-492f-af62-1a8cf8b9080b" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="595c9b4a-7ac1-49df-a977-44e558d46afa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c096d967-afb1-4eec-be01-0dadb4f9cf3a">
+      <statement statement-id="cp-7.2_stmt" uuid="68e1370d-23d9-4f56-bf9a-74e5d4350d03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0022bced-9090-49a0-b688-4cbe1cdc8b49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3294,10 +3294,10 @@ actions is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="930f749c-abfb-4b79-b9d5-78b99e8743a3" control-id="cp-7.3">
+    <implemented-requirement uuid="95024607-d422-4744-97f1-bf428b6302a5" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="3f9f19a6-2411-49d4-9382-b4fcd0afada9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d89e4b38-d30b-4819-b260-ba3e81ada53f">
+      <statement statement-id="cp-7.3_stmt" uuid="2b980aa7-a5b3-4a7f-95f1-b0795f186636">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc015b8b-2d3c-4b46-800c-4543db6ba705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3307,10 +3307,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d93ca5ad-758f-47e7-b99b-f48a60000c9a" control-id="cp-8">
+    <implemented-requirement uuid="6b9ebaaa-84ea-45cd-a54c-948937c852d2" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="d3aa87aa-bebd-44ba-8ede-3b26a7569238">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4e217360-4beb-4854-af76-3428dbdd354d">
+      <statement statement-id="cp-8_stmt" uuid="f613d871-454f-494a-8092-029a5492853f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09905f4-ff48-467e-9d97-71c24ff2b84a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of CoreOS configuration.
@@ -3318,10 +3318,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e09e8eef-f0a6-4e5c-ae3b-7340b590db61" control-id="cp-8.1">
+    <implemented-requirement uuid="7b53957e-e029-4474-953b-a95a8b404120" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="4df3d2cb-e5c4-4ba7-aaf3-3e2988a220cc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c45f60f2-37d8-4014-96f1-fe87b510183e">
+      <statement statement-id="cp-8.1_stmt.a" uuid="13ddf18c-ebf5-4b47-95af-89c0ffd448bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e486185-ab2a-4c88-b3b9-d6845c35e3eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3330,8 +3330,8 @@ time objectives) is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="c8b493cf-fbfc-4bc5-bfb1-280e77d78926">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="643ec595-547b-42c5-a50a-7fac482e5b7d">
+      <statement statement-id="cp-8.1_stmt.b" uuid="e84ee943-311b-4036-ac62-d02b72d8426f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb0b5a84-2ab8-4b46-8fa6-80e6650de336">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3342,10 +3342,10 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c7cdbf8-743a-4c64-a00b-ec32b6a5d926" control-id="cp-8.2">
+    <implemented-requirement uuid="6b7256fe-bee1-4794-8916-90b47c1e0928" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="0c1eb047-ae42-4c4c-b179-871948a84937">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d60fac65-d8db-45bb-bda8-e53f472fc9ba">
+      <statement statement-id="cp-8.2_stmt" uuid="dae765e7-f3ee-4baa-9096-0d74b56e1edc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2197222-54c1-480c-8150-ed20a49092f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3355,10 +3355,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="067d4436-501e-4343-9a5a-6fb39ab0efd4" control-id="cp-9">
+    <implemented-requirement uuid="d9ebf0a0-b779-4d30-93f6-19808ebc103d" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="79cea4aa-daff-4f81-a59c-3ff22a4e3939">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="089dbf73-9c3e-4996-b666-e99dd1bf1ac3">
+      <statement statement-id="cp-9_stmt.a" uuid="e21640a8-ee15-4f40-8389-e389acc1d61f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd4b3b4f-ae69-4660-a361-fd28a230152b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3390,8 +3390,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="56bcd859-9cdf-41aa-b59d-9f623db95dbb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9f2a9d08-1dbb-47dd-a19a-26ed20f6acd4">
+      <statement statement-id="cp-9_stmt.b" uuid="cb59ca89-0a5e-48fd-9854-0a9a0146025d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac97c356-cb33-4444-a30a-6c8fe49e99e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3422,8 +3422,8 @@ https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-wor
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="50107fcf-4507-4769-a9f1-45f7838e34c4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="79fb4624-dc6d-48d9-b82e-24af02791d4b">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3434,8 +3434,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="4bddc8db-a60d-4ca7-bac5-674dfb4c42ed">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8a0ad2ec-7b9d-46a0-abd9-8686a2878205">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3452,10 +3452,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa7ecbad-20c2-49df-99e5-0635a4bedbda" control-id="cp-9.1">
+    <implemented-requirement uuid="ae8590fe-2a3a-4b7e-9774-0f98d99dd544" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="e56c7e82-0759-4576-ad63-d267cf3fc02b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="14633300-f61c-46c0-a99e-f6d30a5af5b9">
+      <statement statement-id="cp-9.1_stmt" uuid="ee0d4d91-c0c9-46e0-b445-c6dd22e6699d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28e73fda-a022-4852-827b-63896f3573ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -3464,10 +3464,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c6fe029-e417-4b9f-90a2-684d7afb67e3" control-id="cp-9.3">
+    <implemented-requirement uuid="5b918628-8ca2-4d46-9a7d-0138c8fc3ecc" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="666f8922-2de8-4663-9fc4-4dea7d190a3e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="42a1cd08-0bba-48e3-b046-9cf3c710c4e8">
+      <statement statement-id="cp-9.3_stmt" uuid="56d56000-5ec2-4fe0-800b-af68e3ac547d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d58df8b8-2c4e-4167-a21e-b29d6dcd1b2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3477,10 +3477,10 @@ operational system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40b88845-7b9b-45aa-9667-2919018e2a07" control-id="cp-10">
+    <implemented-requirement uuid="18c26625-857f-42e0-8fb0-0f7bb56e24c3" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="60678cac-6c14-4ba1-9105-97410c1ffc3f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="acdff711-545e-4c80-a771-a326969cd5bd">
+      <statement statement-id="cp-10_stmt" uuid="62aa28e1-61f6-45e3-97f8-a43ab7567c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="745a7e2b-3a65-4b5a-a6d0-712de9382982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their CoreOS environment. A successful control response will detail
@@ -3504,10 +3504,10 @@ https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-workin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66b338de-8a47-42b2-ac6b-298f881c9576" control-id="cp-10.2">
+    <implemented-requirement uuid="f38b682d-5a68-4e3a-93ea-77d208867808" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="920e3b57-477e-4e8c-b067-3c4beb8a2a83">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5fbd5a2f-0178-4531-9885-e014073eceba">
+      <statement statement-id="cp-10.2_stmt" uuid="1e5bdebd-7dc2-4315-954d-3e911ac29edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3515,18 +3515,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47064dbf-0fd8-4962-a36e-c89b01d96096" control-id="ia-1">
+    <implemented-requirement uuid="9f4f8d15-4472-43c6-b214-95cc5a6d146d" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="2b347dac-3d0f-45a6-ba8a-f8b3b31f9bdf">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b866301b-a01f-4e12-bcaf-c9c6e78bf284">
+      <statement statement-id="ia-1_stmt.a" uuid="f7f6f54f-eff4-4350-83f4-3e39ae53dbde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31dd12f9-2bcf-4a34-8cf1-fb8174f72c65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="268a953f-467f-4629-a8ae-2f46150f569e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c53db958-eedc-4d5c-b462-235af46a8040">
+      <statement statement-id="ia-1_stmt.b" uuid="f8a8eb5a-6754-4d09-8a0f-776340c6a57c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91e2d7c9-6f39-4976-a809-edf8fc802309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of CoreOS configuration.
@@ -3534,10 +3534,10 @@ policy and procedures are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58fe6e88-b704-4bda-912d-7890b74efd3c" control-id="ia-2">
+    <implemented-requirement uuid="6b49cd9e-d1de-4845-b766-89344094f9eb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="52641eed-9da8-4de3-83a8-088e1564e864">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7198934f-363c-4fb3-af09-abf6a33c87f4">
+      <statement statement-id="ia-2_stmt" uuid="3ec41b83-c748-459f-a660-40c1a281aa5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb02e477-a99c-4084-9775-6f3863a4788d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3546,10 +3546,10 @@ https://issues.redhat.com/browse/CMP-299
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1aa52067-2bcc-4319-9ed9-fa72483b8f00" control-id="ia-2.1">
+    <implemented-requirement uuid="06fe78c5-0865-49a2-a9b3-3aa2aea4b826" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="977b0649-1b3f-44e3-8837-40cd1098001f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ab814741-59ff-414b-aa06-44ef1e891e68">
+      <statement statement-id="ia-2.1_stmt" uuid="715ccb15-6d68-4238-8949-8c78c50da9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d315b66-3eba-4daa-854c-b40d92188be4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3558,10 +3558,10 @@ https://issues.redhat.com/browse/CMP-300
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b02901a2-78d0-40a8-b209-f23b306908a8" control-id="ia-2.2">
+    <implemented-requirement uuid="cda69d68-8b6b-4fdf-b072-09609b1b0ec6" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="5426839c-d50f-4d54-8513-1ff309642e52">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="dba2c729-dc27-4131-b649-4bbec36b8ff1">
+      <statement statement-id="ia-2.2_stmt" uuid="d6814443-46ae-4d17-a8cc-01ea9e6849d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8432818b-50d6-4a81-8f5d-a8e5916c2ef2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3570,10 +3570,10 @@ https://issues.redhat.com/browse/CMP-301
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ae68258-8ca1-43ac-b9a6-2e4ece0e314a" control-id="ia-2.3">
+    <implemented-requirement uuid="01aefa39-92dc-439d-9a23-bcf7d10adc0d" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="34d658be-cf90-4974-b2e6-bc15ccf32aa5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2c87a68b-c323-421c-8cb8-d62022a882e8">
+      <statement statement-id="ia-2.3_stmt" uuid="68e20929-077f-4a5c-b563-a734e2f77bfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a60cfd9a-f3d4-4b87-813e-c1cee5ad1f64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3582,10 +3582,10 @@ https://issues.redhat.com/browse/CMP-302
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e535170a-a231-49bf-98db-92570fa4de1b" control-id="ia-2.5">
+    <implemented-requirement uuid="8b576bea-91dc-434e-a3dd-451691905a07" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="ea9a483f-1d84-4283-ae9c-14e045862ef1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1c3fd9f3-8450-45be-b9ea-dcf0a17cbc55">
+      <statement statement-id="ia-2.5_stmt" uuid="3dac95ed-519e-469e-8c43-1a040edc12c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38e79e04-34ae-4195-ba94-11adbea2be7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3594,10 +3594,10 @@ https://issues.redhat.com/browse/CMP-314
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bff9993-8c6d-4799-be15-362af8b91826" control-id="ia-2.8">
+    <implemented-requirement uuid="e9032379-595c-454f-9655-a039cf2da783" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="1c3d10f7-e466-4f0d-b7c8-6c5482ee0bca">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2f294b1b-6790-41f3-8fde-eaa2216ff8d1">
+      <statement statement-id="ia-2.8_stmt" uuid="0ea245a9-5c70-4447-8309-f2540f413fab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ef864c-153d-4201-8a38-23145f5c511b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3606,10 +3606,10 @@ https://issues.redhat.com/browse/CMP-573
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8a32960-0839-4380-8fd4-dddbc1ae5b33" control-id="ia-2.11">
+    <implemented-requirement uuid="5f547165-2b45-4c90-9dff-9ad990c518f0" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="eaeeb51c-a742-42a4-a50f-65b7f4a1c4dc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9040d2cb-8c27-408e-bcd3-b8d127c55473">
+      <statement statement-id="ia-2.11_stmt" uuid="89837ccf-f7a6-4485-b58c-bbb201bd918a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2d8bb037-fb37-48b2-98a7-f7e35dac16b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a separate device from the system
 gaining access to the information system using multifactor
@@ -3620,10 +3620,10 @@ guidance of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d39d4cd2-7060-4bd0-b4dc-3afee52d7717" control-id="ia-2.12">
+    <implemented-requirement uuid="45d37aeb-8b02-455d-8ef9-95144b4575cd" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="c007dcc3-d55a-4ac2-8831-22f21b03f5c0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="62e4ba3e-ca17-4770-a1cb-95c782a501ab">
+      <statement statement-id="ia-2.12_stmt" uuid="539ceb70-a71b-4d6a-979b-85e42826c873">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af00b192-2944-40f8-853a-96d85d52bfff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3632,44 +3632,44 @@ https://issues.redhat.com/browse/CMP-317
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="503192cb-9169-4093-99dc-907d9695faa7" control-id="ia-3">
+    <implemented-requirement uuid="391666d9-8c02-4fb0-9db4-7bdbc624b1a6" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="79d49989-98b6-4359-aba2-04e1d40d3d65">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="275cfbe9-498d-4c0d-9cee-f8b2c37aae79">
+      <statement statement-id="ia-3_stmt" uuid="5491c3d4-3225-4f5a-9863-fc5337254439">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6842ae93-655f-493f-9929-c12d12ca06c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="949b80d5-290a-4a85-85bd-482a606b3c7e" control-id="ia-4">
+    <implemented-requirement uuid="87aeed69-4e40-46a2-bb66-84611a0189a5" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="138ad384-b043-4b79-b26a-1588c8c5bd6d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2680384d-139d-42b7-ab5c-ded01f0ff318">
+      <statement statement-id="ia-4_stmt.a" uuid="952ac5db-5177-457b-85a8-9d9982249390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="83d23282-7d86-4635-815f-2640f0a1b9f1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9837f05a-1db3-4a2a-8964-2ea3e72a68be">
+      <statement statement-id="ia-4_stmt.b" uuid="3c0fee9c-0979-428d-b941-b161dc588fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="349128e2-cc9b-4926-97b0-70c19631011d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="efaf98a1-60f6-4aee-acab-9b96f4eb7a24">
+      <statement statement-id="ia-4_stmt.c" uuid="d9d158ca-544c-455a-9f9e-ff5c6016cf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="ca0067e3-ba89-4abb-903f-b833f9790755">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d4f3fb84-5b67-497f-978b-4de667153d27">
+      <statement statement-id="ia-4_stmt.d" uuid="b6dcd342-64d6-47ec-84fc-4204e11b1969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3677,8 +3677,8 @@ https://issues.redhat.com/browse/CMP-321
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="feb13bb4-2b41-4ba4-ab00-0b9228e39eee">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="73a8b2ec-2cc8-4e77-8bbc-adccb72bbc0a">
+      <statement statement-id="ia-4_stmt.e" uuid="6b0b3383-d354-418a-8882-a91c23fc4ee3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11c2e382-b3c5-4018-adb8-836dda242d2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3687,10 +3687,10 @@ https://issues.redhat.com/browse/CMP-321
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b53f048-f412-4a66-bca9-073e86b3d9f1" control-id="ia-4.4">
+    <implemented-requirement uuid="90cb7590-8af3-480c-bc07-721ee7aa7274" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="7279dca5-0d76-4727-9857-16d602730aa4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="49a5539f-a7bf-4238-ab27-592ac7ec2d08">
+      <statement statement-id="ia-4.4_stmt" uuid="468530a7-a640-40f8-98c8-1ac8aadf3af8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -3698,18 +3698,18 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3ef69af-1b18-4a6a-a6b9-6a7c4d1042cd" control-id="ia-5">
+    <implemented-requirement uuid="625b4fbf-2c0f-40de-8a20-b0552f64ade7" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="7cb67801-650c-453a-94c8-d970ebe71457">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5498c1e4-1e59-4691-bb6d-007d389f2620">
+      <statement statement-id="ia-5_stmt.a" uuid="aa62b80a-2651-45e6-8edb-28d1a6f3a48a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="cb9dc435-9fee-4eaa-bd78-b0713c3ec19f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ecd21032-267c-46eb-8ac2-98414e5162df">
+      <statement statement-id="ia-5_stmt.b" uuid="7675e20f-4a79-4710-8f04-6679de7375fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3717,8 +3717,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="8f19dd05-92a0-4468-89d2-054aa4e25126">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d0695abd-d8cc-459e-b794-b5ca06f339fa">
+      <statement statement-id="ia-5_stmt.c" uuid="07ba01f2-7389-4b79-84a5-9c40775876ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3726,16 +3726,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="791dd58f-050c-4c91-bc5d-30585653802c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ab0b0b31-83b9-43fd-b6fe-679ca0a7ffa1">
+      <statement statement-id="ia-5_stmt.d" uuid="542ddcdb-4ae8-45c3-8989-df62a727aa1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="79951fa8-909d-43cc-8251-95aa255908de">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4ee2346f-7fb5-460a-ba2a-5bb9444cecbf">
+      <statement statement-id="ia-5_stmt.e" uuid="f68df002-5ba4-4afa-aff2-dfc5685ad985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3743,8 +3743,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="9efa1e45-ae13-428e-8abf-36bb12cadb8e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e952a88e-b611-4a08-a464-d6f0e5e8abcc">
+      <statement statement-id="ia-5_stmt.f" uuid="f7a5edc3-8789-42db-851c-f426f31a409a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3752,8 +3752,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="22e01196-8c9a-4d69-8b8d-e68b54f0328b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2dbb6260-3af1-4773-9ff4-2add1052973a">
+      <statement statement-id="ia-5_stmt.g" uuid="b3872af9-fcee-4b75-9358-556a7d9ce2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3761,8 +3761,8 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="1aa7dc00-8cab-40c1-8c4b-26e139ff9af4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9a5af32d-abe0-4c45-a415-400619a6d0b9">
+      <statement statement-id="ia-5_stmt.h" uuid="1dcef40a-162d-48a1-98f0-53af0391fea3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017615e6-b179-4010-b3df-bea3796ba034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3770,16 +3770,16 @@ https://issues.redhat.com/browse/CMP-325
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="53ecfd98-979c-45e2-b307-519251756339">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="612c3717-6f15-4abe-a19f-54b63b5c84d9">
+      <statement statement-id="ia-5_stmt.i" uuid="61a23821-f7a5-4c42-a8cc-0757408fc66d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="8b57788f-92b6-4fa0-ae8a-6ca5a0901559">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3df673a1-b383-4b9c-a448-572ecb46f4fd">
+      <statement statement-id="ia-5_stmt.j" uuid="b92999f4-4612-44aa-9fb5-c2ce1df52918">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -3787,18 +3787,18 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e4782fb-9bad-4431-8b15-23d234903c8c" control-id="ia-5.1">
+    <implemented-requirement uuid="267b5f9e-f797-48e4-bcf1-5a7368856bca" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="91d3bb95-3563-4f88-a44b-86c0c27f0caa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e9c657e4-1674-4c65-ad1f-f26f5af41b1c">
+      <statement statement-id="ia-5.1_stmt.a" uuid="a4b2d0a8-7ae3-4118-a638-349e3d20bc05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="f99d82ff-d3bf-4668-a590-e75cdc8083dd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5c491257-7687-487e-9a4f-2f1ca8eba322">
+      <statement statement-id="ia-5.1_stmt.b" uuid="b0da37b6-5cc5-4d12-be5e-d0ce97842b1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3806,8 +3806,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="b1a6a3e1-ddac-42a5-b9ee-afc6f3c9eff1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e3fe83fb-acb7-446a-9be5-76511e2081aa">
+      <statement statement-id="ia-5.1_stmt.c" uuid="6a4f689c-b3e4-4faf-92e3-0de9d5ea204c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3815,8 +3815,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="3ecdcaac-0777-42f7-b83f-60ef0cfb2929">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1ef95b5e-6dc8-46c4-a26e-a8b0fa484b11">
+      <statement statement-id="ia-5.1_stmt.d" uuid="57231353-874d-455f-b0bd-1505e1e147f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3824,8 +3824,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="a6b128d5-8006-4a72-9299-a4e9e236a66e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="133c8f55-0206-4f4d-92b3-62aa54b2977f">
+      <statement statement-id="ia-5.1_stmt.e" uuid="ce80d2f9-98ff-4216-bfcf-b6166252988c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3833,8 +3833,8 @@ https://issues.redhat.com/browse/CMP-326
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="5aea79ce-a115-4514-9100-cf3895cab8ed">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5fe00df6-1838-4bc8-9141-5e1b54d54444">
+      <statement statement-id="ia-5.1_stmt.f" uuid="661295ca-7fe0-430f-9037-d877834d4d69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ce711fd-57e1-4bb5-9138-236a31e0c9a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3843,10 +3843,10 @@ https://issues.redhat.com/browse/CMP-326
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2942715-fc9d-4206-99f3-fdbeb3a3fe73" control-id="ia-5.2">
+    <implemented-requirement uuid="53ecdfe4-7be2-4032-b5e6-cfbaa729a623" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="f1de3087-826f-404c-96f2-395d9dd3a8eb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c2048016-e428-4ba6-b6af-2c7299e67a1a">
+      <statement statement-id="ia-5.2_stmt.a" uuid="be958084-3712-4395-bdaf-4836a9a54d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3854,8 +3854,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="75b8b0cb-5e1a-4afe-8f44-83a8ce7b6bcc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0afbf1f7-1c0c-4bc1-905a-72aed68019de">
+      <statement statement-id="ia-5.2_stmt.b" uuid="4f8b15eb-4938-40e6-ae48-212a82ee9553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3863,8 +3863,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="b5460900-be0b-475e-9dbe-2439d89af7ab">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="432eed5e-cdad-48c3-9217-ed4a598c3259">
+      <statement statement-id="ia-5.2_stmt.c" uuid="660a15ae-c1b2-4cb2-a069-eb5573697314">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3872,8 +3872,8 @@ https://issues.redhat.com/browse/CMP-327
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="ae3a82ec-9c9d-49e4-bd36-ff5dbe798c2e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2bf3eaa9-b509-47bc-ac2e-bd8a8dc50d9d">
+      <statement statement-id="ia-5.2_stmt.d" uuid="df341d82-0d74-4d70-80ce-21f428ed35d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5201bc2-ef97-472e-ba64-7643e081c589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3882,10 +3882,10 @@ https://issues.redhat.com/browse/CMP-327
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dc448f2-ceec-4466-a125-9b8f6972babb" control-id="ia-5.3">
+    <implemented-requirement uuid="ed758708-06af-4da3-8362-0d7fce322636" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="82dea353-f5f7-479f-833b-a23db5a4925f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="74cae08b-a16f-40bb-a2c7-54ebd44ddc8a">
+      <statement statement-id="ia-5.3_stmt" uuid="329144f8-0949-4774-8d3d-8b546f672be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9850fc6-cf99-4e75-996b-e78e4aac27a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -3897,10 +3897,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52c5034c-8bb1-49f0-b42c-82bf419de25b" control-id="ia-5.4">
+    <implemented-requirement uuid="fbe408c7-8881-4ca0-b798-339ad41eeacc" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="a8a36c0d-3771-4e71-819f-5c832e663038">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d2476f9d-7b63-4f72-9384-2764f177adac">
+      <statement statement-id="ia-5.4_stmt" uuid="0bcbb011-c9de-47a1-9b92-43939b740541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b3bca23-1c65-465f-a165-dabb90601292">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3909,10 +3909,10 @@ https://issues.redhat.com/browse/CMP-328
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42f3d0cd-f8d3-4b86-997b-59424491b27e" control-id="ia-5.6">
+    <implemented-requirement uuid="b7985c2f-f691-4d9b-8891-94b62e98ba62" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="5ce4f798-a140-4ee9-81d3-fe05fa5ab639">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fc2b2fab-7b7c-40c4-a439-2f59b38ebe93">
+      <statement statement-id="ia-5.6_stmt" uuid="84d41cc4-a843-43f0-9a2f-0c4fb6534eac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f4d2b6d-1aa3-4c9b-8a32-81fe48653e85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of CoreOS configuration.
@@ -3920,20 +3920,20 @@ outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="546903cf-88f3-486e-8abc-412c1c9a8eb2" control-id="ia-5.7">
+    <implemented-requirement uuid="304428b1-71c3-47d2-af28-c26324880566" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="73190e59-5141-4da7-aea1-cac76f1877f0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b3f42cfd-5f7e-4828-a80b-5cf43dedfbfe">
+      <statement statement-id="ia-5.7_stmt" uuid="1a08af12-3f36-4c34-a57f-7e8c27084277">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ed29355-2781-4fef-9358-96e4908d46f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-5(7) is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3b5e860-c193-4ab1-990a-39aec33f439b" control-id="ia-5.11">
+    <implemented-requirement uuid="8ab48681-5092-4b20-aa14-10f1981f3818" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="cc8d0bb8-ae91-4e6f-8b19-c0406e6ee4eb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="630ae058-133b-465d-b48e-e1de39acf28f">
+      <statement statement-id="ia-5.11_stmt" uuid="15842798-f01a-4905-b300-8cb508bd629f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a8092a5-66b2-4abb-b930-0f30f40f8ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -3942,10 +3942,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb4bb56f-d9bb-46ef-8273-51315bc4fd3c" control-id="ia-6">
+    <implemented-requirement uuid="865eebb3-b85c-4e9c-b0cd-dc5ce446cecf" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="699fb600-b9ba-43be-949b-5112c68305b4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="795b55da-9a35-4899-9ed3-4e80805749e3">
+      <statement statement-id="ia-6_stmt" uuid="a6a61e98-b7e3-49ce-bf87-b19048f9bbb7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dfbef3f-9d21-43cf-ab83-b1fe5d6125fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3954,10 +3954,10 @@ https://issues.redhat.com/browse/CMP-333
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebd1620e-0a04-463b-bee2-e88de6dea6ad" control-id="ia-7">
+    <implemented-requirement uuid="50b7752b-5f00-4d46-9cf1-1fc7adddbd8c" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="81396d70-56f2-45d5-a89e-e3119d73c7fb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7dacb813-bba0-4701-b262-96e64c235104">
+      <statement statement-id="ia-7_stmt" uuid="23d94d20-a397-4a53-8400-4d64686e6e26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4a15e2d-8d2b-46d0-a90b-6286705fe5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3966,20 +3966,20 @@ https://issues.redhat.com/browse/CMP-334
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ae2c23a-f761-4937-883c-dc5e0b3c7a03" control-id="ia-8">
+    <implemented-requirement uuid="ca731b60-3d8e-4540-94a0-027098462df6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="29c9c38a-12b4-4f7f-896b-b6e5948d146f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9ad063cb-727e-4ea4-bcb2-185cbc6e9100">
+      <statement statement-id="ia-8_stmt" uuid="5dc8de3c-c093-46eb-9727-918ffb8a4603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5e23088-66e5-4637-ac25-c63231140c55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de5e1fe1-1283-4498-a8e2-70fa937af483" control-id="ia-8.1">
+    <implemented-requirement uuid="9eba357a-02ce-4bca-b506-982efb5fb335" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="492c4c52-e0f3-4e7a-928d-6c0ffe53a3f0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7471215e-44e9-4f29-9b77-38adfa66f264">
+      <statement statement-id="ia-8.1_stmt" uuid="93bfaa19-1dd4-423d-ad9a-b73eb1b6e5f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9c5c9c5-e5d8-405a-b968-467718cf284c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3988,10 +3988,10 @@ https://issues.redhat.com/browse/CMP-370
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d329eefe-6379-4f5b-a550-21328e8b989d" control-id="ia-8.2">
+    <implemented-requirement uuid="8f0564cd-efeb-4326-a6e3-67066fdd2952" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="610077b9-5370-49b7-b2b8-a729a1e51306">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f411f926-2083-4eb5-b219-8d9417734e5e">
+      <statement statement-id="ia-8.2_stmt" uuid="6ad10106-b7fc-4ac3-99df-8664987a7afd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9e23f93-3c11-4119-b8fe-87a54aaa2f57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of CoreOS configuration.
@@ -3999,10 +3999,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a29bd64b-b20c-46cf-85b6-a3c7773f7d59" control-id="ia-8.3">
+    <implemented-requirement uuid="f95af47a-ef4a-4f5a-8b74-330c4063104c" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="357cc04a-0023-430e-8df0-df4f29328f6e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="502997de-f156-4703-a2b5-94b93c984bf5">
+      <statement statement-id="ia-8.3_stmt" uuid="3b8e8f20-e66b-46da-88d0-dea35b8f96ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fd1c869-9bf2-46d3-b6e7-ac4179f9757a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -4013,10 +4013,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85d0b432-3f2a-4fa8-b497-8189790469d8" control-id="ia-8.4">
+    <implemented-requirement uuid="75184568-9d36-4b85-93da-89bd20786246" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="75e6fac5-6f8f-4a0c-b452-5877c033201c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9917fc91-f21b-4ce2-9d3d-cc1852d40037">
+      <statement statement-id="ia-8.4_stmt" uuid="8b9a54e4-f379-4f74-9cbf-291acd9b7af7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75876a5b-6071-4a72-9c51-a8304a1ca69b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4025,10 +4025,10 @@ https://issues.redhat.com/browse/CMP-335
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bba58628-4b8b-4a3e-9b0b-2078d924508d" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="dced106b-ce17-47dd-bc61-6a104eca2368">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="093e385d-884c-4300-9f3d-2c61e77d2ba6">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4036,10 +4036,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4230e2bd-e1a8-428d-9520-3db984ef4d48" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="5deab365-1d82-4a03-a962-31d730227045">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="adffb49d-50bf-4b83-8b6a-b0eac16c2731">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4047,10 +4047,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac6711cc-e40a-4d04-b8c6-be818baefad3" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="9bc78bc8-dfd0-44e1-99a3-ddc25f57d474">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="03a3f21a-f3a8-4edc-a9f1-2fb33bcea56a">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4058,10 +4058,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9500e94-0771-4ae4-bf75-a67effa0b52e" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="d893753f-eea1-4f85-80d6-794948548e43">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c147d370-0684-4689-9de0-b75fb0a5bf74">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4069,10 +4069,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fed6454a-959c-42ef-9427-79b1a16096a1" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="0a03c363-c09e-4438-8231-ee838f5ba768">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b41517f0-09d8-463c-9d45-38b0ed8d6798">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4080,10 +4080,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35ff8069-ac18-446a-8246-a2f30342774d" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="c6e41476-1145-4522-a297-62138303217d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fdcda867-6816-4978-ae4e-bdc4a643c066">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4091,10 +4091,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="212e8db4-47bb-46d8-9298-13d68dca9af1" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="295bad4e-cc07-4701-8ab7-6965e696f246">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="77c30d19-dd20-4ac8-b07c-acec4ac81068">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4102,10 +4102,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40a32806-af40-4391-89d9-e5f7c1ba2010" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="9358692f-8ef8-4812-97eb-be34dc81fc61">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1165f27b-8655-4b74-8e14-ec00e3cbe38d">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4113,10 +4113,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f59bef0-7e23-423b-9bf0-3135a1851f4f" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="a0f40128-bd40-485e-a873-8547a82e1561">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="88e400eb-1ed8-4a72-a7fe-169a7a38a340">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4124,10 +4124,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d743362a-22ba-487c-969c-934d02b87ba7" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="6cc6ab34-811b-41dc-8569-39edad1028d9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e39596b5-bed4-421f-be01-04c4a30a7e74">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4135,10 +4135,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="beefa539-db30-44a7-b50a-4c1cbf1fcbd0" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="5a67d5de-cfa9-474d-935b-f9962b30eb62">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2606fe14-401b-4ac8-9647-8091cfc2b0f5">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4146,10 +4146,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b46ff3be-9167-4690-bdeb-1c4fb0446c63" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="8023f115-874f-4772-9eb7-94a7a44ab834">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="95016291-33b3-4790-a74c-b3c252f2714d">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4157,10 +4157,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bc6337a-d5ef-4ab6-8af6-45fa6bb837f4" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="9fde618c-e2e3-4ba6-adf3-deb944c150a8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="59782e2e-8894-4fe1-a033-ac1d913f0d21">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4168,10 +4168,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d74121e-d672-4fbb-9243-73dd83c75d40" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="432ab439-6260-424d-b431-5334a0d5dc98">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f5bb0cec-1c45-46ae-bec9-b3962610368e">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4179,10 +4179,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3341e85b-7cd2-4b8e-839d-800de5bedf0c" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="f5be6aff-38b7-4586-a2b3-00664f75a9e6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a904ff61-d62c-4bae-9a19-06e24e027457">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4190,10 +4190,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="613dc5a3-dbc1-4a25-9493-71fc2349d1d5" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="01378db8-c7b6-477d-9e87-7442f37f5d29">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a2067fbb-8f57-4df1-89ee-ff7be67c4073">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4201,10 +4201,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="815074ce-9ed0-42d8-82ed-acffd8e17d28" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="86991aed-a5c2-4d2d-b1bd-eac6a5056977">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="75fd71dd-cea6-4224-8812-76b6603eaa02">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4212,10 +4212,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="088c72f8-425f-4d16-b8a5-54e518f0655c" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="b95e8d63-dba9-4969-b000-00002de1fecd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4ebd3f1c-648b-4942-b432-9fd29ef6f1ff">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4223,69 +4223,18 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0329917f-7110-4d2e-8f32-d6d986f88691" control-id="ma-1">
+    <implemented-requirement uuid="50b14c60-c01d-4085-a382-fa457b35fd61" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="d768eefd-4f88-4e45-869c-bcd40a1a77e9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c5c8caf6-7775-4e42-a89d-28cf2d80d562">
+      <statement statement-id="ma-1_stmt.a" uuid="b6f304cf-f3d9-47d0-8518-a57d506847f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="9486e5f8-ab8f-4640-9237-7a5ec35950eb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7c65b30c-3269-46db-bc56-e994316b8c2d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="e788bea3-a94d-4162-8294-bcbd07f7cc8a" control-id="ma-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="698c11a9-14ec-4d59-9df1-6729604a7df9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="42f92a03-9f45-4fc6-b849-f09558499cd8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="fb01c614-a62d-42ef-b522-efa6558b3071">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9951bfb0-3628-4285-a397-8b98fa41127c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="2b7a5a72-386a-4c63-86d7-ec8c24d0f887">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5126298f-1c08-45b7-a39e-8a8d3bbe1001">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="6eeb34ee-5f64-4a3c-af16-3ab92361e758">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a0c0563c-6752-4d22-ab2f-d24dc321bee8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="bff76f5b-8ea6-4b84-9ef6-5661aadf59ef">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4eb77289-2d98-468e-b136-a8eb3781fa6e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of CoreOS.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="a90a6c62-eb56-4f97-ab4f-de6eff3dcd79">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0122259a-0cfd-4d77-8bb1-cd8879bcf515">
+      <statement statement-id="ma-1_stmt.b" uuid="71cbcfa2-f0dd-4327-9039-3bed09db8ad7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4293,10 +4242,50 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e077688a-8313-4aea-a141-157b4d4d6b6f" control-id="ma-3">
+    <implemented-requirement uuid="7f9d8c44-fd37-4b6e-b97f-73ad22f8bbf1" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="13624d7d-3b28-4dc7-8a2a-c9c341b998c9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9f2ebb22-cb0e-4c56-a96d-fae8000ccb12">
+      <statement statement-id="ma-2_stmt.a" uuid="9126811a-76df-449c-abf7-e0430a8b6464">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.b" uuid="11e3771e-3161-49c6-b9e7-b28e08121dae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.c" uuid="789faac6-28dd-454f-9f45-f4fd86906164">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.d" uuid="50d4caae-391a-4c9a-be44-1f7740100c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.e" uuid="d6374385-f18e-494f-9c78-5b28c007825f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ma-2_stmt.f" uuid="98d0fbb6-3723-4fbf-9375-d4060f218d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4304,10 +4293,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fa140f3-2049-4495-8140-ee198542f703" control-id="ma-3.1">
+    <implemented-requirement uuid="be52b005-e2ff-479d-94a6-a6e188d751ec" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="da000ece-2ef0-4bc3-8e8f-f4cd9bfceb40">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="24783093-a63c-47ec-819e-d66e5f2823cd">
+      <statement statement-id="ma-3_stmt" uuid="dd03bb5b-d84f-489b-b97d-e98e991a6b75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4315,10 +4304,21 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3475da1-726e-4211-906e-9bcb12b3a698" control-id="ma-3.2">
+    <implemented-requirement uuid="c522921d-0e04-4791-801f-dd09b4e463d1" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="e15bd62c-19e2-40b5-8ef1-fdab0cdd83b3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="63d34c2b-6a38-467c-addc-d57d391e34ff">
+      <statement statement-id="ma-3.1_stmt" uuid="f0558790-7ff1-4071-af13-7c6d1eec9a1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of CoreOS.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="4379d187-09be-456c-83c4-b0484cc43e9a" control-id="ma-3.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ma-3.2_stmt" uuid="237ab4d2-5f79-49e9-875d-5b8e724a98d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91c9aa24-7bab-456f-b192-2b42502e6917">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -4327,10 +4327,10 @@ system is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36a5b60c-1b03-4b22-b56f-95ac21e071e2" control-id="ma-3.3">
+    <implemented-requirement uuid="12e93686-78ba-4c88-ac0d-e38065b6b708" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="9cd7b118-5b3a-4f80-b681-5ed254fdfb95">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="010609c0-9893-467e-9239-5420383e79ce">
+      <statement statement-id="ma-3.3_stmt.a" uuid="9655b3fc-abdc-4b78-8572-c65edffd9d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a6bb18f-ddd2-4f22-bb5c-a486938a6f4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -4339,8 +4339,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="a2820f33-ca29-4047-b60b-df9891832649">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f2482d57-18eb-4ccb-8ff2-dd9e9f56848a">
+      <statement statement-id="ma-3.3_stmt.b" uuid="841bee45-cb0d-44c6-ae9c-cc2dbd74ec38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="85ed37c7-1058-4173-98be-68e27ffa7c68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -4348,8 +4348,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="6f51b080-3808-4cab-9bbd-dc63c596b8cc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="11638f03-2bce-4f6f-9169-332a300f541b">
+      <statement statement-id="ma-3.3_stmt.c" uuid="f7878744-e864-465e-9d0d-5d2c375062fc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f66a31d7-b889-4ea9-a2ee-6eaad43683bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -4357,8 +4357,8 @@ facility is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="60c55562-23ee-4824-b610-1e1ece31d61e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7929efbe-195e-4b11-beda-8bb9ffbe060a">
+      <statement statement-id="ma-3.3_stmt.d" uuid="325407f8-d9e2-4643-be05-210fde8809e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc35676f-af48-4e0f-94f0-fee75f18899c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -4369,18 +4369,18 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b0880c9-63fe-4d6b-a923-f3e5030deaa6" control-id="ma-4">
+    <implemented-requirement uuid="e38aef0b-901e-4933-b193-830da092e215" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="739deb88-f712-4b8d-aae7-199bc1c9951f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6d2ca1a2-cbf8-4311-8a99-43f8f76b83eb">
+      <statement statement-id="ma-4_stmt.a" uuid="9b4fa041-4366-499f-9dbe-aca03562a942">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70acaca1-c029-4a48-b6c6-a29275ac6879">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="c2d562b3-93fa-407e-aeee-65e53bb99956">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="92b08faa-d856-4e14-9cfd-dc1b7cc959bf">
+      <statement statement-id="ma-4_stmt.b" uuid="68f4a8bd-5e99-4f80-9089-45a252290af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e635f2e0-b395-48f6-832b-d60922bbc7a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -4388,8 +4388,8 @@ orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="37090902-d2c2-4d31-8be5-58e4ce4cb879">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="07197f16-1376-4cab-a3e1-0ca15e0c24bd">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4397,16 +4397,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="b9a9e11d-9436-4e00-99a3-980c16736a6f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b034d3f4-d326-4ff7-8de8-8e86865280e3">
+      <statement statement-id="ma-4_stmt.d" uuid="ef043a60-760f-4c9e-864c-01dcea2b9f93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18daba6d-0a0e-4309-846f-cbc8a83b60fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="ef4d06dd-d5b4-4724-9a23-fa46df1be796">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="15d16f4a-9eb3-443a-a682-25d236cfdc13">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4415,10 +4415,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8963bdb7-46ac-4233-a866-db0ff3b0b9fa" control-id="ma-4.2">
+    <implemented-requirement uuid="477eb849-5756-413c-b539-913cd96296c1" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="827e6b46-571d-4985-9252-71b9b9ac053e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8b6ce5be-6193-4aec-8dc2-c19f23a9db64">
+      <statement statement-id="ma-4.2_stmt" uuid="2f10933f-a75c-46ce-adb8-3a12ecdbc5ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4426,10 +4426,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c50316d-fde1-4a0e-9ef0-47d696e6b4da" control-id="ma-5">
+    <implemented-requirement uuid="60cf192b-4c54-49e4-9491-0ba3a68e05cb" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="b4010973-4300-4c55-9063-d032f4a9923f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="838616cf-7996-4643-baa3-e2900415dd61">
+      <statement statement-id="ma-5_stmt.a" uuid="2aeae088-c7e3-41c5-87da-95515fbf80c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4643d896-4c18-4a1f-8e5f-2fc5e15b8728">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -4437,8 +4437,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="619843d4-ec2b-4a8f-9046-26ad6331be7a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="41ef69b9-ae68-4e1c-afb9-5898c701788b">
+      <statement statement-id="ma-5_stmt.b" uuid="fc9cdbb1-004e-4786-8dab-904941239160">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fd5cf2e-d52c-4bab-afb4-912b678f8e60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -4446,8 +4446,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="acd0cf9e-b363-4966-8d10-3800ce44881b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e2ac80eb-dcf2-43b4-b8b1-73cfde41db6f">
+      <statement statement-id="ma-5_stmt.c" uuid="1bc8381b-03f5-4434-9f66-8a0d45a42c2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31a876f0-3b3b-446b-800b-b65e77a928e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -4458,10 +4458,10 @@ scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1f93531-9b1e-407c-a2a6-f770b637b365" control-id="ma-5.1">
+    <implemented-requirement uuid="a407480d-7ff0-4fff-ad65-2dc4961feeb7" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="8bdcb1e8-c3c4-48da-b430-e4001b58ae1a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="774cd57f-eb96-4dc6-ae43-04d9f3e0fca6">
+      <statement statement-id="ma-5.1_stmt.a" uuid="c78267aa-b035-45d0-8b1f-afd653caa783">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e76c9677-6fe2-4e40-835e-8d94057b7ce2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -4469,8 +4469,8 @@ citizens is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="2dfb84e6-1b63-473f-98e2-2bb2204430ef">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8f3f8f3d-08fd-409e-a1eb-f1341ff1b185">
+      <statement statement-id="ma-5.1_stmt.b" uuid="dfc4e419-5d32-46c2-ad2c-edc3e5768bcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fea33215-9f04-494e-ad08-e870fa9a747f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -4480,10 +4480,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2c7b8da-1c8c-46da-a915-481db77ed73e" control-id="ma-6">
+    <implemented-requirement uuid="b76ac05d-9b0a-45c0-b761-e5703e10d170" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="86928d03-37d4-4a1f-b637-252bf9c4c7c4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="977e718d-6b2f-4136-861f-3ff54eefaa4e">
+      <statement statement-id="ma-6_stmt" uuid="8ee4443f-6c07-41fb-a14a-8e96c70a6ab1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -4491,18 +4491,18 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cbb9abe-c16f-4363-9800-ff703844cc2e" control-id="mp-1">
+    <implemented-requirement uuid="db6de972-7474-4a78-928c-103473959819" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="04b03efe-544d-4e1b-aa6c-3726acbd591e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8a597a4e-e127-40bf-af4e-f4e431799abd">
+      <statement statement-id="mp-1_stmt.a" uuid="323ea68c-9123-4ded-865b-111d13e5bc8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="cb2fabea-1a6b-4a73-b9c7-d09de75ee2c8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fde6782f-0935-4130-93a1-041508698fe4">
+      <statement statement-id="mp-1_stmt.b" uuid="0097f982-adc9-42f4-a94f-7ad598d57f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -4510,28 +4510,28 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c894d91a-9cff-4bb3-9068-f04fa157b104" control-id="mp-2">
+    <implemented-requirement uuid="98250c5d-4122-4fae-8c8e-5a991dfb578c" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="998682e8-a933-45d5-89cb-313232e141ad">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="49f84422-92bc-48f7-b9c9-3ba2cd1b739b">
+      <statement statement-id="mp-2_stmt" uuid="0e13fba7-27c8-4803-9ec4-8677e06d9587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="824001be-857b-44cd-8341-d4758e5dce4b" control-id="mp-3">
+    <implemented-requirement uuid="025a8033-119c-45f0-91f1-8edc6c28faf2" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="56bd475f-3977-455a-87ec-f7b33a26af66">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d035f2a8-6228-48fe-8fba-fa2cfc055f52">
+      <statement statement-id="mp-3_stmt.a" uuid="0d3c80ed-ff0a-4ed9-9950-e71d07a65278">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="2a2a6770-b170-49dc-ba24-149bb6e3181d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fb19ea8a-20dd-47d3-b4cb-a7cff03abeb1">
+      <statement statement-id="mp-3_stmt.b" uuid="bc2e6de5-0c28-4a15-8fa1-63f0886effd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -4539,18 +4539,18 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eabb00f3-c548-4f78-bc25-ee7451a706f3" control-id="mp-4">
+    <implemented-requirement uuid="1af33049-40aa-4604-827f-bf30ad77d2ba" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="f79e3360-7142-42de-96f0-f12ed7e7497b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4dad128f-1dbd-44f0-b14d-5d4f921c90e3">
+      <statement statement-id="mp-4_stmt.a" uuid="1c91c49e-c2d4-4a51-b312-0f1e9797a955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="e2c6da7c-1323-48d4-a034-06f93240e507">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0cf370b3-66ef-4c28-9068-d9210cb758e9">
+      <statement statement-id="mp-4_stmt.b" uuid="1afe60cc-bcaf-47e1-8fb0-3f2a7622b7a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -4558,34 +4558,34 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c76b874-4ee1-410f-aae2-8bea0037c939" control-id="mp-5">
+    <implemented-requirement uuid="769abcc8-05b7-489a-b785-f9e42ad6f9ee" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="47c0ac32-8b21-4a90-9d23-8601e51a5849">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5834a152-67bb-46d7-9b59-9a7b71bd1c04">
+      <statement statement-id="mp-5_stmt.a" uuid="eedb4e7a-1800-4f97-9c36-e3dc66c21501">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="cf0974fd-ccd0-4627-8aad-f7c65b957bd9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c728d060-d17b-41fb-91f3-1dcb6503327a">
+      <statement statement-id="mp-5_stmt.b" uuid="b54b9175-1652-46ba-b64b-2957dac00e07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="6d81b044-a17f-4ffe-824b-178adb0e00b6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="deceef91-ab73-4791-a52d-c71f352e73e7">
+      <statement statement-id="mp-5_stmt.c" uuid="c3d78544-835f-43f7-944c-997901ec399b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="7876ac6d-3ef6-4dc5-9d00-18e19e91d6e6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4dd3be5d-ec39-4aa6-8eaf-7c5c52c63f48">
+      <statement statement-id="mp-5_stmt.d" uuid="2af91afc-267c-4bf8-ab52-1019803c1eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -4593,28 +4593,28 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c6f11c8-570a-4314-9f65-02f6b87af802" control-id="mp-5.4">
+    <implemented-requirement uuid="1ad9ffee-54ac-4cdc-a721-9f1cf774e66a" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="848f396f-1e11-4f75-9744-55e206318914">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fd2f69c1-7669-41f5-8a80-1deb50340117">
+      <statement statement-id="mp-5.4_stmt" uuid="34ce79f7-2335-4852-8d02-0a89e7ec4857">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ff74755-3c07-498a-a7d5-ec45e7b15cb7" control-id="mp-6">
+    <implemented-requirement uuid="c7724dcc-1780-4c27-ab8a-4948baa96830" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="6651be73-3157-4e16-98c1-f9aee2dfce13">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="47ee4760-ac9a-4cdd-b621-b3f88e3d02cb">
+      <statement statement-id="mp-6_stmt.a" uuid="bf44b130-318c-4ea9-8b11-917cc390dde0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="f328ae13-f993-471e-8ee9-bf908b72d515">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a07ec623-90d4-4f43-964b-a1a6ae4f64b1">
+      <statement statement-id="mp-6_stmt.b" uuid="065997b5-c670-4635-ae8b-c011cf223764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -4622,20 +4622,20 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="410bc72f-5e3a-4382-958b-10c9eca4572a" control-id="mp-6.2">
+    <implemented-requirement uuid="18e5101a-f9eb-4518-b493-428411cafb6c" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="2651f139-ff2a-427b-a1bc-c14bdd16627c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e2f9b606-bb92-4ac8-8947-2dc49fde900a">
+      <statement statement-id="mp-6.2_stmt" uuid="f8a891e8-46cc-4f93-94fa-e24961fd8e99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0590f9ad-fc05-48fd-a261-4af473464335" control-id="mp-7">
+    <implemented-requirement uuid="6ac60336-91b5-4c2b-97e8-4fc19d3f4d01" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="31774a90-9cb3-443e-96df-b487c83893ba">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e8563b44-35a5-4f9a-8f36-7315b2368d96">
+      <statement statement-id="mp-7_stmt" uuid="53a598db-cd5c-4596-83c8-a23ab639973e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9b28071-a891-4e8a-b0ab-da77b0872c8e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to CoreOS configuration through such
 actions as kernel module blacklisting. A full control
@@ -4647,20 +4647,20 @@ https://issues.redhat.com/browse/CMP-351</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f319d9eb-47ca-479d-bbb1-b62a4b360d56" control-id="mp-7.1">
+    <implemented-requirement uuid="54ec318c-921b-403c-8c13-2d29d0e6de79" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="bdc41d1c-55a3-41ff-8a43-f4c4936c8062">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cc7a6e23-7c3e-4484-878e-60d79fce3c79">
+      <statement statement-id="mp-7.1_stmt" uuid="d63a95b4-8b3b-4f55-bd24-cae7caa4fe38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b72fd-5cd5-4a04-8544-c4d9619bc340">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3369ae4a-d1c4-4015-b3a6-aa71f1ffbfa0" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="02b23773-fb56-4ec9-8e41-d29f1538e615">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b4e21a78-23aa-4a0b-aebe-f00831205704">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -4669,8 +4669,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="b5103c4c-fb90-4556-bce1-e4f9afad92fa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="645c5eda-9a71-4462-b160-a566d6a46674">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -4680,10 +4680,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6546c34d-110f-4315-a577-4b26991e3983" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="27672b3a-dd70-4864-9166-3ae6f4f5bdf5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ed51c799-a7ae-4dba-97f1-cbf6becd37ab">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -4693,8 +4693,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="beddc570-999e-4f86-9ad4-e7243e855809">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fb3e26ac-0f18-408c-a1d2-3f9f767416bd">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -4702,8 +4702,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="180e1c81-25ad-4f60-8b4e-8d5c023ead20">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f4c0ba5d-5d62-42d8-a796-74859d1ded14">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -4712,8 +4712,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="4d2ae367-0696-42f2-918f-def444b85c04">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d8e52326-50da-44d0-a761-03b747e2bdf8">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -4722,10 +4722,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55639e08-6015-478a-a040-4a7740f6e555" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="e5de49bc-2955-490b-a1e9-9d7642df7bd8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5d109675-be74-45fc-8d7f-ddff9cac0af9">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -4734,8 +4734,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="43213827-6483-4e96-bc5b-a2521650163b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ba18a451-e7d5-4b84-b31f-8eae8f8a8106">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -4743,8 +4743,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="8d073bc2-a882-413e-8589-940a3e421a6f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2362c736-cbd9-430e-adfb-6d395bec2638">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -4753,8 +4753,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="ff3e01d4-80c3-415d-8345-512bd8af5979">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4afc8ad1-42ad-4344-860e-c2698bea017e">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -4763,8 +4763,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="1c94cc05-96f2-4864-9688-8a4bca2a75ea">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b0248888-2179-4a33-971f-c045a4fa4d97">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -4772,8 +4772,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="7e0040af-22ce-435b-b6db-0e813dcd9beb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c3ef8cfb-4dbb-4d12-a19c-6715a8cc0e05">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -4782,8 +4782,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="0eef95a9-fb05-4f04-919f-ad58e875477d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="072c3b12-a4b7-4d39-bda7-1b4dd1956dcb">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -4793,10 +4793,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="634096bf-ecce-476e-ab00-81ae29fbca44" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="2475519c-ccf9-4025-9274-2bef60246105">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="01f14f8a-8f61-4d71-b2a2-f9d3903e0318">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -4807,10 +4807,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8c8842e-19b0-44b8-87e0-0764106d3865" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="2c4978b7-594e-4d7f-80eb-59e4147fcaf7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fd206621-7052-41fe-9b9b-a5a712f36915">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -4820,10 +4820,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82486be3-1cd4-4845-9a7b-70a411da08b9" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="969b0fab-30be-424e-9049-f2e8e3837a9f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2301c481-2b7c-4981-9f1b-fcf76f585dbc">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -4832,8 +4832,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="35a131b3-ebfe-4202-a94f-b197dd229c2d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ca4d575b-689a-47e4-8f1b-aca8b53a8ea4">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -4843,8 +4843,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="9d1ef7f7-37f3-435a-baee-8c8f80a3aa62">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="03692fcd-b0f5-427c-a527-c45932d7e5a0">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -4854,10 +4854,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07a67642-ff08-4de7-bc08-a7e8148f4eea" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="620db5f0-571b-4c8a-8699-43d0eac1270e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8c241033-3d8a-4ddd-83f1-13d468cc64ef">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -4866,127 +4866,127 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96390223-c7f1-4f00-9bd8-a97c32cd5671" control-id="pe-8">
+    <implemented-requirement uuid="b9f38e4a-2e80-4aa0-ac02-213d63b5f964" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="72f4c22a-07b5-4344-879f-5c5c417bb019">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d2b80077-a2e3-489b-95db-75f66f84f2d4">
+      <statement statement-id="pe-8_stmt" uuid="3dbccc27-b1fb-4181-b57c-6c97616584b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="887b3f49-1260-443c-9381-56dd364998a4" control-id="pe-9">
+    <implemented-requirement uuid="f9f4b119-31ab-4b7f-8916-07f8a22a3523" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="d4a8de7c-53d0-40ca-93a2-03cc20854931">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f0b6bd63-4060-415d-b563-3a53ae7bee08">
+      <statement statement-id="pe-9_stmt" uuid="78d35767-66e6-434f-8b8d-5278419de9a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c457d33a-b0b2-4c4d-a431-4c50083d62a6" control-id="pe-10">
+    <implemented-requirement uuid="87455508-8dd6-4207-b55b-e4d92917f6d6" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="9021ff6e-1ffe-4858-a996-86952fa193bf">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="78bd900b-b143-4a02-bf35-454cb5345dc7">
+      <statement statement-id="pe-10_stmt" uuid="77205cc3-91f3-4ea3-84ca-ee75581e1e4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3f1d873-9d73-47ae-8725-eee8d04bc4ac" control-id="pe-11">
+    <implemented-requirement uuid="396b23b6-bbbd-42a5-88f6-43da51f0bb1f" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="429ae47d-15ed-4210-a0c1-dc597ad775dc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8746d0a4-9dff-4dd9-932a-93ea2e7d5fe0">
+      <statement statement-id="pe-11_stmt" uuid="13c54bfa-dd61-4a09-9b31-e8baa38aa4e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5587451e-d60b-4487-a1e5-1462f508a5b1" control-id="pe-12">
+    <implemented-requirement uuid="bf2148cd-725d-4d33-bca9-e6059f48ae69" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="9e9b3110-1e26-4dcd-8f99-97b49e904ee9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="271335b7-b02a-4141-98ac-e2923d11fb10">
+      <statement statement-id="pe-12_stmt" uuid="1ba7c150-e414-4755-acbb-b677abb04a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dd64479-4ec1-43c2-99d2-3ff0cc71ed9d" control-id="pe-13">
+    <implemented-requirement uuid="67ab882c-0e48-47d6-ae34-e14e8eed800e" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d9207223-9846-407a-a69e-3d229167e18a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e92280b5-7ce5-494f-8d15-bbb768a01454">
+      <statement statement-id="pe-13_stmt" uuid="cd19567e-4199-4191-88dc-f8a79f7fe5b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac38e20a-ceda-49e2-8aae-37ec283e7f52" control-id="pe-13.2">
+    <implemented-requirement uuid="5318475b-c454-4729-907f-5b140615f3c5" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="73db85f3-6bb7-422e-b9b8-2bc69f8dc0a6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e614e3f5-1084-4263-b37b-201a7ae7164d">
+      <statement statement-id="pe-13.2_stmt" uuid="99bd783b-7ef5-4e4b-9502-352f59798c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82b80dd4-3a81-4231-8eea-d4d26addd180" control-id="pe-13.3">
+    <implemented-requirement uuid="d291abfc-d0bd-45bb-9fc3-36ce1fe22d59" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="d6c71ab0-2020-4f6e-a736-c713580aca99">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="59af2607-ecb9-4fc4-8fbd-b01f0758e257">
+      <statement statement-id="pe-13.3_stmt" uuid="e363535f-ae2d-4e5b-8b2a-a5a713e44f49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6f3911b-081f-4a2a-80c2-526e2049c3fa" control-id="pe-14">
+    <implemented-requirement uuid="98fb3296-437a-496d-853b-92c71a0b01c9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="dcd27fd1-1388-41f4-a848-efab5c2e64f9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a50c9790-d9de-4d38-8644-3e836edd31e6">
+      <statement statement-id="pe-14_stmt" uuid="f410cb6f-ecea-42da-89f1-16544b34d9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d3ff087-b649-4c9b-ba14-1f0403c1d9d4" control-id="pe-14.2">
+    <implemented-requirement uuid="6d838923-a33c-41e4-ad07-dcc1e8183353" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="ed56a531-6502-4340-83e0-3fc7ffd83c5b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8eee2b34-900d-4409-b650-11a61fd3547e">
+      <statement statement-id="pe-14.2_stmt" uuid="348023ee-2218-48da-b632-51741a234bed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f78219e0-e870-4851-8868-89e305353114" control-id="pe-15">
+    <implemented-requirement uuid="3b494e54-817a-4771-a20c-62d7508a39c7" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="e259b665-782d-4e5d-8f0d-a5c52df325af">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f14561d3-a3fa-493f-bede-41a67a862c99">
+      <statement statement-id="pe-15_stmt" uuid="91e060ce-e238-4e32-a2e3-2c485523f69f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf765b5d-52f1-4af2-8908-f34e896f8161" control-id="pe-16">
+    <implemented-requirement uuid="a3e84d2f-1ed6-4c19-8c72-25e6cdde0d46" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="c38d9361-4369-4dd8-9e00-8ae6854b966c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b8ae6c74-f1f5-4ac3-9cd7-81b6ec030d96">
+      <statement statement-id="pe-16_stmt" uuid="acde645c-992b-490d-b159-d6d5576e2bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9ec0529-5c41-4725-aac2-e39f6a18b541" control-id="pe-17">
+    <implemented-requirement uuid="0c34a9a9-de9f-409f-9ce0-1fe6cb861ad8" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="f8737491-2fb3-4ec7-a2d5-ec7ac3f62741">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0b60b3e2-7275-426a-8a47-7573ac90c5ec">
+      <statement statement-id="pe-17_stmt" uuid="9636f382-0552-4eeb-8a10-cad17bb743e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0834968a-bcbb-45e7-acd5-3b8a4c7403d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of CoreOS configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21fe8916-671d-4e92-8fd7-33f36736ba22" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="e425361d-991c-47b7-b274-c98b12ef6f25">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="55f9f971-adb8-4350-8704-6dc33731ac43">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4994,10 +4994,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6b469ba-9486-4b3e-bcaf-39e0bdb5df5f" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="f419a12c-5306-4eb5-953f-6df56e2c6dd4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9c7b37ee-8c3c-4813-9c7b-04db0e0217e0">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5005,10 +5005,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dbdd56a-025c-4f95-8d3a-78bcbe43ae72" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="aeef6377-e400-4ff8-9dae-0a33ea190d0a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c1b51179-112b-4674-b3e2-d82b13ae35f6">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5016,10 +5016,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb5235ef-b9f8-4807-b703-043836dac6ee" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="886fb663-a6b6-4f90-841d-3890c9253da9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="33506c46-97c9-4f8c-a39d-6790a82eac50">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5027,10 +5027,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af127174-7f59-4f7e-8ad7-2bcd1a40c11e" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="7ca7b569-74d4-4ec2-805f-4ec316e505c9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f8d0f375-76fe-4eeb-b55b-979a93e64f9f">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5038,10 +5038,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eab86505-dec4-4a23-a315-d3a9cda64ca7" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="bcd743a4-62b6-4752-89fe-ae122b9478c2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8f76da21-32fe-4638-befc-9b09ca569caa">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5049,10 +5049,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1885fc42-721c-4d57-a761-3b33e3ea6091" control-id="ps-1">
+    <implemented-requirement uuid="0d6fc93b-9959-43e7-ae1b-0fab7ac39726" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="08353160-5b13-4c70-b9b7-0b1240136fa4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="661c4835-3467-44b1-8973-ce3bbc6407cd">
+      <statement statement-id="ps-1_stmt.a" uuid="484243d3-184b-4b25-98c7-ce076f11694f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5060,8 +5060,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="26a17466-bcf5-44ca-9c67-58b40bb9fa93">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0cebfc9f-8840-4e81-b528-588aa3332cbc">
+      <statement statement-id="ps-1_stmt.a.1" uuid="e90c6c0d-1a1d-4b71-a894-3f62807bd565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5069,8 +5069,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="9d70d598-825d-4f74-87a0-163346f1d059">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="344c05e7-8caf-4244-b21f-f0ecf662ec90">
+      <statement statement-id="ps-1_stmt.a.2" uuid="ad2e7acc-28f3-403f-ac8b-3d73a4738beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5078,8 +5078,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="cec5ad33-3945-414e-81d1-95e3598ffca0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="33a8ff69-3bd5-4637-89c4-6737eda98227">
+      <statement statement-id="ps-1_stmt.b" uuid="fae8b684-9938-4b25-bb6d-8b44b03bb116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1fab7a44-4e0c-4a4a-b0d4-f65722d402fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -5087,8 +5087,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="1f133c78-4960-497f-84c1-ae86793e79cc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bbe07b90-9d5a-4882-9336-c218b7c5f976">
+      <statement statement-id="ps-1_stmt.b.1" uuid="388bd160-ca4f-4ecd-adb6-8d9b11e76c5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5096,8 +5096,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="b484cc8f-2314-413f-9b02-977616cbeb81">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f057b5bb-4768-4db7-a279-e5fd92d60565">
+      <statement statement-id="ps-1_stmt.b.2" uuid="9aba6ad7-81c7-4531-b797-ea7ab09eb431">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f27bdb7-0842-4af3-a282-e28aa90caa4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5106,18 +5106,18 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30b744c9-d697-4748-8471-ec8ed5f5a689" control-id="ps-2">
+    <implemented-requirement uuid="2063b7cf-d7c9-4a47-820f-192605a7c815" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="fc8a036a-4218-404b-a034-42a5b0463a23">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9fe19696-1ce6-4214-8038-0977899cf666">
+      <statement statement-id="ps-2_stmt.a" uuid="04f38777-f10d-4327-a851-9b634b75d3d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5470435-d97b-42f1-9cb8-e8ee2e6a3e93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="02f34f7a-1af5-4022-becd-33e1fcf8dbcb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c240ec01-51df-4152-978e-53fd3a3d2fd7">
+      <statement statement-id="ps-2_stmt.b" uuid="1cc918ee-67b2-4d62-8c94-ecdb6bb8bfef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc2e4b27-069f-455f-ba9d-b60e392f2594">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of CoreOS
@@ -5125,8 +5125,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="9ac82c8b-7e7d-432f-a7c4-9580848ba5f7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="af77d501-7453-4909-8d60-38c3b20522c2">
+      <statement statement-id="ps-2_stmt.c" uuid="042591b6-eed4-4da1-a24c-7244deea296c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68978f4e-23a3-4f5d-8f7c-f2b83b063eb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -5135,10 +5135,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb67d6de-3418-4079-bd9a-b44583f3eee5" control-id="ps-3">
+    <implemented-requirement uuid="60c3c056-17d1-483f-9781-99b6bf925ce1" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="74ccc625-845f-4fc3-8b02-923d5ae19303">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="046be293-824c-46a0-8b67-b5f0b35b62a1">
+      <statement statement-id="ps-3_stmt.a" uuid="9ea78d95-7f29-4f79-8867-d329d8d22877">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5499886-17eb-4843-960f-88b0489759fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of CoreOS
@@ -5146,8 +5146,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="f5558849-841c-4000-8043-41a9b14223e4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="95a474ff-e40b-4778-9577-74e74b6c33ef">
+      <statement statement-id="ps-3_stmt.b" uuid="eac234db-81b5-4efd-9a8a-6c1bf5d205a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04005097-2b0e-4353-b3d5-9bce89a97bd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -5158,10 +5158,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="581daf1e-e0c0-489f-8539-1c3856bdf6ce" control-id="ps-3.3">
+    <implemented-requirement uuid="3a12fb07-f633-470a-afcf-7c9b9d7eb8f7" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="faeb27bc-9705-4841-b5e4-4c9b68e63434">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3ab7abb4-f73a-4264-9f90-d6351a89d577">
+      <statement statement-id="ps-3.3_stmt.a" uuid="18c3f100-99ad-4d92-b0fa-12660062418d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eaccea77-dd4e-4b09-880f-1c2e403146e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5171,8 +5171,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="308697be-363d-4761-996f-2b26a3b07bfc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="662cc751-c089-49ad-a9a5-7bc640337584">
+      <statement statement-id="ps-3.3_stmt.b" uuid="d2c69587-74f3-4500-af61-7323363ac6ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40b961b6-1fe6-4af0-9c50-e55df3cff159">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5183,10 +5183,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="189eebbe-fb50-4195-84bd-9920bb39f5d7" control-id="ps-4">
+    <implemented-requirement uuid="da10f8fb-cc1a-4199-97c4-ee86b21da08c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="f9af60e9-1ba1-46a0-89e1-5cfa4b233b00">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e58564d1-dd6d-418f-ab64-86a29321493b">
+      <statement statement-id="ps-4_stmt.a" uuid="d7a444d7-a380-4f01-8cfa-3ed8c6d65386">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f5127ab-95d5-44b2-ba3d-9623d6a768f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -5195,8 +5195,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="fc2ff08e-fc76-4c9d-a137-5cdc5d67cde5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b0b90616-1a32-4cd3-87b1-c0798e9bf417">
+      <statement statement-id="ps-4_stmt.b" uuid="e1088a65-d6a1-4170-891f-afd60daa1151">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de39dddc-4466-41f5-8b59-20a8fbc7090c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -5205,8 +5205,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="005823f1-ac26-4597-8bb6-24a6746d4fc0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c9ce7b91-1a83-49d2-ba76-a2ad6d3011ed">
+      <statement statement-id="ps-4_stmt.c" uuid="c2914a86-37a2-48df-9651-f2d4fb21af3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71b8f8b2-f052-456d-9504-39e0c6e226f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -5215,8 +5215,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="3c83831e-17c6-4e6b-beb7-d91cf88fd6d1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="92d1c822-8112-4a18-bd27-cd29b12837eb">
+      <statement statement-id="ps-4_stmt.d" uuid="be7521aa-782f-497c-a2a3-327a5aa1f541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a8c3238-643a-45a0-a54e-3cedf8269e87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -5225,8 +5225,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="ea684506-b80e-4bb7-af26-d0e68b2f8d3a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="33d24538-efe1-4949-bfbb-13b31bc41e9a">
+      <statement statement-id="ps-4_stmt.e" uuid="d68f408f-28d5-43a4-88c8-ece7c6985979">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c74c79b5-8455-4a63-b3f8-e95436fdb805">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -5235,8 +5235,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="98c87cd5-2e82-4c0d-92db-0feda11c4693">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1c028af3-dd50-40fe-8bbd-286ba83548ee">
+      <statement statement-id="ps-4_stmt.f" uuid="84630747-db8d-4b27-8d27-2a95b929881b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f54285a1-8b65-49f0-8a67-e3eb9f3344d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -5246,10 +5246,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abcac66a-b97b-41e9-a329-2f1dc73261a9" control-id="ps-5">
+    <implemented-requirement uuid="b6f0483b-9352-4587-8500-bc8cd994e8b2" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="917dec80-d9ff-425d-8db2-43ca5945e9d1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e20f9ca9-c3f8-461e-9530-cd06c651d502">
+      <statement statement-id="ps-5_stmt.a" uuid="0aa3e87c-188f-43ef-9d7c-8ae9239ee640">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e279f94f-02ff-4a52-8b68-9e4cfab9c79e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -5259,8 +5259,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="b4de4370-0af7-4bb9-a9d4-f6c57185b2dd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="95655699-5e5d-4602-a046-5e867050ecf9">
+      <statement statement-id="ps-5_stmt.b" uuid="515c35fe-d4fc-4ca1-bd8f-6d5c45605427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d517900-4646-457e-87ca-8ab4718cb546">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -5269,8 +5269,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="cb06ccf6-5f3c-4f4b-b11c-6727bd8ddd3f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="534bb1f1-d703-47e0-85dc-ff5b8fad1da8">
+      <statement statement-id="ps-5_stmt.c" uuid="2edb4391-b20b-4637-b5cb-ecc09df29a6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b78e8a0-9ddd-4594-8dc7-9199f89e3683">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -5278,8 +5278,8 @@ or transfer are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="08002e2c-58d4-453a-9b2f-a24c430619d9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bb162b33-68ed-48b1-b873-731435baafaf">
+      <statement statement-id="ps-5_stmt.d" uuid="b8690aa2-ea61-46c1-b1cb-4dc2a85cf21d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aff56077-e3ec-4b21-a408-01fea0a64369">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -5288,10 +5288,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ab56129-87ce-4baf-bb13-b5358b693f71" control-id="ps-6">
+    <implemented-requirement uuid="dea9ff31-8a0b-47d3-a11c-99433ef1b31e" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="c0bc5f69-0686-4e49-b6ba-de5df997058b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="048e9230-2417-4888-a108-e9b12bcc2fda">
+      <statement statement-id="ps-6_stmt.a" uuid="2f66e87b-349f-4248-8a43-0c731a10769a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2b39e55-bede-4885-bb55-ba1da248bd38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -5299,8 +5299,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="241d0b71-a0b9-410d-9668-fa9c1d69fef4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cce7fd32-85cc-4779-abd1-706b86ca2828">
+      <statement statement-id="ps-6_stmt.b" uuid="eb94419d-f820-407e-9bfd-315a92e12daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cec67604-4082-4efa-bb6a-5ee320b38b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -5308,8 +5308,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="100dfeb1-2afe-4af3-99ea-502fcb0e1ed3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0126635b-2c83-42bf-8285-c3f0fddb2420">
+      <statement statement-id="ps-6_stmt.c" uuid="e800e662-52e1-456a-a977-23a39e42a5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5317,8 +5317,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="e43e7fce-fccf-417e-86ec-d03a4daacc1f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4df4e90c-cb82-46a1-bf5c-9ec3749e854b">
+      <statement statement-id="ps-6_stmt.c.1" uuid="dc15c108-e2d3-4f89-b89e-54e49db92a44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5326,8 +5326,8 @@ access agreements are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="03999ab3-1ac3-47ff-898e-9205e0278fea">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="131c9e51-0140-41cd-b90f-1fae88360793">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d4818871-64ec-4b32-8214-b515d02e8320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5b2fb2f-8f75-476a-908c-7b9a52ead7b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5336,10 +5336,10 @@ access agreements are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e3c0032-2e7f-417d-8f1a-8e778c0d45cf" control-id="ps-7">
+    <implemented-requirement uuid="3bf37c4a-021f-4b34-af32-d7b9fd6a2c4a" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="70f6602e-8954-4878-83a4-e39589b43bc2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d6493bca-bdaa-4780-9179-199ffef311e3">
+      <statement statement-id="ps-7_stmt.a" uuid="2945bdc9-ddf4-41d2-844e-dc72062bdf86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cacae972-7d2e-4057-b8bb-eb041b623dc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -5347,8 +5347,8 @@ outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="5c78bf2f-a282-456f-9ccb-ebbff549fce0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d54a337d-1e72-44ed-8010-921a568ddd5c">
+      <statement statement-id="ps-7_stmt.b" uuid="af9686d3-b729-4b9f-844f-16786efadcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1213e2d5-2797-4ce0-9f11-caaae82fa258">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -5356,16 +5356,16 @@ the organization are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="3d42a31c-2a9a-47ab-9124-b3ab71d45b7a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="54844fec-d7f0-4ad0-9b6a-3a1c38667316">
+      <statement statement-id="ps-7_stmt.c" uuid="c79914aa-3a49-4dbe-8922-c1c5c1e6f87c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c4267dc-3818-42d8-a671-cf44ca7e0d67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="9ea99328-5adb-4180-8566-b6da7259beba">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ca5b4f28-5048-472e-a91a-58678c2defff">
+      <statement statement-id="ps-7_stmt.d" uuid="2d9b350a-8f2f-41f8-be37-43e1f31a92dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9aa191c-a620-4f1a-9d6e-14795465a4f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -5376,8 +5376,8 @@ scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="20e62cce-85d2-4153-b11f-799e474ecece">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1ecdfc54-63c0-4b73-9403-e515444f36fb">
+      <statement statement-id="ps-7_stmt.e" uuid="dcd75ff6-34de-4d8e-afb0-24b21c914f89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="524c0b4d-63df-4619-9803-b2d1e87578ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of CoreOS configuration.
@@ -5385,10 +5385,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="331282ab-f910-4c11-ad9e-f6d39bd58553" control-id="ps-8">
+    <implemented-requirement uuid="144d6958-d305-481e-93ba-1855414237a9" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="a550ea89-b002-444e-9b56-04ea0cc805e5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="225ea0ba-a871-4a01-b617-48a6633dae0f">
+      <statement statement-id="ps-8_stmt.a" uuid="47324678-8588-405b-828f-6836cef02800">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7d7c773-0c79-43d4-afba-87dcde0f451d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -5396,8 +5396,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="d1b4ed99-ad5d-4870-a2c7-30e0c9294740">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ecdf9525-a968-496d-b282-60b1e1fc88b5">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -5407,10 +5407,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="932856dd-08da-440b-b331-0360fb6e4b9e" control-id="ra-1">
+    <implemented-requirement uuid="cbd41f9b-3395-449f-aabb-11982cf4072c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="e2f35fff-adde-4a42-9c08-f3ad1126466e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="89b43fab-73fa-4839-8461-c34e8c8ce484">
+      <statement statement-id="ra-1_stmt.a" uuid="b9ec47cd-c79e-4fec-b740-d0633a43b066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5418,8 +5418,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="339eb967-cbc2-4851-8c73-02696cda5f8c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d4daf804-631a-4a84-904e-687eb721c1a9">
+      <statement statement-id="ra-1_stmt.a.1" uuid="093b0873-cee2-4731-9145-4c5f9403b681">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5427,8 +5427,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="44d45f85-f73c-49c6-a7e4-43587f9fe8d2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c0cda8a7-689e-48c7-8ad2-157d9893a639">
+      <statement statement-id="ra-1_stmt.a.2" uuid="f4ac6d2c-45c5-458b-8dda-9b152e215b0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06775c8b-3982-4e24-916b-550b02d14098">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5436,8 +5436,8 @@ and procedures is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="38c52366-f041-4f6a-b6a8-58f9b9988905">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a8be45d4-e3ca-4638-b178-8b5af52f538b">
+      <statement statement-id="ra-1_stmt.b" uuid="18a2c73d-bd73-4bad-8a65-5327e87af997">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5445,8 +5445,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="5a7bd106-dd69-4db2-a1f5-1d9e1673cf26">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6f0a2857-902d-4f0a-995f-e2ee8f36102a">
+      <statement statement-id="ra-1_stmt.b.1" uuid="8ca1a04b-1ce8-4d10-86dc-998980760beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5454,8 +5454,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="d1f1b53a-5dfa-458a-a275-2999be368775">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0d8f1787-ef83-468c-91e6-80057186998a">
+      <statement statement-id="ra-1_stmt.b.2" uuid="73006780-8601-4739-9bf4-5f9a34cf6373">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6418ffc-3939-410f-8f6d-94c67547d7d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5464,10 +5464,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11ffcee8-86f6-49c6-835d-3e07163101eb" control-id="ra-2">
+    <implemented-requirement uuid="dd4d32ed-c9ee-4c8d-983a-8519b85d93fb" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="639e9395-75b5-4b4d-bd33-5077c71bcb7a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3f8cd6b8-72a9-4351-9981-ebb6e65f56ee">
+      <statement statement-id="ra-2_stmt.a" uuid="bd55c578-2e02-43dc-8d2c-dae6909ff532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38e8d6ad-482d-41e8-a9dc-077244810b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -5476,8 +5476,8 @@ guidance, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="13d6668e-1c9c-4270-b2d8-e9aa59605c5e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="98f777f2-c8aa-4276-a684-898f3439b568">
+      <statement statement-id="ra-2_stmt.b" uuid="02c243d3-21db-4500-a429-f6a93169cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="827fbbd0-994f-4551-b04c-4839494e133d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -5486,8 +5486,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="cc2611b6-d995-4d14-8fab-aad0a227b0cd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3a8c69a6-0b3b-4900-89a9-3dbaefbe7674">
+      <statement statement-id="ra-2_stmt.c" uuid="a761f6b6-b88c-427b-b219-9b6133c05196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="222b3d51-4fb8-42c4-8b2b-00b40d003325">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -5497,10 +5497,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36d6da64-4e07-41fa-8f67-b8641c0c3137" control-id="ra-3">
+    <implemented-requirement uuid="a91d978d-76fc-4f91-996a-ec3bd70d2f20" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="783e2dd5-62ad-4a4e-ab26-96500872deab">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="10c7593b-78b8-46c1-8a24-5ebab18dda20">
+      <statement statement-id="ra-3_stmt.a" uuid="8f28b273-d3d2-4733-9cce-28a43c6f8790">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="440515ac-07ee-4423-94e2-1dac61f0149a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -5510,8 +5510,8 @@ transmits, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="ef3fab0a-89d8-4d02-a6df-1662e32775e5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3508fac6-1bbb-4de8-bb2b-0ad4da47547a">
+      <statement statement-id="ra-3_stmt.b" uuid="8e0a280d-8df4-43f8-ae7c-69fa52679253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d896e942-2f5a-468b-bfa7-69b07720a268">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -5519,8 +5519,8 @@ documents, are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="5aa04c02-3b52-4b3e-8867-cba44fefa11f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2695817c-8cb9-40de-9421-a7393d9ee3d7">
+      <statement statement-id="ra-3_stmt.c" uuid="a4c416cc-7372-4332-9954-f385e2e4a62f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06648176-8f20-4d8c-8dce-9fb6bab40ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -5528,8 +5528,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="5b56a185-3a48-4856-bec5-978ddce1119c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7f47eb07-4309-4c2d-af98-725a38bd8350">
+      <statement statement-id="ra-3_stmt.d" uuid="60b70e92-5e62-45b9-bd5d-51b8d4a533be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1ea9294-5af3-4ef0-9f29-5442a87dfb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -5537,8 +5537,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="c07c5fbf-e4ce-47ae-8145-62dbf5bfcc78">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5d118836-ba6f-4fc2-8cb5-1b24becab0d6">
+      <statement statement-id="ra-3_stmt.e" uuid="4725522d-a508-48c1-a3e9-5928b73d4124">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2f6371a-788f-4180-b531-392900117b2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -5550,18 +5550,18 @@ are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1dcdd7d5-81ef-4a58-a108-c6b39b51c209" control-id="ra-5">
+    <implemented-requirement uuid="faba4d3b-a229-4ef4-92a7-51930564432c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="73d375bf-e91a-4a13-8742-7a2cdfbbea82">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="693de82a-4655-403c-a519-70c262d5757c">
+      <statement statement-id="ra-5_stmt.a" uuid="ac517196-6214-4d51-9acb-fabac78e0911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="1c9ae7cf-00df-4c3a-8561-f9028ea4d2df">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a15f9a8d-3b37-4457-a3fa-1c955187bcdd">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5569,16 +5569,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="cf04a5b6-832c-4880-8e0d-a690803dc0a6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="490e70ed-bab7-4c2b-9d6f-f476c8267f03">
+      <statement statement-id="ra-5_stmt.c" uuid="eb2ceef6-2632-41ab-bd7f-bd9fafd3d08c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="6bc672d2-454b-43c6-9cb3-31d5f90cf2cd">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a8a5d896-18ed-49e4-9a07-63a23ccb545e">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5586,8 +5586,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="bbe789d3-5c89-483b-93b6-f4e5f465e033">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="48e5dfc3-dec6-458b-89f0-0d3500d6cb8d">
+      <statement statement-id="ra-5_stmt.e" uuid="1ff6a01d-7430-40af-9732-808c455f1558">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad407a82-f2e6-46f4-9029-f9fcbe5b785b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -5599,10 +5599,10 @@ of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82251800-1c1c-4ecf-8784-c5727c5bdceb" control-id="ra-5.1">
+    <implemented-requirement uuid="99bfb322-3894-4141-babf-b99bfe1d7692" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="f570b4e5-2676-4377-9bad-0727f37b1ea2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0de32e6e-fa48-4cd2-a3d6-f177bc38b435">
+      <statement statement-id="ra-5.1_stmt" uuid="c78f080b-6d2c-4038-830f-eb3c7e1ae855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e39b5519-8ce6-44bf-b85b-37b0f2295593">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5611,10 +5611,10 @@ https://issues.redhat.com/browse/CMP-353
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="142796da-80f7-4a7d-85cb-3792809ec70c" control-id="ra-5.2">
+    <implemented-requirement uuid="4943ba18-45e4-4e49-a170-d37ebb1ced85" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="944c753c-d452-4308-a2df-fbb6994761d0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="161ed714-d176-4900-98e8-28ed1f40054e">
+      <statement statement-id="ra-5.2_stmt" uuid="de799794-299e-494b-a3b4-c26fc280ba0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5622,10 +5622,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a36742a-4d1f-4eaf-bc8a-f027ad4d4ef5" control-id="ra-5.3">
+    <implemented-requirement uuid="810d5edd-d21a-451e-b7b3-67d6f714aeb7" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="675257b5-ecd7-450a-8e8e-608ec69ec7a0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4880e5b2-8dbd-45e8-b976-346e1ffec65c">
+      <statement statement-id="ra-5.3_stmt" uuid="cf5fa76d-4097-486e-932d-6ffc633e724f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -5633,10 +5633,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="195f3e57-be67-487d-9892-de64e17a513a" control-id="ra-5.5">
+    <implemented-requirement uuid="9c800aef-8511-49ed-bfe2-d907ee7f61ce" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="07ca7b3e-f5f9-4922-87e3-d52efbdfa3a7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="22834227-9a6a-47dd-a800-7dbb0f297612">
+      <statement statement-id="ra-5.5_stmt" uuid="ccca2fc9-70b2-4cab-a980-33d198bb8e93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10028990-75a4-41c2-9cf7-a75f6f72870c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For the purpose of conducting a vulnerability scan of CoreOS, the CoreOS nodes
 should be scanned using the OpenShift Compliance Operator. OpenShift supports
@@ -5647,10 +5647,10 @@ Cluster Administators are able to access and run the operator for compliance and
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59aefd49-845a-41b8-bdd5-ebc7898f55d0" control-id="ra-5.6">
+    <implemented-requirement uuid="3a66b623-7a77-4166-9bc8-fe36369d6a66" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="ba1fc938-7f04-47d6-bec4-6e53d8773f88">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cb240b31-11c7-462a-b621-06e23252963f">
+      <statement statement-id="ra-5.6_stmt" uuid="42e81289-d5c0-4fb6-a470-ca1b979a6f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65f278f2-f1de-4fc4-a2a8-625d8839df42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5659,10 +5659,10 @@ https://issues.redhat.com/browse/CMP-356
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f047842-95e9-419c-a9df-c9cc251d0a5c" control-id="ra-5.8">
+    <implemented-requirement uuid="52cd9967-b86b-41e2-948a-b60259fe9638" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="d1432b69-a44e-4be9-b6fb-a2b0aa9baf62">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="99700845-e5c3-475a-b29b-46384b184e6d">
+      <statement statement-id="ra-5.8_stmt" uuid="d08bc80c-4429-4531-9ec7-df30f390bdf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0e99da8-613f-4e82-b02e-b47289fae021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -5672,10 +5672,10 @@ CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f8c469a-c9c7-434c-a28f-f028a10f6b88" control-id="sa-1">
+    <implemented-requirement uuid="0c0652aa-7057-4f72-b1e0-ee4437f43f32" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="be13c1ed-36e1-4203-9133-a544395b4b5d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a704b341-2dce-4be7-9627-487de290d6f4">
+      <statement statement-id="sa-1_stmt.a" uuid="3d66e025-98f3-4642-b709-8ad2d8f3d5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5684,8 +5684,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="228cf4dd-952f-4717-a0f3-d23f64de4809">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8f3efcbe-6700-4b25-ac9f-7eac7c2678e0">
+      <statement statement-id="sa-1_stmt.a.1" uuid="cd61765c-36f5-4066-b631-f184bb57d5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5694,8 +5694,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="1d354187-f195-4dde-a875-07daa8488ff3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2f1733a1-8a57-45b9-abb3-48c6f1e008d1">
+      <statement statement-id="sa-1_stmt.a.2" uuid="7b92ddc0-42b3-4bc7-b148-475ab42bf48d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37b91a8b-9632-4a75-b29d-456cfc25cd91">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5704,8 +5704,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="2d514924-a683-4082-9719-99d765074b63">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="71f2cc8a-af78-4fad-a489-737757702e86">
+      <statement statement-id="sa-1_stmt.b" uuid="82acdcc6-8d2d-4ac2-b6b5-fa56906034f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5713,8 +5713,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="8ae58997-be3e-4e7a-a1e7-5c3d4720e914">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="36bf04a5-6999-4a68-beaf-5a5b2777447c">
+      <statement statement-id="sa-1_stmt.b.1" uuid="10ddd67f-0dad-4c07-a52f-e9a411a81590">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5722,8 +5722,8 @@ is outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="248fa478-9718-40c2-ad6c-f88cb2172db9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b43c10ba-7f04-41bb-abbf-46dd3107307f">
+      <statement statement-id="sa-1_stmt.b.2" uuid="8c40d9e9-f309-4d84-bbd6-8330b7deae55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9da33e3f-9fda-4316-a44b-69e6910346e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5732,10 +5732,10 @@ is outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="534b3320-bdc3-441a-aa75-f9aa6f74bcf5" control-id="sa-2">
+    <implemented-requirement uuid="7145a51b-2ff7-4828-b118-57aca991d868" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="ce6ed5bb-184f-4bd2-9310-9c3ed9651694">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3c9b0765-959f-40e8-9aa4-4c8f48c38211">
+      <statement statement-id="sa-2_stmt.a" uuid="2755cb68-25bd-40a2-ad83-1998ddbe4b8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b5d2b15-1d23-4308-91b6-81520a9e5d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -5744,8 +5744,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="68528173-0a7a-42b4-9f1a-7966423b71c7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0beb1a42-1354-479d-8103-25c125925bfe">
+      <statement statement-id="sa-2_stmt.b" uuid="c861f1a6-b97d-40b5-bb1c-c7534589144e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bde7c5a-d48d-4ffe-84ce-49d33dca8cc0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -5755,8 +5755,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="04a9c5e5-3935-4593-bbc6-8254a3806fd3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="afa855e2-872d-4398-8429-9e713dd29436">
+      <statement statement-id="sa-2_stmt.c" uuid="16c673ff-ca9d-4e39-9506-2448605a41dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4173a7c3-70d3-4f66-af32-b1d257a4a434">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -5765,10 +5765,10 @@ documentation are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97f57ea7-a567-45b4-b055-98b39bd6adb0" control-id="sa-3">
+    <implemented-requirement uuid="f5854499-3850-4041-8163-2098e8ce66f9" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="680d6395-a089-4a33-8a54-da3c371496ad">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7605d8af-359d-48cb-adc0-c1b2f275852b">
+      <statement statement-id="sa-3_stmt.a" uuid="ab1f9419-2d17-407a-9899-d198c6784c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8091825e-84d7-4e98-b2e5-39a43ff6fd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -5777,8 +5777,8 @@ of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="bf3c7943-9e51-4e14-82f9-71a343fcae45">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="636bbe8e-1e71-44e2-8bd0-d2f01b4e693e">
+      <statement statement-id="sa-3_stmt.b" uuid="f0f0c199-51ed-4b15-aadb-3b2287f0219c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574de2a9-b6ac-4180-9f66-faf08af1494a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -5786,8 +5786,8 @@ life cycle are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="d4504f50-645b-43fb-abf3-80aef3d7e9f4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cdc93506-00ed-4580-ad4c-3428061235e3">
+      <statement statement-id="sa-3_stmt.c" uuid="ba979c87-fd05-4bbc-8c25-bf77aa504bbd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ace7cb98-3cba-441b-a31a-14917d2f9701">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -5795,8 +5795,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="6220c1f6-0429-4577-90e3-5f90bcd22adf">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d501ded5-e6bf-41fe-8d84-fe2d5e3088ec">
+      <statement statement-id="sa-3_stmt.d" uuid="81798b33-2475-461c-bb95-0423f44a2427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a9cb6d6-2615-4dd6-a2fd-739442455a56">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -5805,10 +5805,10 @@ activities are outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab7d1c0d-4866-4ff2-95e5-3f0f0a0db6c0" control-id="sa-4">
+    <implemented-requirement uuid="a6127496-fcee-476c-93ac-985866a01330" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="1f1c1a02-1c65-4d68-a12b-f0489ceb4b4d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1eaf638c-915f-4623-8112-a5d470136c19">
+      <statement statement-id="sa-4_stmt.a" uuid="66e9e982-66c4-4d53-873c-67972cae950d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="572f10ee-08b1-45ff-9ba6-67c5e27bd949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -5816,8 +5816,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="c8dfacc7-45f0-4418-8d8f-c690b15a8f18">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3e50bdd8-83fb-4601-a823-23233bfe22fe">
+      <statement statement-id="sa-4_stmt.b" uuid="5acbbc04-7c5b-46c5-bbbf-1b989d32260c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c001268c-4565-4dc9-a033-258fb2d1aab3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of CoreOS
@@ -5825,8 +5825,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="c9b354e0-b5ba-4341-9674-3a1aa497c1da">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="46face7d-534f-4b28-be43-02183f3520e9">
+      <statement statement-id="sa-4_stmt.c" uuid="ebc06327-df41-4050-8545-c31078c78658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4b17de1-8bcc-44ba-9c0a-9c64b04d39ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -5834,8 +5834,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="45e4851d-1c3f-4b84-98ee-9212e6486c30">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3c8655c0-99fa-4035-9ea8-24f828d49988">
+      <statement statement-id="sa-4_stmt.d" uuid="bfcde3f9-7df8-4058-b708-7076656c4aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a023e396-23d4-4da2-b88a-a82810b4b941">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -5843,8 +5843,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="023cdb42-ceba-402f-a7ef-f7217b99e467">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="012aeb7b-6e4f-4b56-8b0f-aeea1013ebad">
+      <statement statement-id="sa-4_stmt.e" uuid="d209b23e-a57c-45fb-aa56-5d61c0ab647c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64203fc3-95f8-4b3d-8ddc-04cde85cbb81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -5852,8 +5852,8 @@ are outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="7b08bca4-6b9e-4b75-96a3-1501d05d3172">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5d975208-78c9-4e69-9b72-8c648bd1a879">
+      <statement statement-id="sa-4_stmt.f" uuid="1521bbdf-33b5-44c7-bd64-372014b03655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a13a456-f7e8-4774-90ac-3bf599dda9cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -5862,8 +5862,8 @@ CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="5190c1e5-58f2-4450-9c53-7fd24b418672">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b427ce73-e52f-4291-877c-981eebcf9e98">
+      <statement statement-id="sa-4_stmt.g" uuid="e77d9d21-6ff6-4e11-a420-5d1ff9410008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06b0ef7c-0b8e-4b73-921f-ce2b48a7c710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of CoreOS
@@ -5872,10 +5872,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17a4e58c-1488-476c-b1f7-c0a7b0a9df6c" control-id="sa-4.1">
+    <implemented-requirement uuid="5304b0c8-226c-4b93-8016-3c5d124f854b" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="1f970351-8cfd-40de-b448-30edccdd3e38">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="53eed51f-1031-461b-b00e-1e0e261173fb">
+      <statement statement-id="sa-4.1_stmt" uuid="64169bbc-e536-4a43-a859-591743b4b950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d3defd9-e7ba-4864-8474-4487cbcaf84e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -5885,10 +5885,10 @@ https://issues.redhat.com/browse/CMP-360
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bdee84e-083a-4c5d-8896-34216ed294ab" control-id="sa-4.2">
+    <implemented-requirement uuid="44c7e4b7-6adc-4f5b-9dc5-e761001d8982" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="13828224-dc82-4863-be99-597b4304be59">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="564bde09-7d0a-49ee-9a9e-439bec6afd73">
+      <statement statement-id="sa-4.2_stmt" uuid="59c5a200-46b7-48ab-bc21-d6932d43a016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6535c33-0142-4714-8f10-09335fc6dc79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -5898,10 +5898,10 @@ https://issues.redhat.com/browse/CMP-361
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c8c6b83-b0c7-4d45-9718-d3aab3508fc3" control-id="sa-4.8">
+    <implemented-requirement uuid="11659e90-59b5-4173-b43b-1812ae1883b6" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="573d3b61-d70a-4aa5-9740-fd100d7e0b9e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6100923c-600d-44a2-98d2-6bf864e2377a">
+      <statement statement-id="sa-4.8_stmt" uuid="4b9d4eea-be9d-4f5f-9a67-ce7e25a48f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597f1282-83d4-49ec-8766-9be0dbbd2f16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -5911,10 +5911,10 @@ https://issues.redhat.com/browse/CMP-365
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d304be4a-dfe1-47ae-8750-79539beabcec" control-id="sa-4.9">
+    <implemented-requirement uuid="9ff8b64a-8a54-4e48-ad70-1fdaea27c11e" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="710770f6-9cfb-40c0-bee4-a066b06034d6">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="12c0c8d1-9f01-456d-ae0a-a18788e7be34">
+      <statement statement-id="sa-4.9_stmt" uuid="267db06e-5550-47ff-9734-f9d2e6f704f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d42c837f-2526-4ac8-8d24-1add8af53ab1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -5924,10 +5924,10 @@ https://issues.redhat.com/browse/CMP-366
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4df13e3-a223-44f8-88c7-75b674db2124" control-id="sa-4.10">
+    <implemented-requirement uuid="383fd5dd-44f2-4e63-a8a3-045c1fb9f635" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="1b2e8d4b-30a4-465b-9538-46913cd9e026">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d2e9d0a9-a808-4eb8-8de1-dd59e39b44d9">
+      <statement statement-id="sa-4.10_stmt" uuid="0bd66465-3009-4bf6-aaa0-8bd6a2cf2a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -5935,10 +5935,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cb6f219-d813-4c45-ab04-3f55facb4795" control-id="sa-5">
+    <implemented-requirement uuid="f78f691a-653a-4df7-bc18-65ff8336c199" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="46319ec7-ecc1-48e8-affa-fe106a22a7f0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="41390989-7be9-44e2-ad2c-639a5bbae98a">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -5947,8 +5947,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="8367d5c5-d4e5-4619-b713-d72601378893">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e89e33ef-3351-45ac-93df-141184aa6cab">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -5957,8 +5957,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="2240ecf9-35d7-4c9b-8501-da3e7355efcf">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="aad91d8c-7356-4d15-a026-754816204031">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -5967,8 +5967,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="1f53a669-f109-4258-82c5-d53afb4ca107">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c92eeb3e-3915-4eb0-90ec-082ff6184b60">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -5977,8 +5977,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="1252605a-d0b1-454f-9508-4c5159da55b0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="801011df-71c1-45f3-ab7e-c690898fd0bd">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -5987,8 +5987,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="2acc7f0d-cb54-4580-98eb-15ac5d1b1312">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f280d15b-a44d-4241-82ee-45f01ae360b9">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -5997,8 +5997,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="bfd7011e-b2f2-4940-a4c7-7009d5df2ca5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="154e93dd-89ca-4653-8857-b4e71ec9c466">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -6007,32 +6007,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="cef0106f-066d-4f84-9b08-bc45fdeb8fe7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7cabf8e6-48b7-4f64-8950-aeeca0c491e0">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2988f5e3-bd2e-47ab-8b2a-0961b58a6667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="d743427f-a973-4c8c-9622-af4d0c9b186a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="114e117b-1268-408e-b1bb-14e23de303fb">
+      <statement statement-id="sa-5_stmt.c" uuid="35fb7c42-07a3-43e8-ba7e-ea762fba9f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="16a2b955-2290-4be4-8935-a7f3d6ec8f22">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="167b391d-785f-4989-ae1f-13a529c958ce">
+      <statement statement-id="sa-5_stmt.d" uuid="4ce14cc1-b29c-4334-b59c-02ef744b5bfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="f2b04fff-f47c-4878-8d1f-2fab0832742f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6f25cf23-9b3e-4f0f-b423-8cf5f4b47a9f">
+      <statement statement-id="sa-5_stmt.e" uuid="10a7f065-0e7f-4660-b464-b66f5f383362">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6040,10 +6040,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5386c9a2-6b71-4df6-8d74-4529b3de7a33" control-id="sa-8">
+    <implemented-requirement uuid="31b3cb6f-5fd9-40de-b1d9-bea329ea7719" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="3f751848-e981-4e61-afb1-a6a55ae7c2a3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b9728099-9dfb-438d-8f1d-3310be2f23f9">
+      <statement statement-id="sa-8_stmt" uuid="fa213582-083b-4260-be33-7b25b07bc6cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6051,26 +6051,26 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55e2644c-89f5-4f4e-9800-a9185634c19b" control-id="sa-9">
+    <implemented-requirement uuid="8e537434-01f1-4324-bf80-6f36a6ea38df" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="77fac144-7c4c-43f6-a296-4fd1eba605ca">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ebeef966-ac39-4293-8206-bd42d1955b1c">
+      <statement statement-id="sa-9_stmt.a" uuid="13c765df-6a58-4792-b3cf-26d28b151fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="9333afb1-6f53-4223-9dc2-8e4bed54f36c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bdc1ef14-9bba-466d-80c3-f8c49b7bfce8">
+      <statement statement-id="sa-9_stmt.b" uuid="da1eaec2-07be-47be-a90f-2f93fad86c6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="8267ea8f-3b25-4df2-8b10-75f0d94656f9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="37be9615-5dcf-4be8-86d6-cf593726ab83">
+      <statement statement-id="sa-9_stmt.c" uuid="6b75bd8a-ffcb-4b13-8346-a4d8670d7587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6078,18 +6078,18 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d7ef892-6721-4669-873f-42c64adc49e1" control-id="sa-9.1">
+    <implemented-requirement uuid="44070922-c066-48ee-98bc-d1bfddeb98e8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="21886cb5-1a84-40b3-94af-99b646d95f80">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0b0a4366-148a-4d69-9d54-12fe8abf802f">
+      <statement statement-id="sa-9.1_stmt.a" uuid="8e49af8e-4872-4dee-9c8a-83ab82569e30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="f66aae9a-76bd-4c30-b700-49ded4375560">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7872cb03-7a09-491e-a01d-ce8996426d36">
+      <statement statement-id="sa-9.1_stmt.b" uuid="0a3cd44c-a6ee-43d2-9675-763f3eb540d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6097,10 +6097,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5a3aa89-77f4-4834-94ee-64661f5a5325" control-id="sa-9.2">
+    <implemented-requirement uuid="4b7c9524-7b84-4608-9f20-9256082760f7" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="0412d062-53d9-4281-9593-facc7d36074a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="3f82f75e-3902-493a-a099-0658f3011882">
+      <statement statement-id="sa-9.2_stmt" uuid="6c48daf0-dd90-4212-8ecd-3dda8a0301a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6108,10 +6108,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b68e13a-f934-46c5-8f25-8a05a8e4ad7f" control-id="sa-9.4">
+    <implemented-requirement uuid="8e99cd10-f93b-4302-9fc8-507a69e3ae2a" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="d847f89b-efcd-48a2-823c-661e0024852f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2ea3c1c0-9a7c-4aef-b6d0-af96ae143c72">
+      <statement statement-id="sa-9.4_stmt" uuid="294c5b35-62e8-4c8b-b519-59a34102449e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6029159-d5b2-4d28-abf2-13698b7afe55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to CoreOS configuration.
@@ -6119,10 +6119,10 @@ applicable to CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7866ff66-89cc-49ac-8e45-d0d25282a1e0" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="5276978b-0ce0-4c21-96e4-b64be7791541">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b00f17f0-a3e7-4fba-8094-d31c72c56990">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -6132,10 +6132,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e1e8aad-3b87-488c-8208-0a867ac63c22" control-id="sa-10">
+    <implemented-requirement uuid="23e70356-2035-4233-a7f4-8370b3d60157" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="24c01c15-8b08-4845-b689-f31fc79189f2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="facb01d0-a9ab-414b-a50c-fc91df886283">
+      <statement statement-id="sa-10_stmt.a" uuid="95684487-9444-4195-8dbb-962f685d5bd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ac6e51-7ce3-4f56-bc71-b6ee264973d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -6144,8 +6144,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="bf6808f8-2413-4ad6-8e2b-4aaaad6a643b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5502b8f0-7c0d-43ed-9310-b881d764093c">
+      <statement statement-id="sa-10_stmt.b" uuid="3f0d837b-9027-4ba8-ac9e-9b4f1b9544a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa90dca2-ea44-4706-8cb9-2280b5d5f2d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -6154,8 +6154,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="b1e50212-9ef3-46d4-b396-b8d584042e86">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="40cf7fbc-d036-423c-83de-2299457948fe">
+      <statement statement-id="sa-10_stmt.c" uuid="40f2740d-7c38-4a52-aff6-f09b9240678b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe37bd74-209c-4b2f-acfe-3da20c65069b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -6164,8 +6164,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="ea9801ae-fd5d-4dd0-a200-c31dbb27c2be">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="87803212-83f0-4d5a-a4b8-db35d1138474">
+      <statement statement-id="sa-10_stmt.d" uuid="a1e3cfe6-bafd-4bcf-add0-e2df6c385eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51149b43-7746-4674-81e0-9343b6556130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -6174,8 +6174,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="5f43f6af-12ac-4cb8-aeed-ecfeaf89acb2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c5d261d5-a971-4e1e-8148-a0b80850b096">
+      <statement statement-id="sa-10_stmt.e" uuid="1d119dee-e436-41b2-ab4d-2dbd8a87a222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b6d4be-f2c6-43b7-9f49-133379f30817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -6185,10 +6185,10 @@ https://issues.redhat.com/browse/CMP-369
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dad28356-2b6a-4f27-972a-6710b4b323bf" control-id="sa-10.1">
+    <implemented-requirement uuid="4c64a19c-d9a6-4f5f-8362-95028e8a5a27" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="e1c78f7f-e5e3-43d0-973c-f1427feb606d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9a4d93a7-40d4-4b4a-a1c9-a1723ea05972">
+      <statement statement-id="sa-10.1_stmt" uuid="3893e7a9-f701-4695-bb10-3c715ec900de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5a26a-f4da-4af3-97c9-1b9cd4601ff9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -6198,10 +6198,10 @@ https://issues.redhat.com/browse/CMP-373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d032895-88be-4bf6-aa1c-8028fd4c1676" control-id="sa-11">
+    <implemented-requirement uuid="a86926a5-e735-4a73-83bc-60bc088ce819" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="4e97e51e-5ef1-485e-99c0-7b8f17092b14">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="670cb668-5585-4d88-a44b-a156373b46eb">
+      <statement statement-id="sa-11_stmt.a" uuid="46fc688a-6a7a-491d-8c9d-f3ca597d33eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f34b6662-ab38-41e3-ac72-b08cb8675a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -6210,8 +6210,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="6b7b52f5-160b-451e-8fb1-3ae7d9cde7c2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f9b146e5-0ce4-4195-bcc3-b0beca699b10">
+      <statement statement-id="sa-11_stmt.b" uuid="3c6b0a07-19e1-4b56-8978-84f78e5d41b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c00fc148-bd08-4f25-aee0-9ad9d3760062">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -6220,8 +6220,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="50ee3283-27f2-4e5d-a337-0558dab232ed">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="38c86b1b-2497-4373-9490-0d0962fca950">
+      <statement statement-id="sa-11_stmt.c" uuid="95db2f92-ab21-4cdb-bf9b-41002f9858be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c0e9f2-6558-4dd6-b14e-9a254d3cd9c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -6230,8 +6230,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="9d0cae0a-4cd8-4c8f-951d-ea6eaa57d020">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f4b16716-dc2b-4838-81f3-0ef139dd8eaf">
+      <statement statement-id="sa-11_stmt.d" uuid="efebb503-1b64-4ce9-832c-3be4e01cc4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b2f4dcf-5965-417a-8706-e9e23c034690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -6240,8 +6240,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="3f5e4800-5767-499d-830f-2672b094d414">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="22aa77cf-2ef5-4751-bf26-8f82923a3ed9">
+      <statement statement-id="sa-11_stmt.e" uuid="fcf54721-40fd-49b0-af2d-7c710acfa862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="528f9b93-35a6-4d13-8a0f-acb56b90303c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6251,10 +6251,10 @@ https://issues.redhat.com/browse/CMP-374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fb79849-7836-4f27-8b96-4efdc7d634f2" control-id="sa-11.1">
+    <implemented-requirement uuid="390d4359-e23c-4ea7-a03e-33ab0f771c89" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="7e38d2ac-5fc3-49f4-8b9a-613c65f0255f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1231c42c-94e9-4c8b-a88f-c685cc925478">
+      <statement statement-id="sa-11.1_stmt" uuid="78fa5d63-08f1-40f8-aa7f-302d689735df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3953a8df-4a05-4b03-811c-eecbc5b1115f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6264,10 +6264,10 @@ https://issues.redhat.com/browse/CMP-375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="900a302d-ce23-4097-9b35-1fce94184271" control-id="sa-11.2">
+    <implemented-requirement uuid="f6a79121-574a-4870-8fd6-f0b7f8e8264b" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="b1ececb4-ac38-438c-ab58-198ef74e6235">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4056bc0e-a0b9-469e-a863-1a01126c90f7">
+      <statement statement-id="sa-11.2_stmt" uuid="bc1c0016-a06c-4757-af0f-2bebb94fb87b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a25713a-4531-486b-bb1d-534a8fd9065e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6277,10 +6277,10 @@ https://issues.redhat.com/browse/CMP-376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="521ae17a-f295-4910-b085-b098540d8e24" control-id="sa-11.8">
+    <implemented-requirement uuid="b2c4d52c-2d22-410b-91fd-6adcafe27600" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="a6cb5561-a492-4640-b517-1685f9f31a37">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="dfd4893f-06e3-4a9a-acae-5525504ead96">
+      <statement statement-id="sa-11.8_stmt" uuid="6bb50194-184f-4669-9484-5e251888ba63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5626f4d-3991-4663-8a15-b4c106696880">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6290,18 +6290,18 @@ https://issues.redhat.com/browse/CMP-381
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28f5ab4d-28c6-44b8-8c81-a67ca6ec1041" control-id="sc-1">
+    <implemented-requirement uuid="54e9360d-eae0-47f4-a92a-894f7a8ceb12" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="06445937-cc31-4ad8-831a-f34e0fd92723">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="743a2d98-2a02-4497-a009-d94e065eddaa">
+      <statement statement-id="sc-1_stmt.a" uuid="354dc18e-1012-45fc-a30f-c1a9fabd2b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="4b35c3ce-c59a-4298-87e9-0bb4d8b4a156">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d296fc30-ce0c-4c42-bb30-108dd08b7b8e">
+      <statement statement-id="sc-1_stmt.b" uuid="ac80bea9-adb9-4bc1-8c4a-528f150bf852">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -6309,10 +6309,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fc7b98e-aaf8-4856-8740-d13df866a693" control-id="sc-2">
+    <implemented-requirement uuid="591ef3b8-6fee-4e3f-a241-82278e96a4e7" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="0c48c104-f6ec-49d0-bdf7-63951468da44">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="963ab584-d318-409e-bd1b-aad6b1faed0a">
+      <statement statement-id="sc-2_stmt" uuid="143cf0ca-c117-4586-a1cd-91947e3f1a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa072737-5175-4d0d-a2ab-e535883b1181">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -6327,10 +6327,10 @@ https://issues.redhat.com/browse/CMP-429
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ba748a6-c6c8-4942-ae67-5cde6ed2d6e6" control-id="sc-4">
+    <implemented-requirement uuid="96f7fae4-b1c4-4625-92ac-3353f07bb6ca" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="86bd0ff3-c4a2-4aa3-84ec-41a770369fd5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="23607d47-e7ae-4126-b023-b59ec4e359cf">
+      <statement statement-id="sc-4_stmt" uuid="deb25b8f-b7c0-4ffc-87c3-ddb3e0e9e98b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="617b39ae-8abc-4fb0-9c00-c50746b0d781">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -6344,10 +6344,10 @@ https://issues.redhat.com/browse/CMP-428
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02c5b7ab-e3e4-4d79-96ce-b6b43c6600d1" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="c4721979-5e83-4d88-8a36-8c9673305b18">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1e0a85b2-82fd-4e41-bf6e-0df5b530d288">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6357,10 +6357,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f413e33-5a3b-4fe1-a205-402687560fa6" control-id="sc-6">
+    <implemented-requirement uuid="2ecd1aa4-1ec5-424c-8299-2f1847c78d2d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="2345410f-87c8-4c95-8643-9029ace0aeb4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="febd44d5-519f-42a6-88fd-a2249fc0c1b1">
+      <statement statement-id="sc-6_stmt" uuid="1c65ffd6-790a-45be-9f96-dae549f63731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb086507-2e55-4213-b420-2f757534f30d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -6375,10 +6375,10 @@ https://issues.redhat.com/browse/CMP-476
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25556da9-e75a-41ac-abc5-2738e6d4f03c" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="fa94a34d-a755-473e-9819-eb7a32d4095b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8a099eed-570b-41d0-961b-af40a1c89f3c">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6387,8 +6387,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="7b5656ca-82cd-459f-9a05-ff5feb68527a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1af41366-adb4-47a5-ac5f-cfbea27611e7">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6397,8 +6397,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="98467f6b-503c-45cf-8c1f-c505c2ca3344">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="1c42f0a1-15b8-43a7-b8b9-569434e7fec9">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6408,10 +6408,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7149c6ae-6d1f-44fe-a8dd-5ae21424d599" control-id="sc-7.3">
+    <implemented-requirement uuid="186b2385-1f1a-4a9f-87cb-fa9ba58408bc" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="9c5098f2-de2c-4f21-b274-1066431bea72">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cc6e7481-578c-4bd3-a8bc-44465462bb41">
+      <statement statement-id="sc-7.3_stmt" uuid="34c09b45-a0e3-4736-b446-a55a9b2a919e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c23c58f-8d5c-4070-a9c0-8ae34f8b5eb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -6421,10 +6421,10 @@ enforcement.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50a35c7c-0834-4f1e-a854-3b81b3891207" control-id="sc-7.4">
+    <implemented-requirement uuid="036fedec-6866-4c42-a4cb-78e19368a3bb" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="60bb4fb3-a15e-42ab-9b8e-6defb1fad55e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="682ffe72-bd5d-4468-8019-6e92862edc44">
+      <statement statement-id="sc-7.4_stmt.a" uuid="ffaa818d-a56a-406d-8534-d92aa505b945">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64b1aee9-3772-4cb1-baa5-8343ba144412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication service
 is addressed at the network infrastructure layer and is an organizational
@@ -6432,8 +6432,8 @@ control outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="4db663d0-ad27-4c27-bef6-5a22ff1b8c88">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f74ec56f-f602-42d8-a2bb-50fbdf503866">
+      <statement statement-id="sc-7.4_stmt.b" uuid="1bfeefff-ab02-427e-8770-5df42cf390d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5054f3d-48a7-4136-90fd-58c0e36c0c59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside the
@@ -6442,8 +6442,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="d357c150-83b6-41e8-9116-5b3eef6b2498">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a08f4434-78d1-46c8-a2ca-481c1133c415">
+      <statement statement-id="sc-7.4_stmt.c" uuid="1af6eb6a-5c7b-4f09-862c-45b20f777565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79d1d101-b3e4-4324-9904-c33c064ac238">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being transmitted
 across each interface is an organizational control outside the
@@ -6452,8 +6452,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="6f7df8a9-1d9e-4a3a-9486-58e3908d8e72">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c746ca97-31cc-4376-996d-d3ec90a74a80">
+      <statement statement-id="sc-7.4_stmt.d" uuid="c4cbae4e-54d0-402e-9967-5882609908ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2065dfc0-f7e6-4e9b-b625-82ace606cce2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational control outside the
@@ -6462,8 +6462,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="643bfc5c-ba48-4fa3-bfc3-17d8a3f0fd4a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="387b0665-c148-4669-9b3e-81c5c9cb414d">
+      <statement statement-id="sc-7.4_stmt.e" uuid="2e9f316c-441e-4e99-8bc8-edc888c8a30c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98709f04-2185-4da4-8735-f97137a7376d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally defined frequency
 and removing exceptions that are no longer supported by an explicit mission/business need
@@ -6473,10 +6473,10 @@ handled at the network infrastructure layer.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91bfa137-5cfe-4698-9322-541f5d70599c" control-id="sc-7.5">
+    <implemented-requirement uuid="299dcdaf-d2bd-44b1-9f34-7a83c829a2b4" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="1db485c4-b160-4b29-88d1-b24c579ff216">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="da89f0aa-0dcf-450e-b5cb-1e937d62b3d2">
+      <statement statement-id="sc-7.5_stmt" uuid="796764c4-2388-42ab-99f8-bdf5a00fb0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b15b06f-d5dc-4fb0-af24-596c93208d35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -6490,10 +6490,10 @@ https://issues.redhat.com/browse/CMP-424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e77e06d-3efd-4c80-8418-439e1412b133" control-id="sc-7.7">
+    <implemented-requirement uuid="0af997e5-f97f-4d13-91e7-e9c5a864df45" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="dfd88687-42ad-4ea0-bc98-28ae550506d7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e2042568-77b8-4a51-aab6-84ba2f2f11d5">
+      <statement statement-id="sc-7.7_stmt" uuid="cb78b303-47eb-4ac0-abd7-7b7c81060c99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94db18fa-a069-48ec-8c67-6bd51db07d70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing split tunneling is an organizational responsibility
 and not the responsibility of the CoreOS Container Linux operating system.
@@ -6501,10 +6501,10 @@ and not the responsibility of the CoreOS Container Linux operating system.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a563d03f-2195-412c-8ec7-5ec02db61887" control-id="sc-7.8">
+    <implemented-requirement uuid="7decfaf2-b8e3-498b-ae55-671b24506ec9" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="7a2dab38-316b-47f3-b0c0-36b7610d0a27">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="feb16b21-c52b-421d-832a-082087a0a26e">
+      <statement statement-id="sc-7.8_stmt" uuid="833f91c1-8eb3-4422-8059-f8d05cfe7237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adba8470-6219-47a4-aeb4-ba166c6b610a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6514,10 +6514,10 @@ https://issues.redhat.com/browse/CMP-477
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="beb9e59e-6130-4ff2-bdb0-d04f0ce59673" control-id="sc-7.12">
+    <implemented-requirement uuid="7bcc9d61-0924-4650-a79c-d2bcf6e0bfde" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="b835ac29-19c1-4a02-8ac1-69d9974451d9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a99b6487-e749-4b0a-b98d-6afe34dd68ff">
+      <statement statement-id="sc-7.12_stmt" uuid="04b972b1-e2d5-4deb-868d-b1a1bb971393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c721f916-ebf5-44d2-930a-0f52d3887fec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -6531,10 +6531,10 @@ https://issues.redhat.com/browse/CMP-483
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab0e648d-c391-498c-9efb-135b545decd1" control-id="sc-7.13">
+    <implemented-requirement uuid="541d239e-bcdf-4fb7-a5bb-0b3f1a90c476" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="dd092498-20e2-40d4-896f-a3c963c2d68d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="608aa5f8-816e-4a8c-8477-ef3186aeda56">
+      <statement statement-id="sc-7.13_stmt" uuid="4ba0efb2-52e0-4f15-863b-f089605a50b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa550ac-3fea-41e0-bb2e-2fa546c17355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that CoreOS is
 isolated from other internal information system components by
@@ -6551,10 +6551,10 @@ https://issues.redhat.com/browse/CMP-484
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afb54637-5774-46ae-afd6-e94e2269b510" control-id="sc-7.18">
+    <implemented-requirement uuid="7e0070ef-c09f-48d1-9579-efebc49bb27b" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="3ba6b8a0-86e0-4446-a430-429478d63352">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b907527c-4158-440e-a7b9-3db68cfd61b0">
+      <statement statement-id="sc-7.18_stmt" uuid="6bc5981d-371a-4efe-91bb-23f0994ae97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f446eca6-5b4d-47c8-815d-301752b4d6ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6564,10 +6564,10 @@ https://issues.redhat.com/browse/CMP-488
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca4ad1bb-ca10-4d54-b000-96ef5c16c3b0" control-id="sc-8">
+    <implemented-requirement uuid="5204cabf-dbf5-4d92-9cd1-804354d80d7a" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="ccc440d9-9cab-4a90-8ff1-b183983c79ce">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e5a3c803-5e07-4bb0-8559-ea83b9b802b2">
+      <statement statement-id="sc-8_stmt" uuid="10ab3b1d-fa32-4dfb-b7f0-c5c4f924b33c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fee56b6-5600-43e3-9132-b328cd2e17aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -6575,10 +6575,10 @@ information.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="857e8429-ea35-4ddc-9a47-ba29f10d58eb" control-id="sc-8.1">
+    <implemented-requirement uuid="d79b39ec-b75a-4d9d-b839-2f28d69d9e98" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="cada9e05-cb02-4e16-8100-1953d6b5fbc3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="63d63231-986c-4b7d-ad6d-208794010b74">
+      <statement statement-id="sc-8.1_stmt" uuid="84d59cbe-40c4-4f22-8df4-1246640eef00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acd8d90a-0f39-4844-acf7-6a4ed7f9b815">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -6589,10 +6589,10 @@ network communications that carry customer data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aebece5e-3f06-40c7-b041-1c6c0582c7d1" control-id="sc-10">
+    <implemented-requirement uuid="df5e51eb-966c-402f-98c6-1bc7cb654de8" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="7c81bf01-f799-40ec-8c79-11d93cf5a086">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8324e760-afe1-44d0-a7a7-8fb172e498c1">
+      <statement statement-id="sc-10_stmt" uuid="49fd79b3-99f8-474f-82f2-797e2fcb4835">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fcef049-edaf-49f1-ae92-34545047b7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -6607,10 +6607,10 @@ https://issues.redhat.com/browse/CMP-422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20723172-d6a7-433f-b1bc-5e3e477557c5" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="19389e69-4626-4c03-a5c7-3bba2d5553aa">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bacbaa28-bb5a-4c9e-bf4a-8906c48c7e0d">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6620,10 +6620,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e187634-8f25-4e74-93b2-4e9e3a87d9cd" control-id="sc-12.2">
+    <implemented-requirement uuid="f654668f-472a-4fbf-a522-57b6eecda6b0" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="fc7fad62-edd1-4578-8051-8cbb30395f31">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="931a645f-fcbf-4932-bf11-bec3fcbbf1ee">
+      <statement statement-id="sc-12.2_stmt" uuid="67ed0c07-b5b2-435c-bf22-d186feeafb91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7cd35cb-8dd1-4c8c-be3a-46ce4c45892f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6633,10 +6633,10 @@ https://issues.redhat.com/browse/CMP-498
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3880e094-280b-4938-8364-55ff8654b287" control-id="sc-12.3">
+    <implemented-requirement uuid="573937d5-283f-457f-8b61-cf35b660c70a" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="2c35e907-f937-455e-8a08-d2c5c7a7afc9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="88ec66d6-f45e-424a-9b08-894d494e0679">
+      <statement statement-id="sc-12.3_stmt" uuid="a440cef9-784e-4366-a8cb-6d94f9df94bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90872c45-14ad-48c2-8509-c00f5833d23f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6646,10 +6646,10 @@ https://issues.redhat.com/browse/CMP-499
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3ee0f67-4264-4937-88db-5870c77bef3a" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="22abffc2-35b8-4d88-b885-6b8e1977ac1d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e22477cf-0311-41e5-a2b2-b620784804b1">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6659,10 +6659,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe5586c4-29aa-4761-b715-182a5f8f7da6" control-id="sc-15">
+    <implemented-requirement uuid="d4373dc0-0592-44a3-b8ac-19c15a277ed6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="7cf7d2d7-e276-4813-bc26-f0d661cad25f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="45a3dc6b-bfa9-4c44-8ca5-3578090c7375">
+      <statement statement-id="sc-15_stmt.a" uuid="c399b25a-6449-4871-bff6-daf5ff8efbb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -6671,8 +6671,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="5a7f24dd-5656-4bd9-9ffc-9681cbe6ea57">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="17fc1518-455f-48c4-b620-0e111bcc977f">
+      <statement statement-id="sc-15_stmt.b" uuid="c6c7c1ab-cbde-4eee-8df3-ad2e347204ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ebb2a45-655c-4e73-9770-db2a1f0daf72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -6682,10 +6682,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccfb5d96-2d1d-4ffb-85d6-608d26161571" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="0830d162-e0b4-47e3-aaf5-ba214596f0e7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4313449d-a5a6-44ec-aabc-cbbe9ff5fabc">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6695,18 +6695,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29be036b-74d4-4210-a791-0112d3265fab" control-id="sc-18">
+    <implemented-requirement uuid="e66da199-3ae9-4df6-83ae-8f99d17875fa" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="d1100439-59ec-4c5f-bab8-3bccf9249433">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8ebcbc09-0af1-4108-98de-85f8d65f8c28">
+      <statement statement-id="sc-18_stmt.a" uuid="35d7a6e6-8a08-4344-a7e1-192048af3423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1cf039a6-1ab9-4aee-baea-b15765600d67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining acceptable and unacceptable mobile code and mobile code technologies
 are organizational policies/procedures outside the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="cc485140-8906-4361-8d94-a2773b037a06">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="021ab5a3-0b8d-4b95-b20d-926157d79e4b">
+      <statement statement-id="sc-18_stmt.b" uuid="f729f833-67a2-4e17-b454-f166291d36a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30838b6d-1a89-4eb2-a5d0-70d2e52b9a56">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing usage restrictions and implementation guidance for acceptable
 mobile code and mobile code technologies are organizational policies/procedures
@@ -6714,8 +6714,8 @@ outside the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="e270d971-f7ad-4a3e-9474-805040d806e9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="892ea0be-89b4-4163-8d05-0de538ec8695">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -6724,18 +6724,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="011e4eb6-61f3-4243-afec-1b47f6fa41fb" control-id="sc-19">
+    <implemented-requirement uuid="4d25e2ca-02fe-4fb1-a448-051ff7235e89" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="d10db567-a8a9-4bce-9e7b-4de5bdcd0f4a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="874380d3-8e92-4bf4-bd0f-d0ce6a1adb42">
+      <statement statement-id="sc-19_stmt.a" uuid="411582be-7102-4247-9f51-a999d1798bde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="067af3f0-cc22-4bb9-8ab6-3ae19ec24399">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="25185362-9c26-4f31-809d-29474a972ffa">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -6744,10 +6744,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddd8d492-4e1f-497d-b893-7067ebee3b28" control-id="sc-20">
+    <implemented-requirement uuid="c77113e5-0a1a-4df8-a7b0-5847ff7b267a" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="4399cbc3-1422-408a-a497-e75c7e6eb68a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4932c6e8-4539-494f-9a6f-ddb1d2b725d8">
+      <statement statement-id="sc-20_stmt.a" uuid="a38a366e-a171-4825-81ec-29464e4f2441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6756,8 +6756,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="7d4f4995-32b4-4018-9814-71c5a8a38bd4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0ade4c5e-c4f3-42ce-8ce0-6cce7412358d">
+      <statement statement-id="sc-20_stmt.b" uuid="c5749db4-3e0f-4e6f-b7e7-fc8496731ca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2677346d-2d80-4a9d-b185-8bffeb6d91aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6767,10 +6767,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d44c985f-d8ee-420e-8aa1-8d41200ba4d1" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="814cb22d-07d1-4738-a4e6-85c39e8dc0b8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0dcd08b6-646c-480c-92a8-03bddfa8b6ba">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6780,10 +6780,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06109a61-8c50-412d-83f2-a7991abe9ab5" control-id="sc-22">
+    <implemented-requirement uuid="8b7be659-58fc-4f8e-b6ba-fcdc3111e4fa" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="1032a651-13db-4656-a74f-85b6f60ed324">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2715f1c4-8ede-4f12-85e5-e21239768497">
+      <statement statement-id="sc-22_stmt" uuid="5525a272-a750-4ba0-aade-c3c0660b21db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d75e9d7-2b91-4d97-9af5-2efbfc6c5d6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that name/address resolution service is fault-tolerant and
 internal/external role separation is implemented is not accomplished on the CoreOS
@@ -6792,10 +6792,10 @@ node level in an OpenShift cluster. This is done at the OpenShift cluster level.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="120f7258-9610-4e07-9dc5-1b63b1adb4d5" control-id="sc-23">
+    <implemented-requirement uuid="f56a5648-30ff-447d-94d5-438189034ff6" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="b4656d0e-880e-4b2f-b4f5-5fcd820d9227">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="26f2b373-f732-4502-b112-8f99bb6cf5fd">
+      <statement statement-id="sc-23_stmt" uuid="aecd3395-ce0c-4a78-81b5-4b3567af9f5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00370ad4-7c53-40e9-9ed3-16f8ba73ce27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -6815,10 +6815,10 @@ https://issues.redhat.com/browse/CMP-408
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d40a3a5d-2562-486d-b748-83e1f76ee9a4" control-id="sc-28">
+    <implemented-requirement uuid="2f992720-6db0-4356-8634-6339b0d6cda8" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="091c7e5e-a86b-4411-98a6-ee534af3300d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4003c957-8427-4fc8-8137-7fb8314490b5">
+      <statement statement-id="sc-28_stmt" uuid="8ef6d238-c643-47a9-852d-368fa7d3e931">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32649326-f922-49d4-bd77-0b13901bf763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6828,10 +6828,10 @@ https://issues.redhat.com/browse/CMP-407
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20cc0e5a-6074-4a3e-a829-d583246a1e9c" control-id="sc-28.1">
+    <implemented-requirement uuid="44963431-b6cc-4330-b19b-8116a31596f7" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="0abcd611-2bd7-4baa-9aac-a24dbc269d97">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c5d3d99d-cb23-4788-bc21-117fea608f81">
+      <statement statement-id="sc-28.1_stmt" uuid="4e2915fd-e293-42e0-b8bb-1e13f4275ce8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60860935-2e75-41f3-899d-77b295e6650c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -6852,60 +6852,60 @@ https://issues.redhat.com/browse/CMP-509
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="525b7e41-1b93-4874-9b7f-4af5dd927a38" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="99f10ca6-a4d9-4027-b54a-bfb18f1602ed">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7c486852-882f-4368-aef6-375e1736be6b">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="739b5e7d-153f-4b74-9755-34672d22eb96" control-id="si-1">
+    <implemented-requirement uuid="939ad644-f843-44d6-9827-c800985ba52f" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="db905940-6cc2-4fca-8a63-1da89de1a3a0">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5b662a37-a8e7-4068-85a8-4716b8fd1fae">
+      <statement statement-id="si-1_stmt.a" uuid="faf77839-500b-4190-9d2c-bb124cdfe49f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="493b3960-34ab-4302-ab82-3ec403ec1c75">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="416f3c4a-0a1d-461d-b56b-23a03001983d">
+      <statement statement-id="si-1_stmt.a.1" uuid="8a14bbab-9059-4b95-afed-e159522f38be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="84847f54-02d4-44e6-9c95-98062d53e399">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0c54ac2d-9114-4167-ade7-ff8ecef62787">
+      <statement statement-id="si-1_stmt.a.2" uuid="0f66fa58-3e16-483e-8717-de494858c173">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="9b33b287-5054-4731-96e6-3206021f9f6d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b19f1615-39ef-4fb1-9353-b6756902a24a">
+      <statement statement-id="si-1_stmt.b" uuid="80f86133-24b3-46f0-972f-781d6cc87d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="df11d71c-ab54-4a17-8144-afc0022ea705">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="e122d1fb-2c06-499f-8814-1f5d622abb54">
+      <statement statement-id="si-1_stmt.b.1" uuid="e8d3dccd-bd75-4eb7-ac9a-70d5cd1e26ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="d61ce2a2-547c-4613-a76b-12887b7b5df1">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="05cc90f8-ea2b-45ef-ae5c-400442401421">
+      <statement statement-id="si-1_stmt.b.2" uuid="d5091781-e22a-453f-bfd9-da12a3cffbeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -6913,10 +6913,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd5a4a2d-fe91-4409-8fff-09250c01c859" control-id="si-2">
+    <implemented-requirement uuid="4ee1f2dc-9abf-4af2-a0e6-68fc08d98380" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="59d90329-8c7d-452f-97a2-95434d2527e2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="bc05b62e-0ea8-42c3-8831-8be3404927fa">
+      <statement statement-id="si-2_stmt.a" uuid="9720e20d-3df6-4f50-8ae3-a4ef5f8ca8fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dff4e8f-9e35-4256-b12a-0de5fc01866d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their CoreOS deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -6926,8 +6926,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="a890e682-bfd7-43bf-b90e-4cbdab584183">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="b7b56e5e-64f1-4512-9f3d-1b88a61f0b62">
+      <statement statement-id="si-2_stmt.b" uuid="d89d296d-55a1-4bed-aa91-66c08067c4a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b6d6495-2347-4f30-8e10-9044b74463de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing CoreOS updates
 related to flaw remediation prior to installation. A successful
@@ -6937,16 +6937,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="6f8803b6-dcba-43c4-a423-463071e2f76f">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9ba209dc-aef0-481b-be95-ceaaad7e7b83">
+      <statement statement-id="si-2_stmt.c" uuid="e194c214-36bf-47a9-b578-186ef5c68da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="128c6e52-c326-44bf-a724-f87f9ae28447">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="38f89690-12f4-491c-ac8f-8c5fb01130d9">
+      <statement statement-id="si-2_stmt.d" uuid="9cd61549-ae3a-494d-8793-2a0eed029bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -6954,10 +6954,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1513a36-1897-4734-b393-0dcbd6f60485" control-id="si-2.2">
+    <implemented-requirement uuid="25e6bb3e-56cc-4987-892a-3e681e6f3441" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="50f704c7-36c4-42ef-bed7-2db5002ac4da">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="52b9f044-46db-4acd-bce9-b71ce23c09fc">
+      <statement statement-id="si-2.2_stmt" uuid="166767a9-51b0-49a0-a1bf-86af3fa2e962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d5517-24f7-404a-ba5b-c641b36f0d73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -6975,10 +6975,10 @@ https://issues.redhat.com/browse/CMP-405
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b76856f-6ca8-4319-93e5-bcfabc8fa6b0" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="54d72cc8-cd4d-4229-b001-6589b3645442">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a7c30d54-bb4c-41ea-ae70-5b9e0a24b11a">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -6989,8 +6989,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="967ceeb6-e166-4728-a26c-f7c0894c15e3">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ae9db754-dba0-4447-974b-cc19616791ed">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -7002,10 +7002,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56aeb658-4392-4407-b0d0-0ecce41101fd" control-id="si-3">
+    <implemented-requirement uuid="4a1a1387-0d1c-435b-a997-6cf4182f0d3e" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="fc04e362-c7d9-481c-8a33-e5ff5b139bd7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a920e976-4511-4533-9331-35a2be3dcd76">
+      <statement statement-id="si-3_stmt.a" uuid="2cedad34-820d-4c19-8351-320d162dd000">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b9c31cc-1e94-44c8-b9e7-79474eb422be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -7017,8 +7017,8 @@ the use third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="68edd9fd-0d5e-495e-917e-0dc11be6ba68">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4e928008-d04a-4f20-a003-827dde082f58">
+      <statement statement-id="si-3_stmt.b" uuid="f0a8a2c2-9853-40ad-82a3-71d35d099093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acaa67b5-6168-4bb9-a0c4-6520f323328f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -7027,16 +7027,16 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="9fa07c6f-7405-402c-808c-5d41fa134217">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="36fdb370-3415-4024-a969-87cfa852f9ba">
+      <statement statement-id="si-3_stmt.c" uuid="950f012d-7938-4cd0-8513-ad982ac3bb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68db3553-e877-4ae3-b0de-9027603a9df9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="1f35760b-1c8c-448e-9d9d-72049af20675">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f278e228-4216-4ef0-8a93-21d67fe15fe7">
+      <statement statement-id="si-3_stmt.c.1" uuid="7b6729a1-c4b8-4647-924f-6563d03e0605">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eff97d30-28a8-498b-98bc-2e77dc7868d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -7046,8 +7046,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="6bd564f1-63b9-41ad-adf4-43e877d5b888">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7ce7c34b-df6a-4c7c-91d0-d597690a4732">
+      <statement statement-id="si-3_stmt.c.2" uuid="a8c51912-153a-4da5-9705-c24ddc805862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c27f453-80c0-4206-8086-8033410bb8dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -7055,8 +7055,8 @@ the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="34e62e2a-9c9b-4b34-ba56-25318cab9e47">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="30126d20-b1c4-43bb-8829-fa7d6490db9e">
+      <statement statement-id="si-3_stmt.d" uuid="f1faaa16-6cbf-41e9-900b-c0b780d64182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="369435a4-8044-471e-9a54-6d5457f0e4e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -7065,10 +7065,10 @@ the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fa462b9-c58e-49fe-8201-3df709308c7a" control-id="si-3.1">
+    <implemented-requirement uuid="1cb9ce8c-a065-4e29-8ce4-cf2326fb5635" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="023291d5-3be4-45f1-9104-6e6698bf7983">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8cecd61b-3275-4917-8625-9b96eb90d056">
+      <statement statement-id="si-3.1_stmt" uuid="eb659309-6941-4e3f-b759-e9650d65d7f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3e4d451-1297-4cb9-948a-5c981fa69b20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -7079,10 +7079,10 @@ protection mechanism is centered in one location.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7966eea7-ad31-4d45-b471-77009e65076c" control-id="si-3.2">
+    <implemented-requirement uuid="18ccdba5-ad8c-4be5-bc88-3d1aa521f7fc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="3c9acb06-63f0-48a9-83e8-b4ab4f150061">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="aa1bc353-e76b-4126-87a0-3daaadf457fb">
+      <statement statement-id="si-3.2_stmt" uuid="f025634a-0829-43ea-a63b-43512c51068b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9640d91-db08-4e76-86bd-d5f90fb4fe43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -7093,10 +7093,10 @@ mechanisms definitions are configured to be updated automatically.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fae03390-e1ff-46f2-a8c2-87a25125a10c" control-id="si-3.7">
+    <implemented-requirement uuid="cf3810d4-c2f2-4aae-9d19-8a62dc9eff70" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="34fd5609-cc68-42ae-b568-7ca42c18b92d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4c14adcd-3d26-4e87-ba00-78f84c6c6081">
+      <statement statement-id="si-3.7_stmt" uuid="c8f35cf2-5a10-456f-ae5d-d11ebbb2e481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cee870d-007c-4f0a-a265-2c7467b1ffd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -7109,26 +7109,26 @@ do not yet exist.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc63f4a7-f7f4-40cd-a800-d5474e38b0c1" control-id="si-4">
+    <implemented-requirement uuid="bdbbd04b-e0f0-49e6-bbbf-acd8c686f8a7" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="d894707f-fc00-4f9d-9930-f2596b40e170">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="961d8f87-0664-4f13-9999-88155a96900b">
+      <statement statement-id="si-4_stmt.a" uuid="0677e3a7-bf35-4378-a1fc-1be2f318baba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="1b4b5412-e20a-423e-ab09-87291fd42e1e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6957a66e-4cbd-43d1-808a-d36e26488fb1">
+      <statement statement-id="si-4_stmt.a.1" uuid="546c286e-e1be-43f8-b843-7adf97ebb7ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="3046c5c6-654b-42c0-907f-6348ac5069df">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4b72ddb2-e0f3-4702-b037-5564389da530">
+      <statement statement-id="si-4_stmt.a.2" uuid="8a3f7de4-ddf7-40bd-993a-c29b1409bd64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9bb5b42-c476-4aa5-985d-e9ba02c5d707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of CoreOS configuration.
@@ -7136,8 +7136,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="3c66a106-4c2b-4362-a207-93982c030c81">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="86058360-c496-4c4b-a447-a35ee70dfc4d">
+      <statement statement-id="si-4_stmt.b" uuid="680ade86-4b9e-4f2d-8628-4e8d97dfa690">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="148f2e3f-ddb3-4874-b4c5-81e95e745305">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -7145,16 +7145,16 @@ of CoreOS configuration. Functionality to meet this control can be provided by a
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="10316cff-7db4-42fb-b88b-4d69afac29f2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="60fcdd26-b474-4d01-bbf2-bcfa8cb1dbb1">
+      <statement statement-id="si-4_stmt.c" uuid="110eef98-891f-49ff-85a7-15bc1df2df7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9c75a2d-2eef-43c3-8c81-b2d9811bdc9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of CoreOS configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="c2535b59-a6ab-4fa0-831f-55e22e625fb2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="180c6f0f-1dd7-43fe-8543-7c069b54b404">
+      <statement statement-id="si-4_stmt.c.1" uuid="1ddbf432-1d71-4f0d-8899-52c86d4877c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="391a4025-aa3a-4916-a7b6-2675a890739b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of CoreOS configuration.
@@ -7162,8 +7162,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="424dbcb6-c497-4006-bf32-102df4d23fcb">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="71739239-746d-4780-afaf-c3534005faca">
+      <statement statement-id="si-4_stmt.c.2" uuid="07f80a66-1645-4f90-981b-ea7e4f5a704a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ef0e67d-380c-4cb9-a718-3f53e99d2f54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of CoreOS configuration.
@@ -7171,8 +7171,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="8b80b64b-aed2-460b-b922-2aeb5066422d">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="11891b53-99f9-45e0-aca6-8f23996b109c">
+      <statement statement-id="si-4_stmt.d" uuid="23254b38-9177-4e7e-9b4a-640411ae6e56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66c58a1a-589c-4f34-b1d0-7a68570d650e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of CoreOS configuration.
@@ -7180,24 +7180,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="d1d76451-666c-4758-82bd-cb34f8ce599b">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="4948918d-7343-4371-bc3b-f5baee236200">
+      <statement statement-id="si-4_stmt.e" uuid="4ca3ca63-8647-4bb8-ac72-4b879fdf361b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="d250ebc1-79e6-4180-93d7-7fd04af29530">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="7118ada6-33b3-4464-b95f-b34de307af4f">
+      <statement statement-id="si-4_stmt.f" uuid="dcd5cc24-40a1-44c4-8e1e-8596ba232473">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="1a50e534-e278-4470-9d56-d47d15db934c">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="6dcb3d27-3d94-4dc9-b67d-7c5930d93b02">
+      <statement statement-id="si-4_stmt.g" uuid="8fb28cd1-0afe-4a0d-984b-946420b5dfdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cbcb13-f4c1-4687-96d6-a5b320962468">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of CoreOS.
@@ -7205,10 +7205,10 @@ applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c1d6e1f-9d06-4d12-bb5d-6ec37820bddb" control-id="si-4.1">
+    <implemented-requirement uuid="75d89090-a9f0-454b-89e9-ae96313bdb54" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="68dd99d6-0d6e-40e2-9b0c-a1823a91f6f8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="868abe3b-bcdc-4d63-b5b6-df6bce050513">
+      <statement statement-id="si-4.1_stmt" uuid="8ffb6de2-8cfb-4c4d-b919-95476ce9b019">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14256b5d-c5ac-4897-b77f-6022a1d7b073">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the CoreOS environment, and documenting how this
@@ -7220,10 +7220,10 @@ systems.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d1dc0db-b603-43a7-a018-ca78b6fbe09b" control-id="si-4.2">
+    <implemented-requirement uuid="a466564a-c24e-44f5-a371-0d118c5aad09" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="2d22be96-5f23-4140-a30e-f56c5a16d539">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9dd1055e-a1c5-495d-8450-397bc06d5500">
+      <statement statement-id="si-4.2_stmt" uuid="bfec4448-35cc-4e5b-95c3-e12ba645a0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="158a60d2-2cb0-4c25-87b6-2a893330343c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -7237,10 +7237,10 @@ analysis of events.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0200a500-59a7-474c-abae-0ac74f851050" control-id="si-4.4">
+    <implemented-requirement uuid="7b2489d5-2f6f-4d1f-b59f-dca4ae41798a" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="b7b86e8a-d3c3-4859-b877-d5eb3b5a11c8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="958d3472-0e68-41d3-b953-fae518d798c6">
+      <statement statement-id="si-4.4_stmt" uuid="ad0d0571-b244-4c86-9d3d-b043dda2a718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e96419b-1e8a-4449-84f4-3d330c160a20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -7252,10 +7252,10 @@ not, how network traffic is continuously monitored.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0323fb39-6ca3-4686-8bef-c379e0c11207" control-id="si-4.5">
+    <implemented-requirement uuid="9ed28fbd-039e-4879-824c-5fb5fa40ada4" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="c175f5cb-4005-4e95-850a-c3e4c817c4a5">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="35e869ba-1b45-45f4-8a1a-014b7beaa65d">
+      <statement statement-id="si-4.5_stmt" uuid="7d9d1d38-f847-436f-80f1-5f2040122816">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae281442-f332-407e-959e-52cb7a2dd9df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -7267,20 +7267,20 @@ the notification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee5fb763-3896-40f6-9dbf-3ff5b5892243" control-id="si-4.14">
+    <implemented-requirement uuid="a7ebf79a-ce66-45f3-8fc6-f565302c29c1" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="2e377b85-e589-4182-a007-7952ac5ca0b2">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2fe66e04-8afb-48b2-977c-c8c03e15ecf6">
+      <statement statement-id="si-4.14_stmt" uuid="5e1e10e1-5136-4c37-a9f0-c2ecad6147ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5eca404-095e-4b2b-86e6-72099fb623ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An CoreOS infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca58fcda-e052-48b0-8639-9b6cad644567" control-id="si-4.16">
+    <implemented-requirement uuid="07d7972f-8d1d-4f42-ad1a-42cede0f3a4c" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="40220d1c-41cc-485f-8b49-aeb8aa29a5dc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="953bf404-64eb-4891-b9f1-31456a520213">
+      <statement statement-id="si-4.16_stmt" uuid="816c1b9b-678c-4cd0-9101-99a2ad18fea9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9202c5d-7097-4f4d-95f1-5de0b334241b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -7295,10 +7295,10 @@ https://issues.redhat.com/browse/CMP-536
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2e5ec51-c025-4ab6-8903-6b2cd3a6ead8" control-id="si-4.23">
+    <implemented-requirement uuid="27c9177e-deb2-4a15-ba81-b36494cb9ef4" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="8576de12-22b4-4373-b837-5dc439f8361e">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="cac76d47-637b-4e67-83a8-d92b55cb3dde">
+      <statement statement-id="si-4.23_stmt" uuid="090e454d-d7c6-477f-99cd-ef028901620e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac1be603-ec65-4c92-9980-6ba048488476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -7312,10 +7312,10 @@ https://issues.redhat.com/browse/CMP-540
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e82847e0-2296-447a-bdb6-9a11bd1e636b" control-id="si-5">
+    <implemented-requirement uuid="751c1382-670d-4e79-82f3-417934a90459" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="ee103668-72b7-4dd2-9207-d56366f7e7d8">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="a8600b03-a22d-479c-81bc-29aa5a5fe34a">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -7324,8 +7324,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="98d5015f-baa9-4179-ba90-289e8078180a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c521d704-ff83-40de-9255-3e2f0561778c">
+      <statement statement-id="si-5_stmt.b" uuid="2d6f3fd6-5ceb-42a5-861d-ed9429db50d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ffb574f-1429-4a3c-b34e-3661754291ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -7338,8 +7338,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="f90668de-999c-47e3-9c1b-78e55e3f55b4">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="15887fe7-4806-43f5-a348-b7b3d37e8213">
+      <statement statement-id="si-5_stmt.c" uuid="5337086f-8de7-49ad-9a55-b5fb48cda4ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1611a1fa-24be-4608-b7f0-19ba0e92a895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -7348,8 +7348,8 @@ procedures/policies outside the scope of CoreOS configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="9600dac5-1b30-4031-81fe-5bfa8c097827">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="44733fc5-dba1-4b61-b820-87a5d522af27">
+      <statement statement-id="si-5_stmt.d" uuid="d102557b-2f6f-4ccf-80b8-75fa13defc64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fb1fbdc-e1c6-4d94-8fc8-900c172936b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -7358,10 +7358,10 @@ procedures/policies outside the scope of CoreOS configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f33c945-048e-4023-b263-9b5c961d62f3" control-id="si-6">
+    <implemented-requirement uuid="db734672-4491-4bc0-83df-6e1c367064c4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="2eb3ab64-d21d-409a-a266-679db7ef3835">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="886351c7-c314-4583-a438-b06bbf737d19">
+      <statement statement-id="si-6_stmt.a" uuid="705d5b25-1cc4-4a17-a467-dcba7f7eb858">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1be72547-09fa-4e5d-97b8-90d5d6f5c3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -7376,8 +7376,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="de2b1f41-01b5-49a1-ae94-1b4b0b04cff9">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="0f5ecdb3-2af3-4d0c-83a2-ed839a23f894">
+      <statement statement-id="si-6_stmt.b" uuid="c8938a79-90df-4705-8f84-0851a5571634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df99302-8afa-42b5-ad64-d171a878c25c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -7393,8 +7393,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="86d681af-d4d3-4e5e-ba20-b42bc96441de">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="f35884ae-b97c-4ade-aeee-c469b46b075e">
+      <statement statement-id="si-6_stmt.c" uuid="644fd87b-44c6-4637-a737-837a44d925ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0edc2e83-d6aa-4a31-9980-0091fa7f777d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -7408,8 +7408,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="8ff2d409-2127-4657-9382-5c3b6aba999a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="c70a6d19-ae2d-4ef0-ad4b-6e29adbe0950">
+      <statement statement-id="si-6_stmt.d" uuid="ea6a903d-35f5-4cb6-9fb6-1b881404cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="474dceb6-7148-4aa4-92c1-2489caded95b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -7426,10 +7426,10 @@ https://issues.redhat.com/browse/CMP-542
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ee9f013-e7d1-49a6-bef9-c34e75f72371" control-id="si-7">
+    <implemented-requirement uuid="75b37a46-3c5d-4af3-b138-3dd476964635" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="358795d4-f387-4287-9660-70fc5cd7c673">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="25631bcb-c038-486d-af49-14d59019952a">
+      <statement statement-id="si-7_stmt" uuid="8f7edc4b-595d-481e-95ef-290b4ef632cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c1d92f-ecb2-4ea3-a509-a65151878115">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -7444,10 +7444,10 @@ https://issues.redhat.com/browse/CMP-394
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7751a27-5f19-4b8d-be8d-d1ed14de2861" control-id="si-7.1">
+    <implemented-requirement uuid="ca455f35-8815-4603-b38f-dbd91fcb6a79" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="60527132-f1c7-4463-9170-6e36f4418915">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5bfc3b2f-c6d6-4e5b-a075-76b082f9e978">
+      <statement statement-id="si-7.1_stmt" uuid="b9e27bf9-5e74-407b-bc19-f1ee19c96e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a3da903-2950-443c-ba74-bffeec06af44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -7464,10 +7464,10 @@ https://issues.redhat.com/browse/CMP-395
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a44f188a-1126-4db0-b1a0-fc56d4e48c92" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="4498f433-5aae-4e82-a5e7-258bcbfaed74">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="dc8e6413-b4fd-48cc-bf99-ed9075ad5e41">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -7479,18 +7479,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d8f8869-484b-43a7-96d6-b4e1dd9d5bdb" control-id="si-8">
+    <implemented-requirement uuid="da2b38c9-d54a-49ac-84bb-3a53a9d94df0" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="014bea0b-bc6c-48b1-ab71-fd9e8f6e3954">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2e089502-fff3-40b8-87a2-fd9c5178b1a7">
+      <statement statement-id="si-8_stmt.a" uuid="fca0fa64-910b-4e7a-9dbf-1d6824384be5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="6939328d-bd3b-4a3f-9a74-686ffe9d742a">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="5f4b16bc-d365-44e5-b57f-88f1d3224c32">
+      <statement statement-id="si-8_stmt.b" uuid="a75e2a00-e4ca-497f-9875-bb4d092eb7d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -7498,10 +7498,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9685081a-71f6-408b-a778-4f5de62273a9" control-id="si-8.1">
+    <implemented-requirement uuid="4a971b76-f4e0-4345-8f13-67b67665137d" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="9fc5bf2d-fcd5-40fa-9297-b1046dd8fd78">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="ad17fbcd-d35c-4f3b-87f5-b7da9fefb60a">
+      <statement statement-id="si-8.1_stmt" uuid="99f9a6c9-4955-4725-8c5f-5413abb882e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -7509,10 +7509,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7347ae9-b89b-4e31-ab57-f8a713ebf91d" control-id="si-8.2">
+    <implemented-requirement uuid="b4378b5e-99ae-407f-aeba-de3e38aa1332" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="03721519-8731-46f1-b5d5-4339aa629cc7">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="2140516a-606b-4996-8ec9-7e3598ddb650">
+      <statement statement-id="si-8.2_stmt" uuid="8ed3cb71-7439-40a6-bc69-68c2c6e8d40e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86474383-2042-47ee-a282-95e93bc87f28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of CoreOS.
@@ -7520,10 +7520,10 @@ are not applicable to the configuration of CoreOS.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c0be95b-8e15-4297-858f-1ff09cc1d233" control-id="si-10">
+    <implemented-requirement uuid="5637a065-2c41-4b1c-8392-b5ffc146062e" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="d35ea0c6-cae5-4944-aec8-4f963117b9cc">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="22b0b8a6-571f-4011-b3ec-53141b627196">
+      <statement statement-id="si-10_stmt" uuid="ed487876-7061-4778-96a1-04a08a800007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="230d9846-c77c-44ce-970a-06f688716e92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -7540,10 +7540,10 @@ https://issues.redhat.com/browse/CMP-393
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27ca0d6a-10f1-4f30-8ee9-b0a5b8d2b39b" control-id="si-11">
+    <implemented-requirement uuid="e6cb6628-1177-4d93-a4a6-1a0510d6328b" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="7d2fcb17-60c1-4fe6-a457-ff9ed2eb7442">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="8ced2c91-a0a7-41ed-8e80-ddcb83d8c3f7">
+      <statement statement-id="si-11_stmt.a" uuid="13df6b6e-0fac-48ec-906e-3b7eb8dd6700">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a8dcc90-b783-49bd-9457-39a78c8ca167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In OpenShift, the logs depend greatly on the component. Some
 components would just write messages to stdout that the cluster
@@ -7562,8 +7562,8 @@ security information, account information, etc.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="6c927c63-e8ff-4f8c-96e4-d149b9639d99">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="fa8a6637-fad2-49eb-9391-38829063a562">
+      <statement statement-id="si-11_stmt.b" uuid="0e20cfd6-f6a6-484f-9b51-643953bd0ce2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06c151a0-f34d-4bf1-a89b-fd089b157b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the API server logs are protected by UNIX permissions and
 only cluster administrators are allowed access to logs.
@@ -7571,10 +7571,10 @@ only cluster administrators are allowed access to logs.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe449738-b356-4089-8c58-78a838403a99" control-id="si-12">
+    <implemented-requirement uuid="1ce07b9b-8700-4477-9e3f-e78da30e83ce" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="89ea177c-8fc0-4f64-93c5-b344803537ca">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="d46e94d7-e26e-4397-9f5b-9cd3d47057e4">
+      <statement statement-id="si-12_stmt" uuid="24c68931-27c0-4e74-b69b-64db342d38f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5dd9058d-69a0-415e-a099-63f6b05f4622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, CoreOS in
@@ -7588,10 +7588,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f6637b1-9c23-4ad0-b272-644d2051d3c3" control-id="si-16">
+    <implemented-requirement uuid="3680fa8c-408e-4624-8c74-8e70a35e49a8" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-16_stmt" uuid="661b222e-12cd-4ff3-8f2d-e0fb4fb94240">
-        <by-component component-uuid="af3d73bb-ff91-4ca2-99fb-08627e5c416c" uuid="9634d399-aa15-480a-a661-526cec7bedaa">
+      <statement statement-id="si-16_stmt" uuid="f2f8f447-3b48-4547-8d3d-3fd2d6070ec4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7710e88f-bcc8-4c4b-bd62-e807ba8526e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/identity-management-fedramp-High.xml
+++ b/xml/identity-management-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="07f8f05f-0e7b-4d78-b4d7-351bd44f1bad">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="89f3eae5-a44d-40e9-b884-1a6170c47c41">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.56+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.97+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="ff77630f-998d-4d30-a060-882a9b05946d">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="0938ef88-db56-4f6a-9de0-ee3e0b1ed6b8" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="81aa5b0b-baeb-4145-b41c-23941808f28b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="350b1071-6ae9-487e-a68a-1b5eaaf434ba">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec288953-d18a-43fd-9d1f-b294640081bf" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="c0f70be7-3397-49f9-928a-f25ce56f7a59">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="93a0012d-7e37-4325-806d-0bd4e55f26fb">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d686b54e-5898-4cb4-8a81-310fe8636c28" control-id="ac-3">
+    <implemented-requirement uuid="2686232f-124b-4343-81bc-219b4929e933" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="b279b56c-508c-480e-8ad1-266e93c3ae50">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="304f2abb-28dd-4602-bd3f-01277de3645b">
+      <statement statement-id="ac-3_stmt" uuid="6cb50aed-55b2-4713-90b2-41f4da2c9dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbd60c53-75aa-42ae-b8ca-a057ea9b6917">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is being
 tracked on GitHub:
@@ -515,10 +515,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/2'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84fc5469-cccd-4566-be8b-5e4d8d20bee3" control-id="ac-7">
+    <implemented-requirement uuid="68a78243-a112-42bc-b8df-fa935c812ac5" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="e51397b1-8d4a-40be-95ab-0a72ba0b1e02">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3939b1f8-735d-4d39-8f1c-56212bd85674">
+      <statement statement-id="ac-7_stmt.a" uuid="2fe6207d-624d-4450-a641-f12787214cf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af26e73b-91e1-4190-814e-1e564d8c707d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -527,8 +527,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/3'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="6e41bd9d-20d2-4392-a116-2dfab59bcfaf">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="55e528c9-e73b-4ce8-8703-f07e1aacc6e1">
+      <statement statement-id="ac-7_stmt.b" uuid="75233fb9-ae05-4438-8a87-8be6e12967f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d831de-76a9-458c-918d-696396632d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guiodance for this control is being
 tracked on GitHub:
@@ -538,10 +538,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/4'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c0ae73b-b31f-4c83-bd9d-dd85bed0877f" control-id="ac-8">
+    <implemented-requirement uuid="2264582f-57d1-489b-ae0c-2f47ef5bfa67" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="8b4eab91-9fa0-4578-b0eb-e9922e215fb3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="df19f304-823c-42c4-a135-93b1e503f93b">
+      <statement statement-id="ac-8_stmt.a" uuid="88aa2f00-3570-41e6-8c92-fc4427698102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddddca08-6750-4a81-b06a-1d0bf1de771b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -550,8 +550,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/5'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="6fe63644-befd-46a9-b6dd-34a3e566ca6c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="64869c55-e26f-4ebf-b22f-bed09849d9a6">
+      <statement statement-id="ac-8_stmt.b" uuid="5fe50d42-8002-4962-b62b-bc0d11148378">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a483aa78-18cb-4824-87c8-3567e2365668">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -559,8 +559,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/6'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="063aea6b-62d8-48ac-ba57-b023a50e45f7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="bb29ef9f-d25d-4a1f-9f1b-254890684da4">
+      <statement statement-id="ac-8_stmt.c" uuid="c77f2ba5-8451-46c8-8716-0274c31731a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7bd5761-0a23-4c8d-a6c7-ce9f695991c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The banner text, as identified in AC-8(a), and banner acknowledgement,
 as defined in AC-8(b), will be the same regardless of what network(s)
@@ -570,10 +570,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="846d79ac-e6ec-47fc-a5ba-054ec6ffae5e" control-id="ac-14">
+    <implemented-requirement uuid="0dba02e9-1d1a-46a6-8eac-ae228748a7fe" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="9c6c16e9-4628-4673-915d-b2537bc44ed7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="925a1364-12ce-47af-8223-14f0a16823d7">
+      <statement statement-id="ac-14_stmt" uuid="8cb047d6-5057-4cef-8e10-c1b786aa7f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2267fcff-70b3-4825-84f6-70f3605bdffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat Identity Management
 console, unauthenticated users will only be shown the
@@ -586,63 +586,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f949c027-cbef-461a-ac55-d9105fb575bf" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="938df8db-9f64-498b-8858-672abfe34afa">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f1289f22-7b0d-4d22-a42e-678debf7342a">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21acd02a-187a-4019-9370-db766939797d" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="c654d017-0589-42b1-a890-55e0398a5d14">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b7afd7fc-61dc-449f-842f-7f681ddcce1f">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04708d00-db9e-4c50-8acb-eb05f42a6a47" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="bf8f4cd4-5df8-4af8-b1aa-a3008e2c6b46">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8425d265-873b-4f9f-a68d-7ee329a63f54">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1819a82b-b0e7-477d-897c-3f839e4d7578" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="52788178-d44d-46ef-b7a1-841525ce4278">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e03aa622-e3fe-4d96-9db3-4318be87c893">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a2d9cfc-96e4-4293-839c-bc9325534d57" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="b205e570-a3b7-407e-8d5c-5e697a4e9069">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="73a4d500-78f8-4d39-9634-13f5b0df63e2">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7f8fc73-fef5-4feb-a1f9-708f7f1b82e3" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="1a99c681-8162-40bf-af0b-c484acdb65b4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7174e55e-d8e4-4664-8e36-b2d87bd512e9">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="b68e9c72-5e74-4742-b978-6a02f8fa4a4a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9b8158cf-203c-4a9d-a0f2-1d63b659dbf6">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -650,26 +650,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c8f3623-afb3-4e3b-881d-5fb130c5da12" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="36a1328a-db38-43a4-8ebd-b9b87d40e00a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="294be396-f77c-4042-a00b-7c698a4dd347">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="546c494e-49b7-410c-84b0-6fc51ee8396a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="72c8946b-2e2b-44e5-980c-04b32d59e28b">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="018a4ae9-0a94-4ad2-a1a4-58ba2f86db34">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c1d8aef3-452e-4ea6-bdc0-e3a9acfa1d4d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -677,10 +677,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a6d4c32-1b15-40f5-9fcd-d03036a057fa" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="fa91d104-2d0d-4abe-bb00-03e104853d4c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="49995022-96f3-48b0-93cd-397643e3d5b5">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -688,26 +688,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb1bb453-6da4-4c71-bea3-b77faf4bc2bf" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="6742e51f-06eb-4a7b-acf8-4d433a34c8cc">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="297f62d5-ea3c-4bc9-96df-f5cb5eaba0c0">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="aff31702-93bb-4d4a-bce0-94eef95e1d1c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1f73dceb-6b22-40e4-9a95-fd6d9204356c">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="07ad22d0-eb5b-451a-b562-51450170ea35">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1a2aa1ef-b15a-44a3-93eb-2dc16d2a6b6f">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -715,10 +715,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de477643-2a62-47cc-a022-e137b5258d9d" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="7a1ef805-d77f-44e0-880b-9249c628d71b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1302ba8f-77ea-451e-817a-31a00ad84b5f">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -726,10 +726,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a119252-8b57-4103-8c01-bd5b1be6cb0f" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="39fc7f06-f19d-43ac-9ecf-0702ffea894d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b8f5a988-927f-4aac-9a7a-3fc104c78e03">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -737,18 +737,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c40ace87-b000-4a82-bd89-9c1f82958a03" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="c150a195-f71a-4eff-90a9-29edf86d6c5d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0b77d956-d521-4e2d-83f2-b0fa9dbe80aa">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="0f9ca572-3f37-4443-bcb7-531111ba1e1f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a1d72710-2a7b-4135-87e0-e51932fc467c">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -756,28 +756,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1b184a2-ff39-4fbb-8bc0-00eb7cb15099" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="76ca28bc-4e8a-4b18-81d7-504cd0c136b5">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="244e3575-0b55-4542-b181-8c882e1283dd">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22f4766c-e45c-4e21-aae6-7e2166afe31a" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="2efdd661-5259-494a-8027-3804a0d304c3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="14d88425-fcc1-4955-b509-537eff71c2d7">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cf23618-7e76-4a59-acc8-41209951d049" control-id="au-3">
+    <implemented-requirement uuid="f0e3c559-432e-499b-8027-7b9326bc137c" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="ceab4198-59ca-450e-9e15-fbdd10f5a767">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9762cfe4-2c04-43ad-9783-5747aecf54a4">
+      <statement statement-id="au-3_stmt" uuid="6b2dd116-f765-423c-be14-fb716dafadaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eec9f35-3329-4d83-a198-c5eeba770567">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management audit records contain this information
 by default. No additional configuration is required.'
@@ -785,19 +785,19 @@ by default. No additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a8672ed-20fa-4982-b8c5-c1686cb59e39" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="ed8e78ef-fed8-4843-94d8-1008624d481f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e751cfde-04b5-42a3-82fc-85b4daa7b575">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="390cb9da-7bdb-4c9b-b99f-e6a11c6da4d6" control-id="au-5">
+    <implemented-requirement uuid="034ea4df-825f-4faf-88ba-f298c53a7b1d" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="7e5a6653-cc65-437b-b5a7-c4a7a2fae359">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="51a18c61-9ccc-4284-af0e-42b2c3bd1c2f">
+      <statement statement-id="au-5_stmt.a" uuid="5ce2ff49-d8bf-4cd0-9f55-f154246f0ef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1882697-7e9e-4844-8de8-86cd41eb893f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management Administrators  are responsible for
 alerting personnel or roles in the event of an audit processing
@@ -812,8 +812,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/19'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="dcaaf8c3-be18-47e8-ad67-54485be57162">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4aceef5a-5088-4a99-8cd7-4c1f8bf6a43a">
+      <statement statement-id="au-5_stmt.b" uuid="62bb3d0f-d7b5-48c1-a667-b0e5700bd35e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cba42318-7a19-42da-988b-38dcddcfef29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat Identity
 Management Administrators
@@ -830,19 +830,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/20'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62e8e0d9-33c7-40c8-a725-ccbb9b062e52" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="ec6a75dc-68d3-4c0b-85d8-92cdd2d40ffe">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="ce730934-bb57-4f33-90cb-5b3b4a617c50">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c51eae12-b4b1-4acd-86a4-f173d88cae97" control-id="au-8">
+    <implemented-requirement uuid="d315c03d-3602-4936-92a4-d5602c2c2695" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="9531ed3b-1c9b-4c64-9be2-89c54ff9b972">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b8c19119-fdde-4bd5-86b1-75b5415a5dab">
+      <statement statement-id="au-8_stmt.a" uuid="c31c0db0-29eb-4b00-bb36-eda35cd8790d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="631a70c9-5c2c-4fc0-8322-f6f8ba3c1e7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time services
 provided by the underlying operating system. This control is not
@@ -850,8 +850,8 @@ applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="dea21c62-aa07-496e-8c19-b25a91412dc8">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="6ce206a1-adf3-492c-bc10-1f4b68fdbd8a">
+      <statement statement-id="au-8_stmt.b" uuid="57485f21-41a5-4d56-83a6-d0bfc7acbbdb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="031ff5dd-8043-4802-9aaa-fe140c7d142a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time
 services provided by the
@@ -861,10 +861,10 @@ configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2c8ea81-17b3-4160-8f72-b06300289d49" control-id="au-9">
+    <implemented-requirement uuid="9220e518-9a38-4e4e-a1ed-fe9236536b01" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="cbd8a072-29d5-4b33-ae48-8ad089cf96cc">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dd81f1d2-158a-434f-b54a-9d0d62249769">
+      <statement statement-id="au-9_stmt" uuid="f96632ab-f3bb-4a09-89e2-9eab4caebc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e4d92c1-2e60-48f0-95e9-5dc33662d8a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -881,10 +881,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/21'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44f61fb4-5fbe-4d3c-8501-496fcefd8c0e" control-id="au-11">
+    <implemented-requirement uuid="a5527673-ede2-4adf-ae57-5429e7e61426" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="ddc31e36-6ac9-441c-aa0c-132d60f9bf94">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f8f30438-4bf7-4110-916d-73494f88a6ec">
+      <statement statement-id="au-11_stmt" uuid="14bb9cb2-ee94-49b0-a72d-9a5c646e05d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad105910-b599-4da9-ba4b-584f5cab4d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -894,10 +894,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/22'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f476f9d3-6921-42bd-b4a8-130e5a7d21ff" control-id="au-12">
+    <implemented-requirement uuid="2feaf953-6801-4ba5-85ed-d77b00c57295" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="7d58bff1-ea78-4c1b-b78e-ea48bc9edf72">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="16603ba4-165e-4860-8a0e-2d54de5ddb58">
+      <statement statement-id="au-12_stmt.a" uuid="418ce8ab-4857-4355-8366-46c734fd354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a9baf92-f88a-4a46-aed6-d6b671665072">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to provide record generation capability for the
 events defined in AU-2a at all information system components where audit
@@ -912,8 +912,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/23'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="15bcafb5-b7d1-4acb-a2cd-7c69749d32a3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3652eb72-08be-40cf-b18e-8a35ab116299">
+      <statement statement-id="au-12_stmt.b" uuid="6f282e6d-c2b3-40f4-a38d-9732ef3cf585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78ced34d-f455-4993-8c6a-2d6af382116a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -930,8 +930,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/24'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="45fd6c00-8281-440c-8f02-1de90ef0ede3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="94609da7-c21c-4ec3-b10b-6dce12a7dc6d">
+      <statement statement-id="au-12_stmt.c" uuid="1224f7c6-5c3a-4349-8e8b-c38a8187f02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c9eddcc-dcb5-445c-9616-5b79870ad5c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -946,109 +946,109 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/25'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcad5859-9c81-40a6-a78e-dbe5d6efda81" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="47d246af-bf57-4aa4-a07a-41ab2ee4a728">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="16f61bbb-f86a-422b-90cf-5697d2732c0e">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0fe9caa-6ed7-408d-828f-a5a054ace4b6" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="393fd10e-708f-4a79-a952-5c16e2d0c85f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9ab54aa7-b27b-4aa5-9b9d-1e7eb20710b2">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee2abbb3-f6ff-41c1-82b1-c0dad0290029" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="ff9e0c92-8e81-4de0-bbe2-04bd5e0d467d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8916a9bd-2f6f-49b7-a407-0d7894ca69ab">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="239139c0-b895-497e-87e8-5ad3ea511c88" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="2579aa66-4dba-4223-aead-9676aa0a65ff">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2fa0ed38-93d4-4c5c-b652-4adc4da491dd">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85b57240-a42a-4247-81ed-ec682a722eb5" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="6c6d36b3-aff3-457f-bfc5-bccc5d2547c4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0c85e3f3-ce3c-4c5b-9ccd-865ebb0f7fd5">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="931dc529-a00c-43b3-aad9-84da0b83d161" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="426fb354-1acd-47c1-b71f-65313fbeffb3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f1f78049-07b2-4b85-9866-dcbde78752f7">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff24ddb5-889e-48f3-a200-bfaa154b8600" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="78feb89b-f7f9-4541-aa95-7fa387f02612">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dcb638e7-f87a-4201-bb07-df8c5645af76">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30795b44-5c7d-442a-bf24-d32f21ef5180" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="47835388-155e-4e82-a02d-f998df87921f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="93bbc0cf-5c5d-4947-a0be-8fefbbfa94ff">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab33efca-6b21-4753-8e77-577fee8f0d5c" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="43320bfc-48f9-4c0c-af29-1e438a861397">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c8fb1f17-f54d-4dab-8d21-9b0ffc7b7ad8">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="076a3b4c-9a6c-4941-81bd-4198596d8ad6" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="24897571-c8dc-4e13-9ec7-6b81a5b1eec8">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d8855172-3069-4146-90a7-2442623b561a">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="569486bf-eeb7-4ff6-aef7-ddd80b6061a0" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="7154a47e-d8bd-4d0e-bcf9-a2a1e81e57bf">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3d2e9cc7-d6e2-4cb5-887d-6f0c85480e98">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df0d97c5-a5ec-465e-aa19-ac36fc2ac3a3" control-id="cm-6">
+    <implemented-requirement uuid="eb43e7b7-04a2-4bf1-a1d9-714985741a38" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="4fee2632-f34f-46d9-9efd-7ab7bb27da80">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8c2e08a9-4f33-4562-afb1-7e305c5a141e">
+      <statement statement-id="cm-6_stmt.a" uuid="72582835-c086-4505-961c-9c88a556ee92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de7715b7-c6db-4849-828b-0c654b43bbfe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management. Use of the NIST National Checklist
@@ -1057,8 +1057,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="5e382739-d946-43a2-a7f8-ee238f024d4f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0b3320b4-a6ba-4468-9681-16ac4cde2c38">
+      <statement statement-id="cm-6_stmt.b" uuid="8a63aa2b-3443-4dca-8903-1971b9346769">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed14dd7b-0a83-48ba-b6d5-fd6223eaa59e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1072,16 +1072,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/40'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="6f6de595-1d72-4614-8cce-a3cea13c8d0a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="502da5a8-e01e-465c-b58b-ee46e62371e7">
+      <statement statement-id="cm-6_stmt.c" uuid="2a2d2109-32f8-4eef-bd71-d34021ad808f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="7e5584d4-028a-468b-be88-24d8ac8318c4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="56adf1a4-961d-4148-ba26-9e91f87037f4">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1093,10 +1093,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0495d09a-dd62-43ba-b957-f1887f9f2d3f" control-id="cm-7">
+    <implemented-requirement uuid="dc6be27f-2815-4296-a17d-9630b0358a80" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="017345b9-f92c-42a1-b8cc-7ec96e1e9dda">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3c6d3e38-60ec-4104-8542-0419cdc5de37">
+      <statement statement-id="cm-7_stmt" uuid="3eed2889-2c79-4ea1-8d29-292b6f7d0511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43fab0bd-f9e4-4b72-92c5-881550d346bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management provides many capabilities, including
 user authentication, DNS integration, and several APIs. A successful
@@ -1106,73 +1106,73 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ef4b42d-2f8e-464a-a8ed-ce7528143a07" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="7cc7182d-c880-47d7-abc6-649279739dac">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="da54b579-9ea1-469a-bbf5-3ceaed11daf2">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcdb9b81-8042-4962-8fb6-eaa1910dff8e" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="c96a5dec-6091-416f-937b-1624f59e412a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e66f5272-3325-41ff-ac71-f8bb201c4dbe">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2567b9b-e59c-42b2-9adc-f784f4c0df4c" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="d08330cb-64d9-4cdc-9fc4-98d274283264">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0ca911e5-f196-4564-9110-34adb7539af2">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7c54dee-e110-4d41-b150-f9bff0e80f98" control-id="cp-1">
+    <implemented-requirement uuid="a0f6269d-8fb4-451c-91c8-27e046a4860b" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="457e7df5-5c2c-4527-b7b0-5ed94f3413cd">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a11386c5-ddb8-4793-b686-a523ae4635c2">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a68aca1-55b6-469a-844b-7ecb9da91db2" control-id="cp-2">
+    <implemented-requirement uuid="6ccfe701-d079-46d5-9cc2-f6f7d1922a00" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="fec9eadb-0959-4a07-87a1-5719377427f9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4e844326-5f37-42f3-aa1e-4af42b9d546e">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e417c388-bed9-4d9b-97a7-68f19b793cde" control-id="cp-3">
+    <implemented-requirement uuid="a14f7e61-a09e-4a5a-b0c2-f83ca7d9a604" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="e6e83577-ac90-4d25-b1af-5d496c0368c2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="ac166fa4-3e49-4fa7-8955-274454a2c545">
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5159f7f7-f84e-4934-9889-834dc93e6fc3" control-id="cp-4">
+    <implemented-requirement uuid="07999975-1ad2-4276-95d4-c9bd5cade065" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="060da1c8-a379-4a4b-8a41-dca188c2f02c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2d9536df-0b6a-46ff-9714-7be04fe33efd">
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d5a807e-a8d2-40de-a81e-8ca0331a3c3b" control-id="cp-9">
+    <implemented-requirement uuid="71ae0c0d-1063-4bb8-aed5-46b34435ea93" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="6f1146b4-9738-4b66-ac24-674d5f38e7e2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3c33c267-3518-4c67-a8a1-1c1a1feee42f">
+      <statement statement-id="cp-9_stmt.a" uuid="b6de0a33-e983-4088-a93b-2cbf8cd36608">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b283e7a-66e1-49ce-9e5a-b098f19f6b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1189,8 +1189,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/51'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="7e08fed2-1d63-44ef-9fa1-ed442458123c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7e8d0263-2816-42fb-b045-71cb9a6a6219">
+      <statement statement-id="cp-9_stmt.b" uuid="a6aafdf9-f3fa-4924-8ce6-ca0e17cc2c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80930de0-ac6b-48b7-b500-18c0cad04247">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1207,8 +1207,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/52'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="192548ac-163f-414d-8232-2b2ed954d496">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1a503146-85c4-4092-83c3-61a02b9236c8">
+      <statement statement-id="cp-9_stmt.c" uuid="d4b964b8-d27c-4ddb-b5d7-f0b0f2514aa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77d4bc17-9908-4d0f-8a90-a5767cfc149f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1224,8 +1224,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/53'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="2be45e4f-e203-4992-a508-3f58a5cd2bfd">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f943a6e2-c867-43b2-b241-98da1b703134">
+      <statement statement-id="cp-9_stmt.d" uuid="981d1648-443d-454d-8e72-85955631a0e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29c7f194-769b-41b1-be15-f0b6cb7c66fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1241,10 +1241,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/54'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dc5683d-886c-4d4d-895e-19f56a304fb3" control-id="cp-10">
+    <implemented-requirement uuid="0f137ca3-e150-4d12-9529-74058757bf93" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="1b034df8-3725-4ffb-8dbf-d1da10cc1112">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1f99e525-af08-4ff3-8a54-12614a236b8a">
+      <statement statement-id="cp-10_stmt" uuid="97c745a9-c5b3-4340-a551-de3cefa1f5c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758e9828-dc07-44a6-8027-def0ac361a39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute
 their Red Hat Identity Management environment. A successful control
@@ -1255,19 +1255,19 @@ Management environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aa7759c-8839-4718-bb72-381d427a4164" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="ed48dc8a-19ea-4b4a-8a12-10a11cbaee3f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="cd3033ee-7c55-4f8f-9f4d-82657deb0d56">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf6ce4bb-dc96-438f-b8df-748f597917c1" control-id="ia-2">
+    <implemented-requirement uuid="a0552f3b-016b-40d1-926e-a17b256a6b4f" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="8240c8df-6436-43c0-81fc-7c1dbef29a94">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b34a9e55-67c9-4696-82e4-9b4c0f4addc1">
+      <statement statement-id="ia-2_stmt" uuid="1892ea09-ce90-4f45-af27-3cc782b239e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="655fd21c-d8e4-4d7f-a9b4-6286c7973bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring Red Hat
 Identity Management against
@@ -1278,10 +1278,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/61'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9070dcca-c386-47d2-ba10-fc4a6589f800" control-id="ia-2.1">
+    <implemented-requirement uuid="8a64ac47-2a71-46a6-8fdb-dd0589bf6114" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="6c6e0234-7cec-4da0-aacf-9941ae6a7cc7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f8910e35-50c4-4625-b548-7af29124c1d0">
+      <statement statement-id="ia-2.1_stmt" uuid="81d804c1-0f52-4719-b71f-f0a82cdcc372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d670bf3-6483-44d7-83fe-feb5acc447a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1304,10 +1304,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bfb42eda-6df0-491d-898b-ddd1b9953aa3" control-id="ia-2.12">
+    <implemented-requirement uuid="5ba17a8e-8872-4bc9-8a24-0b8f8c73ed1c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="4202aaf6-1123-4dac-9313-dd9ee72eef3e">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4cc4ecee-8998-4f8c-b264-99025b7fedf5">
+      <statement statement-id="ia-2.12_stmt" uuid="49ecb729-40c2-4e20-9846-7d0b7d160770">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="534a5d5f-ac4a-428e-9547-7de76a6cc430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1324,34 +1324,34 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/63'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fd078f8-fa78-4049-b178-0a0d02ff52b1" control-id="ia-4">
+    <implemented-requirement uuid="0066267f-fefe-4dba-b0f1-79ee03e68b7c" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="15ab82b3-9e5f-46be-90e2-2d3233386cd7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="70034da4-a8a8-4849-af72-3065c0761e6e">
+      <statement statement-id="ia-4_stmt.a" uuid="c74e45fe-ba05-4415-8c5c-0171266d0492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="995db0c8-6d6c-4656-9128-16f37af1e696">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f7ecf869-90e9-45e7-9e30-1deec05d2384">
+      <statement statement-id="ia-4_stmt.b" uuid="d45bb245-1b07-45bc-826f-73bee9bc9efb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="4f241ce9-fbbc-4914-93f8-f5f5c6f50fc0">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="af73c9c0-c4b1-4630-9736-37bd4ba7fa03">
+      <statement statement-id="ia-4_stmt.c" uuid="8a708da6-8e06-4d94-adbe-8406f9da9d98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="dc163adf-ebb9-4944-ad78-bb3a6e533340">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0ad79f39-99a4-4362-a238-8597ecb7d4ef">
+      <statement statement-id="ia-4_stmt.d" uuid="b48673e5-0fdd-4f52-ac4c-dd9b602f9f2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddfdc13b-3e8d-4a48-aa1c-b964d1402e76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on preventing the reuse of identifiers is
 being tracked on GitHub:
@@ -1360,8 +1360,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/64'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="941e8e98-06d3-4c2c-8bd4-a95b4c67315f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="71802f26-7edf-410d-b0df-f5a56679a19e">
+      <statement statement-id="ia-4_stmt.e" uuid="b3c63752-9061-48fe-ba7e-1c4af1a907cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6281964b-15ca-490c-9886-2364647f39e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on disabling idle accounts is being tracked
 on GitHub:
@@ -1371,18 +1371,18 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/65'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f48e2ce-8a12-41d8-94ce-28714caa8231" control-id="ia-5">
+    <implemented-requirement uuid="21d196cf-4c81-4c55-b2da-eecb526e88e4" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="ccf37392-88c4-4e8b-94cc-7aa1ff65bd0e">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3ae9eac8-4dd8-4060-9851-3f30d98af261">
+      <statement statement-id="ia-5_stmt.a" uuid="f7ed881f-3035-4afe-8a85-e702d0f20ea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="4fad5bb3-57a3-4a8d-bef7-effb647fb307">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="184b1c38-377e-4ff5-a611-9e1199022f52">
+      <statement statement-id="ia-5_stmt.b" uuid="65fc9a84-3daa-4a6a-ad97-0b0f585c4ae0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb709e7a-0987-4e17-a7bb-9a0de98437b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to configure initial authenticator
 metadata is being tracked on GitHub:
@@ -1391,8 +1391,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/66'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="123a24e1-fd2d-4373-b819-4d48167d56f2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="39f2f1aa-f77d-445a-86a7-5888f63b46fe">
+      <statement statement-id="ia-5_stmt.c" uuid="9767ac0f-26f5-438c-80cb-6fb425db1d11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13a85550-b937-442f-a3da-aec50738c88c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on ensuring authenticators have sufficient
 strenth of mechanism for their purpose is being tracked on GitHub:
@@ -1401,8 +1401,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/67'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="67cea50a-03b5-477a-bfb3-7f3f7b93dc66">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c725ba38-fd3b-4895-a3e2-6f544b3090e5">
+      <statement statement-id="ia-5_stmt.d" uuid="c9132a2f-2739-46af-a054-8b13c9e20a75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4f28238-4d18-4140-8461-133355603f64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1410,8 +1410,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/68'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="85a55e02-d6f3-4d5d-9f93-ea49a80f1cae">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="06813aa0-a95d-4738-8931-bc43f56bdb61">
+      <statement statement-id="ia-5_stmt.e" uuid="1f03b0c1-9db7-4ccd-9f19-44755f11ea71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33f684c-40a6-44cf-827b-4e9543a2fb2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1419,8 +1419,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/69'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="b8a7debd-464b-44ef-973b-6a0b27d078c1">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="27609161-05ee-43cd-87b5-6d61338e5dda">
+      <statement statement-id="ia-5_stmt.f" uuid="214282d0-f500-47da-b482-be2d73b22c3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="784383af-c441-4b0b-8a47-54563b6d86df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance/documentation for establishing minimum/maximum lifetime
 restrictions and reuse conditions for authenticators is being
@@ -1430,8 +1430,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/70'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="0961d5dc-9180-4d73-ab46-c2971e8c652f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="23df1283-2cc4-4c1c-8290-849bc8503906">
+      <statement statement-id="ia-5_stmt.g" uuid="1209ed48-d981-40a7-804d-e824d6fcfae3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="307d12d1-8e98-467c-b541-a63f28fe0250">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on changing/refreshing authenticators after an
 organizationally-defined time period is being tracked on GitHub:
@@ -1440,8 +1440,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/71'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="d694b97c-ad77-4362-9973-bbac33dc63dd">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d73b02d0-1dbc-46a4-8567-1dd6bac9e504">
+      <statement statement-id="ia-5_stmt.h" uuid="24dee65b-b4bb-4038-a8c1-e69547225b2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8aae24c2-6259-4bf7-8e03-e5ce5951d3ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1450,8 +1450,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/72'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="897003f7-e6d0-476b-8db5-98c2fe712d75">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="76391a8a-b543-483d-8020-3139507603bb">
+      <statement statement-id="ia-5_stmt.i" uuid="ee9c909c-a5ab-4e0f-bd24-7ac6414e0f6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23f15f66-8747-4680-895b-ef3f633d22be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1460,8 +1460,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/73'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="2c4bb113-e021-4a87-8e28-362d79220471">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="42bda481-d379-4261-b9c0-ee991067440e">
+      <statement statement-id="ia-5_stmt.j" uuid="ac933449-5342-47d7-8d5f-82d769c8c632">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
@@ -1469,10 +1469,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3af02afb-26f1-4c74-b59e-2a842bd27bc0" control-id="ia-5.1">
+    <implemented-requirement uuid="42662bbc-5676-4534-998a-408bab9862b5" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="f9548d6b-ed00-431c-a5d0-a3ec33ea06fc">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d5e4423d-164d-40aa-85c2-a16321574924">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba5ce70b-5f63-49db-a858-bffd29cbd45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ae1d9da-7a2e-454f-a11e-bed7ca3fbf48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing password complexity
 is being tracked on GitHub:
@@ -1481,8 +1481,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/74'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="3ff99ff3-c1a3-431a-9536-3128c06869da">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="905a79cb-c281-4c82-85af-6627dfb26311">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c73a7f82-552c-43a4-ade4-c7efb437b0dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6524101-0249-4880-b2d6-db9b8bc0ef85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing changed characters during
 password creation is being tracked on GitHub:
@@ -1491,8 +1491,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/75'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="960812b2-fcab-43ad-90cd-a5bc7a5a6f46">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0ab5b1f4-3188-41ec-8896-594eb8d99490">
+      <statement statement-id="ia-5.1_stmt.c" uuid="a8f66fc7-a19a-4820-9c01-988ccda18c4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a74b8cc-80ba-4ee2-afea-31f12f7a20c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on storing and transmitting only
 cryptographically-protected passwords is being tracked on GitHub:
@@ -1501,8 +1501,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/76'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="11425eb9-e722-4c6a-a9aa-c23871638605">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="821580d4-322e-455b-a5ed-c07067946206">
+      <statement statement-id="ia-5.1_stmt.d" uuid="38d52bc1-da7f-4a76-b134-e2ab229a6e31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="02af4d79-0a4c-4582-b124-01dfc0fdfc5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1511,8 +1511,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/77'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="bd9d8d3e-f733-4b74-8111-fdac61fa10f9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1e574f54-f841-4281-8204-e8f0f8e12e88">
+      <statement statement-id="ia-5.1_stmt.e" uuid="cf8eeef4-c1f6-467b-ab42-1b067430b959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd745207-6ef0-4e8c-b76e-ecf20b3b9370">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1521,8 +1521,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/78'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="708b8ed0-29a4-413d-8f6c-5aceef9bc559">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="899441fa-132e-4c10-b672-d54313447b2d">
+      <statement statement-id="ia-5.1_stmt.f" uuid="018f553b-8848-4c8b-a29f-95b1d3bb82f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66186d1c-fde1-4ce2-9dff-d9a7aa087c2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing an immediate change to temporary
 passwords is being tracked on GitHub:
@@ -1532,19 +1532,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/79'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78ae67e5-478b-47fa-92bc-472fc0e5ba65" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="c85fd0bc-b4aa-4fd8-b6d5-b5b772ff9529">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="54d68e28-b7a2-44a2-a16a-1af956c66776">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62155364-805d-4553-a04e-9bb94fc7ba3c" control-id="ia-6">
+    <implemented-requirement uuid="53ebd492-001f-4bc6-aa6b-b16824c48dd4" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="2f75ae5a-9fee-418f-931c-42a79e460616">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="31e26e94-7a74-418b-ae46-939e29245bd2">
+      <statement statement-id="ia-6_stmt" uuid="2fe9bdeb-2642-4d42-a85d-57398f32d396">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2dea1a-1389-44b9-8f44-cb147b2da7a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management natively obscures such information.
 Red Hat Identity Management cannot be
@@ -1553,10 +1553,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bc39809-e3d7-46df-bead-8aaff5f850e4" control-id="ia-7">
+    <implemented-requirement uuid="0b3959d2-7975-4411-aa2e-001b8352c57f" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="0e315962-7edc-4752-921d-251a3bc20f58">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2a3a37fa-a4c9-48f0-9a07-bfd6fec59e59">
+      <statement statement-id="ia-7_stmt" uuid="71243606-9119-4338-9330-9eacf55eda8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5007c322-8d8f-45dd-b70c-294727c63ab8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for configuring Red Hat Identity
 Management to use
@@ -1571,10 +1571,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/81'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6a7cdbb-9d2e-456c-8d86-e63cb26e8102" control-id="ia-8">
+    <implemented-requirement uuid="f950f528-847d-4cc4-82f7-eef3734154b6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="80879a91-c117-4056-b207-97f6da6afb55">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c5e16ffe-c0d6-43af-804f-e75a1641b8c3">
+      <statement statement-id="ia-8_stmt" uuid="993cc9fc-2415-40a9-81af-59e3862576e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eaa11a5-df2e-43fd-bd6a-06de4b2f228f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -1591,10 +1591,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50d6fa8d-d87e-4e47-8f09-9301a3117f81" control-id="ia-8.1">
+    <implemented-requirement uuid="9d62599d-c244-4194-a265-ac718dd01c14" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="b20837f1-35a8-4cf1-9884-f96015eb36ab">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d4db7767-15cb-4947-b6b7-7b10996914af">
+      <statement statement-id="ia-8.1_stmt" uuid="4b6a0697-ca3e-4e7b-93c6-d23bbc41263c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1480101-b837-4ef1-b28b-c94133708416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -1612,10 +1612,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3542bfb-076a-444b-ae5a-a732bfc34605" control-id="ia-8.2">
+    <implemented-requirement uuid="2afae6ef-4fba-4eb3-91e8-4a781deb086b" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="fe06b0eb-93ff-492a-8487-7bff55d703dd">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9a224500-74b4-48a6-bbda-299bdba7c44f">
+      <statement statement-id="ia-8.2_stmt" uuid="9e336773-3c97-4ab4-849d-96381adcdee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1aa00e8-29fa-47da-b341-73713b2f845f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1634,10 +1634,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/84'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1879704f-b85c-4695-b8b2-a476e777990f" control-id="ia-8.3">
+    <implemented-requirement uuid="3548a1ef-07e6-4f94-95b0-dd21edb877e6" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="18ea3bb7-6a3d-4f59-8d50-97ef6819b4a2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f224a759-f27c-4a59-b6eb-7bccf50716c4">
+      <statement statement-id="ia-8.3_stmt" uuid="26eb98b9-eca0-4749-b913-b81e2943604e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b444af8-29ee-4a95-9ef3-45aa8fbaaf26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1656,10 +1656,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/85'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10a632cd-5002-4215-b338-6efd28c26905" control-id="ia-8.4">
+    <implemented-requirement uuid="af1b3249-ffb3-4147-a5c6-f6572c0e2e3f" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="3b1764a9-14ac-4a6c-b37d-42de2947b3a4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7dfd6fd6-267c-4264-a651-d8a45d902a63">
+      <statement statement-id="ia-8.4_stmt" uuid="58788be8-1e9b-49fc-bea5-eeeb465fbe58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d9d198c-af19-4505-a0b2-594e631bd64c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1678,10 +1678,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/86'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9894899-c429-45ea-b133-eebdf4262769" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="96a84bb8-f915-45db-9979-906aa80eadad">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9671245a-fcd2-4ab9-adb2-228b47c6f75b">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1689,10 +1689,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c2eac0a-3fc2-4b8c-b967-7d0747e99365" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="85cb0143-8515-4185-b7bc-cc8a75e5e9ec">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5c2eceae-6a18-4895-8fb7-116168748111">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1700,10 +1700,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fcac318-0661-462c-b91c-c3831fe0fc59" control-id="ir-2.1">
+    <implemented-requirement uuid="78d7845f-de00-4c63-bd97-4e0839f3f0a2" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="a664172c-8246-4686-8c06-7e5c06f1d222">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4fca9ef6-ea70-49d5-926b-949d9cf5cca1">
+      <statement statement-id="ir-2.1_stmt" uuid="2a2123c8-220a-4661-8f26-18515e8eb566">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1711,10 +1711,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4091901e-7514-4c11-8f68-5349620319ee" control-id="ir-2.2">
+    <implemented-requirement uuid="246aa74d-9372-4467-ac4e-954bae434f90" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="926a4dff-f560-463e-b403-0e964ed7362f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="075febb1-4318-40dc-9746-b14e39f087e5">
+      <statement statement-id="ir-2.2_stmt" uuid="f3b8f0bb-f626-43e6-9afa-be7e82b405e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1722,10 +1722,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22aff4a6-64ae-4247-8dfa-fd760c77bee8" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="5d0794c1-a168-4c86-9d6d-9f43698ecc93">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7ba0f8b8-2adc-4fce-861d-69da47fb0cf5">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1733,10 +1733,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9134181-2155-4d8a-bece-b65e7fd3d5c3" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="f3025113-472c-4707-821e-0747086da601">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3393015a-5cab-4217-b5b1-3b4286451f97">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1744,10 +1744,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c15cd626-3f48-4b08-80e3-3af679aa5b4a" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="7d763c06-a396-4e39-841c-352e74a5a749">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="059463d5-b461-49eb-bda1-cde1e3b09970">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1755,10 +1755,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df572d9e-4056-4488-bc2c-37b8fa7d7b1a" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="1e6b9aa9-065b-4e25-800a-71efd752e303">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="44461774-6b65-463e-abec-68a2df1768c0">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1766,10 +1766,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac1a2795-1bd7-4dc9-acfd-73059a63f547" control-id="ir-4.2">
+    <implemented-requirement uuid="7f0a3982-d079-4924-b580-f0dc1d216e85" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="61154d6b-6dc9-4ccf-a3c5-4b5f31b8b78b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d5d443e0-2794-47fc-9507-3527c2cc57af">
+      <statement statement-id="ir-4.2_stmt" uuid="9c563bcc-5237-449c-a4ab-d3b700a97da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1777,10 +1777,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ffb8a33-2542-4695-9013-421626336fd7" control-id="ir-4.3">
+    <implemented-requirement uuid="13b97b42-76d6-4061-b638-febe0cd90231" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="9a8ec64c-8f58-49ae-8872-a1e06b762ee9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="478d59e2-5b2a-483f-9799-25d735c793ff">
+      <statement statement-id="ir-4.3_stmt" uuid="5e0e6990-1ff8-49bf-be0d-5d2737ce63e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1788,10 +1788,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5be93d3e-3a97-45ab-bea9-0458b32be665" control-id="ir-4.4">
+    <implemented-requirement uuid="3f7d2d28-2608-42b5-be50-8da2df81d87f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="9241bce5-66eb-4c62-b7a4-3d9a0ad2f446">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="6f61d997-34b4-426d-ba37-c1478067012f">
+      <statement statement-id="ir-4.4_stmt" uuid="ac63043c-31bb-4d93-b0da-40a829860d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1799,10 +1799,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="105e7d0e-7426-469d-ac10-67a9938fc652" control-id="ir-4.6">
+    <implemented-requirement uuid="37e8a5cc-59e9-4a7c-9bdb-cbeee02214ca" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="f553265a-bf66-46cf-b11a-c9702211b616">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8a94b298-b3b2-4f84-8338-fa492fcec249">
+      <statement statement-id="ir-4.6_stmt" uuid="7ef8f800-1279-4b68-9615-3565349db7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1810,10 +1810,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b020b636-8ce0-442a-8e27-3bdf9a65bc69" control-id="ir-4.8">
+    <implemented-requirement uuid="4e72b7dc-4243-419a-8f07-49afa8e6bb71" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="c656a6d7-df0d-4d42-809f-cf82c3c73737">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1ad30a1b-4420-4738-b927-9a3bc5f5e711">
+      <statement statement-id="ir-4.8_stmt" uuid="eeea2ede-129f-4055-8e4e-5f5514fae167">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1821,10 +1821,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d933251d-7e50-4910-a3d3-a1c3ace99b18" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="82abc3be-6da4-4efd-8a8f-e99894aac507">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="21488fd3-407b-4923-aa11-2072f20a38f4">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1832,10 +1832,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02c58e74-c2f4-4cf0-aaf6-16716a668274" control-id="ir-5.1">
+    <implemented-requirement uuid="6d97e9c2-2cde-4770-915c-0fb3374028bf" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="e9c6b2b1-ebdf-4161-b28d-5f4dc54ba8ef">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="94889e52-bede-4727-8f74-4b70dcbead45">
+      <statement statement-id="ir-5.1_stmt" uuid="555bebe2-f2d2-489a-99b8-98b462646d4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1843,10 +1843,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a58bed4-672c-4cb8-afb7-24355754ebcf" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="c8e904f4-f50c-4451-a271-dd48d5695a2b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e7d5c7c4-014b-4295-b48d-58a36ad6cbc3">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1854,10 +1854,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ea29017-0a0b-419d-8b4b-7df2fa7841f2" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="c99a9839-678b-4581-8df1-d7f4f4ee71f9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5214f12f-9ffc-4a27-b590-2fbb0963b30d">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1865,10 +1865,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14a0ff0e-2162-4aad-8922-bb4ef2a7907c" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="27d0ddb9-d54d-47d4-b0ff-313fe80ea017">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b2b12ee0-71e4-470c-babf-0bed55051932">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1876,10 +1876,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed9b85ad-8932-48d0-a2a1-6c4bdacd7091" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="acdca8bb-5101-400b-ae7e-3f16754d609a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a354f621-42ed-4e09-ba79-49de3c37f7e3">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1887,10 +1887,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b929f66-0b63-41ce-8d0d-f757c707467a" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="fef88159-70f9-4640-a71a-4465b17dcdf9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b9ef6163-3964-4ebb-93dc-ac9a9cc9364c">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1898,10 +1898,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75492e9e-f6b8-4ca9-832a-41e78cdb09b3" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="610cc316-a91a-48d7-ad04-a41911c58a1d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="25a10027-b0ed-4143-91df-7cc30a199ffe">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1909,10 +1909,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d99f93e-6afb-47c7-b184-0cd0ca056382" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="192bcd52-1225-4ae5-881e-c56277ec0838">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2b689c15-b8a8-459e-9719-ad17728db32a">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1920,10 +1920,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69d428f4-856a-4c59-8129-cf9741296aa5" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="8bffbfc7-abf5-44d8-90e2-bba36cedfc56">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="88da81f6-8611-455c-b727-b16c9d249470">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1931,10 +1931,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c0d285d-8512-4548-86b8-9d54b84e4b7c" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="eae418a6-f902-4d83-a17c-e299a14c0d74">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="628a358b-c532-4837-8509-c3a3aa5ce5d7">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1942,10 +1942,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbc630fc-1811-4479-8167-b7483df87cee" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="ddd64324-45a8-49ee-b72c-fce0101051ce">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="67339309-5fda-4a16-82a9-a2f652cb0b2e">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1953,10 +1953,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1692e63b-eb34-4461-9aa5-3b3e142a3a8d" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="9e7044ad-5a5a-44f9-9636-518a805a11eb">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="85711fec-d2e0-47b2-983d-3f67410db07a">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1964,325 +1964,325 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c418ea4-300e-4f8b-b36c-9186aff6128e" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="71835c15-3295-4a3e-9a5a-af3cd2a171c3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4a416d9d-b52d-4ca5-bfc4-4fc3a4592555">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d40f2559-ecad-4d21-8337-47443f3f132b" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="6f06186b-187c-4081-9aa3-18b6d0aa0df3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c1b944f3-5a41-4a70-9a54-468edfddc656">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5df3740-40ef-4767-be1d-100280b2b474" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="f5dff121-e85a-4028-abcb-d364b1067238">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="53b27d5d-e247-4c17-939b-df0b15c80147">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c63e186a-4570-4711-9f3b-dfd069d16ee7" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="9885f084-a86b-4d0e-bd11-fd04dae3375e">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="ce730586-c23d-4002-a617-dc14dad6d283">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b06675eb-dc85-4fa8-8e82-75a5f2b740ad" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="8cbcbe16-471b-4851-9f11-a12cc38b9635">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="89db90fb-d008-4bbb-b332-3c7ca6575f87">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfbeae70-8700-4531-a701-4b6c58388779" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="21aee967-c933-4da1-9f62-e241faec9f1b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c7553b68-47bf-434d-9cde-9785a607bc5d">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5746e93c-113e-40f4-b18f-e42125ffedfc" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="555e1e68-53f1-4418-a651-afc0e2e382d5">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5f05a492-41f4-4782-b5e8-ffec6c6884e0">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fc05498-ac06-41f8-9400-1442d7cda242" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="158992bb-4c36-4137-9c71-c297f2f67384">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e8dad95c-8f41-41cc-bf61-a6e9d829b37d">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4640c412-22c1-480b-90c7-f9ac648fed93" control-id="pe-1">
+    <implemented-requirement uuid="f9d20c79-c28f-4e5b-8991-a010068305bf" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="fc3ecd1e-2325-4926-b9ed-f75700abcec0">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2fd43c39-f41d-47f8-94cf-1e88b2b11b24">
+      <statement statement-id="pe-1_stmt" uuid="e713373e-3041-4175-8df9-1fc7aef4f467">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9300d510-7135-4dac-a78d-841c63c7c4ec" control-id="pe-2">
+    <implemented-requirement uuid="e11036b4-5744-4630-95ed-a531597e3dbe" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="736c5c77-8119-4305-8a5b-fc92d5c11041">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="01c49dcf-9134-40e0-8841-ea59afe676ee">
+      <statement statement-id="pe-2_stmt" uuid="22b5b14e-9fd2-4cf1-a1a3-f07a46bd9af5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f78ddac0-8f9b-46e9-a02e-c43314e7fad3" control-id="pe-3">
+    <implemented-requirement uuid="dcd89883-3566-42a4-bfab-dfe0a048c583" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="60770603-779f-45cb-8fb9-38dcdddb9c2a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d9a284e2-bdb0-48f6-afea-1da8fe30bb8b">
+      <statement statement-id="pe-3_stmt" uuid="97bfc74e-412e-4be0-8696-f4c9ef1eafc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76c4713f-09b1-4834-88c5-ed9cde0407c0" control-id="pe-3.1">
+    <implemented-requirement uuid="eaedaf28-cec0-4a21-9c93-fc6c5ec55316" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="d2ca01d4-f084-4e24-bb09-43d1ea555d49">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="033baa4c-e516-44d4-92d5-406cdefccd74">
+      <statement statement-id="pe-3.1_stmt" uuid="ee206ac2-f86b-4e24-8229-edb274aace9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec704ac5-6ab8-4f0c-bc81-82dda80e7943" control-id="pe-4">
+    <implemented-requirement uuid="76276553-4780-4ff1-8e22-c0b20932de06" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="c6a3bef4-cb53-4f91-8d63-0572d5c3fc74">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="52e949b6-1d8b-41cb-a496-cd10bfc2fe9f">
+      <statement statement-id="pe-4_stmt" uuid="aacdad62-fc70-4031-b49a-fb5140e044d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0466f8fb-ed99-4815-aec0-ba38c025043c" control-id="pe-5">
+    <implemented-requirement uuid="94bc684b-6a3f-43d4-b200-a0cff845555f" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="241ff9e7-6146-413f-aa69-105751b90724">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9304ddd8-f08b-4347-a693-e2247f07d732">
+      <statement statement-id="pe-5_stmt" uuid="3bad50c4-f0ca-4c60-ac5d-c9d07cc34468">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c2d8c29-123a-4b59-8338-639faa47269c" control-id="pe-6">
+    <implemented-requirement uuid="e755fdbc-58fa-42bb-8722-9bd276687bd8" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="ad6c40cd-afa8-4dde-b189-a0c56909a411">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="10472e69-cfa2-437c-b1a0-a550c8ea56d9">
+      <statement statement-id="pe-6_stmt" uuid="ec7353b3-2e5d-4f80-bbb7-347dfe1ada09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7518420e-f4d0-40d8-b077-b4e14740eba8" control-id="pe-6.1">
+    <implemented-requirement uuid="fad21785-fd25-42f2-92ec-6a3a7aea849a" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="c0363b01-636a-4a06-93b7-83998264e0e2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a40564d5-5f8d-4725-ba13-584e368ca4a1">
+      <statement statement-id="pe-6.1_stmt" uuid="49dc6a2d-e5ee-47f5-a1dc-309c9f747624">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdb5e43c-4e8d-46eb-9b23-6e3e1d20e815" control-id="pe-6.4">
+    <implemented-requirement uuid="5eec2092-c0e4-43cf-a80c-35d3362f3e7a" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="b79ec1c1-b089-467c-9f46-503e1a28cbc2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7beb7895-dcc6-4251-beda-78a7a6151173">
+      <statement statement-id="pe-6.4_stmt" uuid="be2f53c8-4a8f-4a80-8d4f-375ddf4351ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45636318-2e0b-46b7-bcdf-37be10428246" control-id="pe-8">
+    <implemented-requirement uuid="050370f6-d90d-403a-b7a6-94ac3922e98a" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="696abe0d-4eb0-4b35-8b7f-1e2341a88caa">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="eff2e292-d928-4469-a3d0-645eac13e7fa">
+      <statement statement-id="pe-8_stmt" uuid="7a1d0807-b0a9-4c43-9797-86d110faf00d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27021d09-3cc7-462e-b0be-d3ce2b650fd6" control-id="pe-8.1">
+    <implemented-requirement uuid="ff7abf6e-b885-4a03-9135-66a2919dd03b" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="b8366164-005e-4f33-a95c-38d14a4ae736">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8e77ad5f-61a9-4fe1-9a4b-00efb986bfda">
+      <statement statement-id="pe-8.1_stmt" uuid="b2d6cfb0-9335-4b28-a661-5beacb09c1e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b1835d7-500a-4fec-81c6-6effc0217407" control-id="pe-9">
+    <implemented-requirement uuid="a20bdfc3-fc7f-4f87-b915-8d01a0f7dd38" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="702a814d-f8ac-441f-b371-997f38a79260">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dacb9fb0-d679-4b10-b0be-eacc0d5571cf">
+      <statement statement-id="pe-9_stmt" uuid="cfd3473d-1e05-4589-9ac7-41e14f0e6a79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c474f24-73eb-4cb2-9034-9b96946a56c8" control-id="pe-10">
+    <implemented-requirement uuid="0c7517db-defc-4990-b618-add23e9ea8be" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="e081a6df-c3b1-4eb6-93ac-2e129dc2d2c1">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="95488cc5-e7ff-4559-ac85-de64fe66c87a">
+      <statement statement-id="pe-10_stmt" uuid="1f270c5b-89e3-4109-8cb3-5b7854b12d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96ac2426-077c-4481-bab3-48a9ffefa0ae" control-id="pe-11">
+    <implemented-requirement uuid="69e0c4a4-7635-4c33-8b58-37c703c53c50" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="0c546a2d-dc7b-4219-831a-57225b78a637">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="12946d7a-efaf-4e66-871f-00807e58814d">
+      <statement statement-id="pe-11_stmt" uuid="8343d926-f0e2-48b0-b649-a65fd5450e7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d002a73-264c-4485-b98d-987a14f07499" control-id="pe-11.1">
+    <implemented-requirement uuid="7559a704-2c27-43a4-a2b0-a4aff9912d49" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="51a25bae-a4e7-495c-aaf0-943789c5262d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4cfef565-df11-4e98-b2fd-9339d19a61a0">
+      <statement statement-id="pe-11.1_stmt" uuid="e60ebaa6-85a5-4e70-a121-ee4391a4f1cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="837e90be-b42d-4c93-8f53-ece9cbfa1e16" control-id="pe-12">
+    <implemented-requirement uuid="4da0d8ee-9c11-4932-bb8b-d68e3e058267" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="f2dafe37-6fb7-48b4-8180-4846b9d188cc">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="bbf8aea2-84da-42f3-964b-70609304a8c5">
+      <statement statement-id="pe-12_stmt" uuid="b92e1c4b-67ad-48d8-8cd3-42d0e3da74d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50699126-4d29-42e9-9d08-f33593acd039" control-id="pe-13">
+    <implemented-requirement uuid="b6f0ed51-cbfd-4701-9f35-e9194942c86b" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="80474aac-8796-4923-90d2-819188324bc8">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b16e82c6-dcda-4dc8-a113-98422cd75211">
+      <statement statement-id="pe-13_stmt" uuid="712b80c4-34d3-4107-9ec5-5d67dc8915fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="268207fd-c2bc-44d8-8cd7-4c998d7959a0" control-id="pe-13.1">
+    <implemented-requirement uuid="535fe846-2ca8-4f56-a33d-39c7da8827a9" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="853badf7-8078-4451-b166-2092689b815c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="502e6341-6521-44c8-8105-bf7e9f49ec7f">
+      <statement statement-id="pe-13.1_stmt" uuid="ecd1044b-0774-4a7e-b4e8-66fb7dc0141d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22d8f8a6-d644-4663-b24f-13e5445e80fe" control-id="pe-13.2">
+    <implemented-requirement uuid="0179e9aa-9b65-4528-a172-d932751cf621" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="1b452d55-1823-4fae-8d90-8c1b4f1b64f8">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="aba292f3-30b0-4e89-a673-12ae415f7b21">
+      <statement statement-id="pe-13.2_stmt" uuid="e9f70eec-c915-41d5-9db8-a56ca66178bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55b7aa5d-6487-4134-9003-f121bc403ff2" control-id="pe-13.3">
+    <implemented-requirement uuid="86ec3ccf-9103-4266-a4e1-1f2f9829e128" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="36e493b6-b750-4dd7-b13a-c912578ab549">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="18392ad1-2ecc-4672-b704-ab5f6dc88989">
+      <statement statement-id="pe-13.3_stmt" uuid="3ed679d3-3157-4df2-a3d3-89f84fc0a14f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eafaef8f-c0f9-45bd-887c-5050bb653ac7" control-id="pe-14">
+    <implemented-requirement uuid="f603a856-ad6b-47fa-a698-6ba7e933a1d7" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="71615af6-0e57-475f-9971-86aabbadc5ad">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0aa8c337-4b6e-471a-8e91-5e121a09db99">
+      <statement statement-id="pe-14_stmt" uuid="919d0b97-aef1-4886-b573-92494e162501">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a8eb9b7-64de-4f6d-a54d-cbfbbd7aa099" control-id="pe-14.2">
+    <implemented-requirement uuid="36bf988d-8fea-4381-b7a7-4d3b83b6b6c5" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="bca943ee-8a0c-43e4-b530-590cd9211b3d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="181004bd-638c-4127-b189-b0a068253156">
+      <statement statement-id="pe-14.2_stmt" uuid="79aa6852-c35c-4a35-a9ec-ba26354561a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab280b67-7131-4ed9-806e-0d7ad2a11a40" control-id="pe-15">
+    <implemented-requirement uuid="575f5513-b068-48ef-9a0a-452b43f07e37" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="2bc48637-c42f-46ff-af3b-d0e2ccb2107a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b502844e-7dfa-46ca-92d0-0c4eebb71d10">
+      <statement statement-id="pe-15_stmt" uuid="0b105b7f-24fe-4336-abfb-6494b3fb99e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b209fe91-5078-42fc-84e3-75a1b7128ba3" control-id="pe-15.1">
+    <implemented-requirement uuid="607a1f44-d345-42bf-8d3b-b1ce79d30724" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="cf4b6d62-9419-4bb9-833d-f0e8dc75bbf7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dd58a9c5-98d6-4361-ab8f-34ef594e129c">
+      <statement statement-id="pe-15.1_stmt" uuid="d374f127-7a0f-43c7-a9f8-284e90de5604">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68aaa0c0-6e39-4599-813d-cc527c34e013" control-id="pe-16">
+    <implemented-requirement uuid="c5e9cba7-d697-488d-8dca-c125aaacd346" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="1cf1d908-7329-4036-8bc9-6bb3535697f7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="884535cc-9555-4042-8b21-1eba689773c0">
+      <statement statement-id="pe-16_stmt" uuid="f01589bd-2452-4390-8650-d1260e65039f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50a39e37-2b53-426d-a748-740e1daf465b" control-id="pe-17">
+    <implemented-requirement uuid="ab0c76aa-c4a0-404b-a745-4b181da0ded9" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="85d9986e-3663-48a0-952d-7e389aea8b67">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="52666cc1-e6b6-4080-99f7-b36e91613e2d">
+      <statement statement-id="pe-17_stmt" uuid="0c8eacdd-3d47-4e1c-bac1-907d7c6a28c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a4362fa-382a-4c24-92cb-8696f63da879" control-id="pe-18">
+    <implemented-requirement uuid="79b35c9e-8c77-43cc-9084-02b3d124fc42" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="7a06f8d8-03c2-44e3-a60a-cc439ded69e1">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="af2e9e3a-9313-44c3-b58f-05daafa27ba7">
+      <statement statement-id="pe-18_stmt" uuid="e9d5157c-cdaf-483c-941a-28131b67fc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="338c6cdf-4f3c-4aa0-ad29-903ae6cecc96" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="05d1b115-53b8-4f8b-b7c8-cc5d1c665eca">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="bbd7096f-5384-4365-9950-ba61c2d8568b">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2290,10 +2290,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61e8e197-988b-4eaf-a73c-ca9d98577243" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="844a7973-3acb-4a3f-80ab-f3f2050fcd78">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="6da04998-5e53-4266-bedd-d93b050cbf51">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2301,10 +2301,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9db5fee-8076-44c6-a0ee-84943bf43688" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="a45b4ebe-619f-4b58-86e1-e4d9ba351b8e">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2f99fd52-777a-41a5-8b97-5f6a91995b3e">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2312,10 +2312,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55455ff7-92cc-4a39-b832-6718b430b9f1" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="d29b527d-5585-4585-ad2e-ebc0742a22ee">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9d1c3075-82eb-42cf-94a5-896a84dd311f">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2323,10 +2323,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="616d0ee9-5fae-476c-a2dd-3bedfa048c1c" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="29af6c57-9d5f-476a-8808-e71e9de09c9a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e4445d00-ee91-4227-a7a2-a9759c624e46">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2334,10 +2334,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19e86377-cdac-4fa5-94f1-580f38e281ad" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="01f0e989-a0c5-40cb-9fb7-6d3fdfc0221f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="c7d4ca22-6ddc-4d5e-80ed-afb27f56c7b4">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2345,118 +2345,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bb040ee-82a5-423e-9758-9364bf0c1da0" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="16f5f993-8682-44e2-91da-7e6a11a9f026">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="abd3bd0b-ec67-4e13-a4e9-0f43538e2d99">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45de4153-7c88-4132-978e-005d971d64e2" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="b4ccb744-77c1-4df8-8b91-5d1eb6632a60">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2fe9c7af-b2bb-47ef-b3f5-ec9d6fa40c6a">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b562756-b58f-4cab-a1fa-4742733c2a8c" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="cdafa0e7-b325-4b1c-a9ea-fe8dd0921211">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="76151ed2-013f-4c0e-af59-9a3c603d87a8">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67f60bed-8de4-46d5-b24c-2ca4cae66713" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="404c7499-a621-4219-bdc9-5a8a68de668b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5c2265be-3c34-4c0c-86ac-01ae59e53cd3">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99644f39-5939-43ba-9484-71c3572303dc" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="d346c21c-ba0b-47b3-93ef-b9be74925e29">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e385896c-1975-40e5-aefc-d88363109ebf">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d60ac102-84ab-49a2-94c6-507cc91f9382" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="4238a793-c43f-438b-9419-405c38e4b108">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="edd04580-0f38-4c11-9df0-4354b07bb7a5">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c09c242c-4528-42a2-a0c9-66a83452f025" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="cd4926a9-1a03-491c-ab67-bb47cb4bbf5e">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="b85bd0b7-2ee4-407c-addc-cd34c159c3ca">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3f959a6-b57b-4d11-bc09-9d72fbcb773c" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="690a119e-6abf-46de-88f2-5241efcce3e4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="78944433-547a-4cbe-a49d-9e34069f9b9d">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbc4afd4-a21b-40f7-95a5-7c55d8157dea" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="067d67db-a50d-4fef-88bc-2a363c0fd37f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="092c5761-f2a1-466a-b762-cd775a0dba1e">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85bc3b7e-f9a1-49c0-a903-c60dfb064249" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="ff391dc6-5cb1-4e23-9309-f0e1aba1873d">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="105845a5-19a2-4b08-bbba-7268d6f899e4">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c2c8778-2d79-4d69-9729-5acc253a8a68" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="15aac426-adee-4bba-a3d6-aaa8eb5566b9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="2830f77c-f414-40a1-a8a6-c490c673b67c">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0f98452-5167-4150-86a2-2616ac9a32c3" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="457bc02a-29eb-4185-80ab-f1fa50d4047c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="1633abec-95c2-4c4d-8b83-4b6e0ae38adc">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f90f2b79-691c-418a-ba90-e7e4fd6d40e8" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="b488ea71-e324-4baf-80c7-f1e74e73b715">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3e5c4830-795a-4736-8f42-76c4cdaa1648">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2464,10 +2464,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a611d22-613a-48dd-9285-534fc689711c" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="583f5333-4d27-4361-8fcc-5a8ff5aa117a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="f457ab20-8489-4616-a840-b1f1ce38c6b6">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2475,10 +2475,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81353c2d-12e8-4fa0-b25c-3098a5903fa1" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="dc80e35a-48ae-4997-86f2-d84b965f44b7">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d693a298-64dc-4293-813a-d17dee02a7bc">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2486,10 +2486,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fafda3a5-1d13-408f-906a-c437ed10fa2d" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="ba3b9d4e-95b8-4a52-9b73-aedaa9b51747">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0fd88de8-dae7-40a8-bc7b-6168b32cbd79">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2497,50 +2497,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd31145a-22a6-4ccf-a66b-05df5c1b6398" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="850ddb45-fb36-4d04-bff7-54bf8a2c5978">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e31b8d5b-4235-4284-a029-67062e58ee87">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="960c4371-2a99-43c3-8134-f4c1d782f640" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="9f2a176b-b5a6-4f81-85bc-0b34d67f6c18">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="658198a3-529c-4fd9-8148-908c081a7752">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffa3422d-10cd-4998-845e-ed5424c4afe7" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="d8fce37e-c6dd-45f3-a9d6-1da1271f1505">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="36d84460-4545-441d-b248-cd87e2451339">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bb07db2-80dc-42d5-a5bd-a19819669b7b" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="fdfb6a83-e7f7-4656-9935-8387e57a2da6">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="e5774b91-0459-4ef0-8846-a011369285ba">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42bb76fe-8dd9-44cb-8215-d440c0cab12c" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="cb0cf542-1498-4492-a8bb-a9166edfbaed">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="fccc9165-53aa-468e-b5de-dcb54a61853b">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2548,10 +2548,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffac499f-aa7c-4be3-9e52-f41b74d6ed19" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="df654ba7-ae51-4d19-9bec-f285bf93ab73">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="04dd001d-566e-4745-ab65-cd4c040df261">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2559,10 +2559,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0395cdc1-24a1-4d29-8631-c8e73afe2c4e" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="3a3de685-721c-4874-a075-205db0c0256a">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="38b5613d-c8e0-4391-b67c-75cae7e1e507">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2570,10 +2570,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f858a6d-6ce8-4ffd-84ed-5d5607450698" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="99582d25-ffc9-42f4-aafc-f7605f70f914">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="400f9ac6-fe45-4887-8ab2-7fa90596af33">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2581,10 +2581,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39a7467a-9064-4368-9a38-29e25150449e" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="2dd2b3dc-9166-4e9f-9414-17f1834cef32">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="39ce2856-c8e4-408e-8229-b57fe0d89018">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2592,10 +2592,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d7a91f2-dcca-488f-95e1-bbf41e689d5e" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="25172bfb-c822-4e35-ba55-f7d6f765f3c4">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="8b79d6bc-5ebe-44ec-8df8-a0908424d960">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2603,10 +2603,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1d05c06-7250-4b63-9b9d-094abc9f9fc9" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="d9311e89-b3ca-4e87-9183-888d002331c1">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="0953689b-61a6-4e62-a8cf-4ccc48b13cc4">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2614,10 +2614,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca022710-24ff-49ff-98dd-8878ff9bd271" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="766767e6-7e54-433e-8508-60d371a116e2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="44e15946-7e99-48d1-a468-c9fa40f0645f">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2625,76 +2625,76 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3c5c77f-1f41-4355-81c5-4ead3af93a3a" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="3debe27d-dc4a-412d-a1e4-de020f0e45ff">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="172a08e6-fa65-4b56-a849-8946a5ce7060">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="eb59b7af-ecf3-4dd3-b980-cf3aa9158cff">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d0c4ee9e-1db9-4c1c-8f62-3fc562ed4c85">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="30803e2e-22d4-499d-9505-6fbbfc88495f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5d69ac72-4323-41bc-992d-55e1d812a5a2">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="042af6a4-e434-4f81-aaf4-cc94b491db30">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3a60ca48-24ad-436b-9ab5-666b1f742249">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="7a76d200-9bba-4a5f-8f9a-75167dab3a00">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9c605c76-bc04-44f4-a00a-877e19354506">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e1062e5-e246-4a03-b16d-81be13d659b3" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="107fd4f0-23d0-4da0-bc1b-5d05913e86d9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="77a7e782-3855-48c9-9bbe-5e9c7722c8e8">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f4db9f0-6a17-4d6e-87a4-ae10a14e11bd" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="ad14b418-6b0e-46fa-a7ff-848b2aeccea3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="bb912465-2871-4165-b75a-3571fa55fe5d">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2479313d-80ed-451f-ac79-61ddd30ac68b" control-id="sc-5">
+    <implemented-requirement uuid="1e539cad-e15d-44e4-8182-77855f2dd251" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="f2b1e0fc-a6f8-4c66-8847-ffb79587814b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="be57ccfe-e19f-403c-83b7-1f77816c749f">
+      <statement statement-id="sc-5_stmt" uuid="bc7b002b-a2a6-4fea-8986-f3f34ab25fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b07019e2-8847-4b89-94a0-d3378c76353d" control-id="sc-7">
+    <implemented-requirement uuid="00783149-d62b-4e7a-aeae-58057ca0ac49" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="32fe8123-b909-4d44-9514-cd892d0e43b9">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="051b4aee-0118-481b-8ace-23b40af32e02">
+      <statement statement-id="sc-7_stmt.a" uuid="d48dff23-baf9-4222-a2b0-af0fb767eff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574e7ffc-08c9-493a-961a-2e3328c62797">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Red Hat Identity Management can be monitored is forthcoming.
@@ -2704,8 +2704,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/142'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="707d96c8-acf1-4388-87bf-c72144081d5f">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="846cf72a-3a57-48f0-9e9a-6839108c97fb">
+      <statement statement-id="sc-7_stmt.b" uuid="af39fa28-0b39-4179-a8c4-78fa4cdbd354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fbefefb-1163-4180-ab0a-d36a99e31d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can
 implement subnetworks
@@ -2716,8 +2716,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/143'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="35940c2c-be1f-445f-a523-dd3343575c9b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="ac05844e-eb6a-4528-ae7f-abcf7f40ff8f">
+      <statement statement-id="sc-7_stmt.c" uuid="d4bd6c47-7d19-41c1-b673-9ecdac16a504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a613d308-0c27-4ad7-96c7-67f0be72ace9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can route
 connections to external
@@ -2729,10 +2729,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/144'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33b914b7-248f-4b86-a51f-d8f593733fb7" control-id="sc-12">
+    <implemented-requirement uuid="c8327394-89ba-4508-817d-7dacaba8e50b" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="fa0eece5-42e7-446f-a48f-ac822a5ddfdb">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a61da491-f464-487a-818e-4b3e14d6eb63">
+      <statement statement-id="sc-12_stmt" uuid="02fe4966-9a87-44d3-8440-63a140dabc6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e1ea452-edb0-4547-b82b-3bebbfc93493">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management generates,
 distributes, stores,
@@ -2744,10 +2744,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/145'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bc9e882-ceff-48c3-b0ad-2d6a4ea2f979" control-id="sc-13">
+    <implemented-requirement uuid="16e89f47-8365-45ee-ad7a-b99f5fc41f13" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="eeebc146-5e95-42e3-84ae-aa3a83a8433c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="9d02164d-e8bd-4750-9fa8-4623eea5e7c8">
+      <statement statement-id="sc-13_stmt" uuid="e653c788-a2ee-4da9-bf53-7abfaf243e6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3a298fd-f2ec-499c-a530-ff92405e66a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat Identity Management's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -2758,19 +2758,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/146'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00424ded-77cc-4037-80b4-b32d6cf24a2c" control-id="sc-15">
+    <implemented-requirement uuid="027a35d6-1870-402d-b9d5-37d944de600c" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="a1300b6b-c755-4cc7-8e67-727048381371">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="ae57a523-6592-4a2b-8394-89c38dff06dc">
+      <statement statement-id="sc-15_stmt" uuid="4654f804-278b-4d2a-b454-1499f231eca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e658e52-8ef7-44c7-9457-be87cba89b46" control-id="sc-20">
+    <implemented-requirement uuid="7ca56f86-dc66-41b5-9216-ab04954d6f13" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="78e0a5d5-8b18-4200-a670-c72d6f60829c">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="aa64bb03-f311-49d2-9c3a-838899eae761">
+      <statement statement-id="sc-20_stmt.a" uuid="9d8b50c4-1035-4eb0-bbfb-cf81f3fe65d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69679a55-3731-4cd3-b7be-e25751928b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure Red Hat Identity Management DNS services to provide
 data origin authentication and integrity verification is forthcoming.
@@ -2780,8 +2780,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/147'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="4e05c7e2-796b-42d9-95c6-0ff2db336030">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="80f95141-a811-4c84-a52a-5723551fda71">
+      <statement statement-id="sc-20_stmt.b" uuid="3aae96a2-5f33-4839-b633-80eca89e3e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a8a8fb7-8dfa-4ea7-be28-60dad7bc2de5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure this functionality within
 Red Hat Identity Management is forthcoming. This activity is being tracked in
@@ -2792,10 +2792,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/148'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a7aae7e-ffc4-4d93-bae3-8051524bec69" control-id="sc-21">
+    <implemented-requirement uuid="5a321394-fed9-48ff-bc89-6f232fe21d74" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="b8c37633-f14b-49c5-ad57-2e3e5c6278e8">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7ca9b970-6511-4169-8b01-79834857d98e">
+      <statement statement-id="sc-21_stmt" uuid="3fcfbed7-2599-430d-bc62-c0e5c6858f0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96a05615-1b7e-4daa-9fa0-e1dd1db830b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on enabling DNSSEC within Red Hat Identity Management is forthcoming. This
 activity is being tracked in GitHub:
@@ -2805,10 +2805,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/149'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21ccecb7-4045-4472-95a1-4df35c8194ee" control-id="sc-22">
+    <implemented-requirement uuid="35ded6b5-e656-433c-91c4-a4ebd2c8b759" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="8f8553f9-bc65-421b-b430-ed2a8012c2a6">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3292d74e-e9db-4578-9b8b-cf8c615d4649">
+      <statement statement-id="sc-22_stmt" uuid="c485f120-6b8e-4407-94dc-0e1161f0507d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2d349a3-aaaa-42e1-bf00-87baf5ec5742">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on creating fault-tolerant DNS configurations within
 Red Hat Identity Management is forthcoming. This activity is being
@@ -2819,10 +2819,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/150'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f6f188b-6f63-4fb6-8918-bbc705b04b0b" control-id="sc-39">
+    <implemented-requirement uuid="e725ca86-e995-4735-bfb5-375a68bc3814" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="c9b30463-7651-42ac-bda4-29b788202229">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="4319d085-2ec9-4060-8b8c-2c3a143d33e1">
+      <statement statement-id="sc-39_stmt" uuid="08d220ce-373c-49b1-b83d-b35156882a11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6710d52a-9f87-412e-9c22-e7bfd898dc7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat Identity Management runs on Red Hat Enterprise Linux,
 Red Hat Identity Management maintains separate execution domains for
@@ -2837,10 +2837,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/151'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d13cd73e-1c32-4590-b80c-9482a87ef138" control-id="si-1">
+    <implemented-requirement uuid="50cc2645-b920-4301-b591-2241e63496e8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="1144dcd2-7fff-45c7-b7ed-26e02cd51fbc">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7234fa9c-3897-499b-9cb7-70054572716b">
+      <statement statement-id="si-1_stmt" uuid="201890d6-df69-4d1d-9b19-45d4210fe394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2848,10 +2848,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e606181a-51e7-48c8-9d32-a050b857a44a" control-id="si-2">
+    <implemented-requirement uuid="7b161967-8f5b-4a41-8cd1-413a848eb9c6" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="b75e5e5f-6613-4832-911b-ec87df30c326">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dc87852f-99a8-4a6e-86e6-52845765a3c4">
+      <statement statement-id="si-2_stmt.a" uuid="219eda2d-eca8-478a-a253-c4697f65d11c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="491ab51d-d992-4f2c-b446-5bcbeac26faf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their
 Red Hat Identity Management deployment for
@@ -2867,8 +2867,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/155'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="2ebc212b-a80c-405c-a28a-851b7590a2d3">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="936b59d8-d384-4d61-bbc2-b8c72a680da9">
+      <statement statement-id="si-2_stmt.b" uuid="44888f74-cbc7-434f-85ff-aad87a82a92e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2497f562-693d-4650-bdce-f7f045c22284">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing
 Red Hat Identity Management updates
@@ -2884,16 +2884,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/156'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="53f47ad4-773f-46a0-9dc3-ddd0a9780d58">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a47cb670-0d0b-413d-ba1a-a6ab43d14ea9">
+      <statement statement-id="si-2_stmt.c" uuid="b48e299e-71da-4d34-bfc6-90d20e36400a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="da5a0d96-a333-4411-9995-3af765059467">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="332ad9fe-06a4-4bc4-b92c-8246dfeaa46f">
+      <statement statement-id="si-2_stmt.d" uuid="0325951b-827d-4d54-b821-49c70e280f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2901,10 +2901,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee46f4c3-13e6-4cac-9ddb-bd77ec003d53" control-id="si-3">
+    <implemented-requirement uuid="1ca92f2d-8c0d-431a-89db-47741bc62f2c" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="29ad170f-6086-404c-a7d9-8064fbb569c2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="a2fb048d-efa5-42ff-af72-db1b4e23cb3b">
+      <statement statement-id="si-3_stmt.a" uuid="b41c03f8-c5fa-469e-ae13-2b155f0f6102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d390ec6c-9084-445d-8836-fb9f16de6b1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -2922,24 +2922,24 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/158'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="46da0378-e4ab-4d86-b18f-5865167a6c97">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="7896bb94-12ff-4f26-ab9b-055f664174bf">
+      <statement statement-id="si-3_stmt.b" uuid="d20717d4-b2bd-4bf7-aa22-a203ee31ea66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="703c82e9-cc3a-4d18-b6ab-9eddcd9e3975">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="27c742b1-58cf-4d64-83db-cb8f2be1e1e3">
+      <statement statement-id="si-3_stmt.c" uuid="52fe672d-c34a-4506-8ae0-54f447ec9d64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e222b8d-5936-4ecc-ba01-4cf21b3853be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat Identity Management, this control is
 duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="a22c6ca8-8829-41c0-a0a6-cad668d6b5f2">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="5268c1f7-9cfb-416e-8321-ef804b0e9699">
+      <statement statement-id="si-3_stmt.d" uuid="e048a640-7ca5-446d-b0e7-4659e9bf8587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2947,28 +2947,28 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f8dbecb-7cf8-4142-8324-50f95063658a" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="39522638-a45a-4e19-8cbe-11d5aef389ca">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="05e569a5-a2e6-4a74-915a-7df9aad1ed02">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1805b54a-c486-47c4-8146-13803e64739b" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="c8224f7c-d6a9-4aa3-bf48-4267fa1cfc1b">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="3cce157e-7c2d-4dea-8163-38fe2d7eb3ac">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb0c1cc5-a381-4d19-ab80-79b02ed090e6" control-id="si-12">
+    <implemented-requirement uuid="23102443-d9ae-4a4e-a002-ea264e74cbb7" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="e0b09209-103c-48dd-baaa-fe43fc14e225">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="dfe50c05-7789-4f15-9cff-69b64d0fc684">
+      <statement statement-id="si-12_stmt" uuid="49f7b842-5014-4ce2-856e-fdf43f79c0d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8456e347-83e4-4e1b-be54-a08042e93135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Identity Management in
@@ -2989,10 +2989,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/159'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd4a8bf4-ccbb-4b5b-bde3-202147e13269" control-id="si-16">
+    <implemented-requirement uuid="0dc6f97d-ff1b-4fe4-8788-6d715267805e" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="a6185d05-51f1-4d0f-9f6a-eba4cd8ebbf1">
-        <by-component component-uuid="8a4b460a-f5e2-4b9c-9f90-ff32dc0b17b3" uuid="d5907c86-f1ad-471f-a65c-a4d1b08171bb">
+      <statement statement-id="si-16_stmt" uuid="c36301bd-387b-44fa-a26f-91221b5f18fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a18477a5-4e4e-4a77-8732-1947aa9a8f53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Red Hat Identity Management Container Platform
 inherits memory protections

--- a/xml/identity-management-fedramp-Low.xml
+++ b/xml/identity-management-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="ba57f4c4-99d0-4566-86af-29382bea01ba">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b2d39cf7-dd41-429b-8f63-54ec108de2dd">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.49+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.86+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="b85ba17b-2cc1-4c32-84cd-3b8ecfad4e90">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="a0008772-3237-467b-a5ab-9c55b00dfea3" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="cc73f32e-2a7b-4cef-af58-17f995248bad">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a1516cd1-a1bd-4502-b5f5-d930bf096a30">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78a80050-8a7c-49b9-a123-4150e1675d52" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="b3d09cd3-2281-466e-96b1-15acd01c4257">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="db3a8836-4b9e-429d-901c-07372bae2554">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1306fe98-088e-4365-8b4e-3a1bbbac0322" control-id="ac-3">
+    <implemented-requirement uuid="2686232f-124b-4343-81bc-219b4929e933" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="45b663c7-c78c-4232-96a0-b536bf9ca14b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="191ef30c-2a82-41e2-8cfa-f82b40300852">
+      <statement statement-id="ac-3_stmt" uuid="6cb50aed-55b2-4713-90b2-41f4da2c9dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbd60c53-75aa-42ae-b8ca-a057ea9b6917">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is being
 tracked on GitHub:
@@ -515,10 +515,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/2'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bdfa98d-ab89-4f94-a09f-525db3d84d80" control-id="ac-7">
+    <implemented-requirement uuid="68a78243-a112-42bc-b8df-fa935c812ac5" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="6f5d14a4-db34-4667-a938-dfe07fe7d768">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="43af518c-9e07-4b38-8066-461223cc696f">
+      <statement statement-id="ac-7_stmt.a" uuid="2fe6207d-624d-4450-a641-f12787214cf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af26e73b-91e1-4190-814e-1e564d8c707d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -527,8 +527,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/3'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="77f9205f-7904-47b3-b12c-155c12ce55e0">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="eb34fb23-bc0c-410b-b283-48dbc3d2d3a8">
+      <statement statement-id="ac-7_stmt.b" uuid="75233fb9-ae05-4438-8a87-8be6e12967f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d831de-76a9-458c-918d-696396632d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guiodance for this control is being
 tracked on GitHub:
@@ -538,10 +538,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/4'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cff44fa-f4b7-4616-ab50-60dc058fe168" control-id="ac-8">
+    <implemented-requirement uuid="2264582f-57d1-489b-ae0c-2f47ef5bfa67" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="acc6528b-c6ef-4771-a7ee-654a7aee2960">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="99b88601-ab61-4abd-ae00-a49f419b756c">
+      <statement statement-id="ac-8_stmt.a" uuid="88aa2f00-3570-41e6-8c92-fc4427698102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddddca08-6750-4a81-b06a-1d0bf1de771b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -550,8 +550,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/5'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="160b2e6a-4370-452e-bf8b-473034aea963">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e0b1ab0a-d3e7-4920-b288-1e6c868d1f41">
+      <statement statement-id="ac-8_stmt.b" uuid="5fe50d42-8002-4962-b62b-bc0d11148378">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a483aa78-18cb-4824-87c8-3567e2365668">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -559,8 +559,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/6'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="7f5812f3-b2e5-45c3-b8fb-282868f40a6a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a6104ee3-e14b-409e-830d-b9418fec888d">
+      <statement statement-id="ac-8_stmt.c" uuid="c77f2ba5-8451-46c8-8716-0274c31731a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7bd5761-0a23-4c8d-a6c7-ce9f695991c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The banner text, as identified in AC-8(a), and banner acknowledgement,
 as defined in AC-8(b), will be the same regardless of what network(s)
@@ -570,10 +570,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="faf00532-cd18-46b7-a308-751055f0a706" control-id="ac-14">
+    <implemented-requirement uuid="0dba02e9-1d1a-46a6-8eac-ae228748a7fe" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="3d1fa9a2-5c41-4271-b88e-dd581057dbe2">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="f64924bd-0bfe-4f73-956a-2c4ab55a2883">
+      <statement statement-id="ac-14_stmt" uuid="8cb047d6-5057-4cef-8e10-c1b786aa7f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2267fcff-70b3-4825-84f6-70f3605bdffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat Identity Management
 console, unauthenticated users will only be shown the
@@ -586,63 +586,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="deab2d16-7c8a-44d3-8198-20d944f73ddc" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="5046f65d-9300-4ac3-92de-b97b2e54a0fb">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="db779830-76bb-4ad2-90be-8a4fa573a32b">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59f05918-bcb3-4824-898d-9b6769dfc4ac" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="7c628610-c42b-411b-9c17-4ac00ad1eca0">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8ccb04c2-3459-4602-b361-4344aa1ebf3a">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74c134e3-78c6-4aa2-a8b7-90abf9724bd8" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="649ae930-b9e6-4d7e-b2b9-f4a294d523ce">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="6a9d6cca-2044-4e27-b7d3-3320d86bd9cf">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93663d06-8393-4851-9d49-f38d054c2786" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="0f0c1e5f-9123-4c85-94e0-3d03dd91e34f">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="19d04546-f3d4-4277-b073-5ad657df28f0">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="746f830e-c04d-4a5f-913d-e313af418422" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="8293b53f-8652-425c-a2a8-31682e84c706">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="acdf1a3d-4f08-4f1f-86cd-b91afb20b5c4">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db670265-5d98-406a-8b23-94f81cd588e3" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="1c769c2f-ae74-4760-aff9-b2f03eaf065f">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="619217c5-ee1a-408d-a85c-d0e96ae619b6">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="5350bcc2-1fbf-4906-b83c-b6ca72311615">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="6aa56228-068e-4e94-80a5-5db0ebe4f05f">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -650,26 +650,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3234aa0-8e2e-4964-b11e-1d5a658ee2c9" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="90274878-921f-43dd-b2cf-58c6da0449c5">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="3fe2e921-1899-41e0-8878-81392469cfb8">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="33f5995b-2a69-4415-b2fc-11da51a88741">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="efb30258-d74e-4efe-a352-fc4ef93f15fe">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="757623ff-39fe-4997-b4bc-5acbeec9295e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ae5d26b4-d7c6-4365-b128-dbfeea669f4e">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -677,26 +677,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6b3abad-b346-4ce4-a450-a8f1c814c728" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="e6b719aa-dfd6-4fe2-ad3f-b14de2e3a0e6">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e5f0d3f1-f88d-4d3f-afad-7ecdc40a29d2">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="aa54320a-ff1c-432a-a709-5fe4b83f5859">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="95f5af0d-cc21-4688-9c7e-1e1d81f067f4">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="aa3161c2-ff40-41c7-ad60-71571aebe96b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="81ad272d-8ce2-4de1-b03a-73d6683f02de">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -704,18 +704,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78146b53-e8e8-4b52-ac7e-bb0d57354d7d" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="47843611-c50d-4f54-b16e-7a273f7d1d4f">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="6ddbc602-0da0-43c0-b011-0cf10ed26b1b">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="7d64ec64-9416-4152-8820-f46449db4339">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="d6738b12-7f9e-4013-adc2-4b97d8d7e41c">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -723,28 +723,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0007b28f-d502-4134-8dee-8c0f4ae39074" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="f42aa74b-fb35-4d56-a233-f7d112ea6666">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="5817d54d-7c8a-4363-b340-fb1fb39c987d">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="163d1dce-74c4-4fa9-8129-8b338d5a0e93" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="223ef076-78e0-4862-9914-bdd79cfccd4d">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="430ca3ac-b436-4ac7-b9f1-bcf201a2dca8">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9183ad1-6ab1-4536-b682-fda64db59996" control-id="au-3">
+    <implemented-requirement uuid="f0e3c559-432e-499b-8027-7b9326bc137c" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="cd0d0d6c-cbff-4feb-aa4d-2685070dbe12">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4f2f3ad5-ab29-4688-8191-0af11acdd89a">
+      <statement statement-id="au-3_stmt" uuid="6b2dd116-f765-423c-be14-fb716dafadaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eec9f35-3329-4d83-a198-c5eeba770567">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management audit records contain this information
 by default. No additional configuration is required.'
@@ -752,19 +752,19 @@ by default. No additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93b3cceb-4df6-409d-b856-15c4d60f6200" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="2657cf68-e922-4d44-9c3b-0004cc9cd57a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="11e607a1-594f-4748-92dc-0d9027dc8e76">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa235913-6d69-4e60-a8bf-b9399853cfda" control-id="au-5">
+    <implemented-requirement uuid="034ea4df-825f-4faf-88ba-f298c53a7b1d" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="a4bb5222-b957-45fe-bf0d-cdfa68da87df">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="45151b98-8987-43bd-802d-ade751d2a3f9">
+      <statement statement-id="au-5_stmt.a" uuid="5ce2ff49-d8bf-4cd0-9f55-f154246f0ef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1882697-7e9e-4844-8de8-86cd41eb893f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management Administrators  are responsible for
 alerting personnel or roles in the event of an audit processing
@@ -779,8 +779,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/19'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="2066ef5f-f9c1-4a04-a5d6-27a79675b87e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="069876fd-0340-45b6-ba88-419f0a3cee91">
+      <statement statement-id="au-5_stmt.b" uuid="62bb3d0f-d7b5-48c1-a667-b0e5700bd35e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cba42318-7a19-42da-988b-38dcddcfef29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat Identity
 Management Administrators
@@ -797,19 +797,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/20'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c11c9bee-2b19-4ea6-876e-6ec475d2133e" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="5cdf863a-380e-4ef9-b5e8-ab3fe4ba4bf3">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="90a15ee2-a0ae-41fe-b82f-6f3242225362">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c456245d-4a22-48c0-9ecf-bae8c5f3e0ac" control-id="au-8">
+    <implemented-requirement uuid="d315c03d-3602-4936-92a4-d5602c2c2695" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="9a15818e-1a56-45c3-8bb4-1de3d5afe3bf">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="0e04f127-b6c4-4cf3-bd1a-6992a5130e1e">
+      <statement statement-id="au-8_stmt.a" uuid="c31c0db0-29eb-4b00-bb36-eda35cd8790d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="631a70c9-5c2c-4fc0-8322-f6f8ba3c1e7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time services
 provided by the underlying operating system. This control is not
@@ -817,8 +817,8 @@ applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="55ef2197-9030-482f-aee5-1bccc2fd721c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="bb286afc-8b2e-46d2-a711-108b5c912759">
+      <statement statement-id="au-8_stmt.b" uuid="57485f21-41a5-4d56-83a6-d0bfc7acbbdb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="031ff5dd-8043-4802-9aaa-fe140c7d142a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time
 services provided by the
@@ -828,10 +828,10 @@ configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89a63f08-93fd-47b7-964a-bc082f951228" control-id="au-9">
+    <implemented-requirement uuid="9220e518-9a38-4e4e-a1ed-fe9236536b01" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="8cf7c0c9-da6f-4a73-8548-3f4e8ee2fe23">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a725877b-6301-4074-9885-91d43e64a95b">
+      <statement statement-id="au-9_stmt" uuid="f96632ab-f3bb-4a09-89e2-9eab4caebc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e4d92c1-2e60-48f0-95e9-5dc33662d8a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -848,10 +848,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/21'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b95a3072-a6c8-4831-b7a6-393434bc71ea" control-id="au-11">
+    <implemented-requirement uuid="a5527673-ede2-4adf-ae57-5429e7e61426" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="3f4b1eeb-5bfe-45a5-91cb-bd597e8d1485">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="3d48bc6a-653b-42b4-8cab-174d2af536a6">
+      <statement statement-id="au-11_stmt" uuid="14bb9cb2-ee94-49b0-a72d-9a5c646e05d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad105910-b599-4da9-ba4b-584f5cab4d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -861,10 +861,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/22'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edee588a-77bb-44d6-837d-baf094730572" control-id="au-12">
+    <implemented-requirement uuid="2feaf953-6801-4ba5-85ed-d77b00c57295" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="4467aceb-879f-4856-a01d-258e1ab067ce">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8ecfa79d-36d1-4fe0-95a3-ab57000686f0">
+      <statement statement-id="au-12_stmt.a" uuid="418ce8ab-4857-4355-8366-46c734fd354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a9baf92-f88a-4a46-aed6-d6b671665072">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to provide record generation capability for the
 events defined in AU-2a at all information system components where audit
@@ -879,8 +879,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/23'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="23a77bad-ccf0-41ea-85f9-aaf9a2a55725">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ec1b0c5f-fc81-4bda-bd61-e06043a34a12">
+      <statement statement-id="au-12_stmt.b" uuid="6f282e6d-c2b3-40f4-a38d-9732ef3cf585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78ced34d-f455-4993-8c6a-2d6af382116a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -897,8 +897,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/24'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="5c61391f-2c95-4ef4-a280-a21cdcf1bff4">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="88bca144-5685-42ba-b892-f7f837daa6b5">
+      <statement statement-id="au-12_stmt.c" uuid="1224f7c6-5c3a-4349-8e8b-c38a8187f02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c9eddcc-dcb5-445c-9616-5b79870ad5c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -913,109 +913,109 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/25'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a176ad2-d5c6-4e49-9fe4-ef7f2b82b758" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="ef3ba9a0-3cec-4fcf-a91f-e95ac75926a2">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="846db57c-b7d1-44c6-87b3-d662a353637f">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56622ccc-04e0-4719-9128-4cd6fc917fda" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="d8f2a742-c789-4f47-bb02-d45cd764a6f1">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="0077babc-9457-46e9-b21d-c10d40e82e37">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e2b4556-70fa-4809-91b2-25ee554c4380" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="8f8a778f-a492-4175-b998-a47bca87b393">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="cadeee17-55b1-4af7-b459-198ad9b34743">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02cab833-7561-4358-84d8-642413ee2f59" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="0bdc6257-549e-42c1-ac73-02953b731537">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="85a62375-feb0-4de8-a1c7-f5cc0a10de57">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da8a97f9-f416-442c-a21d-de3a82a6c05c" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="6360590f-7d3b-4b90-bda6-6a1b47772b16">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e1415ce7-14f7-4670-897e-bac8b0ed2eb1">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57038097-7b4d-42e7-b850-d553dc611a6a" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="0afd93f0-28b4-4c84-a4f9-4baa54500ffd">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="95d2f187-f3c1-4c2c-851d-3f000c91ec86">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e08d092-1747-4a8f-a24f-036de12c1bee" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="1a7d7981-157d-47dc-a1ba-880792bec0f5">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="704c1cd7-c8b3-4063-b272-e25b2e424868">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ca04745-7eb0-422d-8fc2-988818512850" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="b37de6e4-d860-4a19-a519-3a7df7591c8c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="62e026f2-3131-4a86-91fd-aacfa0612dbd">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb905b6b-1099-4749-9c22-7481635043d0" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="3b08b217-50fe-4108-a38c-6d468f77298f">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="afaba651-00f9-43c0-b9db-93c4d4feb70b">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b916b5f-2899-47e5-85db-0ea7d76d28f5" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="65a27183-f757-4b06-bca5-b4cbd2bd249a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="7778176b-cc15-44bc-a734-c2fbef3e3d20">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b91ca2d7-77ae-4fce-83f2-9373e2454b0d" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="fb7f6a5d-c7cb-4126-b502-f957fbcc0aae">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b3337755-0e1b-4d4d-8835-d3f2412780cc">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fee9a3d-cff1-479f-a38b-67e1fb25c30f" control-id="cm-6">
+    <implemented-requirement uuid="eb43e7b7-04a2-4bf1-a1d9-714985741a38" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="cd75e66f-c788-4e8f-bba5-06b1517f18e2">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="43a7f2ee-93ff-4c90-a65e-7d1c87e149f4">
+      <statement statement-id="cm-6_stmt.a" uuid="72582835-c086-4505-961c-9c88a556ee92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de7715b7-c6db-4849-828b-0c654b43bbfe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management. Use of the NIST National Checklist
@@ -1024,8 +1024,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="0182546b-a549-4c18-b091-0e3417ee2bf1">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="caaa69fd-2223-4a2c-9db9-039a0abebaa4">
+      <statement statement-id="cm-6_stmt.b" uuid="8a63aa2b-3443-4dca-8903-1971b9346769">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed14dd7b-0a83-48ba-b6d5-fd6223eaa59e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1039,16 +1039,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/40'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="a96f00ca-0502-4cb8-80b9-43abb62f0078">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="928f0f0b-20db-47ee-9992-71025dc705d6">
+      <statement statement-id="cm-6_stmt.c" uuid="2a2d2109-32f8-4eef-bd71-d34021ad808f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="1cc3b0b0-30ee-4c0b-a639-b01608da39cd">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4b35ff81-6fc2-42d9-adc2-eea4881fbcda">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1060,10 +1060,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73fbf3b4-5489-499c-a5b8-1a1bf45fbca3" control-id="cm-7">
+    <implemented-requirement uuid="dc6be27f-2815-4296-a17d-9630b0358a80" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="c4e6aed0-53a6-4606-9255-5c9a984e269b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ad079740-b43e-4ec2-9804-36e61977e3d0">
+      <statement statement-id="cm-7_stmt" uuid="3eed2889-2c79-4ea1-8d29-292b6f7d0511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43fab0bd-f9e4-4b72-92c5-881550d346bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management provides many capabilities, including
 user authentication, DNS integration, and several APIs. A successful
@@ -1073,73 +1073,73 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87932cef-5a25-4fc6-9a96-f66c6b00d334" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="9911daf7-e8b0-412d-90ef-c22500acd096">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="5fc474c9-4918-42eb-99aa-4115333d95c4">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5a811bc-593e-473f-a4cf-7010d59297e2" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="3f4f0145-3eb7-4878-8cce-e578f46f68fa">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="d599fec5-8d3c-4ce4-94b9-129f95b56a92">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80faad90-2b68-48a4-8c90-59b7acb34921" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="14723dd3-d94e-4cdf-b8a9-88a68fc14798">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="3fa2b5e1-7fac-4f09-872b-fec8b0d0fad4">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09dd58ed-8bea-4e85-b7f9-b736f568e8e2" control-id="cp-1">
+    <implemented-requirement uuid="a0f6269d-8fb4-451c-91c8-27e046a4860b" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="f0d2f540-f4e6-40be-8db7-edc3db81bf20">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9b3f0255-ccc7-46a8-a843-ad82b8057c95">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72a18495-8484-4a5e-870d-a5ec52cefdc4" control-id="cp-2">
+    <implemented-requirement uuid="6ccfe701-d079-46d5-9cc2-f6f7d1922a00" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="0fb3d405-e0da-4903-a283-d288fed55269">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e844a492-748e-484e-b285-795d4bf7fd75">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ab162fe-6e25-4433-a8f9-13270bd45168" control-id="cp-3">
+    <implemented-requirement uuid="a14f7e61-a09e-4a5a-b0c2-f83ca7d9a604" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="81fc8dbb-f934-4e2a-a2b3-3d5f3f03f673">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="93f60283-d6dd-474f-b053-7d26b9e0bd26">
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36cfa349-f013-4546-b069-22281040b624" control-id="cp-4">
+    <implemented-requirement uuid="07999975-1ad2-4276-95d4-c9bd5cade065" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="27535d31-d0c3-42a0-9325-a88ca83dff13">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="edf54911-9f89-4219-9c8a-b1629262a448">
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f63bdfd8-2a9e-4658-ae87-0cccb5560f93" control-id="cp-9">
+    <implemented-requirement uuid="71ae0c0d-1063-4bb8-aed5-46b34435ea93" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="3323307f-f273-4748-9fb2-04d63152374a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="48d00eeb-f55f-4895-a797-e186ccf553c5">
+      <statement statement-id="cp-9_stmt.a" uuid="b6de0a33-e983-4088-a93b-2cbf8cd36608">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b283e7a-66e1-49ce-9e5a-b098f19f6b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1156,8 +1156,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/51'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="0914949f-2191-4f74-ae72-0752c5cc855b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="7a68733f-c018-44b2-a13e-89ed18d4c9a5">
+      <statement statement-id="cp-9_stmt.b" uuid="a6aafdf9-f3fa-4924-8ce6-ca0e17cc2c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80930de0-ac6b-48b7-b500-18c0cad04247">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1174,8 +1174,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/52'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="bf4e7697-c6c1-42a2-8600-07a41b47b937">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c1c7fdc1-fc93-494e-87cb-0623183c4d0f">
+      <statement statement-id="cp-9_stmt.c" uuid="d4b964b8-d27c-4ddb-b5d7-f0b0f2514aa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77d4bc17-9908-4d0f-8a90-a5767cfc149f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1191,8 +1191,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/53'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="02e4c841-1397-4e22-9d5f-e8fd30964aea">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="638c3e87-b874-4415-b4b0-a1be4ddb96c4">
+      <statement statement-id="cp-9_stmt.d" uuid="981d1648-443d-454d-8e72-85955631a0e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29c7f194-769b-41b1-be15-f0b6cb7c66fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1208,10 +1208,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/54'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cfd7380-979e-46c4-af90-d6cdf7de4b8f" control-id="cp-10">
+    <implemented-requirement uuid="0f137ca3-e150-4d12-9529-74058757bf93" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="62184831-6dce-4784-9959-9ccd2b8e7e39">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e5920eaa-16ee-4b61-b5c0-dc12f1502e38">
+      <statement statement-id="cp-10_stmt" uuid="97c745a9-c5b3-4340-a551-de3cefa1f5c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758e9828-dc07-44a6-8027-def0ac361a39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute
 their Red Hat Identity Management environment. A successful control
@@ -1222,19 +1222,19 @@ Management environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1670173-225d-4347-9035-92b206bf8b6e" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="56ed60f2-4c96-4a7f-b39e-2283c55b1c47">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="04a29d27-45af-4c2d-90b2-be9797fc1605">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2425a30f-df7c-445f-a68f-c89845172b2d" control-id="ia-2">
+    <implemented-requirement uuid="a0552f3b-016b-40d1-926e-a17b256a6b4f" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="bde22539-cfc8-4b81-bc9e-72ac8eaa5704">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="02a92ced-759f-48ea-b3e0-5b2f5f85efa6">
+      <statement statement-id="ia-2_stmt" uuid="1892ea09-ce90-4f45-af27-3cc782b239e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="655fd21c-d8e4-4d7f-a9b4-6286c7973bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring Red Hat
 Identity Management against
@@ -1245,10 +1245,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/61'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db51a7a7-7dbb-4c09-8774-8239a6d228f4" control-id="ia-2.1">
+    <implemented-requirement uuid="8a64ac47-2a71-46a6-8fdb-dd0589bf6114" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="115b9c3b-e106-4c90-b69d-80e08208efb7">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ae874fe4-d7dc-4344-9aa1-1f05f9796ab4">
+      <statement statement-id="ia-2.1_stmt" uuid="81d804c1-0f52-4719-b71f-f0a82cdcc372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d670bf3-6483-44d7-83fe-feb5acc447a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1271,10 +1271,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10a0fd90-af4e-49e4-b456-32e9460a9b1b" control-id="ia-2.12">
+    <implemented-requirement uuid="5ba17a8e-8872-4bc9-8a24-0b8f8c73ed1c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="efe9f0c9-a0e2-42c4-9877-c5d6a17e7a56">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="83324f61-f64c-45cb-ba22-20e9d9e3e8bc">
+      <statement statement-id="ia-2.12_stmt" uuid="49ecb729-40c2-4e20-9846-7d0b7d160770">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="534a5d5f-ac4a-428e-9547-7de76a6cc430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1291,34 +1291,34 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/63'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="087d801f-cfa1-4aea-b6d3-480a3d8faf1e" control-id="ia-4">
+    <implemented-requirement uuid="0066267f-fefe-4dba-b0f1-79ee03e68b7c" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="d7ce6b23-fc5f-475c-9292-2aaea95be11e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="f776aa5e-7da9-4356-96dc-cc6339d3d191">
+      <statement statement-id="ia-4_stmt.a" uuid="c74e45fe-ba05-4415-8c5c-0171266d0492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="b97bb6c4-42d9-4367-a88a-1518f2f1d350">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="f73abdb2-ed23-416e-8395-13d0646d5da4">
+      <statement statement-id="ia-4_stmt.b" uuid="d45bb245-1b07-45bc-826f-73bee9bc9efb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="8d533ba2-2eff-46c5-9222-df49825e1dd5">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="3cf1b89c-9eb8-4ddc-b3b3-529c428d2328">
+      <statement statement-id="ia-4_stmt.c" uuid="8a708da6-8e06-4d94-adbe-8406f9da9d98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="f594fc3e-2d55-477d-8290-eb9cc3625a4a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4e55b6c0-4b20-4b50-bf71-824dbdb3dab0">
+      <statement statement-id="ia-4_stmt.d" uuid="b48673e5-0fdd-4f52-ac4c-dd9b602f9f2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddfdc13b-3e8d-4a48-aa1c-b964d1402e76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on preventing the reuse of identifiers is
 being tracked on GitHub:
@@ -1327,8 +1327,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/64'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="ed066b01-6981-4ba2-bb9e-96e47c0dde08">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="5767ba74-6063-488b-9c37-1de2355200b8">
+      <statement statement-id="ia-4_stmt.e" uuid="b3c63752-9061-48fe-ba7e-1c4af1a907cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6281964b-15ca-490c-9886-2364647f39e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on disabling idle accounts is being tracked
 on GitHub:
@@ -1338,18 +1338,18 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/65'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="785abcb8-b68f-4a2b-a5b2-295b0334baa5" control-id="ia-5">
+    <implemented-requirement uuid="21d196cf-4c81-4c55-b2da-eecb526e88e4" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="60be80db-2b19-4af8-b1ac-4e5a31106e6b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1ccb3ee2-e9ec-4acd-a740-0e275fc6a457">
+      <statement statement-id="ia-5_stmt.a" uuid="f7ed881f-3035-4afe-8a85-e702d0f20ea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="1b449cf6-ca90-4e6b-9142-b77bb7169a1e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ef68a0c8-b1c6-437e-a472-8d6e747900dc">
+      <statement statement-id="ia-5_stmt.b" uuid="65fc9a84-3daa-4a6a-ad97-0b0f585c4ae0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb709e7a-0987-4e17-a7bb-9a0de98437b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to configure initial authenticator
 metadata is being tracked on GitHub:
@@ -1358,8 +1358,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/66'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="fbc196b8-c83b-4c64-90d8-158228e0bca9">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="984aedb6-2c62-49f8-9fa8-97a13bb2b7aa">
+      <statement statement-id="ia-5_stmt.c" uuid="9767ac0f-26f5-438c-80cb-6fb425db1d11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13a85550-b937-442f-a3da-aec50738c88c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on ensuring authenticators have sufficient
 strenth of mechanism for their purpose is being tracked on GitHub:
@@ -1368,8 +1368,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/67'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="6d2666e2-34fe-4e70-93ff-30df27fd5496">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="90d1e853-a205-41cd-8db3-ea137956cdaa">
+      <statement statement-id="ia-5_stmt.d" uuid="c9132a2f-2739-46af-a054-8b13c9e20a75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4f28238-4d18-4140-8461-133355603f64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1377,8 +1377,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/68'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="c9413555-2256-4382-a00b-77e4a84addd4">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e9d42982-9908-4844-a8cb-3c898a5b755d">
+      <statement statement-id="ia-5_stmt.e" uuid="1f03b0c1-9db7-4ccd-9f19-44755f11ea71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33f684c-40a6-44cf-827b-4e9543a2fb2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1386,8 +1386,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/69'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="abb54605-6431-49f0-8b7b-4cc215c56a26">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8af0cf83-6f4b-4b0d-a80d-e02bad04f14b">
+      <statement statement-id="ia-5_stmt.f" uuid="214282d0-f500-47da-b482-be2d73b22c3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="784383af-c441-4b0b-8a47-54563b6d86df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance/documentation for establishing minimum/maximum lifetime
 restrictions and reuse conditions for authenticators is being
@@ -1397,8 +1397,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/70'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="a9c03677-b907-4540-8f37-a37ca0a7894e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="f4473be7-5745-4d05-9c95-ff2399a8a8ac">
+      <statement statement-id="ia-5_stmt.g" uuid="1209ed48-d981-40a7-804d-e824d6fcfae3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="307d12d1-8e98-467c-b541-a63f28fe0250">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on changing/refreshing authenticators after an
 organizationally-defined time period is being tracked on GitHub:
@@ -1407,8 +1407,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/71'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="fdc7e646-3199-4ed4-91e8-872ca8f8e736">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="461be080-5a60-44a7-88e8-f354cc9b5bca">
+      <statement statement-id="ia-5_stmt.h" uuid="24dee65b-b4bb-4038-a8c1-e69547225b2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8aae24c2-6259-4bf7-8e03-e5ce5951d3ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1417,8 +1417,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/72'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="54c5991a-7171-4c39-b729-733047d92f7b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c20ebd19-2c7e-41d1-9bb4-c77889e9e1a1">
+      <statement statement-id="ia-5_stmt.i" uuid="ee9c909c-a5ab-4e0f-bd24-7ac6414e0f6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23f15f66-8747-4680-895b-ef3f633d22be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1427,8 +1427,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/73'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="26e911e2-af9a-4eb7-853a-a0dceeb410c7">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ba478344-9444-48e0-bebd-9e8cf9025a43">
+      <statement statement-id="ia-5_stmt.j" uuid="ac933449-5342-47d7-8d5f-82d769c8c632">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
@@ -1436,10 +1436,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="331946b9-1fc8-4a8a-b778-47c81ba06495" control-id="ia-5.1">
+    <implemented-requirement uuid="42662bbc-5676-4534-998a-408bab9862b5" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="081fe181-c8d4-4247-bb16-1fdde947f483">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e7b56f1f-4395-4110-b79e-2c2282a54933">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba5ce70b-5f63-49db-a858-bffd29cbd45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ae1d9da-7a2e-454f-a11e-bed7ca3fbf48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing password complexity
 is being tracked on GitHub:
@@ -1448,8 +1448,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/74'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="5a1b569c-f1b3-440d-80f1-2e48bd66b89c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a66d956c-f957-4fea-9372-c9d1c8975516">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c73a7f82-552c-43a4-ade4-c7efb437b0dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6524101-0249-4880-b2d6-db9b8bc0ef85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing changed characters during
 password creation is being tracked on GitHub:
@@ -1458,8 +1458,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/75'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="a43564fe-2d47-472f-b2ba-b44471764ca9">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e79215d2-99fe-4d1e-bd81-04762b7d8d2b">
+      <statement statement-id="ia-5.1_stmt.c" uuid="a8f66fc7-a19a-4820-9c01-988ccda18c4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a74b8cc-80ba-4ee2-afea-31f12f7a20c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on storing and transmitting only
 cryptographically-protected passwords is being tracked on GitHub:
@@ -1468,8 +1468,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/76'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="d3cb8264-19ac-4486-90d5-046247736a9c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="58e81bc5-e01c-4f34-acd7-2d4ad439da73">
+      <statement statement-id="ia-5.1_stmt.d" uuid="38d52bc1-da7f-4a76-b134-e2ab229a6e31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="02af4d79-0a4c-4582-b124-01dfc0fdfc5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1478,8 +1478,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/77'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="241abe2f-d6f3-4fbd-a2b2-0575842981b1">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="19b83ebd-ddc8-4559-969c-695cbee69c5e">
+      <statement statement-id="ia-5.1_stmt.e" uuid="cf8eeef4-c1f6-467b-ab42-1b067430b959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd745207-6ef0-4e8c-b76e-ecf20b3b9370">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1488,8 +1488,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/78'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="796f2a1d-f195-4c64-8862-33b16941f4e9">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="97bf53a4-407f-4d20-b3cb-91da4ff41e93">
+      <statement statement-id="ia-5.1_stmt.f" uuid="018f553b-8848-4c8b-a29f-95b1d3bb82f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66186d1c-fde1-4ce2-9dff-d9a7aa087c2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing an immediate change to temporary
 passwords is being tracked on GitHub:
@@ -1499,19 +1499,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/79'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a579b89-1c10-423e-b35e-345882ebc62a" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="3b107232-32ff-4265-b3b9-2e8c0fa1bb67">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8c02a3ed-5517-4c55-a2b4-94500422cc86">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd8c7d24-bb91-452b-9e76-f4a214cc3eee" control-id="ia-6">
+    <implemented-requirement uuid="53ebd492-001f-4bc6-aa6b-b16824c48dd4" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="2b4b10a8-bd67-4e46-aac7-0190202ea42e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ffe1b683-27f6-4813-83f8-632fe160568e">
+      <statement statement-id="ia-6_stmt" uuid="2fe9bdeb-2642-4d42-a85d-57398f32d396">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2dea1a-1389-44b9-8f44-cb147b2da7a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management natively obscures such information.
 Red Hat Identity Management cannot be
@@ -1520,10 +1520,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ce5de90-6ab8-42d1-a7bf-b2e836a09313" control-id="ia-7">
+    <implemented-requirement uuid="0b3959d2-7975-4411-aa2e-001b8352c57f" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="a1c20ec9-9849-4c09-9bc5-2f461a70bc00">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1ba36114-c7f8-4a16-b221-f054eaab428d">
+      <statement statement-id="ia-7_stmt" uuid="71243606-9119-4338-9330-9eacf55eda8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5007c322-8d8f-45dd-b70c-294727c63ab8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for configuring Red Hat Identity
 Management to use
@@ -1538,10 +1538,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/81'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98434d42-073e-481c-bbfa-169eb6401f85" control-id="ia-8">
+    <implemented-requirement uuid="f950f528-847d-4cc4-82f7-eef3734154b6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="b7e81d66-b5a4-41c9-9357-fd2c5bdda45d">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1aa68030-896c-4f12-b263-8be98c14176e">
+      <statement statement-id="ia-8_stmt" uuid="993cc9fc-2415-40a9-81af-59e3862576e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eaa11a5-df2e-43fd-bd6a-06de4b2f228f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -1558,10 +1558,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="752cdf09-7e64-4f02-9433-f67dba51ca08" control-id="ia-8.1">
+    <implemented-requirement uuid="9d62599d-c244-4194-a265-ac718dd01c14" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="7f34f731-7ff4-4808-a49d-ca3b5579cdaf">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a174a41d-5f7b-4506-a8c1-4243163b5dfb">
+      <statement statement-id="ia-8.1_stmt" uuid="4b6a0697-ca3e-4e7b-93c6-d23bbc41263c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1480101-b837-4ef1-b28b-c94133708416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -1579,10 +1579,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33c0b62e-21b9-4bae-a243-369c1c66275f" control-id="ia-8.2">
+    <implemented-requirement uuid="2afae6ef-4fba-4eb3-91e8-4a781deb086b" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="af2815a5-4d34-4952-aacb-8eaa15721ea2">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8a326f09-8f37-4b64-9273-ad11332c4638">
+      <statement statement-id="ia-8.2_stmt" uuid="9e336773-3c97-4ab4-849d-96381adcdee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1aa00e8-29fa-47da-b341-73713b2f845f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1601,10 +1601,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/84'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b150d8d9-33a1-4832-b94d-47682214a3b0" control-id="ia-8.3">
+    <implemented-requirement uuid="3548a1ef-07e6-4f94-95b0-dd21edb877e6" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="ff4f0321-81fc-4b67-b6a6-426fb340b76b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ccdf951c-706c-493b-987a-8e28526fcf15">
+      <statement statement-id="ia-8.3_stmt" uuid="26eb98b9-eca0-4749-b913-b81e2943604e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b444af8-29ee-4a95-9ef3-45aa8fbaaf26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1623,10 +1623,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/85'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a01e228f-5889-4723-8fdd-f4418081e4e1" control-id="ia-8.4">
+    <implemented-requirement uuid="af1b3249-ffb3-4147-a5c6-f6572c0e2e3f" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="bae0f830-a408-49d8-87b5-2864b9b5662f">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="58dec603-97e7-47f5-b82c-32b0a9b11faa">
+      <statement statement-id="ia-8.4_stmt" uuid="58788be8-1e9b-49fc-bea5-eeeb465fbe58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d9d198c-af19-4505-a0b2-594e631bd64c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1645,10 +1645,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/86'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3c789f8-087e-40da-b01c-61c50f429f24" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="203965db-40f6-47c2-a265-642382a0b4fc">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ccf58bac-2327-4a99-a498-f5e04a8db661">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1656,10 +1656,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ccfac87-36c5-47a6-aeb1-8ddffb5ff4bc" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="66efef35-2880-4949-8519-e0999997d6b4">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e81beb9b-802a-4473-b58a-9f76e88ceae2">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1667,10 +1667,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8e5a184-7968-46ae-8370-efb4cc09ca23" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="5e8d2ca6-fc79-4284-8fd4-c48365e9de49">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a1368b40-e2bd-4c4c-8cec-25b70df13f85">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1678,10 +1678,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c371961-8e3e-492e-9833-40ba05eed1c2" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="b4eaf9fe-63d0-421c-a4b0-06546ce46fa0">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="2f4f9d35-76cc-4424-a499-6d574621a9c1">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1689,10 +1689,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dab15735-57a6-4e29-86e4-4d2400eaffb2" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="44dc0da0-a9ca-428a-b5f7-6eb0b61c3c19">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="cfd2d0d8-ac5c-4288-b909-4466de7913bd">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1700,10 +1700,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f144aec7-d8ea-44e8-ba43-c35714ba09b7" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="5a68d864-a3e4-4be2-bb6c-ca8b05721c91">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ebde9e36-2081-497c-891f-82d7aca53f97">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1711,10 +1711,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63c79683-8580-49ff-b0c7-1d73a7e46dec" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="cd48a101-3080-406d-8fcd-370a4a5fb70c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="070bfa46-381e-442c-8ed3-5b5421ccdf0b">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1722,172 +1722,172 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="def3be6e-a029-4af8-a4fe-499154b2316d" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="366e5ae1-552d-4ee6-ae73-a7393e161958">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="fc15ae45-060f-4298-8fec-f74ed821c784">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b60a794c-e3b2-4a60-b154-eeb400c40fa6" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="31d9b62f-1598-469a-847d-9f7296f5389a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b189d64e-f4e9-4e53-85c3-3c8543f84648">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b824821-1250-4b1e-9217-6c5377d56749" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="a9cfc355-372a-4511-b7d1-ecc8d1abf681">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="7c32177c-706a-4586-9eef-bd0eaa4ec976">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cda019b4-6ac5-4da4-860a-6a879504f569" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="a7814e2e-f693-4bc1-ae96-f2f02d22009e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1a49aafc-0fef-4404-a7a5-11df213a7344">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c2f45bc-a8fb-4f93-a567-60ea0b0032c8" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="ca49be34-42b7-4c05-b26b-423de4b2b47a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="70054182-8123-47f7-bc5d-4191bbabc636">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fb99adc-9b29-4ea2-99fb-b9b540c83a12" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="a4288acf-b035-40f9-ba3f-74073aa2fe20">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9a5d77bb-05b5-49d5-a635-eb219756c456">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c793d46-4352-40bb-ae26-7a52f79b2e3a" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="16228ba0-77f9-4bf0-9381-9582e7103304">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="596d9d57-4564-4c44-81be-5fd4f61e1d49">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7225dfee-ecec-4e15-ae0a-d2d6c8ad5b92" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="df49b7a8-99c0-4aa0-bb08-d242655724cf">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1da248a9-24d2-4f6a-a1d8-3c814359032a">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8419dc36-c4c8-408b-84e6-3047a3f0d4b9" control-id="pe-1">
+    <implemented-requirement uuid="f9d20c79-c28f-4e5b-8991-a010068305bf" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="2bd3a7dd-c883-4b8c-ab6e-33278535e0fe">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="be4a87fc-03b6-4452-8fb1-b17951a186a6">
+      <statement statement-id="pe-1_stmt" uuid="e713373e-3041-4175-8df9-1fc7aef4f467">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c144c1dc-c295-4ab2-8703-85c9aa24dc6a" control-id="pe-2">
+    <implemented-requirement uuid="e11036b4-5744-4630-95ed-a531597e3dbe" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="75504149-d142-4b2b-a330-f6604cc33968">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e66cdb00-2fd5-4f9e-89d8-0b6f9efc35e9">
+      <statement statement-id="pe-2_stmt" uuid="22b5b14e-9fd2-4cf1-a1a3-f07a46bd9af5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c826ef5-3a70-4cc8-94f6-701834200c47" control-id="pe-3">
+    <implemented-requirement uuid="dcd89883-3566-42a4-bfab-dfe0a048c583" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="83cc3123-6f7a-4f89-9ba1-8512da715fe9">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a3d95c6e-34ac-438e-b92c-e62337aee06d">
+      <statement statement-id="pe-3_stmt" uuid="97bfc74e-412e-4be0-8696-f4c9ef1eafc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4f3874c-00c7-4b16-b92a-830988f98e9f" control-id="pe-6">
+    <implemented-requirement uuid="e755fdbc-58fa-42bb-8722-9bd276687bd8" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="50700fc1-651e-4962-bc6a-6676e0927635">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="03ef7996-f8b8-496d-bc02-a465aa1d482e">
+      <statement statement-id="pe-6_stmt" uuid="ec7353b3-2e5d-4f80-bbb7-347dfe1ada09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f99b7b8-c520-4864-87f9-b53a6875d61f" control-id="pe-8">
+    <implemented-requirement uuid="050370f6-d90d-403a-b7a6-94ac3922e98a" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="2be0cd42-1660-4b86-82ec-42d74003217a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="fcb13ea1-c398-4584-a65d-d2b19b0ad086">
+      <statement statement-id="pe-8_stmt" uuid="7a1d0807-b0a9-4c43-9797-86d110faf00d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="434b0fa1-25e5-436f-b4f0-611ef5a69cc3" control-id="pe-12">
+    <implemented-requirement uuid="4da0d8ee-9c11-4932-bb8b-d68e3e058267" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="29447dff-0203-48bc-9634-62e9d07b1b5e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="989fbfbd-e980-4dc0-b775-a9fd14705ca7">
+      <statement statement-id="pe-12_stmt" uuid="b92e1c4b-67ad-48d8-8cd3-42d0e3da74d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd9e3de2-bda9-4f85-b80b-a45e59365bfd" control-id="pe-13">
+    <implemented-requirement uuid="b6f0ed51-cbfd-4701-9f35-e9194942c86b" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="f3ac3288-d71d-4fff-9a6e-5e957b15041c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="7c614dee-833c-4405-ab65-1194e275c63c">
+      <statement statement-id="pe-13_stmt" uuid="712b80c4-34d3-4107-9ec5-5d67dc8915fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e54396f5-11ff-4802-974a-fbf5a47e62b8" control-id="pe-14">
+    <implemented-requirement uuid="f603a856-ad6b-47fa-a698-6ba7e933a1d7" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="df5a9332-2b2b-4182-a47c-425f4ab3704d">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="74a54eab-79d3-44ed-b13a-10187fb09459">
+      <statement statement-id="pe-14_stmt" uuid="919d0b97-aef1-4886-b573-92494e162501">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74cdd567-3d08-4295-bd85-511f618b4c19" control-id="pe-15">
+    <implemented-requirement uuid="575f5513-b068-48ef-9a0a-452b43f07e37" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="a6d4b7e1-f948-446a-8c55-504f47ff6833">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="fcfe1cb0-1932-4ada-969f-38037b78a566">
+      <statement statement-id="pe-15_stmt" uuid="0b105b7f-24fe-4336-abfb-6494b3fb99e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c027f7b3-3f16-41cc-ae90-71cfd840b0e4" control-id="pe-16">
+    <implemented-requirement uuid="c5e9cba7-d697-488d-8dca-c125aaacd346" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="5a244e67-05d8-460a-99fd-6f69df5da2cf">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="5e3f7884-4314-473b-a924-cbef601582d2">
+      <statement statement-id="pe-16_stmt" uuid="f01589bd-2452-4390-8650-d1260e65039f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a287c62b-9c10-48d9-8648-9104f3613e76" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="73dd5819-972a-48e1-9ceb-17f404a22ca7">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="05d33406-bc4a-43e0-a8a6-c7bd4b4581cb">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1895,10 +1895,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db0b2301-d0dd-45d8-b77a-6432aed38da9" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="36655055-6909-405f-bdad-457c8c7fef43">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b06981ed-445e-4619-b2af-8244b0c86e39">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1906,10 +1906,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dda78e0-914d-4d78-9601-8a219345cafd" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="b5cff336-1beb-4ae9-9b91-613cbafcba4e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1e5842cf-0351-4084-8db2-1d21a6ef41b0">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1917,118 +1917,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af1df3fe-ae59-4e53-89ef-4845dd3e97e2" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="21c8a569-b02b-4f0a-9863-64dba320a3ef">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4b0c2639-9e14-49ec-bf34-3adef493d4f3">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73d28a8d-b3b7-4fd3-92f9-5eb25e92db06" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="2ee4800c-9818-4e7d-ae95-6a2d863a62db">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4dd2e0e7-83a3-449e-8dba-770e6ba0cbf2">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e493069e-24c0-46a5-a6ad-ffb0982c733a" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="dffe9a96-780e-494e-b36e-5b718eba3e37">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="770d54d1-0934-455e-8a2b-e343d2efd372">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be1fa4bf-89bb-4a9b-a1d7-c60c846af8aa" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="123d446c-7620-4c1c-8c50-03db1423f707">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c4e92f93-2ede-4ff2-bc2b-67f35f4c9606">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6ee3cb4-e296-4a1b-8007-61479b55a26a" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="c4cdb8e3-592f-4477-81ca-64a888b8a486">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c86d178a-211e-4d4a-ba83-09498e561e6a">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fa629d1-7a61-4595-989f-c7e5de362487" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="556d1c43-6a1a-491a-a521-14a9e5285d8c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="4fdd9bda-3937-4e9c-a215-c9d132cbe27a">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="410fb581-72b8-4639-bc65-0097df63df6f" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="c6951abe-1d91-44d7-83c3-3eb63977ba7b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9ecd2cbb-d2a8-4436-9955-6d407bf8cfa2">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90324750-ffef-4612-95d9-ab0e861775f3" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="b0c76fe7-cf31-4994-92cd-46140ea83af7">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="7734835a-2dc2-4d91-80b2-5a20e9ba1b33">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5141654c-8a5c-4ae3-9652-31b2f0544efc" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="9748f142-d378-487f-af73-5eb8a80353fb">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="423f70fc-28be-4301-b657-23b03c1bccf7">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="961e2866-24a1-4260-9fff-37753cc81f5b" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="d5cb41a6-bd7c-405d-b0f6-28cb08615786">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="182b9a02-75a0-4edd-9195-ae1aeda39338">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28ef1315-c131-4fcd-a011-030401a89be7" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="c4751d7e-491c-4c9f-afbe-817036dc0646">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="d2f63534-27ad-4004-89ac-19d6812c6cf7">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51fc127d-a5b7-4516-a98d-fbbfecb297d9" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="4e2e37be-7d6f-47de-a84e-ca23647d8aae">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="cba27f67-ae46-441b-a0b6-fde64a87e442">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df8b53ec-2eb7-45f5-bd67-fdaad88db9c6" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="09fa7e11-1590-4c83-bcaa-4fb1d3c0d48b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c08d54bf-85a6-4116-bd23-d93aad5531af">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2036,10 +2036,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d6d4ce5-026d-4dee-8155-549b54960ae1" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="27033cee-71d6-40b8-9c1a-b023b9aecbff">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="3f80dd3d-99a8-4215-a93e-947557a6d452">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2047,10 +2047,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1df3982e-0094-488d-8b4b-bc968a008611" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="2a729bdf-b5f4-45ca-8c3b-219076b4f210">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="bea0a49a-ab9a-4532-bb1f-104e1383fb5f">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2058,10 +2058,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9efe98c-26a8-4dc3-803e-713f47499d90" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="835896ea-5dda-4843-ad1a-8ce6d5b41a5c">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="a3b31bca-a321-4de6-969d-d5e6319ab134">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2069,10 +2069,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18a0f7a4-58c6-4cd3-9de0-c77691a63906" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="8564a9ef-3c34-408e-a32d-08686caa517e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="fff743a6-0a77-445b-a0fb-342d89733c74">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2080,10 +2080,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="132fd7d0-604a-4cd6-8d15-5c816a49295c" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="37cb71b6-9861-4ba7-bed6-fadd5ed9b07e">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="18102854-e719-4049-9163-b950b7e709a3">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2091,28 +2091,28 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a551e154-ed1d-4ff4-bcc8-bf24dc06727c" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="5e01703b-2fc2-4c93-aa45-95b676f0d4e4">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="2aa4715b-074d-44e9-bd68-e18fe1162251">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f55626f-d947-457e-862f-177e82e7873c" control-id="sc-5">
+    <implemented-requirement uuid="1e539cad-e15d-44e4-8182-77855f2dd251" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="1cddace1-6206-403f-8ce2-04577a29118b">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b1564c0a-9045-4fe4-9daf-88d2a5d676f2">
+      <statement statement-id="sc-5_stmt" uuid="bc7b002b-a2a6-4fea-8986-f3f34ab25fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf6695f2-48a7-4c55-b3c1-f04ef9cd702e" control-id="sc-7">
+    <implemented-requirement uuid="00783149-d62b-4e7a-aeae-58057ca0ac49" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="b50e83b6-e5e7-4452-bf98-d2f62914b8b9">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b72be2b8-7633-4253-a2f3-c1686509eb04">
+      <statement statement-id="sc-7_stmt.a" uuid="d48dff23-baf9-4222-a2b0-af0fb767eff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574e7ffc-08c9-493a-961a-2e3328c62797">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Red Hat Identity Management can be monitored is forthcoming.
@@ -2122,8 +2122,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/142'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="67164e37-9eb0-4198-852e-007e6e210c04">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="f2ebb626-6297-42e0-b548-a9eebbbb00ef">
+      <statement statement-id="sc-7_stmt.b" uuid="af39fa28-0b39-4179-a8c4-78fa4cdbd354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fbefefb-1163-4180-ab0a-d36a99e31d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can
 implement subnetworks
@@ -2134,8 +2134,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/143'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="5969ce8b-5755-4b26-8668-ae4549d5a3aa">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8217d0cc-70d9-4118-8c6c-8d94d0629164">
+      <statement statement-id="sc-7_stmt.c" uuid="d4bd6c47-7d19-41c1-b673-9ecdac16a504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a613d308-0c27-4ad7-96c7-67f0be72ace9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can route
 connections to external
@@ -2147,10 +2147,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/144'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdf89d42-1440-4022-8fad-4fedb89c7356" control-id="sc-12">
+    <implemented-requirement uuid="c8327394-89ba-4508-817d-7dacaba8e50b" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="f045b48c-c02b-49c3-86da-9dc9508e0cbd">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="0ab15031-dc01-4c6c-8efc-0ee4499684d3">
+      <statement statement-id="sc-12_stmt" uuid="02fe4966-9a87-44d3-8440-63a140dabc6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e1ea452-edb0-4547-b82b-3bebbfc93493">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management generates,
 distributes, stores,
@@ -2162,10 +2162,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/145'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d13fdb9-439c-4504-b313-655e403aaab5" control-id="sc-13">
+    <implemented-requirement uuid="16e89f47-8365-45ee-ad7a-b99f5fc41f13" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="74d50db3-bf29-4de9-a60d-9e1277ed87a1">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="174d7673-cbf7-41fc-857a-fbb4aecf04b0">
+      <statement statement-id="sc-13_stmt" uuid="e653c788-a2ee-4da9-bf53-7abfaf243e6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3a298fd-f2ec-499c-a530-ff92405e66a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat Identity Management's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -2176,19 +2176,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/146'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f62c89b0-7caa-4019-939a-c0b76e064a58" control-id="sc-15">
+    <implemented-requirement uuid="027a35d6-1870-402d-b9d5-37d944de600c" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="f7ba8d8a-cdb8-430b-bdd3-bd133c2e3d55">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9412ac73-7a2f-4a26-b9db-dfb63a581f57">
+      <statement statement-id="sc-15_stmt" uuid="4654f804-278b-4d2a-b454-1499f231eca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b6c321d-a59f-474b-9332-1aee215fa542" control-id="sc-20">
+    <implemented-requirement uuid="7ca56f86-dc66-41b5-9216-ab04954d6f13" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="231d0762-b170-48df-a140-a4dfb45a66d3">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="646f3a2a-a9c9-49b8-92ed-a0c8273ace4c">
+      <statement statement-id="sc-20_stmt.a" uuid="9d8b50c4-1035-4eb0-bbfb-cf81f3fe65d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69679a55-3731-4cd3-b7be-e25751928b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure Red Hat Identity Management DNS services to provide
 data origin authentication and integrity verification is forthcoming.
@@ -2198,8 +2198,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/147'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="05b8c5fa-5611-4ecf-b884-649e8ca97909">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1d9e5a3d-f492-4c53-9469-024804be44d5">
+      <statement statement-id="sc-20_stmt.b" uuid="3aae96a2-5f33-4839-b633-80eca89e3e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a8a8fb7-8dfa-4ea7-be28-60dad7bc2de5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure this functionality within
 Red Hat Identity Management is forthcoming. This activity is being tracked in
@@ -2210,10 +2210,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/148'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c62ed05-c2c3-4f43-a511-f7a70cd6bd85" control-id="sc-21">
+    <implemented-requirement uuid="5a321394-fed9-48ff-bc89-6f232fe21d74" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="43991e71-788c-4988-948b-010dda41c9f3">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="1a41eeca-bc0e-4d3a-b286-52fe7e41369a">
+      <statement statement-id="sc-21_stmt" uuid="3fcfbed7-2599-430d-bc62-c0e5c6858f0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96a05615-1b7e-4daa-9fa0-e1dd1db830b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on enabling DNSSEC within Red Hat Identity Management is forthcoming. This
 activity is being tracked in GitHub:
@@ -2223,10 +2223,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/149'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="851e05a1-0b5f-48fc-8bb3-091c6c6d38a5" control-id="sc-22">
+    <implemented-requirement uuid="35ded6b5-e656-433c-91c4-a4ebd2c8b759" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="f040b83b-301c-46ee-aa30-15f0d1df3b71">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="c7f71182-4fde-4dd6-9576-3bfcde7b7112">
+      <statement statement-id="sc-22_stmt" uuid="c485f120-6b8e-4407-94dc-0e1161f0507d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2d349a3-aaaa-42e1-bf00-87baf5ec5742">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on creating fault-tolerant DNS configurations within
 Red Hat Identity Management is forthcoming. This activity is being
@@ -2237,10 +2237,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/150'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdbcf601-8262-4e40-b630-1781749ad0f5" control-id="sc-39">
+    <implemented-requirement uuid="e725ca86-e995-4735-bfb5-375a68bc3814" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="1b9e91f4-ed09-4444-8fdc-f24e04768dc1">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="8aca2dd3-84c9-4151-bf4d-26bd437d099f">
+      <statement statement-id="sc-39_stmt" uuid="08d220ce-373c-49b1-b83d-b35156882a11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6710d52a-9f87-412e-9c22-e7bfd898dc7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat Identity Management runs on Red Hat Enterprise Linux,
 Red Hat Identity Management maintains separate execution domains for
@@ -2255,10 +2255,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/151'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd472b62-6a96-4059-b314-38d5eba01a5f" control-id="si-1">
+    <implemented-requirement uuid="50cc2645-b920-4301-b591-2241e63496e8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="84a5d071-3328-4157-8e5a-c838e8de11a0">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="da111f2a-64a1-4fd0-a96b-5c6856350107">
+      <statement statement-id="si-1_stmt" uuid="201890d6-df69-4d1d-9b19-45d4210fe394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2266,10 +2266,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2183bec-8871-4c43-9215-b325ae271870" control-id="si-2">
+    <implemented-requirement uuid="7b161967-8f5b-4a41-8cd1-413a848eb9c6" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="28f21ba5-6907-45f5-b78b-b023bb779fd6">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ea9bacd4-7e30-40c0-ba5c-ce214b72aef4">
+      <statement statement-id="si-2_stmt.a" uuid="219eda2d-eca8-478a-a253-c4697f65d11c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="491ab51d-d992-4f2c-b446-5bcbeac26faf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their
 Red Hat Identity Management deployment for
@@ -2285,8 +2285,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/155'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="2c166ddb-74cf-4a8e-b854-fdf73c51987a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="aef26715-de92-485e-b82c-819d500f2d48">
+      <statement statement-id="si-2_stmt.b" uuid="44888f74-cbc7-434f-85ff-aad87a82a92e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2497f562-693d-4650-bdce-f7f045c22284">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing
 Red Hat Identity Management updates
@@ -2302,16 +2302,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/156'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="acfcc259-7d01-40d1-b25c-aa68a203f73d">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="80c533bd-00c6-4c06-a1e6-f63ff763802f">
+      <statement statement-id="si-2_stmt.c" uuid="b48e299e-71da-4d34-bfc6-90d20e36400a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="e9d3cec5-5d49-4882-8f47-3cfed9c88946">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="da7ee9b2-65d6-4ece-8206-b76039223f04">
+      <statement statement-id="si-2_stmt.d" uuid="0325951b-827d-4d54-b821-49c70e280f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2319,10 +2319,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4056512f-258c-4e2e-8221-0990f54b55fe" control-id="si-3">
+    <implemented-requirement uuid="1ca92f2d-8c0d-431a-89db-47741bc62f2c" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="72b70c40-ff1f-44f2-9581-2b7829183734">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9237c82f-73b3-49da-8229-b48cdece2256">
+      <statement statement-id="si-3_stmt.a" uuid="b41c03f8-c5fa-469e-ae13-2b155f0f6102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d390ec6c-9084-445d-8836-fb9f16de6b1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -2340,24 +2340,24 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/158'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="5b87b7a2-9edd-4c99-864d-ce857653ff9a">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="63f1823a-2c6e-4b70-965f-9635bb9d151b">
+      <statement statement-id="si-3_stmt.b" uuid="d20717d4-b2bd-4bf7-aa22-a203ee31ea66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="931b9681-f8e5-4213-90c5-2f0bbda27a32">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="242ae9b3-e4f6-49a3-b4e0-b8eed158e702">
+      <statement statement-id="si-3_stmt.c" uuid="52fe672d-c34a-4506-8ae0-54f447ec9d64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e222b8d-5936-4ecc-ba01-4cf21b3853be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat Identity Management, this control is
 duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="e10e3e71-785e-42af-93d4-47b0974240ab">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="9b37fe2f-a054-4053-8cb8-ff6a61f174e4">
+      <statement statement-id="si-3_stmt.d" uuid="e048a640-7ca5-446d-b0e7-4659e9bf8587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2365,28 +2365,28 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f0a27ad-07a1-4752-a7fc-83e054779b76" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="664816e3-f395-4d6b-9cbc-06db6fd83925">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="b2b4e411-1f1d-4006-9a41-d9538b44b884">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bfce98f-94e0-43e4-8184-c9216c68217b" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="aadaf88b-8b73-4a67-ada0-0d3a14ff6940">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="919bd9c5-ffa0-4d9c-a214-2439ec9edff7">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02e082aa-f41a-4800-a49c-eccd544c7f18" control-id="si-12">
+    <implemented-requirement uuid="23102443-d9ae-4a4e-a002-ea264e74cbb7" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="78798521-0fa7-4932-8e8d-18e104554536">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="ae9da1eb-c7d9-4ccf-820f-89c8bf41f78f">
+      <statement statement-id="si-12_stmt" uuid="49f7b842-5014-4ce2-856e-fdf43f79c0d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8456e347-83e4-4e1b-be54-a08042e93135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Identity Management in
@@ -2407,10 +2407,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/159'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32d092e9-294f-495c-814b-9ee83fb6b6a8" control-id="si-16">
+    <implemented-requirement uuid="0dc6f97d-ff1b-4fe4-8788-6d715267805e" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="f823d88a-babf-46fd-a576-3597013d028d">
-        <by-component component-uuid="a01d4536-0606-44c4-ba3f-576c5f34e1ca" uuid="e1c6c6a5-19e8-4c73-8559-9a8da523ec17">
+      <statement statement-id="si-16_stmt" uuid="c36301bd-387b-44fa-a26f-91221b5f18fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a18477a5-4e4e-4a77-8732-1947aa9a8f53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Red Hat Identity Management Container Platform
 inherits memory protections

--- a/xml/identity-management-fedramp-Moderate.xml
+++ b/xml/identity-management-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="ef75df4b-be78-496a-bfed-c88e26eb4a03">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f78c777-3973-4bd0-9a7f-c34ec8a20eef">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.52+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:18.91+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="31f6c37f-0ffb-4437-b268-247121ddea23">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="6af1616a-41ef-438f-a3de-4cdb3ed7d519" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="7e1d107e-c281-45f6-9795-d41c9ee9a150">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6166bc2b-305e-402b-b563-c2849707a945">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfc803a1-b376-4c5b-a91d-bf026ae833c9" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="7e7f91ee-18d5-41a3-92fb-37840152324d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d12f5dd0-3a68-4b85-9a43-eb0b0cd7f320">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e48175f-0fb3-4cbe-b8f6-3611805c2ed7" control-id="ac-3">
+    <implemented-requirement uuid="2686232f-124b-4343-81bc-219b4929e933" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="ee4016a5-7527-4de9-bc78-aedffa111a0e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="75ad2efb-fa95-410f-95d7-3db5918631c8">
+      <statement statement-id="ac-3_stmt" uuid="6cb50aed-55b2-4713-90b2-41f4da2c9dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbd60c53-75aa-42ae-b8ca-a057ea9b6917">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is being
 tracked on GitHub:
@@ -515,10 +515,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/2'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98d9eef8-63dd-4a25-ba14-742a63683047" control-id="ac-7">
+    <implemented-requirement uuid="68a78243-a112-42bc-b8df-fa935c812ac5" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="7f070709-4392-4720-966b-5f499e7a4673">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="2ea0ecb1-7a29-4083-a305-fd07bcc16f72">
+      <statement statement-id="ac-7_stmt.a" uuid="2fe6207d-624d-4450-a641-f12787214cf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af26e73b-91e1-4190-814e-1e564d8c707d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -527,8 +527,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/3'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="237bdcac-6a74-4bdb-8edc-e26c846d7326">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="eed66f42-388f-41b0-b66a-b9e7bd378dc5">
+      <statement statement-id="ac-7_stmt.b" uuid="75233fb9-ae05-4438-8a87-8be6e12967f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d831de-76a9-458c-918d-696396632d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guiodance for this control is being
 tracked on GitHub:
@@ -538,10 +538,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/4'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea8fe919-897a-4c65-b85e-e1c1f610b09f" control-id="ac-8">
+    <implemented-requirement uuid="2264582f-57d1-489b-ae0c-2f47ef5bfa67" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="a149614e-2402-4fc5-af72-4a9a48262206">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a4057233-de21-48d1-9d64-79c21a34878a">
+      <statement statement-id="ac-8_stmt.a" uuid="88aa2f00-3570-41e6-8c92-fc4427698102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddddca08-6750-4a81-b06a-1d0bf1de771b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -550,8 +550,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/5'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="1ce9bd25-768e-4dfe-ba3c-90aba03ce635">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7cd96d87-326c-4170-845f-1020834b553a">
+      <statement statement-id="ac-8_stmt.b" uuid="5fe50d42-8002-4962-b62b-bc0d11148378">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a483aa78-18cb-4824-87c8-3567e2365668">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -559,8 +559,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/6'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="9f3e8802-d73d-40e5-9c79-968528aadb44">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="bc8af739-268f-4967-baa3-cefe1513c512">
+      <statement statement-id="ac-8_stmt.c" uuid="c77f2ba5-8451-46c8-8716-0274c31731a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7bd5761-0a23-4c8d-a6c7-ce9f695991c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The banner text, as identified in AC-8(a), and banner acknowledgement,
 as defined in AC-8(b), will be the same regardless of what network(s)
@@ -570,10 +570,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="079bc42b-c882-487a-8f9d-c711274be00b" control-id="ac-14">
+    <implemented-requirement uuid="0dba02e9-1d1a-46a6-8eac-ae228748a7fe" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="c9923ee2-196a-410c-a1f3-6df2eb73c055">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="aeab7464-b101-4f85-abb4-be3474587f20">
+      <statement statement-id="ac-14_stmt" uuid="8cb047d6-5057-4cef-8e10-c1b786aa7f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2267fcff-70b3-4825-84f6-70f3605bdffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat Identity Management
 console, unauthenticated users will only be shown the
@@ -586,63 +586,63 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2cb4c93-b5f6-4968-9dd0-9f42e7fc75e4" control-id="ac-17">
+    <implemented-requirement uuid="b53ae846-8dad-4a8b-9fbd-adeb26d0532d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="b2bd26da-4d23-487e-81a6-92c547d31596">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="bdb27cf0-e2e7-4345-a9fe-2f4ff08fa41c">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c011cb32-16b3-4bf5-a0b0-923e56e62f69" control-id="ac-18">
+    <implemented-requirement uuid="7ba3b109-ee59-432f-bc9e-ee2163a3f934" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="5b5acaf3-d197-40f9-a6f4-ca605bb0ee14">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="efa6daff-d300-4857-8d93-72b5c3d934f5">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1701c12e-0824-453c-9885-2298e5448071" control-id="ac-19">
+    <implemented-requirement uuid="fcff9866-98ea-49b7-afce-ae8dcd8d7bd9" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="120c21db-2edd-442a-a626-28f2bb51fa89">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c90681ef-7641-4dc0-beb7-ea331df29d33">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96616d12-5a8c-4254-8f24-8ce109018df5" control-id="ac-20">
+    <implemented-requirement uuid="070bdb25-e280-4f2e-8440-583dd750bb7b" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="999c1655-a2d8-4840-8216-9513d9a7f7b9">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="34828b46-bcc8-4976-9f88-97562c0604e4">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a99fa780-1790-4d6d-964a-9cae760f8dde" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="03043586-c3ad-4daa-a2cf-d034257f90b2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="da7f264e-870c-4a9f-964b-54966888589c">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54973a44-6b97-4971-a0aa-ae583b60a1f4" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="cb3619d5-cfb8-48f0-b0b9-33b78fa7efbc">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7fb7970a-133c-4e62-8a8b-733aa7100e1d">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="0ad69724-66df-4c7f-a4de-6538d18f1378">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3eb868d5-408a-4891-bafa-6409d2ca4a2b">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -650,26 +650,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20fc616a-9418-4db2-bca2-aebb42f60d15" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="8a275640-5ec6-410f-813d-0d1ad82438d9">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="efee57b4-a783-4993-ad07-40ae27b32cad">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="bd0e4b6e-108e-4669-8ad4-cd38f8f4ac88">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f13dacbf-6b49-42c2-a34a-7f1c43f95319">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="4ef5063e-10c4-45f2-81e0-722211e99040">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ac9cc61f-8286-4a51-953e-3a73eb5c5797">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -677,10 +677,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c8908df-b255-4812-a936-5d7b3256f0dd" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="0bf9c0f4-b5c4-4c9a-959a-a472d0b70097">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="eb40d6b6-694f-419a-96a7-d726a3dc74b8">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -688,26 +688,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ca8461b-bf77-4082-8d49-4d3de349e0e9" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="9aa981b3-ea9a-430d-b74a-1dfab5e2a10f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4edffebd-eccf-42be-a0a5-7580d87de615">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="3b2841b6-470c-4f47-b297-3073fdd6d02c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="fd4aadb4-247c-46eb-a2e9-8b5ffdeaad12">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="1923597e-1179-44e3-90bc-56de2947501c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a0148580-2efa-420e-b87a-de0fdebd544d">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -715,18 +715,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e242334e-c6fa-4a21-a985-3758eae6d2c1" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="66d768a5-b67b-4da5-bdb9-f9fe2b3e2b6b">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ae85a4d7-10c9-44c2-a66e-d3bfca5180de">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="930f6481-950a-4d14-91dc-f58bfeee974c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="461061cf-6d9e-4266-b4c4-51cc8b09dacc">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -734,28 +734,28 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0d4ceb9-8041-4428-b7e6-8de13815e4b9" control-id="au-1">
+    <implemented-requirement uuid="bb8ff8f9-dbe1-4aae-a63c-542b42ad5a6e" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="fc591e60-5cf8-4390-b97b-c881604f4639">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4dae4cac-716d-4eab-ac17-1a125e592cdb">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98729008-6aba-44d2-8cec-9e012f75179c" control-id="au-2">
+    <implemented-requirement uuid="f692e2e8-60bb-4622-a411-3d442a46fa56" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="0f16dbc2-a76d-440f-8ef1-daa068086243">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="983cd5a4-f1f6-4736-a18a-510e8d82d3af">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3247c600-08ef-4ad5-8f21-22042ef73ec2" control-id="au-3">
+    <implemented-requirement uuid="f0e3c559-432e-499b-8027-7b9326bc137c" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="24793aae-26f1-47ca-ac1b-e3d4b5a3b3f2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="0f576c6d-eec7-48ea-8194-e6ab8f452dbb">
+      <statement statement-id="au-3_stmt" uuid="6b2dd116-f765-423c-be14-fb716dafadaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eec9f35-3329-4d83-a198-c5eeba770567">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management audit records contain this information
 by default. No additional configuration is required.'
@@ -763,19 +763,19 @@ by default. No additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6522423e-24ba-4dd5-b327-6e9cdc89349a" control-id="au-4">
+    <implemented-requirement uuid="affb8fc7-312e-46ee-bfea-34f0ec4434dc" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="10b35135-f96f-4768-a714-57bafdbc5b90">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="b7895990-89b5-40aa-b438-70390bb5109a">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d6d8915-22d7-4935-b591-e1cabd69d441" control-id="au-5">
+    <implemented-requirement uuid="034ea4df-825f-4faf-88ba-f298c53a7b1d" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="bfc15aac-f8f7-4b47-a13e-6e89894101f8">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="457348c3-0b8e-4e9a-abd7-54ebe3d9f748">
+      <statement statement-id="au-5_stmt.a" uuid="5ce2ff49-d8bf-4cd0-9f55-f154246f0ef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1882697-7e9e-4844-8de8-86cd41eb893f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management Administrators  are responsible for
 alerting personnel or roles in the event of an audit processing
@@ -790,8 +790,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/19'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="e75a0b6a-b3b9-44a8-bed7-40547556db0f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="49a288a9-59e3-4cba-bdf3-9e3465864de0">
+      <statement statement-id="au-5_stmt.b" uuid="62bb3d0f-d7b5-48c1-a667-b0e5700bd35e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cba42318-7a19-42da-988b-38dcddcfef29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat Identity
 Management Administrators
@@ -808,19 +808,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/20'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3cd779d-a82b-48e4-aeb7-0da3dba916b6" control-id="au-6">
+    <implemented-requirement uuid="d5717083-7c72-404b-8650-1b5e3f179a47" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="54701d37-7896-4b17-9dc8-6075c5f7b3c9">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8c7a2fe0-5d4f-4d84-b130-0b977b03927a">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b94d374-cd42-4e6f-a43a-2ff17db7a1fe" control-id="au-8">
+    <implemented-requirement uuid="d315c03d-3602-4936-92a4-d5602c2c2695" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="0d8be4a5-15c5-4727-8573-1fe2096237fa">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="5cc188e6-e025-4ced-a6ec-3d0a5c627517">
+      <statement statement-id="au-8_stmt.a" uuid="c31c0db0-29eb-4b00-bb36-eda35cd8790d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="631a70c9-5c2c-4fc0-8322-f6f8ba3c1e7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time services
 provided by the underlying operating system. This control is not
@@ -828,8 +828,8 @@ applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="153bea41-2912-4314-b1d7-3a44c6795208">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c81d7900-5383-480d-b58c-b12d5a34575e">
+      <statement statement-id="au-8_stmt.b" uuid="57485f21-41a5-4d56-83a6-d0bfc7acbbdb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="031ff5dd-8043-4802-9aaa-fe140c7d142a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management time keeping relies on the time
 services provided by the
@@ -839,10 +839,10 @@ configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad429a2b-49fd-4131-a8db-f76bac95d259" control-id="au-9">
+    <implemented-requirement uuid="9220e518-9a38-4e4e-a1ed-fe9236536b01" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="4e5ff9a8-8f4c-4635-bcea-13c74f25bb31">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="018b63ef-6c5e-45ae-95ce-5462c9ea633f">
+      <statement statement-id="au-9_stmt" uuid="f96632ab-f3bb-4a09-89e2-9eab4caebc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e4d92c1-2e60-48f0-95e9-5dc33662d8a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -859,10 +859,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/21'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c49c5593-ba7f-4ef5-a2c6-3fdef6c3b540" control-id="au-11">
+    <implemented-requirement uuid="a5527673-ede2-4adf-ae57-5429e7e61426" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="07a99a8f-615c-4104-8d82-15c49e80f718">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c829fcdb-fc48-4b12-8b20-576c99f3313f">
+      <statement statement-id="au-11_stmt" uuid="14bb9cb2-ee94-49b0-a72d-9a5c646e05d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad105910-b599-4da9-ba4b-584f5cab4d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -872,10 +872,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/22'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb393dc7-7dad-4315-a8bb-bee552d83995" control-id="au-12">
+    <implemented-requirement uuid="2feaf953-6801-4ba5-85ed-d77b00c57295" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="da3da13d-0d73-4362-8e57-d86f04bee64d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="294eb42f-1eb5-403f-99ca-185c634e8a95">
+      <statement statement-id="au-12_stmt.a" uuid="418ce8ab-4857-4355-8366-46c734fd354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a9baf92-f88a-4a46-aed6-d6b671665072">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to provide record generation capability for the
 events defined in AU-2a at all information system components where audit
@@ -890,8 +890,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/23'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="6eb276b3-384f-4042-9d0d-102d98367310">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="1627bc28-fcc5-42fd-97d1-76052c9537d2">
+      <statement statement-id="au-12_stmt.b" uuid="6f282e6d-c2b3-40f4-a38d-9732ef3cf585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78ced34d-f455-4993-8c6a-2d6af382116a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -908,8 +908,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/24'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="b98bfdbd-d6ae-472a-835e-a033b4147fb6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="5588342c-0e55-44ee-88e1-4b9a615ad881">
+      <statement statement-id="au-12_stmt.c" uuid="1224f7c6-5c3a-4349-8e8b-c38a8187f02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c9eddcc-dcb5-445c-9616-5b79870ad5c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to generate audit records for the events
 defined in AU-2d with the content defined in AU-3. A successful control
@@ -924,109 +924,109 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/25'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7243ea1e-87d1-460e-8b6a-ff9cddf236fd" control-id="ca-1">
+    <implemented-requirement uuid="91f25697-7c25-4f69-9c02-28f074285ebf" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="9f1eb1ad-352b-43f9-bba0-9ea85019e9ca">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="816c1c15-836b-4721-b282-aa34b32080f3">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="230313ac-16cd-4d89-bfe6-5be118ffba0b" control-id="ca-2">
+    <implemented-requirement uuid="d699c3b6-79aa-4a00-9796-8a7b33dd8639" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="9f9c3f97-7755-4190-947a-7d2e249f4de6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="763f7c91-c60d-4de0-8c78-8f6e76a9d4fa">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c68a48f-7307-4672-937c-df38997df658" control-id="ca-2.1">
+    <implemented-requirement uuid="192ba374-a7e5-4f69-9fe5-03ba1228f085" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="9c6631b1-057a-4fab-9520-2e329d3a9836">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a82cd06d-9684-4389-b884-87520b575e5a">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16933ad6-9309-4da8-97c2-8257285bca53" control-id="ca-3">
+    <implemented-requirement uuid="a67700ac-3bab-44a6-92f9-8b016240cb22" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="7f8a0038-06b6-4ddc-857c-a34d5ba13f14">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4fc13801-017e-4c70-8c79-66883ac37592">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6131ae4c-3c80-4b40-b66f-2b8f3bf13ca2" control-id="ca-5">
+    <implemented-requirement uuid="75f3c582-34e3-47bb-b264-e7ae91928fb5" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="02eb6200-6534-4d2e-a8bd-21e97584017b">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="15f26fe7-8a15-44b6-a4aa-1b3119e6895f">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbeb475b-d195-4fd9-97c6-446ed58c184f" control-id="ca-6">
+    <implemented-requirement uuid="1b5c2f25-53a8-4281-a27f-684125cfb72f" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="febb02f1-888d-4f71-b20d-97d9154232f5">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a5f1d4e7-7e3e-4266-9c21-358894f8e7b5">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6fc93f0-6d6d-413f-8a06-0efc9952b9cd" control-id="ca-7">
+    <implemented-requirement uuid="58f9d2d5-b24d-4e03-bf5f-498f9d13aaca" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="7e1dba0d-a877-4dae-9474-5bfe50ad2701">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="64e0dfff-4872-4271-b48a-79df179a27e1">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74fb9bef-015a-4892-ba7f-6ec07bf92520" control-id="ca-9">
+    <implemented-requirement uuid="e2e1b540-0a59-4408-b76e-a85593f0a191" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="49800786-c5d8-43bc-80a3-8c63d784e4df">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="348c1377-a8bc-449c-bd97-24d1d83bcedb">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="400437c4-55cf-4b2b-a68f-08e68ec0ce1a" control-id="cm-1">
+    <implemented-requirement uuid="a0edb79d-303a-4a05-8ab0-ae2822be8c37" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="310a7ca5-f2c1-4472-af8e-2cddc14bcf3a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a750ebdc-3ba9-4ef7-8ff5-96245ee98102">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f9209f3-279a-4463-a8ce-a3f3a6262318" control-id="cm-2">
+    <implemented-requirement uuid="ee4600dd-7ebc-4a41-bbcf-53791c0731f4" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="c1e14855-b0ac-403b-8d46-5cc5e77d3d73">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="65d210a6-b176-40d3-8440-d81bb3c16d25">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d63832b4-1d65-47e3-9906-0fd12f5734bb" control-id="cm-4">
+    <implemented-requirement uuid="f6aa39ba-079a-4666-bc3f-0c059934e15a" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="b604bc05-8f6f-461c-a8a2-903ac6a3de98">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a0cf6928-d31d-43b9-9e83-df966643cbc4">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="389cc853-c994-49e2-aaab-d656f77d376c" control-id="cm-6">
+    <implemented-requirement uuid="eb43e7b7-04a2-4bf1-a1d9-714985741a38" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="eb7c1354-20e9-42d7-aa0d-7f9fc082e5e6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="92ee2553-1bf2-43bf-897f-a36ddb31853a">
+      <statement statement-id="cm-6_stmt.a" uuid="72582835-c086-4505-961c-9c88a556ee92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de7715b7-c6db-4849-828b-0c654b43bbfe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management. Use of the NIST National Checklist
@@ -1035,8 +1035,8 @@ US Government recognized, vendor supported, baseline.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="a2915393-e9ce-491a-8297-af64e1fec575">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="54816442-d0e2-4b3e-baf8-f8b3c82ba76b">
+      <statement statement-id="cm-6_stmt.b" uuid="8a63aa2b-3443-4dca-8903-1971b9346769">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed14dd7b-0a83-48ba-b6d5-fd6223eaa59e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1050,16 +1050,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/40'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="34142cbe-f71a-4b78-a20a-37c28a986f3d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="5832868b-6ae3-41a3-8243-385597361fb4">
+      <statement statement-id="cm-6_stmt.c" uuid="2a2d2109-32f8-4eef-bd71-d34021ad808f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="03cafe8c-2c63-44c2-8721-b6b93daa975d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f495f31a-3a30-4f36-85e6-dced809d4a64">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1071,10 +1071,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5651400e-f08e-4fd1-b18a-2bd147d15f48" control-id="cm-7">
+    <implemented-requirement uuid="dc6be27f-2815-4296-a17d-9630b0358a80" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="e97dc486-20f7-43c3-ad38-5ef756b16bbc">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="56e2a0b3-7af5-4501-9b06-b23825f97f5e">
+      <statement statement-id="cm-7_stmt" uuid="3eed2889-2c79-4ea1-8d29-292b6f7d0511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43fab0bd-f9e4-4b72-92c5-881550d346bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management provides many capabilities, including
 user authentication, DNS integration, and several APIs. A successful
@@ -1084,73 +1084,73 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a4ece8d-49b3-4c5a-b67d-1707f9482590" control-id="cm-8">
+    <implemented-requirement uuid="46b1bad9-1f74-4091-92d6-b9980d857391" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="ad80f630-7639-4eb0-9582-cac66bdd0b17">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="afecd9c0-989f-4c63-8063-c4b66a102390">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a95e263a-b8bf-4a0c-8b6a-ac5ed7d05035" control-id="cm-10">
+    <implemented-requirement uuid="523be633-4d74-41e4-92a3-7a4ec447c33c" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="b7d03a10-2611-4cf3-bf5a-bc67eba529cc">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="19930872-21d0-444b-992a-e3b0adab9aa0">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0172348-3ea0-490f-9c68-00e0f2867b09" control-id="cm-11">
+    <implemented-requirement uuid="63192d06-bffb-4a4d-92cb-aa55523f45e7" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="b693baa3-9941-41eb-a679-0c5924910175">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="2aa61303-c54c-4b5b-b40d-f0981f95d327">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5227f2d7-27c1-4b22-aa91-30c8a95591e7" control-id="cp-1">
+    <implemented-requirement uuid="a0f6269d-8fb4-451c-91c8-27e046a4860b" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="2be31db0-d344-47e9-a7e8-e31101c864ac">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7318a915-dd63-4ca1-81f5-bdd0b4c79208">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c585dfc-7f34-4382-9b35-09b484a0e1fc" control-id="cp-2">
+    <implemented-requirement uuid="6ccfe701-d079-46d5-9cc2-f6f7d1922a00" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="ffdccc9c-3954-4cea-bbd2-ae9780649488">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="5dd628bf-f02d-4df7-8812-013746481230">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98fb1648-1ea3-4b3d-b1fe-b9ec4b74fb0a" control-id="cp-3">
+    <implemented-requirement uuid="a14f7e61-a09e-4a5a-b0c2-f83ca7d9a604" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="8d92e5b1-0961-4e68-89ad-6b68e9e76f38">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ed5ccc81-d7ec-463f-991e-7f06670b1095">
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="377a764f-a21f-4471-9bfb-0ab80c48189f" control-id="cp-4">
+    <implemented-requirement uuid="07999975-1ad2-4276-95d4-c9bd5cade065" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="a43ed5e1-752e-4ac1-86e1-c4f2e8b8a9a5">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="bda9664f-a996-4473-868f-03cdae6ce3c9">
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0881a23-d8f4-4113-a73f-f1d166b461af" control-id="cp-9">
+    <implemented-requirement uuid="71ae0c0d-1063-4bb8-aed5-46b34435ea93" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="28ca667b-607d-4e0c-b312-68dab17605f2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="95cac154-b7c6-49a0-b0fa-4f1206a1a08e">
+      <statement statement-id="cp-9_stmt.a" uuid="b6de0a33-e983-4088-a93b-2cbf8cd36608">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b283e7a-66e1-49ce-9e5a-b098f19f6b82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1167,8 +1167,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/51'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="c85c6bd8-80a5-4af1-b712-91845c6eacb4">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8c137e73-c116-4a13-9954-00f041e2f700">
+      <statement statement-id="cp-9_stmt.b" uuid="a6aafdf9-f3fa-4924-8ce6-ca0e17cc2c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80930de0-ac6b-48b7-b500-18c0cad04247">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1185,8 +1185,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/52'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="2c3f9241-5321-49ad-9e6c-c5cc4de03b91">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="154733d0-37cc-4a33-ada1-a9367ad3fd0a">
+      <statement statement-id="cp-9_stmt.c" uuid="d4b964b8-d27c-4ddb-b5d7-f0b0f2514aa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77d4bc17-9908-4d0f-8a90-a5767cfc149f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1202,8 +1202,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/53'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="3bc500da-5b47-4d5f-9bf4-eb47853afb09">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8a7f9098-0bf9-461f-84c0-4990cf7aeefb">
+      <statement statement-id="cp-9_stmt.d" uuid="981d1648-443d-454d-8e72-85955631a0e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29c7f194-769b-41b1-be15-f0b6cb7c66fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1219,10 +1219,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/54'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ac64c9c-0661-4c60-a91c-c412d9e7311e" control-id="cp-10">
+    <implemented-requirement uuid="0f137ca3-e150-4d12-9529-74058757bf93" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="2a606c0f-6b3e-4505-9df1-637bd6242b65">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="96f2b558-c1c0-4bbf-8d2c-8dc7e59d63f5">
+      <statement statement-id="cp-10_stmt" uuid="97c745a9-c5b3-4340-a551-de3cefa1f5c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758e9828-dc07-44a6-8027-def0ac361a39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute
 their Red Hat Identity Management environment. A successful control
@@ -1233,19 +1233,19 @@ Management environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9cec5fe8-ae8b-4044-939e-c05017d563fe" control-id="ia-1">
+    <implemented-requirement uuid="f5736091-bae2-4e79-9308-fd4758a56549" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="e33eae29-ec42-417c-a5a5-3f1e35edc975">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6af03b7c-7c4a-4dc3-8d8e-026bb56896f5">
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dff31aa-eeb0-4f18-95e0-5b1745814aad" control-id="ia-2">
+    <implemented-requirement uuid="a0552f3b-016b-40d1-926e-a17b256a6b4f" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="411771e5-45f5-4e36-bd9d-0170065b9ef7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="287d8d31-49c2-4d6c-8479-043a54a5bd06">
+      <statement statement-id="ia-2_stmt" uuid="1892ea09-ce90-4f45-af27-3cc782b239e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="655fd21c-d8e4-4d7f-a9b4-6286c7973bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring Red Hat
 Identity Management against
@@ -1256,10 +1256,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/61'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5992dd43-c3eb-46de-9f51-3cb31fa779ab" control-id="ia-2.1">
+    <implemented-requirement uuid="8a64ac47-2a71-46a6-8fdb-dd0589bf6114" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="44b9c374-d556-451c-9a14-2dce719a22cb">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a505e634-35fd-48d4-89ea-2ddbfcb6a6b6">
+      <statement statement-id="ia-2.1_stmt" uuid="81d804c1-0f52-4719-b71f-f0a82cdcc372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d670bf3-6483-44d7-83fe-feb5acc447a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1282,10 +1282,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fa70ca9-5ca9-4cfa-b3a3-1306618fad34" control-id="ia-2.12">
+    <implemented-requirement uuid="5ba17a8e-8872-4bc9-8a24-0b8f8c73ed1c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="23f10250-473d-45ca-8d72-cd4447ec9d5f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4252e956-6d21-455b-a6fc-3a92b66d839e">
+      <statement statement-id="ia-2.12_stmt" uuid="49ecb729-40c2-4e20-9846-7d0b7d160770">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="534a5d5f-ac4a-428e-9547-7de76a6cc430">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1302,34 +1302,34 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/63'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a0b6136-12f6-4dae-be07-6bee10e92c94" control-id="ia-4">
+    <implemented-requirement uuid="0066267f-fefe-4dba-b0f1-79ee03e68b7c" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="045c2ab4-ea13-4f1b-88f4-f751aa4257a0">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d6e114f5-534a-49cb-b915-1331c91cbed3">
+      <statement statement-id="ia-4_stmt.a" uuid="c74e45fe-ba05-4415-8c5c-0171266d0492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="aac905a9-0b8d-41fa-9a95-f89cc18b9c08">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="35d9ea30-de7f-40a1-9c81-93be0688eee0">
+      <statement statement-id="ia-4_stmt.b" uuid="d45bb245-1b07-45bc-826f-73bee9bc9efb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="85d1dee5-3ec8-48cd-a827-db4e84fa169d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="17a9aa41-4f07-4d28-99fb-e421fd7467b3">
+      <statement statement-id="ia-4_stmt.c" uuid="8a708da6-8e06-4d94-adbe-8406f9da9d98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="121f6c0f-a9c6-42dd-a80c-7aa71895a8e6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c76c1ecc-8834-4e75-941e-7addde592a2e">
+      <statement statement-id="ia-4_stmt.d" uuid="b48673e5-0fdd-4f52-ac4c-dd9b602f9f2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddfdc13b-3e8d-4a48-aa1c-b964d1402e76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on preventing the reuse of identifiers is
 being tracked on GitHub:
@@ -1338,8 +1338,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/64'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="fbbe16d6-3b73-424d-b586-8dd110bcd59d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e8607dd4-fdb4-4b2b-83aa-1b61440c4927">
+      <statement statement-id="ia-4_stmt.e" uuid="b3c63752-9061-48fe-ba7e-1c4af1a907cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6281964b-15ca-490c-9886-2364647f39e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on disabling idle accounts is being tracked
 on GitHub:
@@ -1349,18 +1349,18 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/65'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecf99bcf-3103-4be3-8e45-5c249ab974bf" control-id="ia-5">
+    <implemented-requirement uuid="21d196cf-4c81-4c55-b2da-eecb526e88e4" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="299acc89-84c3-4897-8b92-c49601063cd8">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ad577826-e2a6-4eda-9f53-c6de9c0b5866">
+      <statement statement-id="ia-5_stmt.a" uuid="f7ed881f-3035-4afe-8a85-e702d0f20ea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="6c006666-708b-4c60-9c28-e125b83876e1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="5baf6a3b-3f7e-407e-a512-bdfc52bec9f6">
+      <statement statement-id="ia-5_stmt.b" uuid="65fc9a84-3daa-4a6a-ad97-0b0f585c4ae0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb709e7a-0987-4e17-a7bb-9a0de98437b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to configure initial authenticator
 metadata is being tracked on GitHub:
@@ -1369,8 +1369,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/66'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="02a28833-8102-4016-8f77-f887fe2c92f9">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7a1589f3-4751-4929-9cc7-df31f52cc476">
+      <statement statement-id="ia-5_stmt.c" uuid="9767ac0f-26f5-438c-80cb-6fb425db1d11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13a85550-b937-442f-a3da-aec50738c88c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on ensuring authenticators have sufficient
 strenth of mechanism for their purpose is being tracked on GitHub:
@@ -1379,8 +1379,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/67'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="4044fc79-014d-4e39-abfd-ed4baaae5aa3">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e93c07ba-fe6d-4865-a542-2de6c4d0bdad">
+      <statement statement-id="ia-5_stmt.d" uuid="c9132a2f-2739-46af-a054-8b13c9e20a75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4f28238-4d18-4140-8461-133355603f64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1388,8 +1388,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/68'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="0cdae73c-c9e4-4c57-ac49-e83d6e119d71">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="46c662a6-dfa7-4dac-af85-8a5ad152a5a7">
+      <statement statement-id="ia-5_stmt.e" uuid="1f03b0c1-9db7-4ccd-9f19-44755f11ea71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33f684c-40a6-44cf-827b-4e9543a2fb2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1397,8 +1397,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/69'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="627f3dc2-6fd4-41d3-b094-ed41dd07c4f4">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="369d8415-4349-45c7-926b-665fac790d09">
+      <statement statement-id="ia-5_stmt.f" uuid="214282d0-f500-47da-b482-be2d73b22c3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="784383af-c441-4b0b-8a47-54563b6d86df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance/documentation for establishing minimum/maximum lifetime
 restrictions and reuse conditions for authenticators is being
@@ -1408,8 +1408,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/70'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="c6a48f93-4078-4885-93be-75ee07bf6ecb">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4c6f0722-a8e6-482d-a316-232b5c4cf6f7">
+      <statement statement-id="ia-5_stmt.g" uuid="1209ed48-d981-40a7-804d-e824d6fcfae3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="307d12d1-8e98-467c-b541-a63f28fe0250">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Guidance on changing/refreshing authenticators after an
 organizationally-defined time period is being tracked on GitHub:
@@ -1418,8 +1418,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/71'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="979ae19a-67d2-4a4f-8ee0-ab81893c874f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="af2871a9-17ec-45a9-aa45-87342c1e5874">
+      <statement statement-id="ia-5_stmt.h" uuid="24dee65b-b4bb-4038-a8c1-e69547225b2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8aae24c2-6259-4bf7-8e03-e5ce5951d3ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1428,8 +1428,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/72'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="f611207f-2aee-4b65-b020-68fb2367a0c1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="61e3c50e-39c9-4553-bbab-c5176a1c2f86">
+      <statement statement-id="ia-5_stmt.i" uuid="ee9c909c-a5ab-4e0f-bd24-7ac6414e0f6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23f15f66-8747-4680-895b-ef3f633d22be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on
 GitHub:
@@ -1438,8 +1438,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/73'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="a140bc25-bd0c-40e7-aec3-719ca8aa78c5">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="babf8a41-0118-4b69-b3c0-05d408dee5ce">
+      <statement statement-id="ia-5_stmt.j" uuid="ac933449-5342-47d7-8d5f-82d769c8c632">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="202f18c0-500a-4f3f-9662-500e4b8cf18e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control outside the scope of configuring
 Red Hat Identity Management.'
@@ -1447,10 +1447,10 @@ Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7927251-cad5-46f8-a105-1915049f39df" control-id="ia-5.1">
+    <implemented-requirement uuid="42662bbc-5676-4534-998a-408bab9862b5" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="ecec7d0f-d9dd-4571-ad15-568bbaf5660a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="1a794efa-0ce0-4188-898a-409132a74c85">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba5ce70b-5f63-49db-a858-bffd29cbd45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ae1d9da-7a2e-454f-a11e-bed7ca3fbf48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing password complexity
 is being tracked on GitHub:
@@ -1459,8 +1459,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/74'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="857e6848-7032-4271-8c31-17c6e365aaf3">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a0c5acb5-7760-41ef-aa77-b1c4cb764384">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c73a7f82-552c-43a4-ade4-c7efb437b0dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6524101-0249-4880-b2d6-db9b8bc0ef85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing changed characters during
 password creation is being tracked on GitHub:
@@ -1469,8 +1469,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/75'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="c4e4d251-ce48-4765-b318-733c41dae25e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9ead5ecc-7ba1-43b2-9686-2fef76d191a4">
+      <statement statement-id="ia-5.1_stmt.c" uuid="a8f66fc7-a19a-4820-9c01-988ccda18c4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a74b8cc-80ba-4ee2-afea-31f12f7a20c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on storing and transmitting only
 cryptographically-protected passwords is being tracked on GitHub:
@@ -1479,8 +1479,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/76'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="e283dd8f-0eaf-4dd1-9ea3-b852911149e2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="2c679118-6669-4acb-a684-9e23817bf572">
+      <statement statement-id="ia-5.1_stmt.d" uuid="38d52bc1-da7f-4a76-b134-e2ab229a6e31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="02af4d79-0a4c-4582-b124-01dfc0fdfc5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1489,8 +1489,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/77'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="571587b0-1f49-47ba-9045-a3e9824ff6a4">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3c0fcdc6-5b17-4bce-8782-24d2d7ca9376">
+      <statement statement-id="ia-5.1_stmt.e" uuid="cf8eeef4-c1f6-467b-ab42-1b067430b959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd745207-6ef0-4e8c-b76e-ecf20b3b9370">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing password minimum and maximum
 lifetime restrictions is being tracked on GitHub:
@@ -1499,8 +1499,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/78'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="a14a6963-838d-47ee-8580-07014cfb1d73">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7d8c6426-9618-4bfd-a063-20ebf44b4300">
+      <statement statement-id="ia-5.1_stmt.f" uuid="018f553b-8848-4c8b-a29f-95b1d3bb82f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66186d1c-fde1-4ce2-9dff-d9a7aa087c2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing an immediate change to temporary
 passwords is being tracked on GitHub:
@@ -1510,19 +1510,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/79'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e421d08f-f321-4f28-9770-5349ec125ae2" control-id="ia-5.11">
+    <implemented-requirement uuid="c9847bed-2c17-4de7-b894-f09228f0870b" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="8485380c-7716-46f3-9ed1-f6053525c81d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8f441f50-6b0b-4dce-8b9d-cc7bf1441cc9">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58f24d3d-7aa8-41ee-bca8-1f58ce5a17cd" control-id="ia-6">
+    <implemented-requirement uuid="53ebd492-001f-4bc6-aa6b-b16824c48dd4" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="154f9a7c-1b1c-4837-954c-9d9298a40658">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7584fb8d-d8ed-4dc7-8153-650fb2c97284">
+      <statement statement-id="ia-6_stmt" uuid="2fe9bdeb-2642-4d42-a85d-57398f32d396">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2dea1a-1389-44b9-8f44-cb147b2da7a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Identity Management natively obscures such information.
 Red Hat Identity Management cannot be
@@ -1531,10 +1531,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="944df294-93d7-4d36-816c-b25a3aaf6e81" control-id="ia-7">
+    <implemented-requirement uuid="0b3959d2-7975-4411-aa2e-001b8352c57f" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="6d7af9ba-639b-468c-bdf4-ebadba42bac1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8f33abfd-6c96-4f37-998a-dcb3469fdbe8">
+      <statement statement-id="ia-7_stmt" uuid="71243606-9119-4338-9330-9eacf55eda8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5007c322-8d8f-45dd-b70c-294727c63ab8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for configuring Red Hat Identity
 Management to use
@@ -1549,10 +1549,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/81'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79602c30-7a2e-4e83-99c6-78f914fc1811" control-id="ia-8">
+    <implemented-requirement uuid="f950f528-847d-4cc4-82f7-eef3734154b6" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="1e6b3863-1b3e-45ed-8fec-1af57940888f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="733c7e5c-3811-47b1-8821-98f1d40df079">
+      <statement statement-id="ia-8_stmt" uuid="993cc9fc-2415-40a9-81af-59e3862576e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0eaa11a5-df2e-43fd-bd6a-06de4b2f228f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -1569,10 +1569,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a05f80b-ae52-4f51-871c-acc5d63a8f82" control-id="ia-8.1">
+    <implemented-requirement uuid="9d62599d-c244-4194-a265-ac718dd01c14" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="ae4bdb2b-09c6-4453-a13a-c15139063bad">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="67caf9ed-6a4e-41e9-9ede-9fcc47ddff97">
+      <statement statement-id="ia-8.1_stmt" uuid="4b6a0697-ca3e-4e7b-93c6-d23bbc41263c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1480101-b837-4ef1-b28b-c94133708416">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -1590,10 +1590,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbdc39d2-4747-4cda-a88a-162fe12ffc0b" control-id="ia-8.2">
+    <implemented-requirement uuid="2afae6ef-4fba-4eb3-91e8-4a781deb086b" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="5b7266dd-0f22-4b33-ac38-5441b3c81860">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="1eff6639-c8e5-47ad-8610-365502edc209">
+      <statement statement-id="ia-8.2_stmt" uuid="9e336773-3c97-4ab4-849d-96381adcdee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1aa00e8-29fa-47da-b341-73713b2f845f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1612,10 +1612,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/84'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad450cf9-c8b2-4b64-905d-4af9c9000a53" control-id="ia-8.3">
+    <implemented-requirement uuid="3548a1ef-07e6-4f94-95b0-dd21edb877e6" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="518615d6-b95a-4faf-a250-bcb7180ed6ae">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="b30c42fd-df85-48fe-b745-108ad4de1943">
+      <statement statement-id="ia-8.3_stmt" uuid="26eb98b9-eca0-4749-b913-b81e2943604e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b444af8-29ee-4a95-9ef3-45aa8fbaaf26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1634,10 +1634,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/85'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c727431-ec18-4fae-b467-fc6ee441ac74" control-id="ia-8.4">
+    <implemented-requirement uuid="af1b3249-ffb3-4147-a5c6-f6572c0e2e3f" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="f549109e-71b3-42df-ac34-2d055a709dfb">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3d4934f5-2250-4c85-a739-461682388fb3">
+      <statement statement-id="ia-8.4_stmt" uuid="58788be8-1e9b-49fc-bea5-eeeb465fbe58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d9d198c-af19-4505-a0b2-594e631bd64c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1656,10 +1656,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/86'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7719a167-5b88-4d4f-8155-ddc3e53d3408" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="730729df-d7e3-4400-80da-aa565e0e4eb3">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="04883ca3-5f51-4d59-b130-b66df05b546e">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1667,10 +1667,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0631e612-a22c-4645-a824-0cf4f8f59744" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="e6fc331b-42e2-4a16-af77-b02d2cd9a0cd">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="0a496a7b-7f53-43fa-9547-243f884c4642">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1678,10 +1678,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6771316-ce31-4828-88f8-3afe3cad2f08" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="639c4014-5a1a-42bb-a4e0-468f9c8850da">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6571c5e1-88b1-4bf0-bc40-58d35a220a2c">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1689,10 +1689,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8376f4db-2062-4654-9edf-0f8ac1453fc6" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="f1397478-4d1c-4e8b-a1b2-7a0a79d2915c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="99906b67-5680-4c4a-8de5-1c0e40122eea">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1700,10 +1700,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3480b06a-328e-452a-a0de-49dc4a43eefd" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="76bb7f7d-7cb8-4979-b766-48bd90ce3ca0">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9576d7df-d7f3-49b9-90f4-681adb03faba">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1711,10 +1711,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3328ad3f-54c8-4f62-92b1-223aa4cc60e1" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="b5bf03e6-86c3-40b2-93ab-d2fc1618c719">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c9ae583c-195b-4aa1-bc7e-4d1c584388ee">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1722,10 +1722,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a7479a0-84e7-4b97-9184-90184d5fd342" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="1be10352-46e0-4cf7-aa6f-311bdef149ea">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="72145461-01f6-4071-bb93-6249a956c64b">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1733,10 +1733,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69dd0471-2522-4b19-82e7-86a06f16451a" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="94c00595-2581-4c49-9fe0-0d2705681a2e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c6effdbb-0962-402a-97da-d71bed0a851c">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1744,10 +1744,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="932dea14-df03-44fc-8582-f2e8e45d0ddf" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="f7df0ca5-0dd4-47bc-8f05-a9e2bdcbd650">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="87053f21-13a2-4843-954b-8a8df1ccbc3c">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1755,10 +1755,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0a1bcde-d5ab-4c29-a0e7-fad563d45878" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="cb672ec2-cc1e-4bb4-8fae-bf71492b2cf7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="befbaf94-5f33-42e0-878a-6ba0652f066e">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1766,10 +1766,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb383d13-c4b0-4a88-ae69-8a82cd45c90e" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="a2d5d123-8d95-4e5a-97ce-2ee2a6ea138f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f2e954fd-1f2d-4699-aa89-08305d9ff64a">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1777,10 +1777,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1fd5542-6def-44f2-9868-4e615278487b" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="18f61d2d-9cb1-4c87-84a6-6a8a782f8d47">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ad994b27-2205-4af7-b677-b165a4871fdf">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1788,10 +1788,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0055cd63-ac87-4995-8f1f-0f88d9a4c29f" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="bde7506b-12ab-4bdf-97ac-4eb66937bfe2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d6197b1d-9697-444b-a371-22709d8098ab">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1799,10 +1799,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7eb6bb28-0428-48e5-9287-b45c59dfcf4f" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="1cd3aabb-a4f3-41cb-9f55-177b867f5f5e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4a0898cc-bc57-4d88-8bd1-781cb3af2ed5">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1810,10 +1810,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37a682b8-39d5-49d1-80c5-23fec4c55ce3" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="d4599b17-6a07-4af6-a3ae-8397b0f6fa29">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="de6592e0-706d-4483-b3e4-0919fc97581c">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1821,10 +1821,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39d3b7bc-4a67-40f4-a1d9-3081026a14b9" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="14938cd0-03b3-4c10-b54f-eb8f5da462c7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3dec745e-071a-4c5b-b66e-bdc6691f779b">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1832,10 +1832,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89f34eec-be7f-4b14-8861-39764edf6dc2" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="03b29a8b-21ff-42e5-881a-f3ac29b131ae">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9f73b2c2-75ba-413f-9909-2ba4c7bba74a">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1843,10 +1843,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ab991cc-62a4-40c1-af13-46b96ea55e00" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="967c7832-26be-4ed4-9134-025d6d16afc1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="535ee6f2-988e-4677-ace2-d75fad93e0d8">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1854,262 +1854,262 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1df26256-d6d9-4158-8ac5-4df94b40c150" control-id="ma-1">
+    <implemented-requirement uuid="0247ce19-0c75-4e77-a6eb-4f961eaf7f8c" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="d68c6c34-c3d9-4021-9c93-b8292c4e01d7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="08363930-661b-484b-b44b-530d45cb809a">
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2775553f-d01e-4cc8-87cd-202954b1dfce" control-id="ma-2">
+    <implemented-requirement uuid="1c9382e3-bcd0-4e80-a473-37c2efa23c1d" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="a54205de-ce85-43bd-9b43-1d5ead8a0324">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c9d8515e-18f0-4126-8d6e-7f75075c33ac">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dea815f-fe60-424f-b700-c102d4061043" control-id="ma-4">
+    <implemented-requirement uuid="953faf37-06c2-4c99-b4c0-6b5b7093e674" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="97e4760c-babc-408a-9aa4-48085c4adac1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4f811897-fd43-4a79-ab30-182b1ab080be">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efcee337-ccf0-4daf-9917-963eb6d9cdbe" control-id="ma-5">
+    <implemented-requirement uuid="4ee437b8-15da-4842-84c4-1f9b1aeaa365" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="3bb19354-30d5-4733-a7d0-5112a35cfd9f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9131ee07-2c9d-4bf1-852d-6d0d953839bb">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7def4e2e-5fe7-4ef7-8f81-b43cd7388e1c" control-id="mp-1">
+    <implemented-requirement uuid="24934365-9a76-4198-b421-965cdaf02b34" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="232984cf-0306-4a34-a2c1-b46e97ebdf16">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e6f94f02-9036-435d-bd7c-9610278927ce">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fc8c009-d8fd-4edd-94a9-e7d2df7519ae" control-id="mp-2">
+    <implemented-requirement uuid="0247d496-f8d1-4833-b815-a3aba9edc5f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="a0260716-2f2a-4da8-9fab-18187bcd45f6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="cbf7291e-f587-4afa-a436-8e229089b9bd">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43248f96-0c55-44cd-b379-898c85d99447" control-id="mp-6">
+    <implemented-requirement uuid="4de409aa-95a3-4fbd-98e2-ed2cc1d3f383" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="a285a8fe-10ef-4dc6-b3fe-34d142279749">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a4faffa0-554d-4f68-9fd2-b92ff420bc7b">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09633772-baba-4bb7-93bf-ef693f259ea6" control-id="mp-7">
+    <implemented-requirement uuid="90d768fb-4016-4edc-974f-3ce42619b126" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="c812dc03-8cbd-40bd-b04e-94447eea41e3">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e8101764-6413-43e7-b7b2-9873e1fee596">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e706d49f-323e-44e7-b92d-9f1574837041" control-id="pe-1">
+    <implemented-requirement uuid="f9d20c79-c28f-4e5b-8991-a010068305bf" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="01243ffe-7afa-4948-b802-a061a884d08f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="efd8c198-a8e5-4d15-83a0-6c90d91e8cce">
+      <statement statement-id="pe-1_stmt" uuid="e713373e-3041-4175-8df9-1fc7aef4f467">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a89fbfe-2385-473e-8933-2f795c218797" control-id="pe-2">
+    <implemented-requirement uuid="e11036b4-5744-4630-95ed-a531597e3dbe" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="d8f5c2e5-c982-4358-b528-05b956f3d0af">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="81d7c887-7a08-4b1b-a30e-730044bc0c1d">
+      <statement statement-id="pe-2_stmt" uuid="22b5b14e-9fd2-4cf1-a1a3-f07a46bd9af5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="249392f6-e188-44a8-9b21-a5c1f5b1dc88" control-id="pe-3">
+    <implemented-requirement uuid="dcd89883-3566-42a4-bfab-dfe0a048c583" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="91213ee4-936a-4872-aa09-7d817c1714f4">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="425f0046-cc05-4436-94a9-885ca2eea7c0">
+      <statement statement-id="pe-3_stmt" uuid="97bfc74e-412e-4be0-8696-f4c9ef1eafc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59a421b2-769c-4c71-ab64-ad13aaf074fb" control-id="pe-4">
+    <implemented-requirement uuid="76276553-4780-4ff1-8e22-c0b20932de06" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="e64cd86c-c2ae-4804-babc-79eb35fd3f6e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="77401e0a-2fbf-4f00-b2c7-03177aa35e40">
+      <statement statement-id="pe-4_stmt" uuid="aacdad62-fc70-4031-b49a-fb5140e044d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76c7e668-718b-4a20-a4af-1b77a6f1420b" control-id="pe-5">
+    <implemented-requirement uuid="94bc684b-6a3f-43d4-b200-a0cff845555f" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="3d17cebe-d324-45d4-b0b8-d479ce195044">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="50471a01-9538-429c-86c8-0fd98082bfdf">
+      <statement statement-id="pe-5_stmt" uuid="3bad50c4-f0ca-4c60-ac5d-c9d07cc34468">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92971c23-2bb0-4400-8043-ed3dbe349579" control-id="pe-6">
+    <implemented-requirement uuid="e755fdbc-58fa-42bb-8722-9bd276687bd8" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="406dd8db-8f5c-47f3-892b-5f61600c1f08">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="38607ace-ae82-4d18-87fb-bdd833e5260e">
+      <statement statement-id="pe-6_stmt" uuid="ec7353b3-2e5d-4f80-bbb7-347dfe1ada09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e2ab3e2-a3b1-49db-9cef-03cb3036dc1c" control-id="pe-6.1">
+    <implemented-requirement uuid="fad21785-fd25-42f2-92ec-6a3a7aea849a" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="09c09667-53aa-439f-b36d-ac595849527f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f587620f-891f-454f-82b3-8adfa553b7d8">
+      <statement statement-id="pe-6.1_stmt" uuid="49dc6a2d-e5ee-47f5-a1dc-309c9f747624">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef50dc17-ce41-48c9-a0c2-bb4678edf649" control-id="pe-8">
+    <implemented-requirement uuid="050370f6-d90d-403a-b7a6-94ac3922e98a" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="96ce1ae7-d7d2-4e58-883b-4f3ee74ce684">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d0042ff9-69c3-4843-8c87-c91b7bffb20d">
+      <statement statement-id="pe-8_stmt" uuid="7a1d0807-b0a9-4c43-9797-86d110faf00d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="037752ec-f3c6-4f51-b184-ea6abca3d939" control-id="pe-9">
+    <implemented-requirement uuid="a20bdfc3-fc7f-4f87-b915-8d01a0f7dd38" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="5f56def1-5fb5-4b3c-9b5b-39ace0601634">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d563292a-4b58-4304-a83d-6580f4ffceec">
+      <statement statement-id="pe-9_stmt" uuid="cfd3473d-1e05-4589-9ac7-41e14f0e6a79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fc5fe71-a6ca-461a-a575-9250fc04782e" control-id="pe-10">
+    <implemented-requirement uuid="0c7517db-defc-4990-b618-add23e9ea8be" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="4ab4c031-1b0c-4a15-901b-499021ebd8d0">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9fa164e5-6934-4685-a6a5-89ec2c6a1303">
+      <statement statement-id="pe-10_stmt" uuid="1f270c5b-89e3-4109-8cb3-5b7854b12d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a34344a-32ac-4b8e-b13c-cecfeddc168d" control-id="pe-11">
+    <implemented-requirement uuid="69e0c4a4-7635-4c33-8b58-37c703c53c50" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="151a2153-a4d9-48e8-9085-6d79ede06455">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="85688aec-87ab-4af3-88b7-350e913eef9d">
+      <statement statement-id="pe-11_stmt" uuid="8343d926-f0e2-48b0-b649-a65fd5450e7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e0b5bc9-7efc-455b-9211-01f9600e2f6a" control-id="pe-12">
+    <implemented-requirement uuid="4da0d8ee-9c11-4932-bb8b-d68e3e058267" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="7b6387f5-cbf2-4843-b79f-dc328e854d97">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3bb6af7e-9a93-4e91-82d4-7c055f19a87c">
+      <statement statement-id="pe-12_stmt" uuid="b92e1c4b-67ad-48d8-8cd3-42d0e3da74d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="810da77f-bbc0-401a-9753-74301137ccb7" control-id="pe-13">
+    <implemented-requirement uuid="b6f0ed51-cbfd-4701-9f35-e9194942c86b" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="642a9330-dd95-4dcc-8ff8-9df6fa01ab48">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="2dc98a3f-8f21-4bfe-b6fc-c67c04aa8d99">
+      <statement statement-id="pe-13_stmt" uuid="712b80c4-34d3-4107-9ec5-5d67dc8915fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="553c06ce-9084-4fd3-ab9c-c55454415ac8" control-id="pe-13.2">
+    <implemented-requirement uuid="0179e9aa-9b65-4528-a172-d932751cf621" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="39b8efb5-f148-4d1c-90ce-644414393100">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="01e5a448-fd74-415d-b4ae-6f36abc6eb1e">
+      <statement statement-id="pe-13.2_stmt" uuid="e9f70eec-c915-41d5-9db8-a56ca66178bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a48cc17-1e48-47ab-a6e4-e340a6207f63" control-id="pe-13.3">
+    <implemented-requirement uuid="86ec3ccf-9103-4266-a4e1-1f2f9829e128" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="fccc1cc0-5d21-43f3-a8fc-b044c46010d5">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c768572d-e55c-4ec7-9165-02e7183c4716">
+      <statement statement-id="pe-13.3_stmt" uuid="3ed679d3-3157-4df2-a3d3-89f84fc0a14f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8af35728-c9da-47ec-bfd6-02aed1d8c9d2" control-id="pe-14">
+    <implemented-requirement uuid="f603a856-ad6b-47fa-a698-6ba7e933a1d7" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="ed2ef5f1-cd32-40ee-aced-907b261124b1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d8e57ddf-5c4e-451b-b124-97730c7bbf72">
+      <statement statement-id="pe-14_stmt" uuid="919d0b97-aef1-4886-b573-92494e162501">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea407df6-fe33-4543-bb03-0a2684c9d640" control-id="pe-14.2">
+    <implemented-requirement uuid="36bf988d-8fea-4381-b7a7-4d3b83b6b6c5" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="f015bf54-d7f9-4fec-bb3f-e51d596db054">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e79d5c0a-6823-4d99-b1c8-c64b9edd359b">
+      <statement statement-id="pe-14.2_stmt" uuid="79aa6852-c35c-4a35-a9ec-ba26354561a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4528ca59-6ed8-47a3-bfbf-c5ca4bd5a28b" control-id="pe-15">
+    <implemented-requirement uuid="575f5513-b068-48ef-9a0a-452b43f07e37" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="cec87e52-6db2-4767-9bfc-a859d7a6f4e3">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="7a9f1551-73c8-4b61-bed5-e8ca5e38c99d">
+      <statement statement-id="pe-15_stmt" uuid="0b105b7f-24fe-4336-abfb-6494b3fb99e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f3b2b04-a6cd-4f31-8f45-b77be0404720" control-id="pe-16">
+    <implemented-requirement uuid="c5e9cba7-d697-488d-8dca-c125aaacd346" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="f234d7ce-e984-49d9-9dbd-21e1af549492">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="b001186d-e79d-4d5b-b435-81c16a39af45">
+      <statement statement-id="pe-16_stmt" uuid="f01589bd-2452-4390-8650-d1260e65039f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6784ba7-c810-41ba-8919-b2b81c9df048" control-id="pe-17">
+    <implemented-requirement uuid="ab0c76aa-c4a0-404b-a745-4b181da0ded9" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="e8d64232-ef93-42a9-a87c-685906037a61">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="31e1acdf-4471-420b-b679-98c092fd1f41">
+      <statement statement-id="pe-17_stmt" uuid="0c8eacdd-3d47-4e1c-bac1-907d7c6a28c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe03a7-b6a2-418c-8ce0-3a685dbcdd60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat IdM configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d7968e1-52f4-47cc-934e-44f54c0d0002" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="fad5ec88-1ed7-493d-be7e-c09a2cef8796">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="22849dd4-1011-4b74-8880-3542eee22600">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2117,10 +2117,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9520f4a-4c0b-42a2-9698-7f55b666884a" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="41693787-6aa8-4e96-b96b-192bf1a0479e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e2b498b8-3c21-4573-bd5f-e0e928d0eb7c">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2128,10 +2128,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78ee9fca-836d-4fa3-9c3f-f6728196b179" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="a90ee81a-9fa1-4f0d-aa53-8d2591f4832d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="8262cc7b-23fe-4464-93c3-a9051dcb06c1">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2139,10 +2139,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8fc2f9f-fb10-4aa3-9842-4f86f8ca8c60" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="3a5d54b9-7034-44c4-b514-3a0747991207">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="12d5bebb-480d-4ab6-b482-5dd53331bedd">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2150,10 +2150,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8a63989-0eb0-4f2e-87db-b7d4824c7592" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="96c7b0aa-613b-4427-8bfd-5084fc6cee5b">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="2b43a7ab-58c3-4a82-bbfb-2efe3ec9ddf8">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2161,10 +2161,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9160a9ec-04bd-4d29-be37-8f4ef4c456dd" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="2c5449f3-d999-4b37-849d-c90ac61a63d7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d80c6228-0850-4c66-8e57-32c15e314edb">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2172,118 +2172,118 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7742d776-85f5-4066-9e1a-4fb895e14f16" control-id="ps-1">
+    <implemented-requirement uuid="4660d350-a9ff-4289-b633-868e7169dd7a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="501c6d4e-caa0-49af-95af-563f2824fa19">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ea941c3c-9695-4f5a-b1c0-0950c30d45cc">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdf28aa7-2ad1-42fd-9879-24d2d905709c" control-id="ps-2">
+    <implemented-requirement uuid="0551cc84-c5dc-4aba-9167-aa0605269820" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="4d6f9383-d000-41db-9c11-adc83003f938">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="327edeb0-d6da-4c48-8a0a-a8c5386be7b3">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc02a820-f731-4c9e-81b7-2291de18ed84" control-id="ps-3">
+    <implemented-requirement uuid="232c7c6a-84bd-497a-bbb0-9e93449d1358" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="dfa6c713-e0c0-49f7-b7f8-15d8ce0f7efc">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a15ba335-5ce2-42e2-97ec-7fbc7a09a436">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39ba60a1-0a03-4b15-9ecf-53c5d6d64385" control-id="ps-4">
+    <implemented-requirement uuid="71d842db-a63e-4437-a705-b0d344f3a1ec" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="959c5428-57b2-4991-b492-fd0302edfdfd">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="82121a0b-45ff-4673-941a-22b05e879b42">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddf07eaa-a59c-42b0-b901-a83e3cf4158a" control-id="ps-5">
+    <implemented-requirement uuid="777a3530-a4cc-4090-b68c-8a17fa1f7244" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="cbdc1f96-3319-4c6e-bd84-18fd1973ab70">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="77d102a7-092f-4a6d-88e5-880cb58f91fe">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="164c47f3-2ab9-4203-88a9-8fffdbbfb982" control-id="ps-6">
+    <implemented-requirement uuid="fcde7ff5-6883-4b66-920b-bc531f0c15c0" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="682a05dc-3655-4260-870d-55e7819899d6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="facf281c-fb42-4562-989d-027aef065665">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e1c08e0-1fcf-41b5-b3c0-76579ae7adad" control-id="ps-7">
+    <implemented-requirement uuid="98f77d85-239f-46ed-90cd-dea85a2cc296" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="222ef775-72b2-467e-b44c-d481c4ccb70c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e86ef46d-b3eb-47bf-8d6d-c5b0affae904">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72407b29-591b-469a-8f43-549e83549668" control-id="ps-8">
+    <implemented-requirement uuid="a3b6707a-81e8-45d7-9052-6ec98d912d10" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="47e76aba-f5a9-427e-b4b8-478fe73af9b2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="50225df5-f44b-4e6c-85af-7df11fe28ebe">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43c641d7-508a-4fc0-9735-36e2817f2d01" control-id="ra-1">
+    <implemented-requirement uuid="bdd7689b-bd60-4be1-9085-6328896504d3" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="223a49a5-c2e4-44dd-a1f2-2ac21b5c3e35">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="24449b87-4829-4a2d-8a73-0bb847e5c25b">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eeb6b952-8283-465b-9a70-4ba18db5a691" control-id="ra-2">
+    <implemented-requirement uuid="826799ad-658c-481e-b6a9-51ced114476c" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="3c18918b-8b02-41e9-bdeb-fb7614adaf7e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="58982803-115a-4a8b-8a52-63b06e4a06a4">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b93de865-5303-42ad-8963-59906f997dcf" control-id="ra-3">
+    <implemented-requirement uuid="b6022578-c8af-4da1-9c82-417b53907b91" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="3d8a5394-1d80-4da3-a49f-225047f3d712">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="d01f090e-d433-4045-ac73-f026dc85bdf5">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a08d192-15ea-4cdd-baba-2d981f1b51b4" control-id="ra-5">
+    <implemented-requirement uuid="210f9d7c-f3e3-4d76-9ef2-3057f656386c" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="0753ba91-d8cf-409f-8301-77aa3da88a6d">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="19498b58-da2c-455a-8bc7-9602929a01ef">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89e67a19-2087-4b28-b859-69a1a655feb1" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="dbba1c66-58c0-42ae-872f-0c6ea32f23c6">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="9b52bf27-0521-47a3-9b97-dbbc2eb129b3">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2291,10 +2291,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea9bc639-4c85-4d44-af58-a317256d4b63" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="a6aa095c-59ef-4cb2-87b4-58f2b3deca3e">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="362a082c-fb9c-48f0-950f-898679fb378d">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2302,10 +2302,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81b81373-d9bc-4416-b53b-90e3971e973e" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="ef56f7bd-5b8f-4e53-8828-5470b7c14049">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="bd7ce509-17f8-4d72-848a-6e799a5abc70">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2313,10 +2313,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01c1ccc0-0e61-49f9-88a5-4724d975dabc" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="b75f2bbb-34c9-411e-a97e-7b1bf85ed949">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f405e45d-319c-4059-a99d-1cc03e6646d6">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2324,50 +2324,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7790e9e4-fdc8-4fc3-aa23-b34d024edaae" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="1a54a1f6-cfdd-4fc7-8fef-ebc25bfd5bea">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c178f79e-2a5f-4de5-a8b7-db0ab55ec9b2">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f7e99d6-1601-4d30-b999-d783fb7af6c2" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="e7574c9f-ad77-4f46-9ce2-2eed7c40b6ec">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="49f457de-c1f8-4fd3-a716-faf80daa1aa2">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fcd188b-b379-4563-8a7c-1c8937c63d7f" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="c03874ff-1695-442d-8e6e-eb54d55d2433">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="baabd522-ffce-4e17-ab14-626d1a6d3ccd">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c17bfa6-568f-4768-96ad-44e7b3d09fa1" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="78ca38d1-a8bc-4a67-baf6-90b361a6876f">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="919c0d8b-ce4f-4c14-9f5a-dfe288b981e7">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12658755-8948-41dd-a738-5b76728b6cf6" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="d83f27a8-db20-4c39-b404-4d4f7e58bace">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="0fb10a8f-b33f-4f1c-b1ec-d57aef99d96d">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2375,10 +2375,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99b9f449-aa8a-49bb-a662-96836eab5a47" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="728e0b33-2d3f-483d-ab57-2d868009568c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6c99f80d-5a9f-4ee9-b5c9-917a04cd3914">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2386,10 +2386,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b75994e2-3fd7-4332-bf32-4468164e7315" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="43870c54-5ac8-40a9-86f3-5193592e9828">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3ce13faf-fc05-4d45-8d78-27e4a04ae78c">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2397,10 +2397,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b49e5ce-7d3c-4a5f-b3d7-3ebdaeda85cc" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="b677fb8b-a01b-4f2f-a4a9-616581028e5a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="335f20cf-e03f-42e3-b7fe-63799c6fe567">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2408,10 +2408,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9aefd144-a3a7-4261-ae2f-f7b9a52617b1" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="6c916ca3-219d-4dad-b1a9-1cfcae5db203">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a05e0e58-0a02-4704-ad43-c547a6b9cfd4">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2419,10 +2419,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="312b93b5-50fd-4766-bdb3-16c7110c86da" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="924d6ea4-8bd9-4381-96a0-f95875ce5ffd">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="3b3c83a9-2ba6-4ba8-892f-1793a57dd964">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2430,10 +2430,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a28411c8-c052-4d40-ad22-3dbc7d071d8b" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="63e9edc9-77c7-4660-8205-094cafeeb19a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="f1f20a2b-8125-4e51-ac49-a35ea193e43f">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2441,10 +2441,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4771c5e-c51f-4e0d-bce8-a84e7a3c077d" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="008fcd59-d92b-4294-b3e8-932108fbabf9">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="72d21140-58f7-41d8-aa01-45c3046dce1b">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2452,76 +2452,76 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="683aedc9-30a5-4690-a89d-b7882bcc4716" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="1b0403b0-ddc9-4c1d-a421-4df329c7e85a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="b1bbe813-4cff-48de-aa4c-57377e884c66">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="12f30ca0-cb2f-4ec5-b355-e41fc6b475e2">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="64597231-d96c-486f-9aa9-30d62bb85c05">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="52dc113d-071a-48bd-ad1d-5b2949bfa997">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="750be208-dbc1-4342-9a52-1201e1b3a310">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="618e137e-5f7f-4520-83ed-ca402cf62549">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="240b453a-785a-4eb2-94f2-2c68ffb1b13c">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="92f7540a-5fe3-477c-8331-c4635eacc310">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="41d97521-35f3-413a-bedf-a2b1d5f36955">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8471e602-a3ed-4a3f-b0df-076c7e1acca6" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="adf9b179-bad8-4863-a442-6ec4f0c82923">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="91f39675-091f-416e-b150-7ade1551dc9c">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ec89221-bd12-490f-81bd-5405fe04783b" control-id="sc-1">
+    <implemented-requirement uuid="75e30841-bd65-4ea0-bdda-a5428ad9018d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="92d337b0-d9b3-43ef-9e41-286273a2cf57">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="a6907a24-bd18-4779-8ca4-eab93fb3f961">
+      <statement statement-id="sc-1_stmt" uuid="21b49a11-593b-45bf-8c37-d2bc574f135f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a0ed419-a341-40bc-a962-b67c7d8f0e76" control-id="sc-5">
+    <implemented-requirement uuid="1e539cad-e15d-44e4-8182-77855f2dd251" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="aebef4e4-0b35-4750-b8d6-b084fbbc6278">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="bf66747f-8138-4c41-9e83-6210e18c69ad">
+      <statement statement-id="sc-5_stmt" uuid="bc7b002b-a2a6-4fea-8986-f3f34ab25fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd7e267e-2598-4b9c-96be-ab6917480e7b" control-id="sc-7">
+    <implemented-requirement uuid="00783149-d62b-4e7a-aeae-58057ca0ac49" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="eca6fee5-b954-490f-baf0-ffed5b4b04ce">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="01208e04-5a48-4b7e-b026-707e0b495b94">
+      <statement statement-id="sc-7_stmt.a" uuid="d48dff23-baf9-4222-a2b0-af0fb767eff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="574e7ffc-08c9-493a-961a-2e3328c62797">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Red Hat Identity Management can be monitored is forthcoming.
@@ -2531,8 +2531,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/142'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="ecf560ba-732d-4194-a0f9-752d3ae427b7">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e32c0acb-41e6-46b5-9364-655b5b147be7">
+      <statement statement-id="sc-7_stmt.b" uuid="af39fa28-0b39-4179-a8c4-78fa4cdbd354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fbefefb-1163-4180-ab0a-d36a99e31d1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can
 implement subnetworks
@@ -2543,8 +2543,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/143'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="86f279f6-ab7a-41b4-ae57-0734654351fb">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c0629bfc-c736-492b-9fa3-a805113d2659">
+      <statement statement-id="sc-7_stmt.c" uuid="d4bd6c47-7d19-41c1-b673-9ecdac16a504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a613d308-0c27-4ad7-96c7-67f0be72ace9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management can route
 connections to external
@@ -2556,10 +2556,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/144'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a35af83-4425-4003-8614-4343a19042f9" control-id="sc-12">
+    <implemented-requirement uuid="c8327394-89ba-4508-817d-7dacaba8e50b" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="45c58425-0c18-46e3-8a4b-f677adf502ed">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6441a3d7-a8e4-4fd2-9d12-e456a33467ed">
+      <statement statement-id="sc-12_stmt" uuid="02fe4966-9a87-44d3-8440-63a140dabc6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e1ea452-edb0-4547-b82b-3bebbfc93493">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat Identity Management generates,
 distributes, stores,
@@ -2571,10 +2571,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/145'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7278ae1e-ee45-4c78-b7b7-c40830272060" control-id="sc-13">
+    <implemented-requirement uuid="16e89f47-8365-45ee-ad7a-b99f5fc41f13" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="b05414ea-3bbf-4043-a752-2074819f0f04">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="4a6dc783-1c63-46e1-8454-e7a925c4d8f0">
+      <statement statement-id="sc-13_stmt" uuid="e653c788-a2ee-4da9-bf53-7abfaf243e6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3a298fd-f2ec-499c-a530-ff92405e66a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat Identity Management's usage of
 cryptography and applicability to Federal laws is forthcoming. This
@@ -2585,19 +2585,19 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/146'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04fab96d-a931-4a0c-a160-31e131de9c0d" control-id="sc-15">
+    <implemented-requirement uuid="027a35d6-1870-402d-b9d5-37d944de600c" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="fcc8e177-84b6-4fa1-8e9e-dbe83c54a214">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="189c0719-21bb-4660-a4f9-28dee222396f">
+      <statement statement-id="sc-15_stmt" uuid="4654f804-278b-4d2a-b454-1499f231eca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76646e80-1408-406b-96d2-0dba0cc56e97" control-id="sc-20">
+    <implemented-requirement uuid="7ca56f86-dc66-41b5-9216-ab04954d6f13" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="fc309910-de30-4dd9-b593-e3c666f08d59">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="df318c40-895a-4da7-be70-9c94a841cc2f">
+      <statement statement-id="sc-20_stmt.a" uuid="9d8b50c4-1035-4eb0-bbfb-cf81f3fe65d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69679a55-3731-4cd3-b7be-e25751928b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure Red Hat Identity Management DNS services to provide
 data origin authentication and integrity verification is forthcoming.
@@ -2607,8 +2607,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/147'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="768f7df6-c00e-4730-9f44-211f8864cd33">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="c1ab430a-112a-4bd9-9754-2ab9e149ef30">
+      <statement statement-id="sc-20_stmt.b" uuid="3aae96a2-5f33-4839-b633-80eca89e3e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a8a8fb7-8dfa-4ea7-be28-60dad7bc2de5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how to configure this functionality within
 Red Hat Identity Management is forthcoming. This activity is being tracked in
@@ -2619,10 +2619,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/148'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91720210-2a89-4d69-a85a-4aad277d64bd" control-id="sc-21">
+    <implemented-requirement uuid="5a321394-fed9-48ff-bc89-6f232fe21d74" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="ab5ca69d-18e2-4cca-8a9c-ea2bcec51579">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="99a6254d-2857-498d-b842-fe6ddd78468f">
+      <statement statement-id="sc-21_stmt" uuid="3fcfbed7-2599-430d-bc62-c0e5c6858f0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96a05615-1b7e-4daa-9fa0-e1dd1db830b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on enabling DNSSEC within Red Hat Identity Management is forthcoming. This
 activity is being tracked in GitHub:
@@ -2632,10 +2632,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/149'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0abd141d-e800-4a00-94b6-2f5e17c1c8fe" control-id="sc-22">
+    <implemented-requirement uuid="35ded6b5-e656-433c-91c4-a4ebd2c8b759" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="01d9d0d3-7899-49b3-be5e-eefbb033cd0b">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="fc41b6ae-f846-482f-90ac-6e58846ad4fb">
+      <statement statement-id="sc-22_stmt" uuid="c485f120-6b8e-4407-94dc-0e1161f0507d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2d349a3-aaaa-42e1-bf00-87baf5ec5742">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on creating fault-tolerant DNS configurations within
 Red Hat Identity Management is forthcoming. This activity is being
@@ -2646,10 +2646,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/150'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d737b763-798a-4a84-be15-c903873b1cde" control-id="sc-39">
+    <implemented-requirement uuid="e725ca86-e995-4735-bfb5-375a68bc3814" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="41cdfb94-5a23-4eca-bd8f-ede8b88b62f1">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="83c43371-e415-450b-9b7d-79e23e1c5d1f">
+      <statement statement-id="sc-39_stmt" uuid="08d220ce-373c-49b1-b83d-b35156882a11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6710d52a-9f87-412e-9c22-e7bfd898dc7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat Identity Management runs on Red Hat Enterprise Linux,
 Red Hat Identity Management maintains separate execution domains for
@@ -2664,10 +2664,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/151'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32260655-f35b-46a1-81ad-e8b1308a5426" control-id="si-1">
+    <implemented-requirement uuid="50cc2645-b920-4301-b591-2241e63496e8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="e8ab9467-5322-4523-a3bc-b80c3338dd87">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="0f049a3c-15d9-47a2-9ed1-e12efb57fdc5">
+      <statement statement-id="si-1_stmt" uuid="201890d6-df69-4d1d-9b19-45d4210fe394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2675,10 +2675,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2440f0d2-471f-4f04-8232-8cab2b29c792" control-id="si-2">
+    <implemented-requirement uuid="7b161967-8f5b-4a41-8cd1-413a848eb9c6" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="d417d166-efae-4457-b514-add764f00520">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="0b6035df-64c0-4a3b-a3a4-a4b8ce1b7712">
+      <statement statement-id="si-2_stmt.a" uuid="219eda2d-eca8-478a-a253-c4697f65d11c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="491ab51d-d992-4f2c-b446-5bcbeac26faf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their
 Red Hat Identity Management deployment for
@@ -2694,8 +2694,8 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/155'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="91be295c-9d29-4bc1-a53e-f5d9979ec254">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="6acb61f4-f2e7-487b-8f14-b4c0c41bc66c">
+      <statement statement-id="si-2_stmt.b" uuid="44888f74-cbc7-434f-85ff-aad87a82a92e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2497f562-693d-4650-bdce-f7f045c22284">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing
 Red Hat Identity Management updates
@@ -2711,16 +2711,16 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/156'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="cd175661-aa01-45f4-a393-2aa119503a54">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="e95eaee5-d396-4068-abe4-692975c37e70">
+      <statement statement-id="si-2_stmt.c" uuid="b48e299e-71da-4d34-bfc6-90d20e36400a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="25edafdd-0c52-4d65-82ed-bd7322b1df8a">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="311f7647-3769-4223-b30e-2d6616276c41">
+      <statement statement-id="si-2_stmt.d" uuid="0325951b-827d-4d54-b821-49c70e280f7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2728,10 +2728,10 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d191e9a0-6e5f-4d81-bb32-f10e41f8649a" control-id="si-3">
+    <implemented-requirement uuid="1ca92f2d-8c0d-431a-89db-47741bc62f2c" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="1badad6f-d46a-455b-a0e3-7d0bd47a7b14">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="1006476d-9363-4ce1-a618-b6f6e9652580">
+      <statement statement-id="si-3_stmt.a" uuid="b41c03f8-c5fa-469e-ae13-2b155f0f6102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d390ec6c-9084-445d-8836-fb9f16de6b1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -2749,24 +2749,24 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/158'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="03598fdb-0daa-4c1f-9f7b-abf7ef2e548c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="acefa68f-57e2-42ce-84e8-0b67dbf3d25d">
+      <statement statement-id="si-3_stmt.b" uuid="d20717d4-b2bd-4bf7-aa22-a203ee31ea66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="468a0622-189e-4e40-a61e-34eac1996322">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="095c3b83-13eb-44e6-a4a7-d039c5f66be4">
+      <statement statement-id="si-3_stmt.c" uuid="52fe672d-c34a-4506-8ae0-54f447ec9d64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e222b8d-5936-4ecc-ba01-4cf21b3853be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat Identity Management, this control is
 duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="cd683f20-2a5d-4063-8b44-0c8fdec4c591">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="ce107d72-8d18-424e-ba99-93c0dd6217f4">
+      <statement statement-id="si-3_stmt.d" uuid="e048a640-7ca5-446d-b0e7-4659e9bf8587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3759db5e-e248-475f-bcb7-87eef781d354">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Identity Management.'
@@ -2774,28 +2774,28 @@ applicable to the configuration of Red Hat Identity Management.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="979aa891-6ca4-4d84-9829-8d0dda9c95cf" control-id="si-4">
+    <implemented-requirement uuid="3d4a7146-3c42-40d7-9098-9af48469fe63" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="12acd2ee-7bed-4226-bbc9-04bbc570737c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="aa75a109-021d-4e32-96da-5c701e00deea">
+      <statement statement-id="si-4_stmt" uuid="643c2f35-749c-46cb-9e20-877861d0ee49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a9d0188-7bdb-4914-bfa8-a2fe6e9aede0" control-id="si-5">
+    <implemented-requirement uuid="0432c080-b5e9-4168-8c73-cc1ee7957d26" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="8fc1cd61-c8d1-4687-b8a5-12e77f607246">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="fa48cc1e-ecab-420b-b49a-cbfd2ecb041f">
+      <statement statement-id="si-5_stmt" uuid="42361d80-4a3d-4a80-9f6f-b34397924aea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88723a68-994f-43b5-aff3-a8dc0a020a5a" control-id="si-12">
+    <implemented-requirement uuid="23102443-d9ae-4a4e-a002-ea264e74cbb7" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="1df2031f-40e5-4d13-9056-d3fd85403ecc">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="338111cf-b98e-4b74-896e-b30cf3f2cf64">
+      <statement statement-id="si-12_stmt" uuid="49f7b842-5014-4ce2-856e-fdf43f79c0d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8456e347-83e4-4e1b-be54-a08042e93135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Identity Management in
@@ -2816,10 +2816,10 @@ https://github.com/ComplianceAsCode/redhat-identity-management/issues/159'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="073a9430-66d0-4fc7-be4f-54bc066c7436" control-id="si-16">
+    <implemented-requirement uuid="0dc6f97d-ff1b-4fe4-8788-6d715267805e" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="f25763e0-c4a2-4178-84de-934eefc4ce6c">
-        <by-component component-uuid="6e8b766b-7d7e-4d27-bc42-959a34bff60d" uuid="09427ce5-cf9a-4f87-ae1e-95a153cf2a2b">
+      <statement statement-id="si-16_stmt" uuid="c36301bd-387b-44fa-a26f-91221b5f18fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a18477a5-4e4e-4a77-8732-1947aa9a8f53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Red Hat Identity Management Container Platform
 inherits memory protections

--- a/xml/openshift-container-platform-3-fedramp-High.xml
+++ b/xml/openshift-container-platform-3-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="51751bc6-a088-499c-85e7-27407e7651bd">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="3ee019c5-b1fb-4553-a0bf-9187da0b83b4">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.69+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.18+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="7cbb6559-b0dd-4026-ad57-59fc9e8e6784">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,135 +484,135 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="967861ab-721e-476b-b62f-f50fcc351183" control-id="ac-1">
+    <implemented-requirement uuid="60708a04-b787-4584-88ec-b5a40233339e" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="ce401c7c-cc59-416b-9f07-8c5d233da603">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0352e036-6933-4e6e-aa9e-1364f11285a4">
+      <statement statement-id="ac-1_stmt.a" uuid="a534b272-07f2-4dd2-b131-50e83c8b73c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d03e4f5c-c2b6-4321-ade7-720c3cc1f5b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="8ba80184-fd56-436e-b43a-94fd8993c07a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="549e8e32-1ebc-4fdd-b80d-b44260c28694">
+      <statement statement-id="ac-1_stmt.b" uuid="39869e7b-fbd0-4a76-ba93-35f3b833a806">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2161802-26d4-4ab1-8795-f7c2627f5634">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c942544-06a9-4cf9-a065-7070e5a9dacc" control-id="ac-2">
+    <implemented-requirement uuid="59578d19-03b0-4491-8eae-26a04cc69a05" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="44e576e3-9a00-42be-9895-1a096771c9d0">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b6809be6-7ff7-4674-b68e-b8cc4acd440c">
+      <statement statement-id="ac-2_stmt.a" uuid="f58c922c-f798-4fab-bdbe-a332c7e92d18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ad2c932-3725-4d99-82c3-df7432aac77c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="323c905f-3b4c-4d61-98b5-61ff909da056">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0017dfdf-a9d2-4d1f-89a7-d8bc2ffd01ee">
+      <statement statement-id="ac-2_stmt.b" uuid="5457a123-995d-45d4-a9fd-5db514a88e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2404e9a-93b0-4e58-9e38-0a9b968064af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="74892d97-eebb-460a-9e4f-200c43fa7e49">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bc2359ac-1af6-4332-85ae-5ecfd3051566">
+      <statement statement-id="ac-2_stmt.c" uuid="d2d3de61-15cc-4a4c-9674-3846c86431bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e239287e-a985-4297-8c52-f51f408465e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="c78ac1d9-cdc8-446c-92eb-5ecd3a6c0630">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3b30f2ac-ce38-477d-a25e-a000309b306f">
+      <statement statement-id="ac-2_stmt.d" uuid="96aa180d-68b4-4e6f-9a73-ce5f84362742">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c68a103-5a62-4cda-b74a-a4b30fe404a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="0b9c100d-88c3-4863-8154-3b0c8c93e8e6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b2238c1b-c802-4afa-b78a-c6b6a1899c26">
+      <statement statement-id="ac-2_stmt.e" uuid="9e220f14-127e-4ad8-bee8-035b5f2f7a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b49cfe0-e9b5-4fd0-9e96-24822cf55507">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="41d14c6f-b144-4d45-a9cf-82851c804be8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2e0d7d36-8443-4e76-9820-f7024cd7e438">
+      <statement statement-id="ac-2_stmt.f" uuid="daa02e58-fffe-431a-a6ff-9923736b876a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8b34df7-1b86-4cde-9eb7-1fde4cb7cddb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="01e161db-9d70-468e-9aab-a0743ce9bb2d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="335a1b08-09cf-472e-ac02-6dd48e01465d">
+      <statement statement-id="ac-2_stmt.g" uuid="727f879e-69cc-46cf-be37-9006e8253d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed61ef3a-e2d6-4a0d-8081-5e8c8e72fc2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="a1b6d505-4a75-4a88-857d-867171d369d5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c3215391-981b-4c8a-83f0-031505360373">
+      <statement statement-id="ac-2_stmt.h" uuid="4c706ff6-f1d1-4442-a6f1-1835c98964c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="948375b2-e248-4d06-b3d3-f314aad054c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="cb744db0-d48f-4f69-ae69-4b629ccdaedd">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="340dce9f-28e9-4fb9-9eab-2dcb5e4bf6b2">
+      <statement statement-id="ac-2_stmt.i" uuid="d517b147-73a2-4415-944f-2eb3d12c90db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5056b50e-2182-4662-a649-7f1bca05a377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="c31b9423-c30d-4112-9bc1-f64bc4a94dc7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="72446eec-1a0e-4ffe-9873-b690ee4e9842">
+      <statement statement-id="ac-2_stmt.j" uuid="19d705a2-6ca5-4692-a782-04fc9c41a37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bff8c94-defd-4343-aeb2-065ebe0bd183">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="d0c2fef6-d208-49df-96e4-924a5d0f41e3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b119b366-bec3-4167-908f-d863bddf2bda">
+      <statement statement-id="ac-2_stmt.k" uuid="6d13e74b-b22d-46d2-8000-b5c56699bd00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e050e3-2279-4395-b0ec-05835ee60c2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc3f1347-0b22-4d3a-a4c4-b5525f5d146a" control-id="ac-2.1">
+    <implemented-requirement uuid="dbefa979-2715-4023-abe1-dc7fd1103ff1" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="e268bfe8-2c9d-4aa2-b8a3-6352b67cad6c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e6bee14a-9f82-49c0-88d1-fa6a2f467a7d">
+      <statement statement-id="ac-2.1_stmt" uuid="3c3e099d-f873-4c99-aede-aa89c1d5bfa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="281ea8f1-b026-46fb-a5f5-9e2c29611be8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift components of the system support automated management through monitoring of accounts and system activity by logging of related information.
 While OpenShift can generate audit data, and securely transport the data to a SIEM, OpenShift does not provide automated mechanisms (e.g. email, text messages) after system events. This functionality would fall to third party software.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eeddd111-fb38-4abf-8399-5a06b25be012" control-id="ac-2.2">
+    <implemented-requirement uuid="bbe1af05-a651-4f11-a41f-ae1e41f9e262" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="df941b42-f489-4d6e-86e8-d358472004f5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9d125e29-1c66-40e7-81e0-4af413a2d200">
+      <statement statement-id="ac-2.2_stmt" uuid="e3babbb6-c300-4e61-8764-d1ef8530dc49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c27a240-2a8b-4b8f-ac1f-030322aa1aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the capability to create guest/anonymous accounts or temporary accounts. Any external emergency or temporary accounts will be inherited from, and managed by, an external identity service (e.g. LDAP).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12b5993e-660f-495e-8932-5afd9621ab9b" control-id="ac-2.3">
+    <implemented-requirement uuid="00d46d8e-1fb8-45de-a5de-30365eae3277" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="ad73a34f-6e61-478d-8690-ee213f0d0f97">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8c23295a-0f62-4431-aafc-b4d4b6bdbf74">
+      <statement statement-id="ac-2.3_stmt" uuid="d0eaefc6-97af-4294-94b7-c9bd78a4dd70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35edb55b-ec8e-4f66-9894-946287d912cb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift end-user account management is inherited from the hosting environment.Automatic disabling of these accounts must happen at the centralized account management level; for example, within LDAP, Red Hat IdM, or Active Directory.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="139a26d9-8226-4c69-845a-acc13fb8d2ab" control-id="ac-2.4">
+    <implemented-requirement uuid="8708f73f-5233-4211-82d4-411bea1a4c0a" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="0c081a30-c961-4233-a346-ff2e0d127062">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b8a74605-70a6-48fe-bc56-f49de7c8a6ea">
+      <statement statement-id="ac-2.4_stmt" uuid="1208642b-e08a-4373-9321-d7d810eff5fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c7fa6d4-f3ad-409e-8456-0a9299a8df6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet FISMA requirements, OpenShift must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -626,10 +626,10 @@ service.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fe453e4-fdbe-4016-9e70-430d9e2c8cbf" control-id="ac-2.5">
+    <implemented-requirement uuid="105d1fd1-5772-494b-9941-3867decbdc50" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="74911f92-fbf4-4f3e-bc0c-e0d5f4acc91d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b9d616cb-8e79-4f44-820f-b7c2e5971a76">
+      <statement statement-id="ac-2.5_stmt" uuid="7263b83a-47f5-4af3-8c51-2a38686cc512">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="012c492e-9cb9-468d-acd3-5c7195e2fd4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Within OpenShift, the sessionMaxAgeSeconds variable in the
 master-config.yaml file controls when/if users must logout after a
@@ -638,10 +638,10 @@ period of inactivity.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98663859-bc41-46c2-9c28-198b5c39a417" control-id="ac-2.7">
+    <implemented-requirement uuid="2d879320-2d71-438d-82fd-a8efddee152d" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="4e2ddcb9-cc61-4df7-8341-1e29e73df916">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4ea42491-544f-45db-a133-96a8d84cc7da">
+      <statement statement-id="ac-2.7_stmt.a" uuid="1fa5180f-c0e7-4a36-b597-1a2d1528f975">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df8deefd-6141-4833-bff5-3c47ea28ed43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift roles can be used to grant various levels of access both
 cluster-wide as well as at the project scope. Users and groups can be
@@ -654,16 +654,16 @@ https://docs.openshift.com/container-platform/3.11/admin_guide/manage_rbac.html'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="4eb791e2-992f-4a16-9d74-08e65fa1ed59">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fe0bf88a-5282-4312-9d3f-b7674f6159cb">
+      <statement statement-id="ac-2.7_stmt.b" uuid="6e27cd28-4cfe-49c0-ad40-95d887f6ec11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fce24ac-a9cb-4c56-a9e0-cc2f658fd82d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control and not applicble to the configuration
 of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="a7ed5059-942d-4e0f-a7e6-38b859ec8545">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="64dc9004-2a44-40ed-816c-420e3b9147d6">
+      <statement statement-id="ac-2.7_stmt.c" uuid="1cfc2d0a-2681-4fc9-89a3-cf7f69a845cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fce24ac-a9cb-4c56-a9e0-cc2f658fd82d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control and not applicble to the configuration
 of OpenShift.'
@@ -671,10 +671,10 @@ of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f634e56c-fe3f-41cd-adb3-3ba924d739e3" control-id="ac-2.9">
+    <implemented-requirement uuid="dc5698cf-558a-430a-b523-68fba567a124" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="47c71448-b82d-4878-857a-8422b730f499">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7c1ce64f-3aae-4a65-aaaa-00292ca625fe">
+      <statement statement-id="ac-2.9_stmt" uuid="77669137-ea0e-42e8-8e85-57dd2da82fe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -682,10 +682,10 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fdad6a5-50ac-4646-a4e3-9c7f44018e70" control-id="ac-2.10">
+    <implemented-requirement uuid="788053ba-0c40-4273-a55e-58a115860315" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="ec191137-3e01-4c8c-860b-6d6ac2cd9459">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="79f13217-afc8-4aa6-bf3d-476bf15536b1">
+      <statement statement-id="ac-2.10_stmt" uuid="9099931c-f89a-4c51-beef-ba7a3dfdec63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d09d9271-4abf-4960-b408-7673e0a10703">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift does not have the concept of group accounts.
 
@@ -696,10 +696,10 @@ of operating the shared identity service and not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="899be471-97dc-4770-8f65-e6bcd9e12548" control-id="ac-2.11">
+    <implemented-requirement uuid="c7372960-1c81-4db5-9a0a-983a3f182ba6" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="9b6a361c-a8b6-4023-bbbc-a455c9bc9958">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="58846b85-6b99-4185-9405-eb01017f0ceb">
+      <statement statement-id="ac-2.11_stmt" uuid="c62b505a-b75c-4f24-b303-9e96b9156c70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -707,18 +707,18 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f43d7bc-a1c5-4bcc-ae42-bbc23e2ef075" control-id="ac-2.12">
+    <implemented-requirement uuid="86466902-6096-4cf7-99df-b4bfab460261" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="55defb22-a6bf-4dab-9d0d-a2b84f6fc537">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="da9df79c-aae5-4df0-bb0c-f3c463a9648d">
+      <statement statement-id="ac-2.12_stmt.a" uuid="cca33a0f-d39f-455c-9c64-896aec65c3f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="2a04c4b8-8963-4d5b-b118-206ca411fe7e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5c3f4fc1-1e3c-453e-b89e-d1c8cf7224f2">
+      <statement statement-id="ac-2.12_stmt.b" uuid="2683ff06-15cd-43db-b511-2f8cd1037855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -726,10 +726,10 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d82ba5fe-146e-4db1-a9a7-71c7413aa2e2" control-id="ac-2.13">
+    <implemented-requirement uuid="99f956c4-e059-4063-9d5c-299eef2d09bf" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="8f59a0d1-caad-4546-82d5-943762d43020">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="160e8897-4aca-43c1-bf46-a589390097de">
+      <statement statement-id="ac-2.13_stmt" uuid="34ca92a1-f143-474f-a0e8-ba8c747e46ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -737,10 +737,10 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="830ea682-5e60-4f27-81c0-626d48adc377" control-id="ac-3">
+    <implemented-requirement uuid="d8db6759-def8-4339-bed8-ffc870482ca6" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="711dca6b-4b17-4734-8bf4-b227985cb7a2">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e783eaf4-1f4f-4553-87d0-12f18ec831e2">
+      <statement statement-id="ac-3_stmt" uuid="8725b63b-97f4-467c-89ff-3ae6966d072f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47a19d86-79ce-46b6-90bc-f6ee32905688">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Authorization policies determine whether a user is allowed to perform
 a given action within an OpenShift project. This allows platform
@@ -764,10 +764,10 @@ configured.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c905f47-ddae-430e-b729-f11fbe23adf2" control-id="ac-4">
+    <implemented-requirement uuid="22b018bd-c73c-47cd-b3d4-b7012b7ed531" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="2cf4d73d-0752-4115-a109-d0d1e8fe5b67">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3c34c496-03c7-4ef1-bed0-bfc6e932f4eb">
+      <statement statement-id="ac-4_stmt" uuid="d047fabe-5feb-4872-93ca-0fa02155a9da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd16a7b5-4b2d-4002-baa9-dcfe261b671e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for controlling the flow of
 information within the customer application, and between the customer
@@ -784,10 +784,10 @@ https://docs.openshift.com/container-platform/3.3/architecture/additional_concep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c43d2f19-2d23-4da1-8050-a7b9e609e0df" control-id="ac-4.21">
+    <implemented-requirement uuid="294150a2-1120-4ce0-9561-b1c72c4fb24a" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="ada741e6-6f0e-44a8-954c-e363e98afab5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bda23f6c-ea13-4b04-9826-440850ee7c4f">
+      <statement statement-id="ac-4.21_stmt" uuid="f1d01aa6-f4e5-43b2-9265-e1f681f8c11c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5069b83-98d5-4b64-afdb-e769759dbe2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -798,10 +798,10 @@ techniques used to accomplish this separation.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8f38f2c-e7f5-4a44-827d-d77a80fffc81" control-id="ac-7">
+    <implemented-requirement uuid="ce816ee8-00dd-4a1c-b9f6-3b5cd0f8f33f" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="8d137676-bdd9-4343-a161-36c4fe185fbc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="919b1819-d04c-4ed4-ab38-f362f9e12ff5">
+      <statement statement-id="ac-7_stmt.a" uuid="24aa9850-e243-41dd-a61d-54f533d38f35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72873987-046f-4ee7-b2f1-546624878717">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -812,8 +812,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="6958ca6a-b32a-4319-94f9-972671eea065">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="784498aa-37d9-4550-9b15-1f3605957cea">
+      <statement statement-id="ac-7_stmt.b" uuid="bd16ba30-0829-4fcf-b9d5-8c39a0ecdd9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c23be9c-70d3-46ea-80f4-312055fd2b2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for taking the FedRAMP required
 actions defined by the customer, upon account lockout.
@@ -825,10 +825,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aefae2c-0a0f-4b38-bbcc-4cb066558521" control-id="ac-8">
+    <implemented-requirement uuid="0681d54c-f2d5-4a76-ae06-e309f36db328" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="e6b4ed91-d38e-43cb-ae07-133b5fb1018c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="51c5f3db-089f-41af-9c6e-55bdc75f5961">
+      <statement statement-id="ac-8_stmt.a" uuid="5959ee14-d888-43ac-bc94-2a1672d052ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a6982d5-2fe0-4a79-a9cb-0270677cf54b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -847,8 +847,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="e60d10e4-26ac-4e37-bb39-0da60d028c5a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="480b89bc-c773-497b-83fe-7fc35b07b19d">
+      <statement statement-id="ac-8_stmt.b" uuid="8ab258e2-1c3d-4d32-a32e-eab24fbebd5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e75e0ed9-63a8-413f-9a6a-b36bdf2d62f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -862,8 +862,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="943f924c-00db-4e65-bd32-4ba6bb4c936a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9effec31-c4d0-4b5a-98c3-15814a99705c">
+      <statement statement-id="ac-8_stmt.c" uuid="d1a44f1f-f6bf-47ff-8dd3-c88ae2bfef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3123693e-d71e-4719-a6c8-fec6e9ea36be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'
 '//*
@@ -879,8 +879,8 @@ of the system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="bfa2032d-787b-4e2c-994b-26c0ae09d8f9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9dc242d4-f9d9-4cfa-946c-eaaa8d0f32bb">
+      <statement statement-id="ac-8_stmt.c.1" uuid="fea90977-1c02-4513-94c0-bf4662ec9e28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbd396e3-ea13-4211-82c2-ae7149526204">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for determining the conditions
@@ -890,8 +890,8 @@ conditions must be reviewed and accepted by the FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="725dff3f-4307-441a-a2bd-f2e230d2d099">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b917ac93-ddd0-4ed5-8d88-62ec305e9202">
+      <statement statement-id="ac-8_stmt.c.2" uuid="89d2ef17-0208-44c1-bdd4-1866797b04b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a631d91-5ab8-4a75-b5a9-5b055a4728b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for how the system use notification
@@ -902,8 +902,8 @@ FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="b7b4d8e6-0e22-433f-a02e-13c6f5ee5a6a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9a854919-c7f9-4d98-b5de-bfd042c6ff7d">
+      <statement statement-id="ac-8_stmt.c.3" uuid="e94c4031-2e2e-467c-b852-1842d215ee2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c3edbe-cbe0-43df-9b89-c7d7ce1ae00c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for verifying that the system use
@@ -916,10 +916,10 @@ review and accept the process used to perform the verification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d17a1114-2f33-4a4e-9b01-c6961db98929" control-id="ac-10">
+    <implemented-requirement uuid="1070c906-98a3-4885-aeb7-b9878c1f03c4" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="9b6ac671-74f4-4801-8196-d36e353b5fff">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4640f49e-7ef8-4f4a-b88d-f96ee16aaaae">
+      <statement statement-id="ac-10_stmt" uuid="0b6b8dbe-0946-48d6-a2d2-6bb987d3193f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd0fbe9b-14f6-4ef6-b059-99cb6103941c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -934,10 +934,10 @@ https://github.com/ComplianceAsCode/redhat/issues/616'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5a587b0-5cb7-427d-9794-f8bd959a18fa" control-id="ac-11">
+    <implemented-requirement uuid="b22123c1-5174-4ffd-8bb7-ef3aec2074d6" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="edce969a-b8cf-43b5-99c6-26e1a7811288">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="249777da-9771-4f1f-991c-36d08624ec40">
+      <statement statement-id="ac-11_stmt.a" uuid="abb16fdb-f7f5-4bce-ba81-f1f3f9228cb7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fd0cfc-fa17-4b42-b071-06c8855d57b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to disconnect the idle users
@@ -945,8 +945,8 @@ from the management console after 15 minutes.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="8f569ce2-8250-4ca5-9b20-2aa473521fc7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f382b0af-336d-4ccb-b175-08a068ef0154">
+      <statement statement-id="ac-11_stmt.b" uuid="38618eaf-ba46-4874-aec1-afde297cdb26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fd0cfc-fa17-4b42-b071-06c8855d57b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to disconnect the idle users
@@ -955,10 +955,10 @@ from the management console after 15 minutes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e7fdb4-483f-435f-a84e-e73e58ae15f3" control-id="ac-11.1">
+    <implemented-requirement uuid="74004b67-b127-447a-94af-b5997b3c674d" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="d1c09476-14fd-4da1-8a05-f6be4f80b99f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f98a41cb-406d-4935-964b-d9a50a86e55e">
+      <statement statement-id="ac-11.1_stmt" uuid="c9a6bc6d-5585-4f4d-84c5-0f0b66e1b733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6cfc7a3b-523f-47a6-89ff-34641ba30c13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to logout idle users from the
@@ -968,10 +968,10 @@ will be the OpenShift logon screen.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77ea8f03-8590-4396-8e71-9e7073b1ba7e" control-id="ac-12">
+    <implemented-requirement uuid="8584d2b4-1dd3-4b00-9623-1e780f2922eb" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="e192f526-badd-4450-9807-b1b01cffff00">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="89bd34f3-0a32-47c9-8f4b-ccb460269a5a">
+      <statement statement-id="ac-12_stmt" uuid="32aa90d4-9c73-404a-b0ae-8cc86b8c87e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0c64846-1e12-416c-a31b-f6fcef3ae688">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -982,10 +982,10 @@ or conditions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d29da25b-4b9e-4f27-b463-e37b9b7f33f5" control-id="ac-12.1">
+    <implemented-requirement uuid="993a0ca8-d06e-47dc-bf70-94f5ea582d4d" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="19842ed5-31b8-4881-b18a-6c0372db2696">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c5313532-7b6c-4393-947f-47b082214628">
+      <statement statement-id="ac-12.1_stmt.a" uuid="5673a1d6-38a7-45a1-92ec-1f71991b9efe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5cfd919-43b2-4f87-a6a6-88bf69083972">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Whether user-initiated communication sessions originate
 through the OpenShift web console or through command line,
@@ -995,8 +995,8 @@ Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="374752c2-9c87-4e9c-96d5-2f7ca9ded3f5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c431ce2a-5f28-41d5-8cca-9cdd70455ab1">
+      <statement statement-id="ac-12.1_stmt.b" uuid="7a2f0321-f24e-4923-9b9c-56a6344e5f62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6611e734-c100-4a78-bd32-e79739af447d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift displays an explicit logout message upon user
 session terminiations. This is default, non-configurable
@@ -1005,10 +1005,10 @@ behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06482b91-4c80-4ac5-aa39-bbb81a2a27e5" control-id="ac-14">
+    <implemented-requirement uuid="b1a2b672-e170-480b-817e-9f392a21bff5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="bd3c7064-90f9-4754-bbd5-d7c975aa97a4">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="cee26479-1454-4061-a06f-ade54caaf086">
+      <statement statement-id="ac-14_stmt" uuid="e7a01511-c0f7-4332-8e84-f809e32215cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63bf72c5-0fe5-4ffd-a6eb-ed61cbbe7a7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -1018,10 +1018,10 @@ non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9403f13-07b8-43e3-9021-280bde6bb0e6" control-id="ac-17">
+    <implemented-requirement uuid="a7fa4407-680e-468b-8503-6d1394a6cb1d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="e4f7ca75-2714-4cc3-bc66-934dabad9283">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="680c6b5a-84c5-45fe-ad52-ab50c0f51abe">
+      <statement statement-id="ac-17_stmt" uuid="625f3c93-8015-4643-85fc-92d115742ab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1029,10 +1029,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cf469c5-168d-4c92-b7a5-760455035432" control-id="ac-17.1">
+    <implemented-requirement uuid="493fbbbb-008d-4451-aea6-263e27816acb" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="3690116d-e449-410f-afd5-09bcf8522bc5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="461bacc1-3f85-4b12-ac2a-6bf931eda89b">
+      <statement statement-id="ac-17.1_stmt" uuid="6a02d385-1cae-4704-a601-21f3add78b90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="703c52e5-98be-4f0d-acf0-a720d55b8c72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'All system events, regardless of local or remote, are captured through
 the OpenShift and underlying Red Hat Enterprise Linux audit subsystem.
@@ -1041,10 +1041,10 @@ This control is inherently met when auditing is enabled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a19ee532-b26d-4b91-a0f9-597ede9e10f5" control-id="ac-17.2">
+    <implemented-requirement uuid="429deebc-d20d-4be3-ab68-f7abadd9e39f" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="cb5ccf0b-34d0-4f3b-bcd0-3b9567eeb188">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bc8d62f8-745a-4f14-8576-82767db5257c">
+      <statement statement-id="ac-17.2_stmt" uuid="41e9e645-8eae-4be9-8a06-7707a7aad8a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94856d52-6948-4056-9a9d-e4b2d1615b9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Beginning with OpenShift 3.11, when OpenShift is deployed on Red Hat Enterprise
 Linux, and FIPS is enabled as a kernel setting, OpenShift will use OpenSSL
@@ -1072,10 +1072,10 @@ and integrity of remote access sessions:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd13ad4b-deef-4952-ba00-b73f41404dce" control-id="ac-17.3">
+    <implemented-requirement uuid="5d17d406-b350-4806-acfb-8455a6cf57ce" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="5e310f2d-985b-4de5-b90d-35ab2f96f14d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ec20e6e7-f491-40ea-9bc7-4202fbec7d5d">
+      <statement statement-id="ac-17.3_stmt" uuid="08264ef6-255c-47ad-9bc0-9acc30ca3499">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8edcd83c-b250-4b8a-883b-e7541d0b5223">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1087,10 +1087,10 @@ to protect those access control points.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8608b63b-0f52-4632-ac2c-6877c622d19b" control-id="ac-17.9">
+    <implemented-requirement uuid="9870fc33-f39b-4f7b-b08e-3e88b42970ba" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="84d76153-12a9-494a-9c0b-e0a7e1610494">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="76602e51-0a69-4181-92b9-a8c080e0f344">
+      <statement statement-id="ac-17.9_stmt" uuid="f40721b4-b50a-4459-8b5f-3212077a13de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ccf7378-9cbd-43d0-9b46-1c907fd7e0f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the firewall technology embedded into Red Hat
 Enterprise Linux. This technology, named firewalld, allows a system
@@ -1109,10 +1109,10 @@ for tenant applications immediately.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4f107b3-88e4-4f66-9171-400cf24a1846" control-id="ac-18">
+    <implemented-requirement uuid="faf889c1-c3e4-4611-b3aa-81ade0b60c72" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="f263399f-795c-426a-8bf1-5b5958992f4f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c8b3923d-fb89-474f-9256-33e69c56115b">
+      <statement statement-id="ac-18_stmt" uuid="1fa47f7a-07fe-4570-ac1e-4c7bf1746a61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1120,20 +1120,20 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ea7937b-83e8-4d23-bf38-f9f980feb58b" control-id="ac-18.1">
+    <implemented-requirement uuid="53522277-cafe-4b95-98bc-a36e02ccd271" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="161bee19-24ea-4171-9ab0-776b6c3ba88e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c31251e0-c846-4e2c-8d48-fa9b012f8e6a">
+      <statement statement-id="ac-18.1_stmt" uuid="17dfe968-cf6c-4226-a456-242b6022e24e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba7c1345-e5c0-4242-9343-a6054f9cbfa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is confired by the host operating system.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d05e59aa-1d56-4122-b2ef-66c96702f520" control-id="ac-19">
+    <implemented-requirement uuid="5e70b3c6-335c-4757-ad39-72b66ec7193a" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="ab49dadc-688c-422c-ad4a-e01aee677ad5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="606ec930-874e-4421-846d-15b41026a9ae">
+      <statement statement-id="ac-19_stmt" uuid="d0cf94d2-2d0c-4b28-9bfc-007e463cf3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1141,37 +1141,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df4d7136-075f-4772-82f5-c240fc249096" control-id="ac-20">
+    <implemented-requirement uuid="67fc136f-3487-46d0-b749-950f22cfed99" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="a04f29ae-62e2-498b-8f15-a5a7b51ec4a1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1e8016bb-c18d-40a9-b164-3d723e72722e">
+      <statement statement-id="ac-20_stmt.a" uuid="d852d7f9-5f3d-4fa7-94b2-623432ac3474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="29fa8f2b-ba0a-428e-83fe-82446264d14e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="76d874f0-d2af-4d19-bf6a-3ec13f6764b7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="deecdb3d-8d60-4cdd-9d72-2c4c9c30f739" control-id="ac-20.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="06f28f69-b468-4053-8a34-340348a1feed">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2522e3bf-5091-412b-810d-f1c349a99174">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="e559d95b-8515-4bb1-9e08-e2ec49f612ac">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9aee1068-9974-44a7-9f84-02500fb4f54f">
+      <statement statement-id="ac-20_stmt.b" uuid="50117407-a947-4180-b837-5df60acef77c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1179,10 +1160,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="335b2b33-55cd-4717-ab1c-4adea0e5ee62" control-id="ac-20.2">
+    <implemented-requirement uuid="2110df62-3c74-4a44-a75f-c7cedcfde146" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="ae205072-ad82-45f9-b6f8-dd118b72cb3c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d22f776c-050e-4f2a-a360-2834a5674604">
+      <statement statement-id="ac-20.1_stmt.a" uuid="df75ccd7-cdd6-40a0-87ad-98412f406658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ac-20.1_stmt.b" uuid="1d938772-4ece-481f-a10c-9cfd11f59079">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1190,18 +1179,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cda96284-21fd-4172-9f41-3e4b270f808f" control-id="ac-21">
+    <implemented-requirement uuid="c86b5405-7bd3-4f4d-bfe1-2ecd05cb59ad" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="285374c6-e14e-4afd-b75d-25966e9e0435">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="177f8245-a8e6-4097-8061-a5b05fb98fc8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="cb51f522-0e06-457c-9269-0f13f5d08d4f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9ee57382-dc9b-47ec-8cfc-113ec6272d33">
+      <statement statement-id="ac-20.2_stmt" uuid="3b896ffe-ca98-4f8b-9f85-f6b139a5f4d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1209,34 +1190,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b676eacb-5a9f-47a8-b7d1-84f927a7203c" control-id="ac-22">
+    <implemented-requirement uuid="980dfc0b-1962-44e1-8a0b-113be5e653d4" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="e806a3a0-d811-44a3-80ed-35f1403ecac3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9bc3b7c8-0992-4cc7-bf1c-83cdb0844180">
+      <statement statement-id="ac-21_stmt.a" uuid="e9e80274-8948-45ca-aa95-3655bdbc99fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="0243a27c-c9f4-433b-9dae-83a7e67d9175">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="db6ea263-64d3-413d-9012-046f0f78564c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="780b48f3-8275-4b16-892f-d4bfe3bd28e8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bca427f1-ecd8-462f-bc31-33803ca53171">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="825b30aa-9281-4aab-8349-4ab9df66b9d6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1152904c-c320-4816-9a7d-7bf5cd6c08e0">
+      <statement statement-id="ac-21_stmt.b" uuid="97952866-6afa-4069-a178-2b4488cdbeca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1244,135 +1209,34 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc03fd89-4ed4-48cc-b025-99153b501691" control-id="at-1">
+    <implemented-requirement uuid="2e22dd86-a8db-41af-8b95-b169b4837f17" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="11d18055-e57d-442f-a6d1-382c1f6a50f7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c2000b5d-fe19-4fbb-b7cd-17c6eb815909">
+      <statement statement-id="ac-22_stmt.a" uuid="38377e70-0989-4f2c-b71c-91a4e3680228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="85307850-20d5-4b32-8761-2e18efab20b6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ec6e85e3-c053-45d6-ab23-d4be2d71752d">
+      <statement statement-id="ac-22_stmt.b" uuid="68c4d6dc-9dc9-42c5-8f34-93d19c06153c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9e10912c-cc6c-4119-8f48-f1fc907643cb" control-id="at-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="5b16e63a-838c-4355-879d-973f6b5c6228">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7402b8f5-1648-43c9-bcec-382b74748f63">
+      <statement statement-id="ac-22_stmt.c" uuid="7b8bfb09-8cc0-43ad-be77-ca0e1b177c4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="2a4cb3a5-cecb-48ac-96fe-f13d4445591d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="13100ef4-15fc-47aa-85b0-f5b2ae1207f6">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-2_stmt.c" uuid="db04bbe5-116a-498b-a261-00091e009ef1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d1b55c9a-ca4b-47b7-98ce-f9f7c0cd3994">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3fb844b4-453b-4c9c-bec6-fb22060d8dab" control-id="at-2.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="abad7a92-de0f-4a7f-a0a7-2f3f8dc2e06a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b28e6e39-e67c-4786-b9b0-c77ad0c8dadb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="43354b1c-9fb0-4cce-94ec-16b7159aa299" control-id="at-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="74f8c0d8-ddcc-410c-a200-c81195bb3a06">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="cb8dd3bf-2643-4959-96de-0a67b34c324f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.b" uuid="04b13831-d77d-44b4-b15f-e386f9a6b5c9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="064118cb-b27a-4bbf-8ed7-41345b93d164">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.c" uuid="eaf46c58-45a2-4714-b15f-482b447b0f57">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fadbae18-6c23-4454-b505-f666605fd4e8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="a852989b-c704-4a3a-9ddc-0a5ae1f936b7" control-id="at-3.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="ec3d551d-12a3-444c-b0c0-ac9bffc30dfb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="22460d9a-b74c-4b60-8774-d212dac76f6b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f52a4cae-dd65-4be0-aaaa-794c6794fb41" control-id="at-3.4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="6349b12b-c691-4a35-8166-9dfda5f416f9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bc7f85a1-c8e0-4f61-94d7-35e942fa77a4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="4043ffaa-20dd-4c95-8c90-6a81b377f33f" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="39500bc0-d53a-40c7-84ce-d715821fec14">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="126a05ce-a926-4a00-b120-98be104bd714">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="3c83ae5f-de80-4a3a-859f-571c2974111a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d0f33f62-0222-4f59-afe6-f251d0c49a8b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f09d2227-8df6-4017-87dd-5a79263969e2" control-id="au-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="410c795b-9265-495b-afca-0be507c10652">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="aad8a547-adb3-4a37-859f-24b1f45cf987">
+      <statement statement-id="ac-22_stmt.d" uuid="a34f247f-0e09-4045-97dc-142c54d65da6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1380,10 +1244,146 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c944579d-00e4-4526-8a3b-f340dbfce4b0" control-id="au-2">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="996e2c13-2215-45eb-8ee9-d7e1416bd7ad">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6636b739-7896-432d-b2ed-d0b91b609817">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ff356bcd-4854-4223-bf9e-e8ea3a310cdb" control-id="au-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-1_stmt" uuid="42ab131b-17cd-4db6-bace-aadded17e94c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="df0fc4ec-86fc-43d8-9709-a51f8882cc4b" control-id="au-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-2_stmt" uuid="f4a9622c-4261-405f-82b5-919e8d481c56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1ece91a-779e-4a5a-85d8-7b2c87fd0588">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -1394,10 +1394,10 @@ OpenShift through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72b80fcc-52f9-4de3-bfc3-9ea2cd7cf640" control-id="au-3">
+    <implemented-requirement uuid="a1741e48-4de6-4549-ad9b-cf2088e4e2ea" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="09c30060-1382-4c64-b8db-0d5beaea949a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="15bb48a7-3e66-4415-be92-6bef9a1587a1">
+      <statement statement-id="au-3_stmt" uuid="f8f48da5-0595-412b-a4f1-85231f500cc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6364b03-a0e6-4926-b96d-a03faf8e0cb4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift audit records contain this information by default. No
 additional configuration is required.'
@@ -1405,10 +1405,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09041e46-40a3-440f-b620-85b8612424ea" control-id="au-4">
+    <implemented-requirement uuid="0885c7da-ffa1-40f0-9109-4b822dafab35" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="740d143a-c528-42d4-bc57-3f8374ea8439">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a6d980a0-8d4a-4250-b7c5-ea744bd858d5">
+      <statement statement-id="au-4_stmt" uuid="4fbbbe83-ed9a-4bfb-af19-ea8c8b7124d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef0522af-af8d-47df-a85c-dc20f28735ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift. This control is reflected
@@ -1432,10 +1432,10 @@ https://docs.openshift.com/enterprise/3.2/install_config/aggregate_logging_sizin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f18a625e-de92-4197-b23e-80252df8a2c5" control-id="au-5">
+    <implemented-requirement uuid="f873dd86-9b68-473d-a5f8-df8df82df7aa" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="b401ac4a-e3be-46c1-9339-421af800bcd1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7ace9cbc-690a-4853-80e6-15d421a11b25">
+      <statement statement-id="au-5_stmt.a" uuid="391206f4-940b-474c-8d11-9edb3899a6f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dac2725-ee2f-493c-bfb4-5590df1386e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -1444,8 +1444,8 @@ when an auditing failure occurs.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="cae88773-212e-442e-bb63-efb836d57530">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="347d79c4-5318-4afe-a1c5-992a1fdf6a80">
+      <statement statement-id="au-5_stmt.b" uuid="4e876cdf-c65d-476a-ac41-9617baa4928b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bda2746-ccb4-48f8-b7fa-23c91788498b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, OpenShift Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -1456,10 +1456,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e670d05a-45c7-49b3-a512-cfbf760f8f7f" control-id="au-6">
+    <implemented-requirement uuid="2fe84fb8-05ad-4cbb-b9fd-22da40910edd" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="818c25cc-64e4-4dcf-854e-8d23f13ea085">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="15d4301b-da2e-4f8b-bec1-b5bdd5df462f">
+      <statement statement-id="au-6_stmt" uuid="6c925364-79ba-40b3-8d16-7d0c218e7aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1467,10 +1467,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1122933-4e7b-4a31-a393-d970b85b80f1" control-id="au-7">
+    <implemented-requirement uuid="78fe86ba-7151-46b8-9514-e7088a584da6" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="b6d773cd-f4b6-481a-b4d5-383b805d489e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="29b06532-2cd5-41fc-a698-8fbd4bb9006d">
+      <statement statement-id="au-7_stmt.a" uuid="f60782ae-416e-4e77-9baf-38195be249e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c5c7a8-2fb4-43b3-9a41-24fd7795f348">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift embeds the Elasticsearch, Fluentd, and Kibana (EFK) stack.
 This pre-integrated audit reduction capability aggregates logs from
@@ -1483,8 +1483,8 @@ may be setup to detect atypical use.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="0dfd7955-3b02-4066-9acc-7395dc1e7433">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a50ade4c-7541-4c08-badf-2bf2fd790bf8">
+      <statement statement-id="au-7_stmt.b" uuid="091243bd-bcc1-4809-855f-c2c82f5b51fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbb57050-cbde-4118-8ba0-6caddcb6fbb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift logging subsystems do not alter the original contents
 or time ordering of audit records.'
@@ -1492,10 +1492,10 @@ or time ordering of audit records.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a453a05a-22c0-44e7-92de-8298d7e4cc74" control-id="au-7.1">
+    <implemented-requirement uuid="55eab158-fc49-4893-a95e-312b82183285" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="472b4e17-afed-4b95-8aba-9496bbe9d05f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="787f5708-4be6-40d0-add9-a9b51ea4615a">
+      <statement statement-id="au-7.1_stmt" uuid="fff83246-d10a-451f-becd-3187510fa3a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98a0b716-433d-4ef3-a2b1-591a621e0731">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are responsible for ensuring that the information system
 provides the capability to process audit records for events of interest
@@ -1507,18 +1507,18 @@ fields.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d55af92f-55b5-4c17-9564-4af23e655875" control-id="au-8">
+    <implemented-requirement uuid="b0cc2985-4fa3-4643-b69d-2bc0e6b4891b" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="94acf1ce-e502-4b5b-b61e-3976fc92c4a1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0dd5fa11-d017-49e5-9a96-8a446284c29f">
+      <statement statement-id="au-8_stmt.a" uuid="1e983df4-6832-4b42-8841-4647c61d19a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eac111fb-f99a-4d90-8fc3-c3f2be4e07bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift logs are generated using the internal system clock by
 default. This is non-configurable behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="7cf96ae4-8867-4896-8a16-9b948e28d403">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="04ac6557-a29f-469b-9bb2-b5d6cf0de2bd">
+      <statement statement-id="au-8_stmt.b" uuid="1af2c1ee-5635-4ca7-a125-0193a83686dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f8c71d9-556b-47ae-83d6-f8354e7d5a7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift time keeping relies on the time services provided by the
 underlying operating system. When running on Red Hat Enterprise Linux,
@@ -1542,34 +1542,34 @@ https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Sy
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8497382f-b309-49ea-ab29-f391f882bfb4" control-id="au-8.1">
+    <implemented-requirement uuid="0ca6b291-4a5a-49f4-af21-34b5d45081a6" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="7f70345d-026b-4e6e-9df2-2e0524fcb916">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="872582af-1a89-4aa1-bbd8-7cd4b5d15b5d">
+      <statement statement-id="au-8.1_stmt.a" uuid="71bb68a5-1eda-4509-aaca-b70501447657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f57e9f3-fa29-463d-9bed-2c7c555b0c49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underlying operating
 system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="3485261a-4d68-49f5-9741-5c86bc5b7a61">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8a87ae7f-19fe-4ff4-855e-4a7a1a47e5bc">
+      <statement statement-id="au-8.1_stmt.b" uuid="86c7f7f7-fe64-4367-83bd-9ce51dc193e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b.1" uuid="9a3386a8-4c5a-44fd-9b97-d01d153fafa9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a0b79caf-aba1-4bdc-a968-b76659881f97">
+      <statement statement-id="au-8.1_stmt.b.1" uuid="3adb07f3-38ac-4879-8c86-5897180e448f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b.2" uuid="d00f7433-fb92-4979-a5f5-8389afb56141">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a8e9ebe5-e9e4-4a97-95f6-7ca85696699a">
+      <statement statement-id="au-8.1_stmt.b.2" uuid="844aa359-4a5e-459f-b6ec-fa0a1664f55b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
@@ -1577,10 +1577,10 @@ operating system. This control is not applicable to OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e7d33d0-9df7-4211-a0d5-136d5275a9fb" control-id="au-9">
+    <implemented-requirement uuid="25be9da1-c399-4518-a66b-b7420619381d" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="b2392268-b349-416f-80d5-ab4904b81563">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="04418345-fa89-43a4-b047-3e0856f8163a">
+      <statement statement-id="au-9_stmt" uuid="40dda508-78eb-47f8-af8d-7712aa8bb3a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859a0daf-8b78-4978-a3c8-6ed9377b5f0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -1596,10 +1596,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44c7da5f-fe13-4b55-97d3-2602642d0c4a" control-id="au-9.2">
+    <implemented-requirement uuid="45a664f4-ab35-44d9-bdcc-da46510a3c04" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="937ca86e-3b73-4191-9eb8-e7b147fce4f7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="230a052e-b56f-4c12-a7c1-b3005e51779a">
+      <statement statement-id="au-9.2_stmt" uuid="e6086580-7c2d-4771-94c3-ff3671eccb8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04f2b951-f38b-4d1f-97f6-aacb16650965">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to back up audit records at least weekly to a
 physically different system or component than the system being audited.
@@ -1613,10 +1613,10 @@ audit records to a central service via AU-4(1).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f81711-b7c8-41fa-b742-a3c01068692a" control-id="au-11">
+    <implemented-requirement uuid="20998a4f-4e1b-4087-8b46-810c9a4cda5f" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="d0bc2de7-6b31-42c8-9e85-8970c8c29b04">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e6b14c55-7daf-455a-bc13-5f6794103713">
+      <statement statement-id="au-11_stmt" uuid="12b59756-4cf2-416f-98dd-68f2dd5cf8d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f45482a5-2b41-4044-8637-f7a8da5224f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in Jira:
@@ -1626,10 +1626,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26683344-0259-425e-a852-3c4e416254ca" control-id="au-12">
+    <implemented-requirement uuid="ac5c7e83-3ce6-41b5-9a42-9004361d21a8" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="df41771c-e5ab-4ac3-8ac5-efd143bb14a8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6107bd37-ebed-4301-8e51-c34fdecdf047">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -1641,8 +1641,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="fe25d03e-e3c8-4889-b0b5-62da342ed454">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8c2b27b5-8c93-49f6-b90b-caa33872726e">
+      <statement statement-id="au-12_stmt.b" uuid="0876f4fa-4a0c-4f9f-9e37-86ec35acdbb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a14957d9-85f7-4af6-bff4-e5b13f768c2f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -1660,8 +1660,8 @@ is recommended that OpenShift specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="bf116e09-ba0c-4541-81b3-72cac2fdfbc6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b7c55ef8-9375-40f4-a838-54e8138a5fd4">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -1673,10 +1673,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed81dd7d-785b-47f5-821d-dfe7e81d4fc4" control-id="ca-1">
+    <implemented-requirement uuid="137a1bb1-2be5-4792-8402-b452ebdc8289" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="77bad987-4e8e-414f-8480-7c2dd57bf5df">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="81fa948d-ca27-4319-afc9-31c0be7384bc">
+      <statement statement-id="ca-1_stmt" uuid="82ebbeae-39c1-4a32-8ace-cfae81e476d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1684,10 +1684,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6513e6f1-34a0-434e-9d00-9efd74250996" control-id="ca-2">
+    <implemented-requirement uuid="92f26f75-6eeb-4bc8-9686-ed1d8181854f" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="b18f7317-0562-4fc8-bea0-d30911b80dc0">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="88b24543-9dbb-4d0a-889d-4ab653f15bc1">
+      <statement statement-id="ca-2_stmt" uuid="8340ac1d-6c63-41e0-8926-68ab5c1ae749">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1695,10 +1695,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="026f4f35-21c1-4d48-a65c-2dce51b955f6" control-id="ca-2.1">
+    <implemented-requirement uuid="66592cdc-3f3f-4577-8e34-34002c14f287" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="8fcb2da6-dea4-4745-866e-d24985729533">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1d9c7177-ec6b-4ecb-bafc-a9348a345f13">
+      <statement statement-id="ca-2.1_stmt" uuid="4c836022-5b78-4150-8ec3-61d6b865e198">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1706,10 +1706,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccef6071-25df-49c8-879f-438f0aa993ab" control-id="ca-3">
+    <implemented-requirement uuid="deb63227-f2a7-4ccb-a8f4-c3daf16b1b00" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="ac473260-9bab-438a-93c2-e15fa7b9e016">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="826b979e-2685-424e-bf54-124213efd169">
+      <statement statement-id="ca-3_stmt" uuid="4515c02d-a038-4872-b604-333eb17af574">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1717,10 +1717,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd57049c-7484-4492-a3eb-50074891b559" control-id="ca-5">
+    <implemented-requirement uuid="461cac5d-4510-49e7-8996-a044e976ea00" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="ddc72fba-f3e0-4265-9f02-a8d5c8dc7917">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="307967ec-01a5-4cff-8977-69a23c8fe0cc">
+      <statement statement-id="ca-5_stmt" uuid="75a60994-46b3-4a2b-b437-8a8ade88dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1728,10 +1728,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be05184b-edf5-48ff-88cc-e6a9760df714" control-id="ca-6">
+    <implemented-requirement uuid="91eec0d1-f1ca-4478-bc79-1cdbb27fe7bb" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="fe00d3fb-2d79-40e2-a9cd-6ce6aa960a85">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="266726f5-a458-436b-a67a-2a90af5d09ec">
+      <statement statement-id="ca-6_stmt" uuid="fc00e0cc-b43e-4250-be0d-0a9cfeed4bf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1739,10 +1739,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd5d660c-7b77-4eb2-9f8c-0a8b182cd01b" control-id="ca-7">
+    <implemented-requirement uuid="e64d358a-f134-4e34-9117-5d6767731abe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="c2e9ab07-444f-4e48-aa1d-2035e0709ebe">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2bbef901-05f4-4fb6-bcbc-5063754db5d8">
+      <statement statement-id="ca-7_stmt" uuid="1361fa12-ec53-4f6e-b5a9-517e3e7eca7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1750,10 +1750,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e7bea6c-b728-4f4b-bb78-a1305eacb8f4" control-id="ca-9">
+    <implemented-requirement uuid="229eadf1-80c0-4c84-a297-4cafca0aa898" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="27f300b2-041b-4e06-8cd4-614cd03bf2b3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="94f87ddb-f108-4242-a7e8-39527a4ac5ce">
+      <statement statement-id="ca-9_stmt" uuid="58b1d545-6ac8-40c0-bfaf-7fb6d3d1d6ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -1761,10 +1761,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8defae5-ce04-4c19-a194-9402ed3e5662" control-id="cm-1">
+    <implemented-requirement uuid="6db18908-efb6-400b-8ff5-6c6425f4a511" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="59b6f72c-93e2-464e-9d2a-5ac98b6ad83c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d251ab8a-74ad-44da-89be-8539f820bf93">
+      <statement statement-id="cm-1_stmt" uuid="3d140bf0-9c1f-445d-9da3-0f4f78994802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1772,10 +1772,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="358e2da0-7bc2-43f4-9feb-733e024e2e1f" control-id="cm-2">
+    <implemented-requirement uuid="03633224-a901-4b5e-8a83-9f11fcc66564" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="72138f7f-eef0-4c01-aa70-0559336eb718">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d1991d86-9ad3-43b4-943e-bb60b4562158">
+      <statement statement-id="cm-2_stmt" uuid="a179fc74-d550-4122-9846-c936bd97eba3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1783,10 +1783,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81ff28ce-83b4-47bb-89d8-48bd251d98f7" control-id="cm-2.1">
+    <implemented-requirement uuid="cbf42a12-ed9e-4209-a4ce-e4c4f16bd500" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="99c2fb27-6bb7-4bb9-8e7d-db559aa3677d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4afc4e77-2fdf-4cd5-8b33-20500e6c2be1">
+      <statement statement-id="cm-2.1_stmt" uuid="99ef247e-b28d-4cc0-aa97-a7c66fc541cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e0af131-9823-44ea-bce0-b7fae6cc158a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for reviewing and updating the
 baseline configuration of the information system as a part of
@@ -1797,10 +1797,10 @@ configuration as a part of installations and upgrades.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6247502f-3518-464b-8088-1373a1edd051" control-id="cm-2.2">
+    <implemented-requirement uuid="18e30419-e9ef-4760-af0b-008b07d96c77" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="e0295f20-9c07-456f-bdd8-6caa570a77ee">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e94badc9-0d86-4c1d-b83b-8bb889a2b5fa">
+      <statement statement-id="cm-2.2_stmt" uuid="69e642ca-f24c-4a81-b377-d53d1d258dfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81f190ff-6802-44ef-bdb2-354e9c6cd692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing automated mechanisms to
 maintain an up-to-date, completed, accurate, and readily available
@@ -1811,10 +1811,10 @@ help maintain the baseline configurations of the information system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2961647-63e5-4851-942e-3697f683f05a" control-id="cm-2.3">
+    <implemented-requirement uuid="46b94187-e85e-4d7c-8ef9-29c5ec81558c" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="ae3f4688-1449-4018-b22a-488f2d6e513b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a34ba639-4876-484f-8730-6151e53b3454">
+      <statement statement-id="cm-2.3_stmt" uuid="b9f34dee-fbad-4dbf-8f34-372c22e1d24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4e6d314-6951-471c-86ea-442d2de3e471">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for retaining previous versions of
 baseline configurations to support rollback. A successful control
@@ -1825,27 +1825,27 @@ version.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4db759b0-271b-4e43-805c-8223caea89ad" control-id="cm-2.7">
+    <implemented-requirement uuid="7b848231-284f-44d5-8639-b7eb19397f8f" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="b3891738-df77-4745-af96-3bb69b8603c2">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0c4d2e7c-288e-408f-84cb-fb8705c656fe">
+      <statement statement-id="cm-2.7_stmt.a" uuid="afabc90a-9a85-4e1a-a2e0-adfa85a37ceb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7422da5-e491-494d-ab20-460f4bf1cac0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="144b0872-3e8a-4b99-b0ac-0c552d8473bf">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f3834c42-2c89-4c13-9a26-b767da93a7e3">
+      <statement statement-id="cm-2.7_stmt.b" uuid="e42c3a5c-b46b-4c95-85b0-13665548e268">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7422da5-e491-494d-ab20-460f4bf1cac0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="610d1ac4-d849-4b7c-ae03-95ed64cba926" control-id="cm-3">
+    <implemented-requirement uuid="6b730e13-852a-4faa-b6aa-2c4ad228c566" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="0c00b567-613b-467a-8676-46e49eccbac7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3cea7c7e-d914-4027-bdf2-909c21dcf010">
+      <statement statement-id="cm-3_stmt" uuid="e256ede3-9788-4b8d-b138-a7478aefd573">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecce0170-2439-4ff6-b241-0274cea1e1e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing approved
 configuration-controlled changes to the system. A successful control
@@ -1856,10 +1856,10 @@ implemented after approval.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53985697-d164-4745-8df5-65579a8378e0" control-id="cm-4">
+    <implemented-requirement uuid="7d9cae12-888d-449d-8d98-a97f9953cab2" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="60967dd2-7a50-4e92-80fb-67f8ff6355ab">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7f441953-5bd9-44ce-9024-c16cce3aad34">
+      <statement statement-id="cm-4_stmt" uuid="e8ad8b2d-ba3c-48c8-8103-a1ca0da104a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1867,10 +1867,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aefa407-8e58-4a3d-afbf-74b6758ef432" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="af8162ec-2812-456f-aa2e-d74ebfe9a9f3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="23a35539-955a-4530-aa6e-6539fdcdcba6">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1879,8 +1879,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="744e745e-377a-4280-b50c-9e94759f4499">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="44513f52-1753-474e-bfb1-acb4856b3e1b">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1892,10 +1892,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="683549be-a075-4a8a-9be4-9a6e2141f4ba" control-id="cm-7">
+    <implemented-requirement uuid="470be975-e9e3-43a3-8eea-dca908192731" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="3947406b-b495-409d-ae09-65a107c20edd">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c7c3d41b-93ba-4c04-8710-5ad7e4623318">
+      <statement statement-id="cm-7_stmt" uuid="cd05bebe-a619-4f4d-8b81-69900e91bfa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1903,10 +1903,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1ad50c5-338d-4e56-8f40-2d3556c355ce" control-id="cm-7.1">
+    <implemented-requirement uuid="e3b9edbf-fdfe-4343-8820-b5c720f1ec99" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="76874c1a-15e5-43e0-91b0-fff384bc70a1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="867e4fea-7a10-48db-85f9-da6a661eb33b">
+      <statement statement-id="cm-7.1_stmt.a" uuid="8c47a1c6-c2b9-46b4-b536-34cc016b073f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a7baa6c-52d1-4cb8-b448-762527c19c84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for reviewing the information system
 at least monthly to identify unnecessary or nonsecure functions, ports,
@@ -1915,8 +1915,8 @@ how often functions, ports, protocols, and services are reviewed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="30a14c56-a7c1-4f77-8398-898363ab87b7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0800df39-58a1-4be4-a342-e2ceb72a5715">
+      <statement statement-id="cm-7.1_stmt.b" uuid="3a34ef9f-664e-4468-95b7-b673f0081b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88c4f1a4-2b9d-4d4a-8b98-e515518eea60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for disabling functions, ports,
 protocols, and services that have been deemed to be unnecessary or
@@ -1927,10 +1927,10 @@ process are disabled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85f1d449-2800-4b0c-bf3c-1f6f751b4ffe" control-id="cm-7.2">
+    <implemented-requirement uuid="d2420728-51f3-4640-9294-eb10afd9fad1" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="99f7f79d-a70e-433b-b831-ea8acaae78a6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ed995e84-38a7-4ca1-9e5d-742b32ad593b">
+      <statement statement-id="cm-7.2_stmt" uuid="f7ed7fa7-bea1-4a5b-ba2f-07b7d7aedab5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9141925-6989-4263-8ee6-65bce0d81e0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for preventing program execution
@@ -1948,10 +1948,10 @@ said trusted registries to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4f6f943-8fa6-45a0-923d-e3ade5d157c7" control-id="cm-7.5">
+    <implemented-requirement uuid="ba99eda2-e418-4708-857b-840deca1e407" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="7133a34c-a7bc-4dd1-84ec-22cbad3b6f5f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f8844950-7759-464a-922a-1e71104df647">
+      <statement statement-id="cm-7.5_stmt.a" uuid="7f8b45ec-3f43-4aca-a6bb-d5b6a529262c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a33b96cd-a3f0-42f5-bb8e-d7a7443a8e96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for identifying software programs
@@ -1969,8 +1969,8 @@ https://access.redhat.com/articles/2750891
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="9a006270-8501-4038-9e89-5cf7341d6e45">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ba90f967-7a52-44fd-a157-d6f3eb8ecbea">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a40b6918-43ca-4fbc-8ef7-a6d855c57dcf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43c7eab-230e-4e52-b17b-622d05b857d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for employing a deny-all,
@@ -1982,8 +1982,8 @@ information system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="0f0ec7cf-5403-443d-aed7-b17f8c0b51c3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c3083a08-f267-4e26-a785-e738c5f87d58">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3c2af6c1-3279-4193-98ad-2ef9c5af5024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f755ec40-6e8d-4e33-acea-b13158a010d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for reviewing and updating the list
@@ -1996,10 +1996,10 @@ least annually and when changes are made.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74c69362-f2e6-417a-af44-e54ecee33856" control-id="cm-8">
+    <implemented-requirement uuid="3b307e64-c650-4276-a4d0-c8ed972f20f3" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="a42c8aa3-86b6-4548-8124-a1681c6ce009">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5b6aae7a-65b6-4da2-8d1e-d149c2116ad0">
+      <statement statement-id="cm-8_stmt" uuid="18c51ee3-a770-4ab1-bbee-3980394252d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2007,10 +2007,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0dee97e2-a4a8-4663-bcb1-ac1b5788b2db" control-id="cm-8.1">
+    <implemented-requirement uuid="4360872b-bba4-4302-8824-9ee4495f7b22" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="fc5f2467-5759-44ba-be27-6eae5229ea9d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="70ba4761-eda1-4ccd-8ace-d17bcd227b8c">
+      <statement statement-id="cm-8.1_stmt" uuid="37b54ce4-be5b-4f8a-8930-b2180b131405">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2018,10 +2018,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0942e46b-7580-43e4-bb73-d6cd1ee3f6b8" control-id="cm-8.3">
+    <implemented-requirement uuid="a07a949e-2c93-48a9-9fa3-9de2d836c7e6" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="efa80ed4-98cf-46a5-9fd2-46a94ed1074e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="301a0d62-14f0-4abe-b091-1a2183fdaca4">
+      <statement statement-id="cm-8.3_stmt.a" uuid="9d25e150-95ef-4c7b-bf47-dcbaa9be7e9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9db15659-5eca-4c26-ba11-2f8497e0f5dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for employing automated mechanisms
@@ -2033,8 +2033,8 @@ on the information system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="fd21ab01-57bf-4aa6-a596-b6b258589706">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bf086a38-b2c1-44fc-9bfb-e6daf16f980e">
+      <statement statement-id="cm-8.3_stmt.b" uuid="4bcd3838-705b-4b9e-976c-84d4be55930d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b7ff5f9-c1f1-457a-ba36-b6fd8b1011e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for actions taken when unauthorized
@@ -2047,10 +2047,10 @@ to that system.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc382660-80c8-43fa-ac9d-cfd1b0efe1eb" control-id="cm-10">
+    <implemented-requirement uuid="3bc27d95-ce5b-4e58-9770-3fbb02ec4c77" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="4f9bede6-3939-4a26-bb4a-9b98249247db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b2895898-3770-4d3a-830d-bba4ca40a7d6">
+      <statement statement-id="cm-10_stmt" uuid="e13a24c6-d01f-4c5a-8c08-8c46900fc403">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2058,10 +2058,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d2a0eaf-cd3c-4acc-aabd-af9da1de5aca" control-id="cm-11">
+    <implemented-requirement uuid="fa0e44f3-2c7b-4054-987f-d444f3e19b9c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="87d45514-06f3-4b6a-ba2e-c1b59b5e22c6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5035e083-c6bb-44f4-9a35-dce662f3e20b">
+      <statement statement-id="cm-11_stmt" uuid="a274e760-9a2b-49a8-97d9-8f3fd4a919a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -2069,10 +2069,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd4883ef-ecae-4c26-9635-c8548b2c643b" control-id="cp-1">
+    <implemented-requirement uuid="9b43dfe7-3d77-44cc-8441-be42c3c95fd8" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="14121ac0-d49f-4b57-a50d-1eb8e5e0e6a6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1a4e11f7-ff72-486a-aab5-d19a18ee8038">
+      <statement statement-id="cp-1_stmt" uuid="850321e7-8708-47d2-8a69-b673e8e35e8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2080,10 +2080,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e56d7d5-0f09-4b6d-afd4-c945a59b1051" control-id="cp-2">
+    <implemented-requirement uuid="5bc6aa5e-a6d3-4ff9-88fc-f511a52e07e7" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="4f79a3ed-d756-4515-9d82-30689414f4a5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fd02db7c-31a4-4389-ba22-fd8fd3ccfc73">
+      <statement statement-id="cp-2_stmt" uuid="321b56a3-e3e2-4f7d-afd1-95811c0ed14c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2091,10 +2091,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d6e79e7-065b-431e-87f9-c3148b21688a" control-id="cp-2.1">
+    <implemented-requirement uuid="53ebacd2-f8ba-4f80-bf61-38185fa54e56" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="a4a703e8-ddb9-4f6f-a01a-bf349e043199">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e321dbaf-3425-4db7-8937-66cfdcc00bcc">
+      <statement statement-id="cp-2.1_stmt" uuid="6529d16a-eb54-4f30-9cc3-7dff40657627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2102,10 +2102,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e936a1d-cae3-405e-93a6-bf19f7386ae2" control-id="cp-2.2">
+    <implemented-requirement uuid="11a1fff1-b22e-4abd-9a88-c41d6d7b6740" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="4927069f-918c-4c7d-a86b-174c9edd3db8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7b288db5-f4c2-4375-8f6f-b2532d2269ca">
+      <statement statement-id="cp-2.2_stmt" uuid="38043c5c-757e-4d2f-a714-0c3ff20d3388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2113,10 +2113,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7c2ea75-2051-4301-99e3-9be669966423" control-id="cp-2.3">
+    <implemented-requirement uuid="fa4c13a9-12eb-4413-a7f7-3bedd032122c" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="798225ea-36bc-4e03-bf12-600f178b4173">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5eba4b9a-fd28-48a0-9505-ec82fe35c1c3">
+      <statement statement-id="cp-2.3_stmt" uuid="f83767eb-b395-4597-81c9-ccc0506c3744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2124,10 +2124,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb310870-9619-4c97-b0f9-78dbb5fca2c2" control-id="cp-2.4">
+    <implemented-requirement uuid="8abc2b2f-595f-4335-b38c-eab0f22d1cbb" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="16203bbe-fc99-4de5-9db9-e5215c138d6b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="64aaa596-79ea-4230-ac41-0d938b69d6af">
+      <statement statement-id="cp-2.4_stmt" uuid="5aa7324e-db40-4f3d-8182-fdf67b6d4f61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2135,10 +2135,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="366cefb3-9c7f-4f69-8991-80e5a287f625" control-id="cp-2.5">
+    <implemented-requirement uuid="d54e677c-5057-425f-9b28-9d43e240b8dc" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="f821a3d2-57a1-45cb-94b1-44825d0ba113">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7f06c4db-ad44-4bb7-83a4-20e729e4d836">
+      <statement statement-id="cp-2.5_stmt" uuid="ff99845c-c842-4529-bf00-d1ed591d4d7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2146,10 +2146,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07d6176d-4c75-47c4-88d2-58d0a4b1487c" control-id="cp-2.8">
+    <implemented-requirement uuid="1940d06b-6b33-4cbe-85fa-bcbf53449aef" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="b72d66d0-d49b-402d-95eb-c5571e274416">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="731258bc-33d4-4be4-84c4-dffd1de7f3fa">
+      <statement statement-id="cp-2.8_stmt" uuid="84da0c5f-f1d3-4598-9d8b-b9e2ec5ba264">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2157,10 +2157,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b306a99a-b4f2-4d80-9ad8-2b60bb54ddfa" control-id="cp-3">
+    <implemented-requirement uuid="3bb16503-975f-4a69-a00e-ed061e343cc4" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="97a2138c-9dec-4778-bf85-9cbee469ca97">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0bf4c833-cdf3-4753-afa4-85610c34e598">
+      <statement statement-id="cp-3_stmt" uuid="edfe15fa-e205-462f-9592-ffe56fd32204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2168,10 +2168,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89fa6f5f-2903-423e-b8e6-9c826e2dbc76" control-id="cp-3.1">
+    <implemented-requirement uuid="1b0307c0-678c-4321-9a55-2b3ac4d8fad1" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="f6b94dc2-b147-40c4-b27e-79cd2f28bc2b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="333978fc-b1a5-44c8-bf0a-989c68820f4c">
+      <statement statement-id="cp-3.1_stmt" uuid="c8ca59c7-bbd6-4a4b-bf33-417dc4011283">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2179,10 +2179,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="872b4cd5-502e-4f2f-b796-315f4306bf9e" control-id="cp-4">
+    <implemented-requirement uuid="0b0e16bb-221c-4d77-9b07-51c08862fec6" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="d3aba822-6bb7-444b-ba2f-74388c1b9842">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f3f26e9f-d5b4-4290-8255-bdfb786ef71a">
+      <statement statement-id="cp-4_stmt" uuid="4aff4b76-0858-4d63-8284-04b56780c4a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2190,10 +2190,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e82506cc-fd80-41df-b338-be7df7177c7b" control-id="cp-4.1">
+    <implemented-requirement uuid="61457040-7b61-4e0e-9938-5488f8f8e30e" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="b3a04ede-17b9-4a92-8a75-308a1349467c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2129b280-05a5-4129-99c2-6384e3431006">
+      <statement statement-id="cp-4.1_stmt" uuid="9735ea7c-0632-4604-94c3-4ee147a2ff79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2201,18 +2201,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="229a661e-fded-413a-a4f3-724f700d6377" control-id="cp-4.2">
+    <implemented-requirement uuid="c79b0f2a-2bd3-4079-a8e1-dc8866d842c7" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="04714944-2373-4c44-bf0b-0b889b69924a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9ee02fc7-64a4-4d22-8319-cb1a85acf08b">
+      <statement statement-id="cp-4.2_stmt.a" uuid="b4ef3dfa-7f22-4961-a48a-b94e4ecb0b8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="a120a3e9-0b8a-438e-a694-d4c8adf0fad9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="de34a59a-ac55-45ef-8b43-0ba045f366ce">
+      <statement statement-id="cp-4.2_stmt.b" uuid="d98aea0e-3c94-429f-a87c-9c89e987188c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79b368c9-b51f-4719-8c6c-ad7416e31f72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2220,10 +2220,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8e9e988-0add-496b-9908-75a90f0e0190" control-id="cp-6">
+    <implemented-requirement uuid="a66e6296-58a0-4726-93b7-a549896a6738" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="9cb5eb07-eabd-4296-adb9-9f0804c3b336">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c8e130c5-9d7d-445a-94aa-e94561ed66e9">
+      <statement statement-id="cp-6_stmt" uuid="160aaa1a-93a2-433a-8ef8-6c4672264ad8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2231,10 +2231,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a375960-621d-49e9-9cd9-b8f93141a174" control-id="cp-6.1">
+    <implemented-requirement uuid="99b83a59-32f6-48ee-9fcd-ec9ffb531296" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="06ca2d5f-df83-48d1-8e27-f12651640b6e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7e7507a4-fadd-45e0-8d48-b79c26c86365">
+      <statement statement-id="cp-6.1_stmt" uuid="1a1af641-21e8-4817-b8aa-67bf997fe8f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2242,10 +2242,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08985b50-0237-4ee4-b86c-49390a7b6b30" control-id="cp-6.2">
+    <implemented-requirement uuid="6b10893c-de5b-4343-9c75-8f8a0ec8cc9f" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="aca4cbf3-31f4-462b-9b03-ddc55ffe1fd6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2e7dce67-f370-47db-87a2-a4efee53911c">
+      <statement statement-id="cp-6.2_stmt" uuid="59e542d1-3a06-4936-8e88-e4558ee67d69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2253,10 +2253,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d53a4923-6cb8-4720-9268-ef31b54efd68" control-id="cp-6.3">
+    <implemented-requirement uuid="4124987b-d89d-42c6-bed6-eb84e1d841d4" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="f002f9fc-e114-43fe-9fa7-0e9a08f6bf2a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f169716e-1f1c-4496-98f2-a5cf416bbb0c">
+      <statement statement-id="cp-6.3_stmt" uuid="8cdc8375-15c7-4e54-90c5-6de5788f2627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2264,10 +2264,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20c8ad78-e51e-4836-a98f-9538a6091f75" control-id="cp-7">
+    <implemented-requirement uuid="3054c2ef-1c61-4d1b-8ced-280632da8fec" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="a7256e7e-3086-4fb1-b446-6930ff2c36f0">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f14e8384-d053-4c9b-9fbd-a0ef0207c5c3">
+      <statement statement-id="cp-7_stmt" uuid="590ac16a-9627-436c-af05-a0ead357275a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2275,10 +2275,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42d35dec-faaf-4e1d-8373-c82d3d87fc00" control-id="cp-7.1">
+    <implemented-requirement uuid="6c0df842-e0d6-43c6-b13e-1b1d697a9313" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="74a1af4e-71f4-44bc-bd37-ea914a22f083">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3a013efd-1858-4b11-af23-f67c7cdbbbac">
+      <statement statement-id="cp-7.1_stmt" uuid="992dbd8e-c091-4f53-bc1c-11a0ec69a5ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2286,10 +2286,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1630c121-546e-4349-a75a-c6773a9ca2a5" control-id="cp-7.2">
+    <implemented-requirement uuid="1673da4a-1268-4c3b-8b17-38f8f6ddd3a0" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="34c41e2a-240d-45b6-b66c-181ca7525c60">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="821af810-3557-41b2-85a6-bb39e7143447">
+      <statement statement-id="cp-7.2_stmt" uuid="4e68b95a-319f-46a7-a8df-a0b0c7e05446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2297,10 +2297,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64c1b676-7930-4a1c-b763-bbfa165ffcd4" control-id="cp-7.3">
+    <implemented-requirement uuid="a77f4e3f-1dc9-424e-a1c5-e8f2b48fde1e" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="201deda3-0057-4b33-beac-10c3a7308319">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="37d2bb9e-6638-43e3-aa79-af3d981ebba4">
+      <statement statement-id="cp-7.3_stmt" uuid="a7f5a540-576b-4b9f-b193-ad006d9f51a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2308,10 +2308,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="571cd877-cff6-4907-8a07-8d192084603b" control-id="cp-7.4">
+    <implemented-requirement uuid="6b9af821-ccf3-4496-94cf-fd3ec8179041" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="063be023-3e67-479a-8e14-5890b9e83b60">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e3151734-d33b-4a55-929b-b23c11ba1fc2">
+      <statement statement-id="cp-7.4_stmt" uuid="69e31c66-03fa-4cba-8b4f-45d30f152e80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2319,10 +2319,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53a83d07-2512-45f0-ad67-a052f6775e9f" control-id="cp-8">
+    <implemented-requirement uuid="fbd871f4-43e1-47d5-9302-cd7a852e3e9e" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="b683f794-0d63-435f-9203-556bc3e1bd8f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1e93cef1-6fcf-44a8-8baa-ba016278e0f6">
+      <statement statement-id="cp-8_stmt" uuid="ed1526c5-658e-4280-a3b5-3f7affc00674">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2330,10 +2330,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa3d0603-96b7-46c7-a890-4983fbcdcc17" control-id="cp-8.1">
+    <implemented-requirement uuid="ccc9aa45-abff-4056-b521-b92198d7eb00" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="bc869089-904f-4178-8dc0-059c3b67fd43">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="80cd9af7-c118-4375-a939-b19bb7a0b089">
+      <statement statement-id="cp-8.1_stmt" uuid="95bbd4b7-6b9a-44ae-a1ba-1304ace33ea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2341,10 +2341,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04f9e3da-61b1-415e-880c-52716d12c675" control-id="cp-8.2">
+    <implemented-requirement uuid="c93439ba-4314-4f20-b70c-3186e61de945" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="b389ecc7-1e1b-4f31-8181-96e2e9b9471e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e053a0fa-70d7-4697-a3aa-fe4eca666205">
+      <statement statement-id="cp-8.2_stmt" uuid="0e95fdc6-26e8-438a-9605-7a1d81cfea1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2352,10 +2352,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16277fba-ac9d-49ca-a4d7-5b7c471b8c95" control-id="cp-8.3">
+    <implemented-requirement uuid="dc213ed0-2364-4977-a987-fbb16ec98f95" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="d1f0458a-c01a-4db3-803e-81fa244b7c2d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="476fbf12-050f-4278-9fb0-1f131eae3e1d">
+      <statement statement-id="cp-8.3_stmt" uuid="36aa7fc2-67f2-4569-ad5a-796230fbfeba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2363,10 +2363,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e4fa2dc-e170-4f05-a93b-a326938f392d" control-id="cp-8.4">
+    <implemented-requirement uuid="677478d6-3977-4593-a8c9-fa8fb54ca7cc" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt" uuid="4e68fdce-0548-4df5-92e0-a70968ef53ce">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bf02c0c3-47c6-49bd-8eab-2b30f2d6e2bb">
+      <statement statement-id="cp-8.4_stmt" uuid="8766ec75-22e7-493d-b2c1-4f8804224c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2374,10 +2374,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80c88da3-714e-46b8-9032-8846d1ce3f57" control-id="cp-9">
+    <implemented-requirement uuid="bc22a3cf-95d9-4b22-9112-6fc1b4ff81f6" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="186b42ed-1afe-4718-82ae-533d73abedc9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a3e9fe1d-467d-4eea-911c-e0577ffa6066">
+      <statement statement-id="cp-9_stmt.a" uuid="b8249024-8595-4c8f-b43d-1877b1539f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a08f7f0-9663-4cb5-9700-734cf93d3a58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -2393,8 +2393,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="ca138275-f71c-417a-9f1c-303ed2e7322b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="66c1a2af-6c6f-43de-bab5-38f4d694d66d">
+      <statement statement-id="cp-9_stmt.b" uuid="2de89133-ecda-472d-99c4-efa326e6714e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3753498-0e8c-4971-901d-2ae5853f8faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -2410,8 +2410,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="5cdde663-fe40-406e-8df1-aac2ef1eb213">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4ddce750-fd9c-4752-8d7f-77b5356faf71">
+      <statement statement-id="cp-9_stmt.c" uuid="f9c08a44-9d5b-46db-980c-d64ee467af2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dba5d26-fcff-44e7-853a-fbd3e9d16a23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -2427,8 +2427,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="78cc20f5-3295-4dd1-a953-71263d89e107">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b7668703-c078-4a4c-a862-7bc41ff22d99">
+      <statement statement-id="cp-9_stmt.d" uuid="a8885751-e451-479e-9783-8cc776849233">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d827a66-3be2-4d48-9834-d5adcab4c487">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2444,10 +2444,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8716a4b-63fe-461f-a5a8-af21c7151d4d" control-id="cp-9.1">
+    <implemented-requirement uuid="01074291-dca3-46e3-a8a2-c45cf9e3a3c2" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="91c1640a-c2c8-45c1-92fe-7cecb1ebded3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="38f2ff4a-8a25-4f0a-8db0-a55ba20f39b6">
+      <statement statement-id="cp-9.1_stmt" uuid="bc93c8f6-96fd-4247-907d-9c22e22ba948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2455,10 +2455,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6106f6e4-308b-43e5-aebf-6511f80058c8" control-id="cp-9.3">
+    <implemented-requirement uuid="1a44a893-e374-4449-a5f3-1aaf3e9650ce" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="2db03e12-452e-4e0a-a57f-84738b9f834b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="889a3a5d-c1d9-4f71-9da4-a94eff8ce0c7">
+      <statement statement-id="cp-9.3_stmt" uuid="6d4386c8-1e74-4d0a-928f-c614329f00e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2466,10 +2466,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="729e42f1-78ef-41de-92ca-4f9e982ef6fb" control-id="cp-9.5">
+    <implemented-requirement uuid="c8e16404-0d67-441a-ba45-67da210bbe8f" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="b5276eaf-78bd-48d0-9ecc-7c9921e22183">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6b083cd4-2e6b-43c7-95ef-1b18f57413ba">
+      <statement statement-id="cp-9.5_stmt" uuid="3d736bb3-d22c-4f83-99be-30db228cf675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2477,10 +2477,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1549da98-f6e4-449c-85f9-40aa84560235" control-id="cp-10">
+    <implemented-requirement uuid="02f89333-b0c2-4c4b-b1e7-a38e1ffca80d" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="e5fdfb5e-0c68-4b40-a040-73dc50f3e23a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6538c5c7-af73-4071-97ef-5f9093bdad0e">
+      <statement statement-id="cp-10_stmt" uuid="d96de4d7-6285-427b-b6d3-27b06c7ee126">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05c68c3e-793f-4b6f-960e-cb0cad097f1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their OpenShift environment. A successful control response will detail
@@ -2489,10 +2489,10 @@ processes used to fully recover/restore the OpenShift environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fed691a9-600f-4b2c-823a-3e9b4125022e" control-id="cp-10.2">
+    <implemented-requirement uuid="1720f0b1-6202-4c8a-8e3e-889266d2db3d" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="e5de22bb-29f0-4c3e-866e-2f52198fb9a5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b18d4d82-60aa-4308-9091-3ddb9910b8f9">
+      <statement statement-id="cp-10.2_stmt" uuid="c6e19b08-a73b-4a7c-9cb3-383e92bc7174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="688c2729-55ce-48e0-8647-94d6e4cd0f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for implementing transaction
@@ -2504,10 +2504,10 @@ the case of failed or conflicting transactions.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9221a7b-dafe-41ec-9d43-137733c88ef1" control-id="ia-1">
+    <implemented-requirement uuid="1ac74505-b835-4d8b-9a65-0072731a1432" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="59329836-25d3-475b-9f05-84d6ddd3ebd3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="78c5543e-4190-4d75-9ce9-5aa7871983a4">
+      <statement statement-id="ia-1_stmt" uuid="4a264b65-a3e1-4bbb-aa0c-6a39ee9a705a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2515,10 +2515,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caca6fa8-70c5-4454-81d4-0e4455e42dcf" control-id="ia-2">
+    <implemented-requirement uuid="d85437b7-d62b-4023-ae67-cbe3dca95dd6" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="af45f630-114e-4de1-a95c-7737c47fbd45">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4460bc9e-b747-4d28-951d-501df2acb457">
+      <statement statement-id="ia-2_stmt" uuid="48880db7-6cff-4e77-8fe5-8522f4a8077f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad09895f-4ac3-43fd-b43b-8d04184ea227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -2526,10 +2526,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb908b5f-4cc9-4672-bb25-7ea13dd6ccf7" control-id="ia-2.1">
+    <implemented-requirement uuid="b6207e75-1e9b-44fd-896a-744868a7ee3a" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="33ed97ee-f1f3-4924-a73c-3c3e4017832a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="29deecf2-e124-427b-9f0f-c6186ba42e72">
+      <statement statement-id="ia-2.1_stmt" uuid="2c5aa764-2ef3-4ad6-8f03-acd8a22ac68e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be67a4f8-46f8-44a4-98fa-d862af3ead31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2560,10 +2560,10 @@ OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2255695-c673-4205-8a6b-7a41f8453e15" control-id="ia-2.2">
+    <implemented-requirement uuid="b20e807e-447f-4f60-bab0-abcf80ce1b16" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="5569af06-0752-4235-81c5-2fd44dbb5a28">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="111dbf76-3f35-4ead-b69a-af293bebfe49">
+      <statement statement-id="ia-2.2_stmt" uuid="eb39e647-8766-4855-8b0f-b8924bdf20b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f02082bc-c604-452d-9d17-42181e8f1412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to non-privileged accounts.
@@ -2574,10 +2574,10 @@ multifactor authentication is enforced for each.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85d8e3a8-b835-4759-991a-39891cdd5de9" control-id="ia-2.3">
+    <implemented-requirement uuid="4a611d8f-eba4-455d-b134-4174c2ce9a4f" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="30227e45-d9c4-458b-8849-f0e705a85303">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2315cadf-a4b5-48ef-965b-6f86cadc8655">
+      <statement statement-id="ia-2.3_stmt" uuid="aa9ead1e-a7a7-42f9-9ff6-d847e6801260">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37f0bdb6-1840-425a-814e-366fd45da66b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to tenants of cloud computing
 platforms, such as OpenShift administrators.'
@@ -2585,10 +2585,10 @@ platforms, such as OpenShift administrators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7cfa357-f001-492f-850f-12e79019fb33" control-id="ia-2.5">
+    <implemented-requirement uuid="0cf74701-7838-45ad-8c29-7a3719147fd8" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="f27a4bd8-b687-43ea-91e7-c5f8222760b1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="208cc761-83ca-46c8-8a84-cf8b9919c8d6">
+      <statement statement-id="ia-2.5_stmt" uuid="36c07a99-a75b-4752-b345-544ddf1e77df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e156758-4269-4c10-87c1-78bd4ef29fe1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift requires individuals to be authenticated with an individual
 authenticator prior to any group authenticators being employed. This is
@@ -2600,10 +2600,10 @@ authenticated, group access/privileges will be granted as applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d428c17-13fd-43f4-9954-af691100d760" control-id="ia-2.8">
+    <implemented-requirement uuid="b4dd3658-3599-401d-bb60-840216e51eda" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="28f2d8f8-cc69-4abc-994c-37fdbc184e84">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c4fcd1c8-57fa-4144-a794-8db4a7ab77ad">
+      <statement statement-id="ia-2.8_stmt" uuid="5004b172-e82d-42bf-b037-4ecc39c4a274">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03f28c95-2188-4c2b-ada9-b13aaf594206">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing replay-resistant
 authentication for access to privileged accounts. Microsoft AAD and MFA
@@ -2614,10 +2614,10 @@ replay-resistant authentication is required for each.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e70a6957-3198-4b04-abfc-ffda8d018fb2" control-id="ia-2.11">
+    <implemented-requirement uuid="07da1097-875d-4ef7-9dd8-938a112602ed" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="8cec5f1a-a09e-4e46-978d-fbb500619c40">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="78e502f5-ed03-41b9-9706-652c0f71e321">
+      <statement statement-id="ia-2.11_stmt" uuid="d8dead12-9d75-4ff6-8f2a-f612a984c021">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f50fdae5-0fe7-41cb-abc2-452270b5308b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication such that one of the factors is provided by a device
@@ -2632,10 +2632,10 @@ solution.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7902cf40-bbf4-458a-b38e-8ec3f35f8871" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="542dd0c5-9358-4973-be92-f2567d7a6ec3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9ca6f23c-3e63-46bb-ae7b-fea866cb41cc">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2648,10 +2648,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b27ec461-4450-4de3-b8ea-8d091379961c" control-id="ia-3">
+    <implemented-requirement uuid="17ecbece-8e0a-417d-adea-f82e3ec022a7" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="24220d0a-7ba5-4a0d-a344-24c92e575e35">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3b163cd2-fdb2-40c9-a5b6-fd8cc975d40b">
+      <statement statement-id="ia-3_stmt" uuid="78a34ad0-b977-4a39-aae7-aea1bb756afc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95e0a535-e1ec-4e09-afc6-4b7b15f8a692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring that customer-owned
 infrastructure is  properly authenticated prior to establishing a
@@ -2666,10 +2666,10 @@ will provide identity of the machines.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e07822e-e2cf-438c-b61c-89e23c7d121a" control-id="ia-4">
+    <implemented-requirement uuid="e21d6a2a-d400-4480-89b6-7f40b0c50ae4" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="ae1dfa5f-d99e-407d-ad9c-fb760d36ab25">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="68682b63-7769-4559-96f2-b17a4ffe75a7">
+      <statement statement-id="ia-4_stmt" uuid="5cc82413-d164-4bb0-9b39-108524a03fd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2679,10 +2679,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9471313-544d-4a68-bbd6-09668a54eb56" control-id="ia-4.4">
+    <implemented-requirement uuid="a4c50edb-200e-490f-9bda-660c2feb689a" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="f46b9fc9-2468-43e4-bd06-b380960ddb26">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c8d7498a-84f3-4629-b20f-6ce93479728a">
+      <statement statement-id="ia-4.4_stmt" uuid="2786021c-8862-4dd8-9eb4-18f064af13f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0fdb38a8-add6-480a-b5a8-bb33347a30eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for including contractor or foreign
 national status as a part of individual identifiers. Microsoft AAD
@@ -2694,10 +2694,10 @@ into the individual identifier.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0256fc6a-7ffc-4e44-80de-6bec45d43b5a" control-id="ia-5">
+    <implemented-requirement uuid="82b7e251-336c-4f51-9d1b-dd1d2a18baf5" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="a5f188a4-dd59-47ac-9182-0dcfee0a5e9e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4ae06f2e-c3f0-4fca-b78c-e57c67246fc1">
+      <statement statement-id="ia-5_stmt" uuid="9b4c1651-4e00-46ed-9296-95d1bbf5af34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2707,10 +2707,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b444c5bf-cb78-400e-85b8-4fbd7d0a883c" control-id="ia-5.1">
+    <implemented-requirement uuid="9ae4fc53-7521-4cd9-8d91-a1f38dd953ed" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="12e6794b-9eac-4516-8d4f-352e01922ac6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="742e9fbe-4bf9-48c9-9174-f6b0c7b7a8b2">
+      <statement statement-id="ia-5.1_stmt" uuid="7aaf7dd2-6511-408d-b902-bfa59d362c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2720,10 +2720,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2aae9d5-b0ca-4d38-bc6d-2888684cd5ad" control-id="ia-5.2">
+    <implemented-requirement uuid="7c40ed9c-69e4-4303-b1d0-e499d81994ca" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="064c4802-b67e-48fd-b175-43b1f0fc8f18">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="74c9c27c-e071-456b-a80d-9b08e6b5ecfd">
+      <statement statement-id="ia-5.2_stmt.a" uuid="8ee288fb-da30-4a24-87b4-518a90bcdd10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f04ddaad-c8ca-4af0-a857-7eb406ac2956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for validating certificates used
 within the customer application. Active Directory Certificate Services
@@ -2732,8 +2732,8 @@ to address the mechanism used to validate certificates.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="1049600b-b0cf-47b7-aea2-4296f1f1a974">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b3912c0c-0c5c-491d-bc80-bf312e036037">
+      <statement statement-id="ia-5.2_stmt.b" uuid="1142e1f6-aef9-4d40-9595-4083f196a56f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44fa2414-ba77-4d7e-8f2b-a032cf71511b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for the enforcement of authorized
 access to private keys associated with certificates used within the
@@ -2743,8 +2743,8 @@ address the mechanism used to restrict access to private keys.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="3f391f91-7d94-414e-9638-3f930ca46dea">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b77a9f4b-2d98-4a53-b59e-5e40fe3c6f3f">
+      <statement statement-id="ia-5.2_stmt.c" uuid="014c6d68-100d-4fb1-9cca-32361c3a25e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4ec1356-ea47-4e3b-a267-e3ef8e25e0ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for mapping the identity
 authenticated by a certificate to the account of the individual or
@@ -2755,8 +2755,8 @@ certificates and accounts.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="efccde82-d249-4248-81e7-dabf82471a7a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="def24043-6e46-4413-b454-427ee2e24780">
+      <statement statement-id="ia-5.2_stmt.d" uuid="31080905-d7cb-4a4b-a958-1e99d8b51614">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bccdc38-799e-43e1-94cd-45e1345889de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing a local (i.e. within
 their subscription) cache of revocation data. Active Directory
@@ -2767,10 +2767,10 @@ populate the revocation data.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="526a8215-723e-429d-85e8-d178186077f3" control-id="ia-5.3">
+    <implemented-requirement uuid="4bdeb903-68a9-4110-85c5-b5824149fd94" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="1933c6ea-ee5f-4b56-84bb-6dbe65457bb7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b6040bcb-4603-443d-96f6-a707c1c0c05c">
+      <statement statement-id="ia-5.3_stmt" uuid="aa18ec7e-04f5-478f-b2df-4dcc177c8ddb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b682d871-f7a5-4f95-b244-88377d365c2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for distributing
 authenticators in person with proper authorizations in place. A
@@ -2782,10 +2782,10 @@ authorization for distribution of the authenticators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="892dc5af-cc4a-485d-847a-f62b20f891fb" control-id="ia-5.4">
+    <implemented-requirement uuid="e2176a2e-1b27-4529-8607-7d3beb4c9210" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="72e27393-ea37-40d0-84cc-217052778023">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b751e05c-b2ea-4ce0-b981-b33335655380">
+      <statement statement-id="ia-5.4_stmt" uuid="be8079a5-6d92-4bc6-a2b1-e14e864850e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42170b86-81ae-4aca-a9fe-5f35f2f9e130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing automated tools to
 ensure that password authenticators meet strength requirements.
@@ -2796,10 +2796,10 @@ enforce password strength requirements.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77740b63-67f8-45fa-928d-b8750593bffe" control-id="ia-5.6">
+    <implemented-requirement uuid="698df71b-53ce-464f-a1c1-56e790b28067" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="c7b3cfea-ea46-43d1-9376-6a06db2e8835">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="436af9bc-dc8f-4de7-a229-bbd82cd4b1e0">
+      <statement statement-id="ia-5.6_stmt" uuid="26fc0646-a774-4b2d-8b6c-dfdf58458259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38c79c30-7a15-4e3b-8464-57c79dff95e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting authenticators.
 Microsoft AAD solution may be used for this purpose. A successful
@@ -2809,10 +2809,10 @@ tools used to protect authenticators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="115c5778-b934-4025-b027-bbfd54c8e32f" control-id="ia-5.7">
+    <implemented-requirement uuid="562238bd-4063-4ddf-b042-ec969ce76847" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="d3cd49fc-4d56-47ec-bcce-a6c2e9dd3352">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="28107f17-d0e3-4873-af81-dc54df2c3c96">
+      <statement statement-id="ia-5.7_stmt" uuid="7c818933-0a51-488a-ba95-bfe132fdff5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3875aa2b-4008-47ae-8bb7-8f4278e96140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift does not embed or store unencrypted static authenticators.
 OpenShift cannot be configured to be out of compliance with this
@@ -2821,10 +2821,10 @@ requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="539d7ed8-4b93-4137-bd17-5ddcebd82264" control-id="ia-5.11">
+    <implemented-requirement uuid="0c8d9074-74b1-43e9-b7f2-588b07d91ac0" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="536d3f45-61ab-430b-99cc-8f834bd6f2e6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="cfe6cf64-eca7-4d08-857c-6dd0ea857e5e">
+      <statement statement-id="ia-5.11_stmt" uuid="46876a3c-1392-4a20-abda-4720c149ba69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2834,10 +2834,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d94bb006-d769-45a0-a3fb-769e46fa4a95" control-id="ia-6">
+    <implemented-requirement uuid="12498f82-cc76-4b1a-970e-b52e957da8dd" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="67fe224c-3259-45df-b8fc-365fb26ccbf9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="13ab2470-de74-4dad-afa0-d046d8d9ad60">
+      <statement statement-id="ia-6_stmt" uuid="70f01749-e367-4d73-85ea-84c3a6c22764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3296420-39ec-4baf-b4eb-3c52f4535a3b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift natively obscures such information. OpenShift cannot be
 configured to be out of compliance with this requirement.'
@@ -2845,10 +2845,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64ea2525-f8da-430c-bd91-12d50caf8223" control-id="ia-7">
+    <implemented-requirement uuid="d4e53f34-f8c9-4b80-a352-3b044bfd5837" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="a98c4c0b-ae81-4ad3-b6c8-5b7e2d54c7f4">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b6f0423b-65da-406f-b7e6-de5358b593ac">
+      <statement statement-id="ia-7_stmt" uuid="380e5148-4be4-4cd9-a28a-fc132df2e116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1ba60b8-1e70-4e76-b334-583c33bc5670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to OpenShift nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -2870,10 +2870,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93ae0219-3492-4992-ae11-7c0d92ea6b94" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="c81a9590-d5d4-41bc-b9f3-794e0d1a2b73">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b31fdc64-d8f0-429d-ad96-5e08993ee895">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -2885,10 +2885,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fe6f9f7-d00c-4c1b-9627-c843b46b5835" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="988acc40-1cb5-49a4-9dd9-f9f888c9ff58">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3b94372c-46eb-4f4e-a7ba-0b18c57f1f19">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2901,10 +2901,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75be71a3-1ef5-4f0a-a175-8685440a5cf8" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="0b205d39-4194-4ce1-bfbf-f0e2218034b7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="182ee15e-7649-4141-a813-4480310fb0e5">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2918,10 +2918,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f5bad9c-cdd3-4d8d-8a56-176abd8357b7" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="7b6feb1d-7719-448e-8894-250dea00ad7f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c4695797-11c4-411d-b8ef-8e77433b223b">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2935,10 +2935,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee475846-a0a8-4fcf-9cc5-737ca2308b21" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="1a2145dc-1dbb-493b-a468-376f198f2820">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="427a8a4c-3864-4c8c-a982-5f1217649e23">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2952,10 +2952,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63cdc7c3-f610-485b-9671-8072dca14e30" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="d1d006b4-d717-4dca-b3cf-4049b7c2481b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5e9d108a-4b41-4f97-904d-ac83392a8366">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2963,10 +2963,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95d96e72-ec5d-4843-83ed-c5befd66224e" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="bc8319a3-ef1e-4a33-be87-a6c8e63971f2">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e1c050b1-46ef-4eac-8bc4-df60c55c89d6">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2974,10 +2974,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f43400cb-7e8e-4fb1-99eb-0d1ce487f528" control-id="ir-2.1">
+    <implemented-requirement uuid="78d7845f-de00-4c63-bd97-4e0839f3f0a2" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="d90b491b-de2d-4ae3-b2df-13e86b7e355e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="75fabd8c-c939-43b4-9d40-2022ff55defd">
+      <statement statement-id="ir-2.1_stmt" uuid="2a2123c8-220a-4661-8f26-18515e8eb566">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2985,10 +2985,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="812a99fd-84af-432c-9d78-e37f19bf06ba" control-id="ir-2.2">
+    <implemented-requirement uuid="246aa74d-9372-4467-ac4e-954bae434f90" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="50f224bf-c808-4063-bc31-f87e77bd7107">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="dcefb890-c9f9-425a-b527-ad5056c2e55e">
+      <statement statement-id="ir-2.2_stmt" uuid="f3b8f0bb-f626-43e6-9afa-be7e82b405e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2996,10 +2996,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fe09e38-173b-4fe0-9eee-6b756b18121a" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="32814275-b224-45d5-9350-ef148ce9334a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c6bb401f-3fc7-4495-bd75-7c30f5754bc1">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3007,10 +3007,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fad9f63-8e25-485e-abb7-ec6e165259e6" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="6dabd9ae-684e-4f1e-a19a-577069c12fd7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="60ae4213-5dae-46f7-b4bd-830170b25e5b">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3018,10 +3018,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66e1ef84-d501-491a-85c7-f154afb13fb2" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="dec96481-1a9f-4215-8998-a5284ca46c58">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="164ab922-09de-42d9-8315-e9cb624be2e2">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3029,10 +3029,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4efe1e7d-3385-42b8-b252-e96d315d0c52" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="e9f79ecb-f54d-4c95-8646-251f687cce3e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="097d6e8f-c9c0-428c-b49a-492b51d228dd">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3040,10 +3040,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad0c08cf-a244-48df-bd00-886bae2f20ea" control-id="ir-4.2">
+    <implemented-requirement uuid="7f0a3982-d079-4924-b580-f0dc1d216e85" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="ef246741-5bc6-4ef7-b19b-2ac26fa505a3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c2aa8955-5fe0-4e6d-b1a7-22cae0b3c562">
+      <statement statement-id="ir-4.2_stmt" uuid="9c563bcc-5237-449c-a4ab-d3b700a97da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3051,10 +3051,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdd4a255-2fac-4337-8cf1-521d7ff16e02" control-id="ir-4.3">
+    <implemented-requirement uuid="13b97b42-76d6-4061-b638-febe0cd90231" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="f0b28c23-41a2-4060-972e-07985ba56313">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="93df5b16-330f-4937-8569-1af241652d82">
+      <statement statement-id="ir-4.3_stmt" uuid="5e0e6990-1ff8-49bf-be0d-5d2737ce63e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3062,10 +3062,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e5f1154-cd59-440e-8367-45556ce0121f" control-id="ir-4.4">
+    <implemented-requirement uuid="3f7d2d28-2608-42b5-be50-8da2df81d87f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="95bba43a-3832-4748-8398-59cc73f9f07d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="775d43a8-3122-43d4-8a45-961cf0afde15">
+      <statement statement-id="ir-4.4_stmt" uuid="ac63043c-31bb-4d93-b0da-40a829860d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3073,10 +3073,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69cda51e-08dd-45f2-8b8a-a66f0a20e1ff" control-id="ir-4.6">
+    <implemented-requirement uuid="37e8a5cc-59e9-4a7c-9bdb-cbeee02214ca" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="d6d532e3-5b1c-47b2-b795-9791858d427d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ef46f4d7-5c20-49fa-a2cc-2aa7952f5e81">
+      <statement statement-id="ir-4.6_stmt" uuid="7ef8f800-1279-4b68-9615-3565349db7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3084,10 +3084,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="356b405f-f61a-4401-a7db-6884600daad0" control-id="ir-4.8">
+    <implemented-requirement uuid="4e72b7dc-4243-419a-8f07-49afa8e6bb71" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="ea9564f7-e800-4576-b92b-cf1619ac1edf">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="18bba221-333a-40a7-9603-2217c25eaa84">
+      <statement statement-id="ir-4.8_stmt" uuid="eeea2ede-129f-4055-8e4e-5f5514fae167">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3095,10 +3095,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e65ddbad-16aa-4a25-a00d-b40be9160a23" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="59049be0-baf5-414a-86dd-a571d99f9a4c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ab0f97a4-e38c-46e1-a51b-3b0ccc67f3f7">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3106,10 +3106,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b7385f7-ccd2-4944-8df9-e24de1c41cd9" control-id="ir-5.1">
+    <implemented-requirement uuid="6d97e9c2-2cde-4770-915c-0fb3374028bf" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="d8117390-f714-4bb7-85c1-fe2aabacb541">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fd525604-8a0d-4cf4-97d6-1bc4c87889fa">
+      <statement statement-id="ir-5.1_stmt" uuid="555bebe2-f2d2-489a-99b8-98b462646d4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3117,10 +3117,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28494ba8-5d33-4f1c-b74a-8f9bae78d361" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="313d3d6e-718c-45a3-819e-24f81e3d19a9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="23a342f1-7605-4de0-a6be-525f9699f25a">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3128,10 +3128,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1ad1bcf-8882-4afe-b7f8-850082bdd7b9" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="7e51f21a-9ed2-404f-8332-3ced8964ed01">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6dd16d85-29f6-4748-b202-54e505632f83">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3139,10 +3139,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9708ccf-5961-483b-8fff-9247d51dd190" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="563c99ea-259a-44cd-b7dd-1f1a2cc3cfeb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fc1dca52-9765-4ee4-9a29-02d7cc49c378">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3150,10 +3150,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1324906d-ecb9-478c-aa55-abceb9977d3b" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="08027e63-ecb9-448c-bd4b-e51b0bfb5abf">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="87838b59-3665-47d6-b472-c240b9ce6215">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3161,10 +3161,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb037b09-61e4-4820-9f67-6ae3da3b0151" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="e102c372-9a26-4d99-85ac-b1264fb12e88">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d8fdabd7-64ec-45c7-980b-30db247c49e9">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3172,10 +3172,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fc62122-bab4-4756-a66e-2845b38d6ebd" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="6e278f18-536a-45e4-87d3-63325877258f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8b4b7471-96cf-48f8-a9f6-118c4491e6cc">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3183,10 +3183,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1d4d463-69e6-471f-839d-26044fb602f9" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="281c15a6-a2e7-4320-86f2-18d8f115f9e3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d04c0894-9bc9-439b-85c9-3e09df6e5914">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3194,10 +3194,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b753648-a993-4aac-9c7a-7ecf5e84a352" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="2e41c14a-6e6f-4b12-aeb5-8e252edf375a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a327d583-f422-4b84-a87c-6d6a4cf0847d">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3205,10 +3205,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d31afbf3-38c7-435e-ad1d-49b5b8cf025e" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="96ef01cc-2a18-4008-893b-7ff874048ceb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0a9a8eac-8822-457c-9530-a7cda1133431">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3216,10 +3216,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5eac4a24-fea8-440a-901a-31611e566534" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="9b793e3e-ada6-4323-8cf3-5118e7ff4904">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="881481c9-532d-40bc-a71c-58e572fa53c8">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3227,10 +3227,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8cc44d4-7350-4737-badf-1118b8af8653" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="8626419b-dcac-4d66-8d89-011ecffb22b2">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="189a1632-0fb2-451c-9ce9-37ac6b78f319">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3238,10 +3238,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f81de3b-1f61-4160-8d00-f3210fe469d3" control-id="ma-1">
+    <implemented-requirement uuid="ab96e205-f5ae-4f92-aeba-9d65d4089811" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="cd7cba7e-0c85-448a-aad8-72754accd1be">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4d6b1806-84df-4556-802d-573d50641534">
+      <statement statement-id="ma-1_stmt" uuid="cff15548-e6ea-47ab-bff0-ae27d840911f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3249,10 +3249,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75919f6d-06a9-452a-89a4-cca6c8bad929" control-id="ma-2">
+    <implemented-requirement uuid="ac03a1fa-a125-4831-b841-a85b0d07e099" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="d89af2e8-be10-40e8-b97f-eb32634cfcb4">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="763a524e-3d6e-48af-b382-7c32134f7969">
+      <statement statement-id="ma-2_stmt" uuid="69953a5e-05a4-477d-b010-34cc2cd92d8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3260,26 +3260,26 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fa0063e-ae4c-415c-b62f-2d9b703cbbd7" control-id="ma-4">
+    <implemented-requirement uuid="1c8083fd-9c42-40a1-a265-ec2662dadab9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="3173125d-3a62-4d72-ae68-a12d122013cb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f5a17bc5-8e59-4b84-afd9-79bba7f0eb81">
+      <statement statement-id="ma-4_stmt.a" uuid="8d3a7d1e-86fd-4ab7-8d6a-20abf4d58af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="38cc4aea-5743-48f1-972f-9fa422500293">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="619eee04-06e8-4e5b-8fa1-ffbdd0b44f55">
+      <statement statement-id="ma-4_stmt.b" uuid="424f393f-8bd9-49ca-b75b-972873f8a80e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="771dd934-cd33-47a6-8853-1fd25c12ecff">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8bacada5-91d4-4b4a-a093-d982c7c934d8">
+      <statement statement-id="ma-4_stmt.c" uuid="55e15a38-efa6-4f16-8548-50432deac845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6aa2bb26-eb59-4d99-84cd-822805438767">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.
 
@@ -3291,8 +3291,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="3c306f38-3685-41d7-8098-95ad9df1ea13">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="951230f3-34d8-4fe9-8242-b3fc1e0dfebe">
+      <statement statement-id="ma-4_stmt.d" uuid="755528dc-d98c-41d7-aa24-5e6e32ad6223">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ccef3b2e-7c65-495e-88dc-4ee72829f552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -3302,8 +3302,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="e348bd98-ef6b-4aee-b9a1-cf8b4c89515e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7e226838-b9da-48b4-9cab-b635bc0be866">
+      <statement statement-id="ma-4_stmt.e" uuid="3937c74b-e19e-4c0e-890f-5cd9268105c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dcad0664-141b-4ab9-8272-91128053ab87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -3317,10 +3317,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67687bb4-aaa6-430e-8ab8-01f98db44c71" control-id="ma-5">
+    <implemented-requirement uuid="7bae4cdc-5101-4916-9bd0-32097c3a5540" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="64f555ad-96b7-4641-9037-1c74bb9f2a9f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="656f053a-4e11-44d0-b17b-2eaecc6af8b7">
+      <statement statement-id="ma-5_stmt" uuid="4de28098-f4b1-4383-b6c7-d8cb36cb1ea0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3328,10 +3328,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9edd7bea-43cc-4462-9bce-b96cef4b1d8c" control-id="mp-1">
+    <implemented-requirement uuid="6e3641b8-d91a-4b4c-aed5-1d4b9fa8b9f9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="3f8d1ef3-ec5d-431f-9df7-347a3e9393b0">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e3ab2024-f75a-4326-9cc5-c6f40a5df2f0">
+      <statement statement-id="mp-1_stmt" uuid="6a0d866d-901f-4cfa-b1d1-3dcdcfdba280">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3339,10 +3339,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a601410a-cb36-4ae1-81aa-27839f893595" control-id="mp-2">
+    <implemented-requirement uuid="0b1de93b-94fe-4940-bd9e-2557cabb300b" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="7f2138dd-4593-4aae-958f-06a8c2e4758b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f46e10cc-c658-4487-b297-9bfa230df353">
+      <statement statement-id="mp-2_stmt" uuid="4ca98bdb-106e-4c20-9b26-a7fbfe88bc72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3350,10 +3350,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bdbfe87-47c4-4f6f-9e50-f9915c7fa152" control-id="mp-6">
+    <implemented-requirement uuid="80536df1-978a-46ac-a7d2-fb7be3c4fb15" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="12c02bcd-fde1-4c78-82dc-f6bc6279fd48">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="28f92778-c34e-4464-944a-70d17316b9bd">
+      <statement statement-id="mp-6_stmt" uuid="989e0404-089c-4307-80ec-eb9b5f6f0cc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3361,10 +3361,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b53ffdb1-0cf6-4cc4-b2bd-46a03404d0fb" control-id="mp-7">
+    <implemented-requirement uuid="07d86507-30da-4926-9f98-7b39d4efe030" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="a6a12ff3-a6ea-4775-9eca-99d6b9e6782a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="212790c8-39f6-4c9e-8015-d7d19f4b01be">
+      <statement statement-id="mp-7_stmt" uuid="5624b235-5824-4baa-8814-03e6b6aaed21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3372,253 +3372,253 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ce5bd10-0b4e-4331-a1ce-35a2b94ed892" control-id="pe-1">
+    <implemented-requirement uuid="efcc3344-7813-4729-8b4c-353c3b06428d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="0a126233-d872-41e4-9572-cbfbd216cafb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fcab26fb-29d3-4a21-8443-f85e47702e25">
+      <statement statement-id="pe-1_stmt" uuid="a69e0d62-407d-4910-ab66-18c03b168392">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cfbc646-4843-4e3b-9752-6bb09034dc54" control-id="pe-2">
+    <implemented-requirement uuid="92271e93-1df7-4bd8-ad4d-8ffd06fb2877" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="f46c11b1-9e11-43b1-a850-66cf8696d701">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5b164e79-0f81-4c27-b8e5-a8543d0a1e57">
+      <statement statement-id="pe-2_stmt" uuid="341520a8-ee52-4acc-ac44-4715de827f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ce7147b-3ed4-4055-8299-4198399bc37f" control-id="pe-3">
+    <implemented-requirement uuid="329c7586-aa2f-4ed6-aec0-f17c8d698026" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="e0188fa6-b5c1-4d0c-8f85-495d4fffe0a3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="919f107a-0efa-4a90-aaf2-eb9dafa0770e">
+      <statement statement-id="pe-3_stmt" uuid="c14a9afe-deb5-43e9-9fdd-96cc22ecd1b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4efd1fe1-ce89-47e2-81ed-812a6fd58261" control-id="pe-3.1">
+    <implemented-requirement uuid="0cc17ff9-af74-497b-92ab-f8cc2cf2a593" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="ea06456e-62c3-469a-a1ce-e4166b477413">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f7cca651-7f9d-450d-988d-8bd6a699dd23">
+      <statement statement-id="pe-3.1_stmt" uuid="6a86e48e-a060-45eb-996b-50e91898f321">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87fdf1f4-1dc1-44f7-a294-bf9de886e4e9" control-id="pe-4">
+    <implemented-requirement uuid="8083e64a-83f1-470b-847d-494c1a3fdb0e" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="5bd2943f-b561-48de-8cfd-13929e024052">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4b886a90-496a-40df-b1e3-0c957b073f84">
+      <statement statement-id="pe-4_stmt" uuid="8f899cea-0cd3-40de-8fdf-764d248e83dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b315f47-61c1-476b-924a-967d9113b63c" control-id="pe-5">
+    <implemented-requirement uuid="de758ed1-4b71-45fc-8221-880bc9ac1e4d" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="db1a1916-0468-4100-a074-3b13a74131af">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="44dfeb37-ecad-4da3-ac76-de3ea56c5f1e">
+      <statement statement-id="pe-5_stmt" uuid="c68b2bed-84ae-40a1-a30c-f98ed3cf9a35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0caec416-f7a4-4caf-9f07-c23d3d11ca5e" control-id="pe-6">
+    <implemented-requirement uuid="01f99faf-9f68-4c8a-8ad0-9b3d90c9b014" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="f71900d4-c241-4902-8412-30cbecb34858">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8b1817b9-ce13-4ef3-bab5-cc677c81f3c9">
+      <statement statement-id="pe-6_stmt" uuid="63fe7eb2-34c1-478a-a4b3-085ad3ba8a25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="981d0dd1-3810-49e8-9025-f1a0631c035d" control-id="pe-6.1">
+    <implemented-requirement uuid="24829d55-bb86-408a-aeb6-9ce69948046d" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="b558585a-84cf-47d5-ab14-f6e7eeb419ef">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="08e975df-de0d-4ea0-998f-dc8951f4c841">
+      <statement statement-id="pe-6.1_stmt" uuid="1f4e403d-0995-4eb7-a723-2e0d380f0e68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1174d9ee-9b58-4c51-a885-2ec6e2a20172" control-id="pe-6.4">
+    <implemented-requirement uuid="843dfa96-7dea-4abb-ad67-0547342e72fd" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="f747ebb0-cce1-4eb1-a344-580b37644a42">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1bed4b9e-54d5-468f-b76d-4aa39ac45755">
+      <statement statement-id="pe-6.4_stmt" uuid="98c0fd61-055b-4dfb-b566-ad2580877d75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2b6e02c-ded3-4b08-b7ad-5065bddf687d" control-id="pe-8">
+    <implemented-requirement uuid="242f3d8e-b3eb-4058-b1a3-bfbe712a1b15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="2d3a0fac-492a-4381-b2e8-5b8808a9eab8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="dcc84ae1-9dc2-4fa7-9944-6b43111ff627">
+      <statement statement-id="pe-8_stmt" uuid="8eebb287-2309-4986-8ade-187dc4bdb8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6864367-d37e-4798-9d50-9f80ad3b1330" control-id="pe-8.1">
+    <implemented-requirement uuid="14b5be6b-9e20-43e9-bf28-e4b4d2dd4924" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="2d18c595-2d3f-40ee-85c5-5792849f4307">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="83a5bd52-bd07-4dc5-bb5b-b3c583e6956f">
+      <statement statement-id="pe-8.1_stmt" uuid="3f433e7d-cdcc-4f71-b1f7-547d14b24eae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c631217c-fc8a-46de-bef1-9eb912cb36f7" control-id="pe-9">
+    <implemented-requirement uuid="b87ebbc9-80c1-4c38-a9da-50a6a208afc8" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="4012a448-2815-444c-9443-408e8aa6a829">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3374742c-b993-44c9-9d81-924d8c0b53c8">
+      <statement statement-id="pe-9_stmt" uuid="fba9f39d-2894-48f5-bfcd-c08770a0820f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbce53ba-5f96-4895-aea3-488278b94b2b" control-id="pe-10">
+    <implemented-requirement uuid="960caf3c-e746-4500-a2ef-a6070c2c6f0f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="1ddb063c-703e-4690-835f-2056ea1e897b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d7870726-04e3-4f87-b97a-de082e95b8ce">
+      <statement statement-id="pe-10_stmt" uuid="e90c7233-d86c-4f97-917b-af27de2f277e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43702a6f-7a37-4b66-9ab6-6fc25f594e27" control-id="pe-11">
+    <implemented-requirement uuid="f921eb9b-4410-4723-98ba-e64ef7098585" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="4546f1c0-d4c8-41b1-82bc-28693038517a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6b781956-89d8-478f-a430-a0645a0d3de7">
+      <statement statement-id="pe-11_stmt" uuid="e69acfac-306c-48de-a0c8-633b6ff40d61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cdabd39-e7a7-4f00-95aa-13368736cbdb" control-id="pe-11.1">
+    <implemented-requirement uuid="14711f20-c9f1-4151-875f-006372a02a9d" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="88c610d7-cd36-435a-bb74-85498e1bc5c8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2e0f4a84-65d5-478d-a522-0303ff55ad19">
+      <statement statement-id="pe-11.1_stmt" uuid="1024a622-b1bb-4b9a-a3a7-f2af5eabe241">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8cf152aa-573c-40a1-8b24-c892035f9d56" control-id="pe-12">
+    <implemented-requirement uuid="7e18ab07-c4b5-4978-b6f7-370814ec6a6e" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="f8f2e691-17d8-461f-9164-2afbe129021d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5c294f08-a123-4d8f-a173-32073df7434e">
+      <statement statement-id="pe-12_stmt" uuid="8b9427b8-b0fd-4c10-a090-a0fc02b43a7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="557485ad-e794-45d4-955e-3ec1f27536b2" control-id="pe-13">
+    <implemented-requirement uuid="f2ef922c-3e62-493a-a497-cc8801cebcd9" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="e427a5ab-0f8e-4938-90a2-6d004dc20cb4">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f9b20309-016f-4eca-876a-a8087aad0d1f">
+      <statement statement-id="pe-13_stmt" uuid="2af78162-9be5-41d8-a16e-89489da79133">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05156deb-a983-4da8-b61b-5bafdec5a876" control-id="pe-13.1">
+    <implemented-requirement uuid="e2802521-fc97-42d9-9600-4fbcfae5e993" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="2e9c97d0-ead4-4d33-859c-96879c94a24c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="498bd779-7424-46e6-8c94-4d2244a1e579">
+      <statement statement-id="pe-13.1_stmt" uuid="4dbae538-1e50-458f-8765-158d78f73d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5740f899-867e-4b4c-a570-cb4594a7b632" control-id="pe-13.2">
+    <implemented-requirement uuid="a8b37e1b-9aff-4181-9f21-165f65a2838c" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="1a681b88-d9f4-4afc-abfb-9abe0f97aba1">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8f4ce225-db5d-42ac-8702-217e37a3b5ce">
+      <statement statement-id="pe-13.2_stmt" uuid="8f514ea6-42f7-4b73-80bd-e4f3c7a5d30e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3392c08d-8190-46b7-a1e7-8ef206d76d88" control-id="pe-13.3">
+    <implemented-requirement uuid="35ab7bc0-d210-4edd-9357-0a0009a3614e" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="908f2ea8-aa1c-49da-a76c-ae5c43e06641">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="255930e9-aa91-47fa-959d-8b7d8936c55e">
+      <statement statement-id="pe-13.3_stmt" uuid="22407131-9365-4076-9059-98b185e0dabd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d051a37-3b72-47de-a35c-f78d70e21426" control-id="pe-14">
+    <implemented-requirement uuid="0b6ac012-3ebd-444a-8c15-179b449dd03e" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="f6359427-0fc4-4195-baa7-ffac624c3fd9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="51c5da3d-965f-48c9-be80-acd921e573a3">
+      <statement statement-id="pe-14_stmt" uuid="2430b2c7-3867-4c68-9475-33402076cbd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab657ff2-679f-4dda-b74e-9016bbf6a01b" control-id="pe-14.2">
+    <implemented-requirement uuid="76fd6216-6bdb-4757-94bd-09455569b009" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="0eb3e6f1-9313-4dc3-b9be-b3ef2eb6be6d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ca6ee6f7-7b2d-4d49-bcc0-e7b34f9e28bf">
+      <statement statement-id="pe-14.2_stmt" uuid="7b7d786f-adb0-4b21-82ed-39527c26e5bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b700990f-632f-4e30-a581-8cf735caebd6" control-id="pe-15">
+    <implemented-requirement uuid="7fd52cb0-bc5a-4989-bd0a-e5edad6a6875" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="eb2eef45-7fe1-431b-b2b0-12c68998c1cd">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b208b417-c98e-4974-9ef9-2b488453b816">
+      <statement statement-id="pe-15_stmt" uuid="e280552c-8bca-4408-803f-85c89a04f109">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55a6c666-9f6d-4266-95b1-601ac940acd9" control-id="pe-15.1">
+    <implemented-requirement uuid="07535b9a-11cf-41ec-a476-0eab0e5e8bc1" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="a8b03407-c4f5-462d-b9c7-f3692473f15c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b856970f-6506-47a6-b326-c1fde8d3d9a8">
+      <statement statement-id="pe-15.1_stmt" uuid="57295bd7-8564-4f2b-94cc-a60342e7c19a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d0b0eb3-72ea-4e25-846a-af30ae06c5d0" control-id="pe-16">
+    <implemented-requirement uuid="a2a949e4-02f8-423c-9c40-5a7d49d329aa" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="9363ea2a-92af-4578-8530-b63d2dd9ef03">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="04455544-5a90-43c4-93b8-d40e934a965f">
+      <statement statement-id="pe-16_stmt" uuid="3c91da19-2cf3-4882-a0f0-35464a9c622c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c72026dd-02ab-4313-aea3-6d04aedcc929" control-id="pe-17">
+    <implemented-requirement uuid="10588914-a432-4ccf-8761-1fbabbda47f9" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="4596c102-5c97-46ac-b217-aa66ae4da96c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c9001947-2004-41a0-b6cd-e895bf86674e">
+      <statement statement-id="pe-17_stmt" uuid="2e9d2e39-9ff6-44d6-bcad-2d17a6cd9c8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="378917a8-f075-4cc0-a479-63cda7399c0e" control-id="pe-18">
+    <implemented-requirement uuid="723e5199-7b02-490d-a287-9356d2954bbd" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="f92d998f-ca17-456d-aafd-0cd60ecb6b08">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="eee54b46-ab74-4ad8-87e6-b1ece8b43bb6">
+      <statement statement-id="pe-18_stmt" uuid="10782a76-273a-44e8-aca1-4f8cc1017096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7860e891-01b2-4104-9581-d0a5f6f13f58" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="cf570e60-195b-433f-ac91-c1d9a9ec4966">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e9152c41-c24f-416b-896b-96d72aa6163b">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3626,10 +3626,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6808dbd8-0e59-4f4c-bcc9-d096646d9bc8" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="6b01fc0c-6ae5-44de-ad01-49cb42612c85">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1e0b80b0-e6ea-4e6c-a3e1-dfa9faa9b4e8">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3637,10 +3637,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfe04dab-00e0-4af1-b557-3c6f8b43bc6f" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="71155e28-1d5a-4f8f-b708-86dfbe9b691d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a68b686e-a116-4e1d-b8d4-4ac5f63e9ff8">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3648,10 +3648,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="110ba5fb-3778-42a0-8588-5c6607ef5cb0" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="76c849b2-622f-4947-8255-d501733ba0a5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="70fcd00c-f42a-48a3-a974-c1f7d6f6466c">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3659,10 +3659,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec6c2d19-7c5d-4f62-8ad2-6b8cbcc8ec4e" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="5ffcebba-d1e1-4cae-a33b-01fb348fff5a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b2714639-43a2-4649-931d-e4864aec0515">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3670,10 +3670,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a60b3a91-4f7a-48ac-b51d-0b2b21b65ecf" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="70519129-b230-4d7f-8709-e56d09f0806a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9b370a04-f5ea-410d-bd52-6b09ca3b75fd">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3681,10 +3681,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d351e56-15d0-4c9d-8a49-1ef9d823298a" control-id="ps-1">
+    <implemented-requirement uuid="4d136db8-e7eb-4b3e-b037-381487f0532e" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="9a956f84-6d9c-4c64-970b-7ccb11e7ceef">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fd8bf463-7473-4aba-be93-ea5f7a805b04">
+      <statement statement-id="ps-1_stmt" uuid="9af3ca73-229f-4538-abc2-efd626ea3055">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3692,10 +3692,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4238994b-07f1-457f-8708-3764382dec91" control-id="ps-2">
+    <implemented-requirement uuid="6023f53c-f1f6-461b-bc4c-59bf5bed97b4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="d78c53ff-307d-4cd8-9acb-f7cfeedc513e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c4954bd2-ecee-4859-8801-7643fb5c372b">
+      <statement statement-id="ps-2_stmt" uuid="100d4a3d-c1eb-45a7-9e8c-0bc8dbb62d2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3703,10 +3703,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91c4a07b-cb2e-4283-b8fa-faa009627bf3" control-id="ps-3">
+    <implemented-requirement uuid="ab01fa25-d8b0-4d7b-ae45-d2ab5d8b1382" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="bdf0a2f2-e389-4539-9341-f0c5c485c599">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c0507e07-7bf7-447c-82b5-24730860e2c8">
+      <statement statement-id="ps-3_stmt" uuid="1c3a8a5e-7e84-4341-abd4-3063ab3fb9f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3714,10 +3714,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82fd2bfb-7599-4c39-b874-59b2ec159f36" control-id="ps-3.3">
+    <implemented-requirement uuid="b63d44b9-6723-4059-b6a9-b511cc880ce4" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt" uuid="a9b219be-467e-41f1-bda0-bbdcfe6af72f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c6f506ed-edad-49f7-8350-6478ab3b9dd9">
+      <statement statement-id="ps-3.3_stmt" uuid="c04a351f-987e-4ab0-86f9-e053b86080ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3725,10 +3725,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91bd4ce3-8d04-4b60-a96c-3a039bb8ac36" control-id="ps-4">
+    <implemented-requirement uuid="d59ce3bb-2024-4bc6-be8a-e4afb6334739" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="22a064f0-4991-485b-991b-c451839cf535">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="495dce50-465d-4371-bd69-d6f764597aa6">
+      <statement statement-id="ps-4_stmt" uuid="5298ca65-c410-4e9c-8825-e7bb70670a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3736,10 +3736,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6c6c475-134f-4d5e-98ed-0f206304f9c4" control-id="ps-4.2">
+    <implemented-requirement uuid="538a9f61-b5cb-4868-a3b6-3bf0a375a439" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="d2ef67c1-a39a-4d9a-8152-1209cf299463">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="161f44da-f801-4703-ae85-6e6fdc74ecfd">
+      <statement statement-id="ps-4.2_stmt" uuid="515f96a1-94be-48a6-beaa-62959723cf25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3747,10 +3747,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd3846b1-0962-4515-84c2-55b63c2b9b77" control-id="ps-5">
+    <implemented-requirement uuid="dbf6994c-27d0-4bc3-b60f-bc0958c0a878" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="e52d8d95-4684-411a-a530-6aa0a915769e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b36e15d4-9bb7-486d-99ec-1825c02cfd48">
+      <statement statement-id="ps-5_stmt" uuid="a92e9df3-3a63-4925-8654-7c596d51f667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3758,10 +3758,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="757c6d13-a22a-4daf-80a2-94f684786f5b" control-id="ps-6">
+    <implemented-requirement uuid="868fa3ff-5e6c-421f-9cc2-55267f6d9a46" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="c68c4455-77c2-47f8-9b3e-b02d036e26aa">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a50c6d59-8120-4b74-8c70-660231098277">
+      <statement statement-id="ps-6_stmt" uuid="7a665411-ce9f-4cfc-8716-8f61343d8336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3769,10 +3769,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02aa5de6-9ea3-47e6-931e-def4f0b2aac5" control-id="ps-7">
+    <implemented-requirement uuid="a95b32cc-6f69-4da1-a053-66b13b726e6b" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="32fc6e16-c718-4a5e-a71b-17ca346a667e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a920a587-8d00-45ff-820f-9a7eff06e2f9">
+      <statement statement-id="ps-7_stmt" uuid="f1f9a6d5-9a56-4e67-ab67-93e63f5c593c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3780,10 +3780,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="308e66e4-840a-4247-a809-bc246c8d0d23" control-id="ps-8">
+    <implemented-requirement uuid="b32f79da-715e-4149-bd0f-e74f904b811f" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="370ce45d-5a48-48a7-b662-931bbe7f9d1d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2c487126-3822-42d2-9510-a7b6e8fcbb77">
+      <statement statement-id="ps-8_stmt" uuid="09459806-68af-4733-802a-aa394b87a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -3791,10 +3791,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4665e8ce-4d62-425b-84e9-a24aaf4852ff" control-id="ra-1">
+    <implemented-requirement uuid="e37cfe14-b5fd-4d96-ac49-1a57863c6f72" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="bd4d9e25-a11f-4a07-832e-dca7ca37d2ed">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="966bf024-a256-4579-bed5-e4cb3ff04269">
+      <statement statement-id="ra-1_stmt" uuid="2a1973bc-26a3-4d6f-93c2-dc280fe40b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3802,10 +3802,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb5a0bb0-b7e1-402d-be97-f78187a398fe" control-id="ra-2">
+    <implemented-requirement uuid="b330baef-38cc-404f-b2f9-cac39cb6bab8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="eac0ff4d-e237-43f4-81a9-80ee9a5dac8c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="904f4a9d-4ec4-46d3-ac43-40cf351422e9">
+      <statement statement-id="ra-2_stmt" uuid="fc8a77ad-f129-4504-a1c6-b4e72a971c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3813,10 +3813,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cd1f4f6-06c3-4d72-b69c-cf8085245895" control-id="ra-3">
+    <implemented-requirement uuid="ba31e6ad-7602-4a1a-a279-267f87ac58cd" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="e46050bf-b2ad-437a-b1d5-c5977c6cf19a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a68f5d39-9f59-44e9-9846-94bb402372e5">
+      <statement statement-id="ra-3_stmt" uuid="3c5a3049-9ba4-4284-8163-0c6046d289a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3824,10 +3824,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a31ebafb-6a6c-43b3-90d1-5f4726da8085" control-id="ra-5">
+    <implemented-requirement uuid="3911668b-2301-41f2-a0e5-ff0d3f95db08" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="ae2e8490-8212-4385-b421-d604d3a46a77">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="42daf554-913c-4dca-9e95-c0f71ae923c6">
+      <statement statement-id="ra-5_stmt" uuid="e68ebbe4-3b22-428d-9d9d-9eeee4865235">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3835,10 +3835,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eef81445-a02c-4c5c-930b-c4439d5a08b9" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="cd574e1e-fe53-4b29-aa32-a3b47bf325bc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="51c0dd96-5682-4e62-af74-5e1593592a28">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3846,10 +3846,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ffe3771-c277-4873-b0c7-9b34c441cffb" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="8045daaa-7ed7-4826-93a8-9097311a588e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="dd82aac4-3fd8-43ea-94d2-a20c80fd722a">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3857,10 +3857,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="178c206b-298b-4d15-a802-2bccd41e1015" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="072671e4-4d54-4309-83ac-d8991aa2a5b7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="aceb7210-1315-4a0d-a35f-ba12af5cb43d">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3868,10 +3868,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b743239-fcd3-46a2-b96e-460921559fa2" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="ebf1fcee-edb6-4e87-bbc5-39d945b3cf69">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9b869c3d-b900-456c-885d-151d496375c8">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3879,50 +3879,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39eab9ab-bc31-4494-ba78-e62742223011" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="833d0d45-96d6-4ec0-a67b-7c40d2c00001">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="367eada4-15bc-43aa-9351-fefbb8b5ae16">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ea22111-a16a-44ec-a154-44fa2823db24" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="013091f3-68b1-4291-be0f-ef5d9e338bd7">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9831fe91-bb82-4298-9927-6b912f2535f8">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc7c5f39-4f91-4ff4-956c-6666833814bb" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="a6495b50-de04-41bf-911f-adcd4eb65bf5">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="99f80792-1610-454d-a6a8-944406742600">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b5e3a58-2125-4dbd-b709-22fc2e2b9472" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="3c7cb301-324c-42bc-a4f3-df97407e600c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="85cc2e80-cb65-4875-a595-1766fbffd57f">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34bf9188-f35f-4f4b-bfb7-8bd905b716b8" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="6bb7aa69-c7b2-4464-b86f-0499db02c69f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2a02758b-e581-45e3-a32d-980c2ab735d1">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3930,10 +3930,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a103b06-5365-4d40-b07c-e1861928e642" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="d2edb066-8066-4deb-bbc2-01e74315404e">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2f28b6f1-6a96-4fa7-bdf3-43b914fca0c5">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3941,10 +3941,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4c40b64-3ab6-426d-aca8-103871fe6c34" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="af582a2b-3473-477d-8f07-ac0f054e5a56">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6c3fbd3a-a84e-40da-85cd-e91383eac834">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3952,10 +3952,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fe8023c-0d83-4001-9ffc-92c5a0a9cfe8" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="89255a28-2290-418d-a8d7-5f4b35924ab3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="57166236-7ea1-4d56-92ca-8b5fe367f198">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3963,10 +3963,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d87331ba-b6fa-4e20-81d1-bc774cb77589" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="de43db68-502d-46bc-9c3f-7cdb66c3de9d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e6b2aecf-64f6-492e-8589-126e3b855bf1">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3974,10 +3974,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="383fce08-4f09-483b-8e53-cd2f175e481f" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="1ded8b1c-75f2-4647-aafd-8ba9ae715024">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="33dbaa26-d165-4522-9b74-3ff313853ef2">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3985,10 +3985,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68680cad-d917-4c39-96bf-91d041052b4c" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="6ca69a50-b422-413c-8d00-a38e19b71c37">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="74726269-0246-4ca6-92ce-786ece78b9ae">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3996,10 +3996,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cba4522c-6995-4337-96ca-c8bc3995a38c" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="00d53caa-4ba0-4bf5-bd9c-25c8a46d514a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="e847ba82-9445-4007-8688-8542ef64ca5d">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4007,58 +4007,58 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4fe5fd3-aa01-4dfc-82cc-bc76772e7d96" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="47087688-141e-4020-a085-84744a3f260c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b02d0987-5088-457e-acbb-1b5e10e2ecb6">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="5de1a05f-8992-41c1-8f1a-9d47d140fc31">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6d386e8a-0d3a-47e7-b0e8-5933bcf93d68">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="671d866c-7b03-4d7a-9e49-eb003e6dca46">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fcda0168-b674-484d-8584-eda1a80e43e4">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="199399e9-a42f-485b-a248-3d16eb219ad8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="aea1ad00-0dee-4628-befc-08648093a17f">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="9a79ea92-94cd-4d5f-9986-0314313e60bc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="af2fab25-6d6e-4d77-8c04-9699ef769871">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="202064ae-b0e9-4d56-9404-86e2dfc3ccfe" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="f1fc771f-e79f-4b86-bf11-578f91f2b754">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0ac6f912-92c7-4517-ad74-9601e04cff83">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1773f909-2082-4079-afe4-424bbb298c45" control-id="sc-1">
+    <implemented-requirement uuid="5651d80a-c6dc-48a2-a7d4-59d286b6168d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="657b9f08-7542-463d-bb73-b0c7d461007b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9b5e040d-ef68-4d76-9f50-80db12070b3b">
+      <statement statement-id="sc-1_stmt" uuid="f95841a1-e7a1-45cd-8dbf-fb9f208730da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4066,10 +4066,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34a77fed-5ae8-44e4-ac50-effeed5057b4" control-id="sc-2">
+    <implemented-requirement uuid="45184a65-ac16-4ba7-8370-1b3d059f73a3" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="d93a0043-7935-4e37-af46-fa271f6eac3d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="065e8ddc-9dc5-47c8-a1cd-7694dd42b2d5">
+      <statement statement-id="sc-2_stmt" uuid="676e19b8-f19f-45c8-b57e-3e55be805135">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f886952-6505-477c-897f-a16f051d5e0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -4079,10 +4079,10 @@ and management functionality access is separated.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9029488-2b3a-40cd-b489-d73d30504121" control-id="sc-4">
+    <implemented-requirement uuid="1ceea3d3-3782-4c64-8e55-4178aecf31be" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="60ce7bc3-90f6-4a26-a229-ff803847d068">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ee111d06-1a3c-4e81-abd2-444a456f4549">
+      <statement statement-id="sc-4_stmt" uuid="bffdbbcc-af07-4296-a380-38d3e96ddf1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea85ab0c-4c54-4353-bfe0-eaed665e08a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -4091,10 +4091,10 @@ successful control response will discuss how this is prevented.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6392bcf7-67dc-4e17-95eb-d838dd3e852b" control-id="sc-5">
+    <implemented-requirement uuid="f499ec6c-51d8-4b49-a2d2-5776775a3493" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="454d1f09-0113-4bed-9e74-f2b0c1c7df03">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8869bb2b-34f5-49d7-827b-5495b431a324">
+      <statement statement-id="sc-5_stmt" uuid="33eaa098-ca31-4f63-84d2-6138c7a098f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4102,10 +4102,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0258343a-76d2-4d8d-b11a-21c577acbf25" control-id="sc-6">
+    <implemented-requirement uuid="145e3693-4b5c-4687-aa01-06faa69d027e" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="dbd964ec-6f7c-44f5-b88a-c3db6a08bb67">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="58f8383f-f2ca-470d-b4a1-1c9603d2dceb">
+      <statement statement-id="sc-6_stmt" uuid="cdaa6955-af96-4ded-b044-651ce8e5951c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98311916-bff5-4d0a-907c-d0e8a6c7e5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible to protect the availability of
 resources by allocating processor and memory resources by process
@@ -4115,10 +4115,10 @@ discuss how resource availability is protected.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62d42578-1d87-4b99-a711-cddecf554a9e" control-id="sc-7">
+    <implemented-requirement uuid="3bad8fd3-057a-419e-847a-320c75185d9f" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="d272b1bf-15f1-44fc-8c01-ab6ed200db66">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a9d16a7b-dbbf-4eb9-b3fe-7b15f6023dca">
+      <statement statement-id="sc-7_stmt.a" uuid="3f72051b-6578-4787-97d9-6e4f8619b2e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdabd9ff-7ac0-464d-b4e2-2085625778c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Openshift can be monitored is forthcoming. This activity is being
@@ -4128,8 +4128,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="147cfe7e-6ad9-48b5-ac70-3a43450c34db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="99b0887a-b385-477f-8c77-9414186d7349">
+      <statement statement-id="sc-7_stmt.b" uuid="6fc0305a-c430-4dbd-ac33-7226cdb84d44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7519cc9b-c5d5-489e-94c3-d8233cc8a4f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -4139,8 +4139,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="50431690-d058-4268-b068-6fe1d431f8db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="37ada04b-33fd-443a-b761-be8bc7e3fc68">
+      <statement statement-id="sc-7_stmt.c" uuid="eab9b163-d436-4802-af0f-69f8986ad962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5494a31b-da22-49a8-b068-5b4d3b701e2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can route connections to external
 systems through a managed interface is forthcoming. This
@@ -4151,10 +4151,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da7f46e5-a2df-437d-9d77-d1e60735b0ac" control-id="sc-7.3">
+    <implemented-requirement uuid="1b8306d1-b23a-444c-a90f-b6384351098d" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="9fc6979c-ea11-469f-aa87-5ed8d178d064">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f204469c-9fa8-46eb-b394-f7c6002ceb5b">
+      <statement statement-id="sc-7.3_stmt" uuid="f5a6d0ce-ba0e-4ce6-b0b1-be3f546c100a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10d1d997-e522-435d-a550-05ced6eebbcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -4164,48 +4164,48 @@ enforcement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d77ef56-a63f-407e-9425-0ad050799b1d" control-id="sc-7.4">
+    <implemented-requirement uuid="40b05aa6-c8d1-47d5-b5f7-65cf07004596" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="f2fdfc53-2698-4ab7-9915-40caed0e2b8b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="15115560-7e57-4050-aa93-d1d1552979b6">
+      <statement statement-id="sc-7.4_stmt.a" uuid="ff5f8537-02cb-445b-a1cb-d37293e742bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="873d5e28-f3be-49a0-be08-2dc7d8263ebb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9f2ca423-9ed1-44e9-8a25-490b622b54e2">
+      <statement statement-id="sc-7.4_stmt.b" uuid="9be0639a-8be4-47bc-ae2e-4359af0794ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="103e0900-96a2-4d7f-8a84-4886061efbe6">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5967430f-e5e4-4f1d-8deb-4772b7a86b1e">
+      <statement statement-id="sc-7.4_stmt.c" uuid="78435ec2-e899-46c7-8b36-778aaf1c867e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="da17e42d-0fc6-422d-b990-3dfb2ecdd4db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5c6354c2-eb62-4269-b154-55d89f0eaeea">
+      <statement statement-id="sc-7.4_stmt.d" uuid="4240e31d-db4a-481c-b00a-5e74bc7b3961">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="4848b199-67e6-42ff-85b9-8f0797ea9ad9">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="917fc95d-4afc-4c00-9d77-f373d3811d23">
+      <statement statement-id="sc-7.4_stmt.e" uuid="e8b6561b-d8ad-40e8-a6b6-f3d1192981ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d8be004-a042-4a83-a907-aea5ad03c2e2" control-id="sc-7.5">
+    <implemented-requirement uuid="02e34c4e-d275-4ce6-83ab-aa52bfb3cf82" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="ba6d61ca-2fc1-4a20-9cd4-10a456e9f1fd">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="dd12a803-f2d2-46ef-9ea4-10e1de4edf17">
+      <statement statement-id="sc-7.5_stmt" uuid="8df5ea74-cbae-4161-b62a-fb5cce809979">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba6f5e62-9e53-413a-8956-3ac4fab17cba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -4214,10 +4214,10 @@ by exception (i.e. deny all, permit by exception).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e82667e-56ab-41f4-93a4-2010e23d8c64" control-id="sc-7.7">
+    <implemented-requirement uuid="a73a61b0-42a6-47c2-af43-30ca614dd309" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="ccba86da-2fdd-4395-8c77-52ac8ee762db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ba1e4a1e-1ed5-4250-a2f2-73441c355e4d">
+      <statement statement-id="sc-7.7_stmt" uuid="269d30c7-ab78-4404-afd0-5d61e1a5a6d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42fed431-933a-486e-aec1-ae00744cbd36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing mechanisms to
 ensure OpenShift nodes to not act as proxy or relay servers between
@@ -4226,10 +4226,10 @@ internal and external networks.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36c5bc63-11bd-4b6c-bb7a-762359cc17cd" control-id="sc-7.12">
+    <implemented-requirement uuid="fd9e6b7b-a1b0-4d03-8372-b5c90491186d" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="9aaa08df-b41d-4364-81a5-1e421ecc54aa">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="56b82a8f-f38b-42a4-83af-e5ed7a058797">
+      <statement statement-id="sc-7.12_stmt" uuid="e7f26f01-e38a-4229-a5e9-d05c5a3ab47c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bcae28b-c686-466b-9537-914db5b23547">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -4238,10 +4238,10 @@ local firewalld and SELinux policies.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="258a9ce5-e4b3-47c3-9205-5733701195d8" control-id="sc-7.13">
+    <implemented-requirement uuid="395df344-6436-4c37-af8c-101052db6073" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="b6f4c192-da2b-42a4-8aaa-4b2c5788be1c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a86c6951-35e0-4e74-b9f3-8a8b27b59e4e">
+      <statement statement-id="sc-7.13_stmt" uuid="ff75535e-3178-4875-b64d-b3fcfa26aa97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5fe9fd7-6ec7-461b-8b81-7a81d9cb6a0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring that OpenShift is
 isolated from other internal information system components by
@@ -4253,20 +4253,20 @@ control.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06fa6feb-8137-44cb-926d-b58a717246da" control-id="sc-7.18">
+    <implemented-requirement uuid="f6a1d6dc-5556-429f-84e0-9522b0efd320" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="072c354f-9b46-4e76-9f66-e49f2ccfe845">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="fd389e54-d976-4618-8dbb-9a65fa0b2e6b">
+      <statement statement-id="sc-7.18_stmt" uuid="f5c35cf5-b700-4e5d-b405-77a19cd7267c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="baa2cef2-011f-4e6c-9be1-5e650016ed64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited through organizational network services.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50fa1713-78ba-4df2-9e82-eb1b5c7f733a" control-id="sc-8">
+    <implemented-requirement uuid="dbb58d1d-24a2-40eb-8223-1874cf17736f" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="0b5acf0e-42e8-47cf-ae79-4c298c0f6ac0">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="70fd300b-28e3-4784-a29a-393e347bdfbe">
+      <statement statement-id="sc-8_stmt" uuid="b4ccb602-816d-43fa-9615-899936dc596c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6de910e-149e-4a43-913f-5f6c531617b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for configuring TLS for transmitted
 information.'
@@ -4274,10 +4274,10 @@ information.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b8f17e3-f219-44bd-9160-f03b1de50342" control-id="sc-8.1">
+    <implemented-requirement uuid="309ecd34-3d20-46be-a07e-846a1fe45f27" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="9b30fadb-0d3f-46bc-84cd-d5ea0c1a80aa">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="67874b72-8d26-47f1-986f-719523d6dce3">
+      <statement statement-id="sc-8.1_stmt" uuid="09048457-8308-4541-8769-d1219ef438f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4a7f402-aad1-4175-b5c1-f0d7545dcc23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -4288,10 +4288,10 @@ network communications that carry customer data.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0738448c-adee-47bf-bc97-1d635f438ceb" control-id="sc-10">
+    <implemented-requirement uuid="bfce6633-b22c-48d0-9e5a-72b19040d678" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="942584b1-fee2-4d7c-a509-ab269ec30283">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bc7dac93-8d1e-45a0-b777-148e5e840e39">
+      <statement statement-id="sc-10_stmt" uuid="2f812c81-df98-40d8-8293-788cb91deef9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c67d9a1d-74c1-4612-9056-3c368ac37a2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -4301,10 +4301,10 @@ means on how this is established.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cdbb942-0ea7-48d8-a6dd-abc4e8638f96" control-id="sc-12">
+    <implemented-requirement uuid="7c88e161-ba05-43dc-ab5e-884b8dcb10bd" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="2ac91e90-6cb5-43f7-bcf2-2d8dd3861c78">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f35024b1-e594-42c5-b6e6-0829b335eb2e">
+      <statement statement-id="sc-12_stmt" uuid="02134109-c5f5-45e9-a1d6-e052124ef3e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="352d0e88-8e3f-4f3e-9b22-26e69493b31e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -4315,10 +4315,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba8c198a-4880-49a2-8978-2914a898f9f3" control-id="sc-13">
+    <implemented-requirement uuid="3f412236-08c3-4871-b71a-c5eabf00f94f" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="ac5c6c0f-1c52-4d9f-b30d-bc77392330ee">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0fb4306e-dcfe-466c-9e13-f9bed37d34ae">
+      <statement statement-id="sc-13_stmt" uuid="489f455c-5055-47cc-8e10-8437a43748e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f74300e-0237-423b-836d-8f145bac0762">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding OpenShift's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -4329,10 +4329,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c57ab0c0-b49f-4b38-89a8-f0ff0f8b8ef0" control-id="sc-15">
+    <implemented-requirement uuid="76ca3ea7-c2d8-410c-8ca5-4404d7072b39" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="54e0207c-f403-41ce-b3dd-0b8904eb0564">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="86bbc92a-30bb-47a0-8190-704e51867ef6">
+      <statement statement-id="sc-15_stmt.a" uuid="65568e0a-645b-4332-a928-6fd568a15f5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4341,8 +4341,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="ff5e7adf-4df9-4f22-a9d6-0703361d2c76">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2b376629-cbb5-411f-88b0-f084391acb27">
+      <statement statement-id="sc-15_stmt.b" uuid="5afe21bb-69ec-494c-98e3-bcdacfde5d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4351,8 +4351,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="3c2145c5-f9a7-4049-a655-557cc634afcd">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a4f9b8d0-50e8-4c7d-8154-f07bda1f9d1a">
+      <statement statement-id="sc-15_stmt.b.1" uuid="d65a4a16-075f-4578-aadc-d9a267ce2130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4362,10 +4362,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65f64cc4-0fcb-4575-8ce3-d17a0e94b748" control-id="sc-18">
+    <implemented-requirement uuid="e632bdf6-9def-469a-9f51-f787715c8d51" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="c53b7a1d-4b79-4a5d-8caf-0084a9480988">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7cf559f7-6d11-4c9e-aa53-67ee69ffd754">
+      <statement statement-id="sc-18_stmt" uuid="e4cf3bca-cc87-4d2f-bca1-9a6e873b7c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b076ca-9681-445c-8b71-37fcecf9b185">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -4374,10 +4374,10 @@ with organizational policies defined in SC-18(a) and SC-18(b).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="901031aa-fb1e-4dca-ad49-4fa9bfb35e7b" control-id="sc-19">
+    <implemented-requirement uuid="a333d58f-a031-4846-986b-65403531f85b" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="3544ab6b-841e-44cd-a67f-f6fd74a1b9fb">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d7c3290c-5388-4721-ab60-2a426e481190">
+      <statement statement-id="sc-19_stmt" uuid="99a38163-d7a5-4f40-818f-422bf601fcb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a02f55cf-9d87-4641-abcd-91fb726b65a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -4386,10 +4386,10 @@ organizational policies defined in SC-19(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20d6d10b-bac3-4a61-949e-9857440276ff" control-id="sc-20">
+    <implemented-requirement uuid="f8b830ff-57af-4e37-854b-788171e6accd" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="02d86187-7cac-4aab-9875-4b01eac4f015">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="4831515f-2f29-45d2-9a54-eb3e5a409243">
+      <statement statement-id="sc-20_stmt.a" uuid="e5127dc4-3261-4308-8dee-f2d6a1836dfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8cd61eb-4c1f-4240-bf35-1ef4202ccd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4410,8 +4410,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="f73c39d4-5ab5-4b78-9786-b784fa48579c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a063ec7a-a1f1-4df6-bae0-00f609352a1e">
+      <statement statement-id="sc-20_stmt.b" uuid="5801a7ff-229f-4f6f-bdc7-61ce7f4809c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a8570ee-bd65-41dd-9064-8453735ed2d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4433,10 +4433,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c99db656-dab9-4999-aab2-7a81b6006a7b" control-id="sc-21">
+    <implemented-requirement uuid="3bd8b52b-1b3a-4228-a4f6-f4a456a753e1" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="1c0c052c-3446-443a-8da3-54171cad31fc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="68c255dc-8905-41c2-89f2-4ef17d189ef3">
+      <statement statement-id="sc-21_stmt" uuid="121f52df-4b04-4051-97a3-d05a14dd503e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="289e55b2-eac1-428c-8f3a-d3a0e8a486b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4455,10 +4455,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b33dda4-da2a-4aa3-b023-55f8635cdeb9" control-id="sc-22">
+    <implemented-requirement uuid="c20eba14-fc75-48a7-b425-9d93b361f7d5" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="acbb8a80-30e6-4d6a-80d5-4bb05fada9d8">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3006b647-dbca-4de4-96d9-5fd6a4c27a8d">
+      <statement statement-id="sc-22_stmt" uuid="10885e32-cc85-40ae-bed1-b469620eab66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="808d8d96-a64a-433c-ad12-ccd41c1a4b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4477,10 +4477,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb626b45-db5b-4cc4-96c9-af71e75cd68d" control-id="sc-23">
+    <implemented-requirement uuid="8c4987c8-a619-49a2-8c27-4d6a68cf9c0e" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="0e77794c-6d58-4802-8aba-45370af888db">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="090f735d-679f-4d84-9db6-941c2aae74f5">
+      <statement statement-id="sc-23_stmt" uuid="0a5b40f2-5655-4ca3-8c38-81c3d33f5504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f7cfbc5-f939-47d6-a7e3-44377d12ec68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -4495,10 +4495,10 @@ the authenticity of communications sessions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3822ee2d-6fe2-46bd-804f-b4ff50bbd4ef" control-id="sc-28">
+    <implemented-requirement uuid="97c63d21-0394-4cc1-a9a5-6eca1aa05b33" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="7a137373-bb5d-4079-a39d-f594fee2a566">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="29c63a53-ff59-48ef-9c6f-7fefd8a587df">
+      <statement statement-id="sc-28_stmt" uuid="d79a9a88-b123-4dfc-a893-b36de54eb28e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f69f9f92-e028-44fe-baa3-9712e7949912">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A successful control response will need to address the means by
 which data at rest is protected.'
@@ -4506,10 +4506,10 @@ which data at rest is protected.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f77a2ea-0cd2-464b-b0a1-0fc556b88709" control-id="sc-28.1">
+    <implemented-requirement uuid="a5b59816-840a-4297-ad03-1ec2f09f2ff3" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="92c7e360-a998-4191-ab11-a7a867efeb16">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="89e65d27-ce18-4121-b968-3c7a823261ad">
+      <statement statement-id="sc-28.1_stmt" uuid="58dcc4e2-a2b7-456e-8f96-0049fa3be1f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c8e01f8-d1d8-40b8-a6e5-1b60b89fb596">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -4525,10 +4525,10 @@ protect confidentiality and integrity of data in transport.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="026d31b3-1e49-47cd-8361-a2d16bc1cff3" control-id="sc-39">
+    <implemented-requirement uuid="fc3dd2a5-0331-4978-ae59-af93cdadd306" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="0f3365e5-054e-4fa0-af7b-af935ac1aaaa">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6d6932b9-d12e-4b05-975b-ad3474aead33">
+      <statement statement-id="sc-39_stmt" uuid="0ebe79d3-820a-4763-b0a0-3bfa9bcd25b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18033792-c0d4-4b01-890f-9d7957b9c16f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When OpenShift runs on Red Hat Enterprise Linux, 
 OpenShift maintains separate execution domains for each executing process by
@@ -4542,10 +4542,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="646bfa44-0c03-49db-ae47-fa182049ca00" control-id="si-1">
+    <implemented-requirement uuid="a61cc071-ecc0-458f-902e-f49cc09131fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="7374be45-9661-4cd7-bd3a-3addc83cfe71">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d3f134c9-63b5-44e8-8688-4e3f8a920cf9">
+      <statement statement-id="si-1_stmt" uuid="e90085e3-09ec-4da8-8312-dd6fdd8d33ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4553,10 +4553,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fed46f1b-55f9-4cda-aa64-4a6bb39e41aa" control-id="si-2">
+    <implemented-requirement uuid="51ff2fe8-0d0d-4955-8bb5-69d7e5140461" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="c73970a6-ffa2-40bc-a6c6-e393554e22bc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="22674c5f-f79b-4949-b5a6-ce16cb59a313">
+      <statement statement-id="si-2_stmt.a" uuid="cc54398b-c182-42bc-882f-cdae56f230aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d014d8d-6355-4b52-878e-8d2d9125edec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4571,8 +4571,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="d8e4f737-8379-4ead-883e-bac662ece33a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0811ae84-2c27-4034-a5e9-67023746d023">
+      <statement statement-id="si-2_stmt.b" uuid="3e9e1351-2baf-48ae-a626-ec33a0b98eaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d5e34bd-e241-4c53-b67b-e398909b0837">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -4587,16 +4587,16 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="f1ee9cb1-84d7-4771-929a-34ae5bf16782">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="0f4955c5-d627-4845-bd91-30379c1bd34e">
+      <statement statement-id="si-2_stmt.c" uuid="819d1252-34e4-4c59-9721-a280e31aacb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="a6863910-f6c6-4d7c-aa68-4050d569b381">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2a3500c3-efec-4483-a7d5-50a93fb3569a">
+      <statement statement-id="si-2_stmt.d" uuid="0233489c-5aba-44f9-b7ca-a084496a95cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4604,10 +4604,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d962101c-498a-4d72-96eb-fe454b5b134b" control-id="si-2.2">
+    <implemented-requirement uuid="9a5cfa9f-0693-4234-ae47-92ce1f7dd379" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="41aa558a-7190-4d78-bb10-d087a1c82c5c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="896e9ff6-b484-4cab-87b8-ecb8feb4de3b">
+      <statement statement-id="si-2.2_stmt" uuid="58c9edd8-bda5-4e73-a634-2f55dd4e2746">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0df12449-b791-47ce-968f-a15fd77929a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be required to employ automated mechanisms on a
@@ -4622,10 +4622,10 @@ the state of system components with regard to flaw remediation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee9890bf-848a-4edd-9d1d-3bddb2ad58e2" control-id="si-2.3">
+    <implemented-requirement uuid="9cab4d15-649f-42b6-84a7-ea91d7fbcba8" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="87370279-23e3-472f-a2f8-feea0dab7d7f">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="de545cee-9297-4cab-a157-8eff345143af">
+      <statement statement-id="si-2.3_stmt.a" uuid="b688cbad-d425-4f78-ab3b-fd4deb9ae645">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8778d770-db90-4f5d-9c90-2c388459b19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer is responsible for scanning for flaws in their
@@ -4638,8 +4638,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="483b2540-4d6b-4b75-8dfe-bd2c71ea7f4c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="6eb8c597-497a-40f7-9cb8-c8bc314d3c54">
+      <statement statement-id="si-2.3_stmt.b" uuid="73c6a5c3-bcf3-4cd9-9d14-bce099d237cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27ea413-c18c-42b0-b5e7-9c7dd7985ae9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for scanning for flaws in their
@@ -4653,10 +4653,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a1da587-6a55-46b8-9bec-ecba02a269e4" control-id="si-3">
+    <implemented-requirement uuid="a73549a8-4ef3-4e35-ae59-78a92edd5429" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="54cf9ac4-4e5a-4df2-81b8-2d2d82d91f0d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c05ce47c-b22c-41b2-a0ce-8e76c7014487">
+      <statement statement-id="si-3_stmt.a" uuid="99ffeb16-9f41-4901-85cd-a64f801b69db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68c758ff-1223-4c00-ad94-b38ad58e96ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4673,23 +4673,23 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="08a8848b-b8a3-490a-9a5b-290f10158e41">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="8103fd3d-5d1f-404f-bec9-003ef3ca36fc">
+      <statement statement-id="si-3_stmt.b" uuid="4378e159-c248-484d-866c-616e57ae60cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="66b1686a-bdff-448c-ad9d-8c84fc3b8f32">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="19d85b27-6492-4f39-a6ca-57ae8d564181">
+      <statement statement-id="si-3_stmt.c" uuid="c3dfb7d0-4929-477d-8c51-72da41d4adf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f8d3c4-5693-46c1-b279-e6c96c419175">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of OpenShift, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="d4ada3df-a044-4599-997f-b60fa3a4c464">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="21796e4d-0674-4ff0-b1ed-5e12430f2a3f">
+      <statement statement-id="si-3_stmt.d" uuid="7fd01259-94de-4af2-8c6d-f320e41c911a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4697,10 +4697,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a60261cf-327c-4e32-be19-7a1055a7d276" control-id="si-3.1">
+    <implemented-requirement uuid="25e9e8d7-8802-4d20-8337-c9e71f14b3be" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="1ebb6ed6-9d64-4410-85b9-1ddb5f7a0e2a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7e5d4fb0-64b0-45fd-81da-4ef3ff9309fc">
+      <statement statement-id="si-3.1_stmt" uuid="a6a982d4-20fd-433c-9572-58f50789bd1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18991304-6891-47d4-992d-b5041cbe24d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -4711,10 +4711,10 @@ protection mechanism is centered in one location.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc456332-7503-451f-9895-e8b15c9cf71c" control-id="si-3.2">
+    <implemented-requirement uuid="f8c3f7f6-df8e-4dbf-a40f-4f32a2933d05" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="7bcae1b6-2aaf-483a-b3a3-9cac51e57e74">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="cd207db7-af7d-4608-9f08-b9ce04001047">
+      <statement statement-id="si-3.2_stmt" uuid="94de5dc7-a75b-46c2-8c98-8cd9804687ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe606ac6-77ea-4087-8fc2-91a8ec937fa7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -4725,10 +4725,10 @@ mechanisms definitions are configured to be updated automatically.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a407695-7fd8-4e3c-afc4-d7aa29eeae28" control-id="si-3.7">
+    <implemented-requirement uuid="4e714453-dd81-4590-b826-1c2bb0dcb62f" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="0cadc06d-2547-4ed3-a6ee-1eceb47bbf7d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f00a532f-4d90-4f49-ab66-b151a3e68b85">
+      <statement statement-id="si-3.7_stmt" uuid="367bf051-09ab-4d20-9684-b74507109378">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64dc97f4-62a3-4e8a-88f5-7c1695cfaba2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -4741,10 +4741,10 @@ do not yet exist.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f242679d-91bd-4f8f-a37d-8e9bc0ee3632" control-id="si-4">
+    <implemented-requirement uuid="1a0b3492-5535-4428-a0a7-647598146b89" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="a8582901-d5fb-4ebd-a6b3-3685378991cc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9f65e337-768a-4013-93ad-e826cf063218">
+      <statement statement-id="si-4_stmt" uuid="8497c3eb-0eaf-42d0-aa8b-824b58f6096b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4752,10 +4752,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="377ceae9-72e2-4eef-b482-71afc5ef7d8b" control-id="si-4.1">
+    <implemented-requirement uuid="d53b1333-fa4e-4669-822e-63db227ec10d" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="0a9b91ef-8b49-4886-91b5-b6db3da17981">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="b66f28c7-6a3a-4836-b1f0-2ad91d70c060">
+      <statement statement-id="si-4.1_stmt" uuid="c5f2f43d-5cfa-4d3b-b099-4883f976e8ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2020ec2-9be5-454f-bf0b-9068e8dac025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for integrating intrusion detection
 tools into the OpenShift environment, and documenting how this
@@ -4767,10 +4767,10 @@ systems.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df72d8aa-a5da-43dc-b457-6bd2b64371be" control-id="si-4.2">
+    <implemented-requirement uuid="6e20e0eb-e7c1-484f-a633-f37c9f4a1ff2" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="c0ab0487-ee5b-4e98-9348-9eefd20cb7c3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="90b2ee50-1189-45d9-b1f8-4afbd3504003">
+      <statement statement-id="si-4.2_stmt" uuid="223935ff-f4a3-40d6-a42f-add4fefe2475">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d20beca8-8fc6-4991-99a0-7a9e75cd7e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -4784,10 +4784,10 @@ analysis of events.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04aa62bc-7686-4028-9afd-1601921a9a01" control-id="si-4.4">
+    <implemented-requirement uuid="297237c1-5d71-4fee-9c8e-7aeff55ba236" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="34c194fc-ee8e-447e-8871-84cabeb032ad">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="7a7044dc-68b0-4c40-a9bf-4cce4877b157">
+      <statement statement-id="si-4.4_stmt" uuid="60189981-962d-4567-a3e5-59dae8dc7554">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee591d3c-02c1-46ee-b641-7bd52c931aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -4799,10 +4799,10 @@ not, how network traffic is continuously monitored.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87538bd5-d825-4699-8576-24b28192c1d7" control-id="si-4.5">
+    <implemented-requirement uuid="c5b122cc-64d1-4cbc-869d-8ae2f0be1d11" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="02b70abf-02cd-4f67-845c-37c543fc272c">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="bc49ec50-57de-4f6d-9dcc-1537e901da4b">
+      <statement statement-id="si-4.5_stmt" uuid="9ffd0a22-36f0-4373-b488-c6aad26578f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eea7dca3-3df0-4e0b-8984-df260c203e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -4814,10 +4814,10 @@ the notification.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2123745f-a4c1-4b1f-92e6-e5d088c10149" control-id="si-4.14">
+    <implemented-requirement uuid="d8d89aec-fdab-413e-bb22-e8b2fb64f912" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="b6a4dddb-ba59-4a2d-b43a-df80e292a992">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="13686b46-8e38-4d19-8095-1ed5c298d749">
+      <statement statement-id="si-4.14_stmt" uuid="445ba79b-c8a5-455c-aa8a-67d35426b09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ea8a35d-d1b5-4012-948c-5daf8cde1bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'An OpenShift infrastructure does not have wireless capabilities. This
 control is Not Applicable.'
@@ -4825,10 +4825,10 @@ control is Not Applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bab77db-33a7-43cc-872b-dce1f4bc3d73" control-id="si-4.16">
+    <implemented-requirement uuid="9cd2ac9f-ed6d-463b-8be5-79b53f0381c4" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="5b2b5146-23f7-42f5-93d9-f45924c7c0ac">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="c5bc1d51-2ea3-4627-befe-a6d83a64b03a">
+      <statement statement-id="si-4.16_stmt" uuid="725cc6b3-bb59-4f54-b171-73848a6b89e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2922f053-40db-44dd-95ee-14eaffe76810">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -4838,10 +4838,10 @@ tools.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8610f234-29fb-4ae6-8646-b0133e4e327c" control-id="si-4.23">
+    <implemented-requirement uuid="33c28549-42b7-4698-af7d-b40674518e04" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="a4e21d8c-9d34-470f-9481-61202b20af2b">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="93524d35-0c88-465c-bc77-0b698ea6395b">
+      <statement statement-id="si-4.23_stmt" uuid="f4b89be2-1c8e-4cd7-9eb2-276c39d2ea70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="56298acb-1788-4933-a8a7-da0d96406a13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -4850,10 +4850,10 @@ various elements of the OpenShift infrastructure are monitored.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd807202-65d1-467b-bbc8-9fa896b864d3" control-id="si-5">
+    <implemented-requirement uuid="2fd16570-0cfb-4746-8964-2c214f8a6923" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="1c37f125-51ea-4c29-9e40-cb049cf8cb00">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="eca7bed9-f7f9-43a4-8bfd-d69bef92ac7e">
+      <statement statement-id="si-5_stmt" uuid="21e36570-d66a-4acb-b429-693ab619cbf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4861,10 +4861,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ad7a87b-6712-4ff3-b9e2-ce631f7fb489" control-id="si-6">
+    <implemented-requirement uuid="09ebcd4c-e600-4a27-be86-3bc3ca19d9a0" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="637377df-0922-4d60-ac01-2986a9c8336d">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="5868a13b-6ff6-4379-821b-cf342bc42655">
+      <statement statement-id="si-6_stmt.a" uuid="9f9f4cdb-9814-42eb-951e-ae802d477502">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5de98c5-bc8d-4e49-a6c7-a0c0ec6e77e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -4874,8 +4874,8 @@ for testing the correct operation and resolving any issues found.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="6408d0f1-ba14-4bb9-b1c5-b667ebc4b731">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="f84273f3-849a-4357-a318-454a3615bd31">
+      <statement statement-id="si-6_stmt.b" uuid="682f7c94-eeeb-4d66-9387-2fa5d2b4702f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7062c134-d97a-4089-b445-4566ce4f47dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -4886,8 +4886,8 @@ of security function verification.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="1270a100-6fa0-4904-b2b2-87cf1cc5a054">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="22d78827-af8e-4dea-a418-b1b753fd2f0c">
+      <statement statement-id="si-6_stmt.c" uuid="49484c73-0f61-4ba3-996f-99c3f95b1edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99aea6d0-89f2-4318-978d-10b4cd4c47ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -4896,8 +4896,8 @@ system administrators and security personnel as required by FedRAMP).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="3c13d65d-c1fa-4227-9a0d-0d1fb37557ff">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="703713ab-7f44-4a9c-95fb-855e8f4b19dd">
+      <statement statement-id="si-6_stmt.d" uuid="079b2480-3826-4fda-bdc3-514bbbac2736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d710cccc-b0f9-49df-8ac8-7a3fefa99a5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -4909,10 +4909,10 @@ actions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8191ba0-4c71-4355-88b4-8ee13a96bc7c" control-id="si-7">
+    <implemented-requirement uuid="31231978-1139-4dad-9bbf-07a6ce92ed0f" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="0e038bb9-8111-4c0e-9897-1b68630f4492">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="02744dc0-b584-4bc0-a5ac-bb576931382a">
+      <statement statement-id="si-7_stmt" uuid="af4c246b-3dea-4eb4-b12c-cd205a006755">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="526bb75a-1ee8-4aa5-82a6-eb372d5f335f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -4922,10 +4922,10 @@ the integrity-checking mechanisms these tools employ.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="285bfd77-80a6-4238-9ae9-070be4cb08db" control-id="si-7.1">
+    <implemented-requirement uuid="e158fe68-a21e-4e68-9259-38cce9525912" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="a71b158d-7de2-4777-bbbe-e5d5df37dafc">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d1119319-4d00-4c8e-a752-efbd7459ea6b">
+      <statement statement-id="si-7.1_stmt" uuid="2ea053d9-f748-4174-bc59-e02ad01501a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48215e55-046d-404f-b076-dc7e726ecab6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -4937,10 +4937,10 @@ for selecting those criteria.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a62b09f-ba49-4d3a-b31b-17da28ead2a1" control-id="si-7.7">
+    <implemented-requirement uuid="dea939b7-9c10-46bd-b840-3ea8ff8dc36d" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="c2681480-e32d-4508-ad23-e0f2dd091e10">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="9eae4ab1-cdef-44c7-bbbd-b0cea108d227">
+      <statement statement-id="si-7.7_stmt" uuid="0704b7a3-aac1-4815-82b3-933f7128bef5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79ba709b-7d3e-4f22-99a2-9c69bb10afbb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -4952,18 +4952,18 @@ capability is invoked when needed.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f61a9f95-319a-409f-a0b1-8857667fa267" control-id="si-8">
+    <implemented-requirement uuid="a40414d4-81a5-443d-9225-15a536a6574c" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="14bbeccb-89c7-43c6-9f60-49abc07334ff">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="dd7dd8db-856d-44f6-b351-f843501d84ca">
+      <statement statement-id="si-8_stmt.a" uuid="88fee8fa-447e-439b-8c26-486a649ce9f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="c1efb522-4489-4826-9e12-db6fd72f22e3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="3974f9f8-ca5b-49f9-adde-c8450ae03295">
+      <statement statement-id="si-8_stmt.b" uuid="fefd44a3-1622-4e1a-9713-2f3363ff0502">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4971,10 +4971,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67b7ac1e-3698-4588-8777-8230d346f2c9" control-id="si-8.1">
+    <implemented-requirement uuid="3612cdf8-22b7-448a-ac06-e1de0743fdaf" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="b8ec8116-ed5f-41a3-9f7a-02960fce9971">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="a827060a-d718-4221-96b8-8ffe5131a389">
+      <statement statement-id="si-8.1_stmt" uuid="723b5cd5-ee8b-4d82-b30b-3e19cba30e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4982,10 +4982,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e70b8eb5-4210-4c46-8d52-acfab4b55910" control-id="si-8.2">
+    <implemented-requirement uuid="95a31156-d8ff-4c33-9205-548a95c14f9a" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="ad4987d4-ecc1-4c4b-95f0-3c58300c9708">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="d3849b52-4104-40f1-b108-3d6fd7380cb4">
+      <statement statement-id="si-8.2_stmt" uuid="57cd2400-1e11-428f-815b-d7dedcaece48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4993,10 +4993,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34cd760e-36a4-4ac1-96c5-e9cce0f3e2ba" control-id="si-10">
+    <implemented-requirement uuid="ae9dd3f8-7cd2-455a-a57e-f2459f1c2f79" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="64fca1bd-d856-47b3-8f10-e15caeaff277">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="27f2e951-24c3-4f64-a64e-ffeda8135423">
+      <statement statement-id="si-10_stmt" uuid="79d9a7ec-bd65-4269-aa02-ef39d9bd6c69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ad60ae-977a-489e-bb5e-4ce317aee27d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -5008,10 +5008,10 @@ taken by the system to invalid inputs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31744553-5d39-47e5-b86a-5896c15335c8" control-id="si-11">
+    <implemented-requirement uuid="81b6555d-b189-4501-897e-b9c7c701241b" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="9f34ad5e-8dd9-4a05-9b30-0c60e7725c38">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="2e1ab8be-086d-4a35-a5ac-8d761f72e660">
+      <statement statement-id="si-11_stmt.a" uuid="4cc8c111-af1c-45f1-a298-f78ef7ce09a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdb9ff34-317f-4d79-8e38-2dbe2dd33022">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -5022,8 +5022,8 @@ messages are created, analyzed, and corrected when necessary.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="22d930ed-f2fe-4a83-81d7-4e64fb0744a3">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="97e778ac-06f1-418c-b6f5-9152c42d9756">
+      <statement statement-id="si-11_stmt.b" uuid="e97305e4-bcf5-42c1-85a0-577fe12ca489">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b44b58a-2baf-478a-aaf7-ee2501a05615">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -5033,10 +5033,10 @@ to error messages is controlled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c14ebbd5-8add-416a-9dd2-9a5c0e2bc193" control-id="si-12">
+    <implemented-requirement uuid="06214fcb-4a37-4659-be34-919e761ed58f" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="f1052795-1b5d-4b6c-8a16-04d9e090e515">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="1e90d242-4cbe-4a2f-870b-3965deb7c6f0">
+      <statement statement-id="si-12_stmt" uuid="a54c2fc4-ed14-4568-988f-77430a6cbdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="703257cf-df00-492b-900f-ddaddf2efa2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -5056,10 +5056,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ffa5498-b6d6-421b-befe-06c8748c3a0f" control-id="si-16">
+    <implemented-requirement uuid="ea08db6a-8104-4ede-b641-fcd2b014ff1a" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="08095c6a-cb64-4b61-8f1e-b8d0e881658a">
-        <by-component component-uuid="9d4c3209-30f3-4403-ad0e-dd4236f146ab" uuid="ecccb39b-c24f-45bb-b7bb-0af6c0f13475">
+      <statement statement-id="si-16_stmt" uuid="dcd7a2a8-e255-4157-90e8-2f52131197c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80f11f03-6cc3-48b9-9807-d8b86e5c0b07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-container-platform-3-fedramp-Low.xml
+++ b/xml/openshift-container-platform-3-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="33ed3ac9-8e96-4f34-9487-8f342c781a26">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="d86cb1b1-2582-46b1-950f-fadceedd7f16">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.61+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.05+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="737f7696-f086-4225-adfa-babc4dec8ee6">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="551a702d-0ab7-4317-bf50-9e9682fca9d8" control-id="ac-1">
+    <implemented-requirement uuid="60708a04-b787-4584-88ec-b5a40233339e" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="51856808-9669-4089-ba49-cec3f6ddf379">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="de690211-c810-45aa-a273-ce670f23bbe0">
+      <statement statement-id="ac-1_stmt.a" uuid="a534b272-07f2-4dd2-b131-50e83c8b73c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d03e4f5c-c2b6-4321-ade7-720c3cc1f5b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="6e32e979-2049-4ce5-b45f-c26492c1ccab">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="2b09d96e-9e8f-497d-8399-5fcffb0d2ce9">
+      <statement statement-id="ac-1_stmt.b" uuid="39869e7b-fbd0-4a76-ba93-35f3b833a806">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2161802-26d4-4ab1-8795-f7c2627f5634">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f094cdab-f000-46bc-aed5-1ecea8bd1226" control-id="ac-2">
+    <implemented-requirement uuid="59578d19-03b0-4491-8eae-26a04cc69a05" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="44562c94-8d75-4d78-92da-2d65ef6a24d8">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="fb068701-5b41-40cd-a8dd-a7032ac44346">
+      <statement statement-id="ac-2_stmt.a" uuid="f58c922c-f798-4fab-bdbe-a332c7e92d18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ad2c932-3725-4d99-82c3-df7432aac77c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="23034043-af0f-40d7-8add-5e780f139fc7">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="09ee38b5-952a-44fc-ae70-5503324f92d5">
+      <statement statement-id="ac-2_stmt.b" uuid="5457a123-995d-45d4-a9fd-5db514a88e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2404e9a-93b0-4e58-9e38-0a9b968064af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="f5e3af5c-0c02-43f0-8ac2-19e0f62557d6">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="416a8fea-e9fe-4d26-9d2a-28e72521fc32">
+      <statement statement-id="ac-2_stmt.c" uuid="d2d3de61-15cc-4a4c-9674-3846c86431bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e239287e-a985-4297-8c52-f51f408465e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="fcb4e006-ab5b-42b2-8282-bad1810a48c8">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3e9418fb-f31c-4f20-b165-07ad1e6b1478">
+      <statement statement-id="ac-2_stmt.d" uuid="96aa180d-68b4-4e6f-9a73-ce5f84362742">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c68a103-5a62-4cda-b74a-a4b30fe404a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="c5aad027-e925-4ae3-8ea7-e450880ea99d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="8eac2950-692b-48f2-8494-9cd983983015">
+      <statement statement-id="ac-2_stmt.e" uuid="9e220f14-127e-4ad8-bee8-035b5f2f7a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b49cfe0-e9b5-4fd0-9e96-24822cf55507">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="88ab1a8a-24d6-417e-9162-72e4b58535fb">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="08535f1d-0b7a-4966-bd82-a92d40121a73">
+      <statement statement-id="ac-2_stmt.f" uuid="daa02e58-fffe-431a-a6ff-9923736b876a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8b34df7-1b86-4cde-9eb7-1fde4cb7cddb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="ad29cf12-f812-4d30-a489-1bcc5c354689">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5272bd4b-bbd1-4732-80fd-39d50d14cd20">
+      <statement statement-id="ac-2_stmt.g" uuid="727f879e-69cc-46cf-be37-9006e8253d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed61ef3a-e2d6-4a0d-8081-5e8c8e72fc2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="1447f8df-9776-45b8-8fd1-58f73022a190">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="69e55f8f-2d6c-47bb-86cf-f39a28d494d8">
+      <statement statement-id="ac-2_stmt.h" uuid="4c706ff6-f1d1-4442-a6f1-1835c98964c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="948375b2-e248-4d06-b3d3-f314aad054c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="0c8bfd40-c7a4-446c-83bf-0458e2d7bb02">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="c887baa2-1178-4f80-8fff-0b8df98abca1">
+      <statement statement-id="ac-2_stmt.i" uuid="d517b147-73a2-4415-944f-2eb3d12c90db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5056b50e-2182-4662-a649-7f1bca05a377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="37307a9d-7024-4c0d-9180-d4e8f53be9ce">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="472ac321-81f9-4c92-8ab1-1082a13ef11d">
+      <statement statement-id="ac-2_stmt.j" uuid="19d705a2-6ca5-4692-a782-04fc9c41a37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bff8c94-defd-4343-aeb2-065ebe0bd183">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="4e23f034-f627-411c-9cff-cc88a670eb64">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5fc25ba1-3a3c-47c0-8776-2f80fdb4a66e">
+      <statement statement-id="ac-2_stmt.k" uuid="6d13e74b-b22d-46d2-8000-b5c56699bd00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e050e3-2279-4395-b0ec-05835ee60c2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae06a05e-ccc0-497d-a37e-769891db27bb" control-id="ac-3">
+    <implemented-requirement uuid="d8db6759-def8-4339-bed8-ffc870482ca6" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="482ccc63-9d19-4dd5-8db8-c2dbf3325fb2">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a8c76d84-e619-4004-8315-88cd639cc92d">
+      <statement statement-id="ac-3_stmt" uuid="8725b63b-97f4-467c-89ff-3ae6966d072f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47a19d86-79ce-46b6-90bc-f6ee32905688">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Authorization policies determine whether a user is allowed to perform
 a given action within an OpenShift project. This allows platform
@@ -608,10 +608,10 @@ configured.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="148dc117-7273-4fce-bb7b-61e08010eec4" control-id="ac-7">
+    <implemented-requirement uuid="ce816ee8-00dd-4a1c-b9f6-3b5cd0f8f33f" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="375f7abf-4399-4657-9568-bc8ad203aa14">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ae9bc737-254c-4104-b309-851205542c6a">
+      <statement statement-id="ac-7_stmt.a" uuid="24aa9850-e243-41dd-a61d-54f533d38f35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72873987-046f-4ee7-b2f1-546624878717">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -622,8 +622,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="558ad2d6-6c62-42bb-9cd8-771fa04a9994">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="284b2250-e964-4082-8309-aaf315e2e3f1">
+      <statement statement-id="ac-7_stmt.b" uuid="bd16ba30-0829-4fcf-b9d5-8c39a0ecdd9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c23be9c-70d3-46ea-80f4-312055fd2b2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for taking the FedRAMP required
 actions defined by the customer, upon account lockout.
@@ -635,10 +635,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5fc428a-0bcf-4d28-a44f-ee523eb67549" control-id="ac-8">
+    <implemented-requirement uuid="0681d54c-f2d5-4a76-ae06-e309f36db328" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="a3dd8dcb-447e-4a91-aeee-4319b75ff566">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="00d79562-190a-4500-9955-ab542a098ace">
+      <statement statement-id="ac-8_stmt.a" uuid="5959ee14-d888-43ac-bc94-2a1672d052ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a6982d5-2fe0-4a79-a9cb-0270677cf54b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -657,8 +657,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="c7daf361-7a00-438a-b0f7-d13c80f8ca41">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="524e9a8b-5582-499a-a555-cd99ded5c21a">
+      <statement statement-id="ac-8_stmt.b" uuid="8ab258e2-1c3d-4d32-a32e-eab24fbebd5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e75e0ed9-63a8-413f-9a6a-b36bdf2d62f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -672,8 +672,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="61ff5090-43a6-4e43-bb89-c8d0533c76b5">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="b93344da-7c6c-427c-8cb6-d33422fc3986">
+      <statement statement-id="ac-8_stmt.c" uuid="d1a44f1f-f6bf-47ff-8dd3-c88ae2bfef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3123693e-d71e-4719-a6c8-fec6e9ea36be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'
 '//*
@@ -689,8 +689,8 @@ of the system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="c8b95414-f1e9-42a2-aa9c-3e6082017a3b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="2c033e94-b2b2-4d0f-a392-9b2caa61d885">
+      <statement statement-id="ac-8_stmt.c.1" uuid="fea90977-1c02-4513-94c0-bf4662ec9e28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbd396e3-ea13-4211-82c2-ae7149526204">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for determining the conditions
@@ -700,8 +700,8 @@ conditions must be reviewed and accepted by the FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="bd146b6c-6e23-4ec7-81e8-9fd7bf62075e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="41b718f6-ce29-41a1-9a26-422f24faf93b">
+      <statement statement-id="ac-8_stmt.c.2" uuid="89d2ef17-0208-44c1-bdd4-1866797b04b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a631d91-5ab8-4a75-b5a9-5b055a4728b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for how the system use notification
@@ -712,8 +712,8 @@ FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="33d37635-48f4-4118-b4db-a73d6c9813ce">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="221702f1-f5e9-48fa-8e3e-ca9918ecad22">
+      <statement statement-id="ac-8_stmt.c.3" uuid="e94c4031-2e2e-467c-b852-1842d215ee2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c3edbe-cbe0-43df-9b89-c7d7ce1ae00c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for verifying that the system use
@@ -726,10 +726,10 @@ review and accept the process used to perform the verification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caf07af1-2a2c-4346-8f3b-e2ec134cd9ef" control-id="ac-14">
+    <implemented-requirement uuid="b1a2b672-e170-480b-817e-9f392a21bff5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="b1539a3d-8652-421f-adf7-c349bc2a6875">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ccfda4b1-61fc-4285-a893-c04c5f51328b">
+      <statement statement-id="ac-14_stmt" uuid="e7a01511-c0f7-4332-8e84-f809e32215cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63bf72c5-0fe5-4ffd-a6eb-ed61cbbe7a7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -739,10 +739,10 @@ non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58976b08-4ecb-44e8-b6df-1f310d9a8b98" control-id="ac-17">
+    <implemented-requirement uuid="a7fa4407-680e-468b-8503-6d1394a6cb1d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="9149902f-387f-46f1-a25d-622092837182">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="7ff97632-08a6-477f-acfd-4cf79d138655">
+      <statement statement-id="ac-17_stmt" uuid="625f3c93-8015-4643-85fc-92d115742ab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -750,10 +750,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bba13ab-f493-4d11-9263-dca574c530c9" control-id="ac-18">
+    <implemented-requirement uuid="faf889c1-c3e4-4611-b3aa-81ade0b60c72" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="fa128fec-bf09-4a0a-bae5-c8ea336937a5">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="899cc07b-4662-4782-b309-49750f1d0434">
+      <statement statement-id="ac-18_stmt" uuid="1fa47f7a-07fe-4570-ac1e-4c7bf1746a61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -761,10 +761,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1bb809b-c274-4296-b124-833d81ed4b98" control-id="ac-19">
+    <implemented-requirement uuid="5e70b3c6-335c-4757-ad39-72b66ec7193a" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="73c7b40e-6dee-436e-9da8-d169c39ae259">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="777798a4-48df-4019-a213-5f13c16604f9">
+      <statement statement-id="ac-19_stmt" uuid="d0cf94d2-2d0c-4b28-9bfc-007e463cf3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -772,53 +772,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6936a717-e75f-4624-b4c6-263ce7523205" control-id="ac-20">
+    <implemented-requirement uuid="67fc136f-3487-46d0-b749-950f22cfed99" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="da0adb03-4ac3-4488-939f-264186eef76f">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9419a0f2-1120-4f09-a0c4-47f0130af7a3">
+      <statement statement-id="ac-20_stmt.a" uuid="d852d7f9-5f3d-4fa7-94b2-623432ac3474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="11222d57-154a-4cd0-af94-4c68594abfcd">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f3524432-7159-4094-b30c-593be6dc9b24">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ec634e56-dd1e-434a-902d-10b8b90b483e" control-id="ac-22">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="a45ea71b-3907-4c98-af0c-01476af133f2">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="c930c1a9-30d3-4bd9-9e1e-e93ba800d185">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="b846a8a6-1800-4b8f-b3b3-81c1f9bb2485">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="b4df4bad-e243-4a59-af27-3e34c0113457">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="5cf5cd22-efe2-4e38-b2f2-d25f3beff160">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="6606d5e0-34b5-4a19-a987-7bc773d8fc3b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>'This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.'
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="bc8165df-5a1e-4c6c-acb3-2e2af84dd9ca">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="82c37026-f58c-4ca2-8b14-56201ce35884">
+      <statement statement-id="ac-20_stmt.b" uuid="50117407-a947-4180-b837-5df60acef77c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -826,102 +791,34 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46c9cbc6-62d3-4f53-9905-f3fd8c7c8bb7" control-id="at-1">
+    <implemented-requirement uuid="2e22dd86-a8db-41af-8b95-b169b4837f17" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="4de0160e-6eac-4696-a9bd-128668e57d54">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="c2b5a523-b5c4-44db-bff4-b304cb6f059a">
+      <statement statement-id="ac-22_stmt.a" uuid="38377e70-0989-4f2c-b71c-91a4e3680228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="6418bc6b-eefa-4075-ae19-aa8e735b24d9">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e314af57-0dac-416a-870e-17a329a8141f">
+      <statement statement-id="ac-22_stmt.b" uuid="68c4d6dc-9dc9-42c5-8f34-93d19c06153c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="c2098e79-be70-47ab-9e4d-73d1261e8da6" control-id="at-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="95d45d8d-e04a-44c4-9b0c-65172431bc9c">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="8e7eec42-f083-44a2-9031-c78a52b538e7">
+      <statement statement-id="ac-22_stmt.c" uuid="7b8bfb09-8cc0-43ad-be77-ca0e1b177c4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="86191570-5e55-464b-b1c6-0968d89c624a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3d4007e5-d08c-42e1-9a6b-3aab3dead485">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-2_stmt.c" uuid="4ef6e97d-22de-4e69-b685-ecbc1a31004b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="808a6775-df85-4a12-9592-d6c432e8058a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="90830a97-1f48-4fec-904b-71e1767f8448" control-id="at-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="85052b29-b36a-401e-9935-757259fb7f6d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5b6c3da8-8baf-48cf-8cd5-8b4595fa5e11">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.b" uuid="475d4c4e-acad-4021-ad3b-0f6ac400e992">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="bb04e744-048d-42fa-8de5-11690666c0bd">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.c" uuid="22fca82f-b5cb-4cc9-a958-907e2158100b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e529fe03-98db-4f3e-a076-1d04753ebe3b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5b34af79-2e89-48b3-ae2b-ec745fedfe9b" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="5bd1292c-ad42-4666-b44e-19b9e81bfa37">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ebac3bb9-1481-48a4-a261-9fbcc0ca58f9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="892690e7-8bd3-4865-819d-e39104420069">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="18046381-91f5-4816-8470-c57b809ddc01">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8d7c370a-bbe5-496a-98c1-b8d15af068ee" control-id="au-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="bb2f800d-4cb8-453d-91e5-b8dd0f86a825">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="04eade17-a5fb-47f1-aab7-f519a36d795a">
+      <statement statement-id="ac-22_stmt.d" uuid="a34f247f-0e09-4045-97dc-142c54d65da6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -929,10 +826,113 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e3ff040-2758-4d6a-8b0c-8622db62320d" control-id="au-2">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="31401293-618e-4f82-994f-4ba0dd633ffc">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="c25fc137-86b1-4abb-b427-6a5a9cd899be">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ff356bcd-4854-4223-bf9e-e8ea3a310cdb" control-id="au-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-1_stmt" uuid="42ab131b-17cd-4db6-bace-aadded17e94c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>'This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.'
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="df0fc4ec-86fc-43d8-9709-a51f8882cc4b" control-id="au-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-2_stmt" uuid="f4a9622c-4261-405f-82b5-919e8d481c56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1ece91a-779e-4a5a-85d8-7b2c87fd0588">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -943,10 +943,10 @@ OpenShift through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="655bd503-e0fc-4b1d-ae8d-327ed1d18f14" control-id="au-3">
+    <implemented-requirement uuid="a1741e48-4de6-4549-ad9b-cf2088e4e2ea" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="05a89385-c55f-492d-a312-2583cc7924ec">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="475518af-73cf-460e-872c-e8c028f91c74">
+      <statement statement-id="au-3_stmt" uuid="f8f48da5-0595-412b-a4f1-85231f500cc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6364b03-a0e6-4926-b96d-a03faf8e0cb4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift audit records contain this information by default. No
 additional configuration is required.'
@@ -954,10 +954,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="907e4935-c96d-4ba1-940c-6694d57e2875" control-id="au-4">
+    <implemented-requirement uuid="0885c7da-ffa1-40f0-9109-4b822dafab35" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="f725a947-352c-4d5c-afc3-2c63d5e122d9">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ed1e91a3-b030-4dcb-969b-c28f798f651f">
+      <statement statement-id="au-4_stmt" uuid="4fbbbe83-ed9a-4bfb-af19-ea8c8b7124d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef0522af-af8d-47df-a85c-dc20f28735ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift. This control is reflected
@@ -981,10 +981,10 @@ https://docs.openshift.com/enterprise/3.2/install_config/aggregate_logging_sizin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a53ccb7c-23fe-4dd6-b413-85df8f83dc48" control-id="au-5">
+    <implemented-requirement uuid="f873dd86-9b68-473d-a5f8-df8df82df7aa" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="4a71c93f-c19b-4c20-9bdd-2d066e98364b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="38d2b049-c3ce-4cbe-9162-3889746dba75">
+      <statement statement-id="au-5_stmt.a" uuid="391206f4-940b-474c-8d11-9edb3899a6f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dac2725-ee2f-493c-bfb4-5590df1386e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -993,8 +993,8 @@ when an auditing failure occurs.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="f9f13ac4-7fa1-4936-8e63-653b8abb55ef">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3f32f7ce-6241-4545-a11d-835891d1f262">
+      <statement statement-id="au-5_stmt.b" uuid="4e876cdf-c65d-476a-ac41-9617baa4928b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bda2746-ccb4-48f8-b7fa-23c91788498b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, OpenShift Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -1005,10 +1005,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f75db6b-e952-46fe-aa48-1f4b037334b6" control-id="au-6">
+    <implemented-requirement uuid="2fe84fb8-05ad-4cbb-b9fd-22da40910edd" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="bb6399a7-6eb3-47a7-bd57-c9ff9bddbbfe">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="13bba233-a41d-4985-9553-6b707da4202d">
+      <statement statement-id="au-6_stmt" uuid="6c925364-79ba-40b3-8d16-7d0c218e7aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1016,18 +1016,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f3faf4f-5bc3-48a0-be56-83f1d2344c5f" control-id="au-8">
+    <implemented-requirement uuid="b0cc2985-4fa3-4643-b69d-2bc0e6b4891b" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="301fe38c-7a0e-4215-8358-064ce7e31527">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="d100c721-4d24-45d0-9f4b-2ead18a2ab7c">
+      <statement statement-id="au-8_stmt.a" uuid="1e983df4-6832-4b42-8841-4647c61d19a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eac111fb-f99a-4d90-8fc3-c3f2be4e07bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift logs are generated using the internal system clock by
 default. This is non-configurable behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="a3ec9162-a738-40f9-be53-a796b1a40837">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="58ac823d-ee58-42bd-b472-7455f5b3c724">
+      <statement statement-id="au-8_stmt.b" uuid="1af2c1ee-5635-4ca7-a125-0193a83686dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f8c71d9-556b-47ae-83d6-f8354e7d5a7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift time keeping relies on the time services provided by the
 underlying operating system. When running on Red Hat Enterprise Linux,
@@ -1051,10 +1051,10 @@ https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Sy
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c94c76d-7997-440a-9e75-da737a150876" control-id="au-9">
+    <implemented-requirement uuid="25be9da1-c399-4518-a66b-b7420619381d" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="ee255f74-d9f0-45c1-a557-74284f01fdc4">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="71099155-c910-4f68-961e-2e529bfbc8df">
+      <statement statement-id="au-9_stmt" uuid="40dda508-78eb-47f8-af8d-7712aa8bb3a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859a0daf-8b78-4978-a3c8-6ed9377b5f0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -1070,10 +1070,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c33768c-a63a-4df4-88ff-f680603c4df3" control-id="au-11">
+    <implemented-requirement uuid="20998a4f-4e1b-4087-8b46-810c9a4cda5f" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="a2dc04ff-5248-4bba-9c5a-2d53273c6874">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="739e9b8c-519b-48cb-84db-8c22cd87d586">
+      <statement statement-id="au-11_stmt" uuid="12b59756-4cf2-416f-98dd-68f2dd5cf8d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f45482a5-2b41-4044-8637-f7a8da5224f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in Jira:
@@ -1083,10 +1083,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62a6dce8-4a02-4213-a376-60f7bb890f7c" control-id="au-12">
+    <implemented-requirement uuid="ac5c7e83-3ce6-41b5-9a42-9004361d21a8" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="0bc6f730-cda3-4d7d-b886-7fe949c2276d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="42894ecd-a380-4b06-b17d-3b73ebd2c4d8">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -1098,8 +1098,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="3577862b-17e3-4c28-bcef-21591418bc77">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="39b2baf0-3e36-435f-9eaa-3e8684ebdb75">
+      <statement statement-id="au-12_stmt.b" uuid="0876f4fa-4a0c-4f9f-9e37-86ec35acdbb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a14957d9-85f7-4af6-bff4-e5b13f768c2f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -1117,8 +1117,8 @@ is recommended that OpenShift specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="cecfb547-a09a-4e48-bcc4-1ee2612f7b28">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5b595cfa-c68e-4bc5-b26e-d04dd9c471c6">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -1130,10 +1130,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba11225b-c770-44d1-8475-e72dda96edb8" control-id="ca-1">
+    <implemented-requirement uuid="137a1bb1-2be5-4792-8402-b452ebdc8289" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="7f4d3e70-7a0c-47cd-9e77-a90e2209db09">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a43f7a62-61ae-4bb4-a3dc-cad2e7e63071">
+      <statement statement-id="ca-1_stmt" uuid="82ebbeae-39c1-4a32-8ace-cfae81e476d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1141,10 +1141,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0d224e4-7764-4a2b-b80e-eaef33a2bb31" control-id="ca-2">
+    <implemented-requirement uuid="92f26f75-6eeb-4bc8-9686-ed1d8181854f" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="ea1695b6-783d-4c83-83de-cb847dbb3cf1">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a4758e82-ecf5-42ee-a743-11b35a480665">
+      <statement statement-id="ca-2_stmt" uuid="8340ac1d-6c63-41e0-8926-68ab5c1ae749">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1152,10 +1152,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2260b8b3-322c-4a6a-aa76-2c183863bfe4" control-id="ca-2.1">
+    <implemented-requirement uuid="66592cdc-3f3f-4577-8e34-34002c14f287" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="46e111ea-0718-448c-84d5-347b17867519">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1b317906-b992-4357-b6a3-51da664813e8">
+      <statement statement-id="ca-2.1_stmt" uuid="4c836022-5b78-4150-8ec3-61d6b865e198">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1163,10 +1163,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95f22979-1dbd-4faa-9f6d-e5da3082983f" control-id="ca-3">
+    <implemented-requirement uuid="deb63227-f2a7-4ccb-a8f4-c3daf16b1b00" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="f76d3cf7-1105-41cc-bc67-b12f30c01dab">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="27a6b13e-b582-4cef-bf68-1c782994c0f1">
+      <statement statement-id="ca-3_stmt" uuid="4515c02d-a038-4872-b604-333eb17af574">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1174,10 +1174,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="687be700-8ab2-4db5-9b58-2ad7216679a6" control-id="ca-5">
+    <implemented-requirement uuid="461cac5d-4510-49e7-8996-a044e976ea00" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="7752a005-cd1a-4504-bc26-a16857f8048a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5d75edcc-1e20-4e67-8e6e-0bdf3aa81e72">
+      <statement statement-id="ca-5_stmt" uuid="75a60994-46b3-4a2b-b437-8a8ade88dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1185,10 +1185,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54dc58d9-a1c1-465b-96b0-284f876c28f0" control-id="ca-6">
+    <implemented-requirement uuid="91eec0d1-f1ca-4478-bc79-1cdbb27fe7bb" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="6e319519-0e64-4c15-babe-da2ccf6747ff">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e52ee16e-024f-4d87-a4f7-b3d8e958523c">
+      <statement statement-id="ca-6_stmt" uuid="fc00e0cc-b43e-4250-be0d-0a9cfeed4bf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1196,10 +1196,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b03125e3-9279-40fa-8c31-75ea4a5ae9c8" control-id="ca-7">
+    <implemented-requirement uuid="e64d358a-f134-4e34-9117-5d6767731abe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="98e896e0-127c-446f-8c78-f74fe0adf021">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="94af8731-ed6e-4cff-80a2-0657b100b519">
+      <statement statement-id="ca-7_stmt" uuid="1361fa12-ec53-4f6e-b5a9-517e3e7eca7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1207,10 +1207,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13c9dd24-e924-42a9-a6c4-b41e2caea9af" control-id="ca-9">
+    <implemented-requirement uuid="229eadf1-80c0-4c84-a297-4cafca0aa898" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="2ccc13e3-f754-43fe-ad8a-1d398bfd0013">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="01917e1c-01b7-4ec8-b155-e697d92716d9">
+      <statement statement-id="ca-9_stmt" uuid="58b1d545-6ac8-40c0-bfaf-7fb6d3d1d6ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -1218,10 +1218,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2089540c-e92e-4331-b8fe-684224bc10f4" control-id="cm-1">
+    <implemented-requirement uuid="6db18908-efb6-400b-8ff5-6c6425f4a511" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="f9b7ca67-314e-47d6-a0ab-f921a3659b2d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="d8bd5040-c48e-45d1-975b-750320ef4d64">
+      <statement statement-id="cm-1_stmt" uuid="3d140bf0-9c1f-445d-9da3-0f4f78994802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1229,10 +1229,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f3add4a-95f2-4a89-96f6-0234f09afc30" control-id="cm-2">
+    <implemented-requirement uuid="03633224-a901-4b5e-8a83-9f11fcc66564" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="1d17a40b-606f-4328-86a2-0d239be0a25a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="c38ac491-f7c6-48ce-9f9e-68e22da33afe">
+      <statement statement-id="cm-2_stmt" uuid="a179fc74-d550-4122-9846-c936bd97eba3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1240,10 +1240,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="502a70f3-f4e2-45ef-be1f-6e3b2e6184b7" control-id="cm-4">
+    <implemented-requirement uuid="7d9cae12-888d-449d-8d98-a97f9953cab2" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="57c7887f-e569-4814-b234-4af6fef08099">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="93b2e1b6-c777-4eb0-98f7-6fceef13e97c">
+      <statement statement-id="cm-4_stmt" uuid="e8ad8b2d-ba3c-48c8-8103-a1ca0da104a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1251,10 +1251,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e18a257-4307-46ef-8df2-e2365839f3d7" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="d37c970d-73b2-44f9-b3c7-31049eb13064">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="15a7a4e6-d589-480a-8b5d-deca5120881f">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1263,8 +1263,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="366bcfb0-1100-41a3-9d9d-df3bd38cce76">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="829c79d6-fccd-40d7-afcf-87bb30fd399b">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1276,10 +1276,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c211e609-fad2-4a6d-90e1-34144a676591" control-id="cm-7">
+    <implemented-requirement uuid="470be975-e9e3-43a3-8eea-dca908192731" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="a9374f02-b5e3-4f17-a611-14a9b5923690">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="d378e845-52ce-4a2d-961c-0182a270794a">
+      <statement statement-id="cm-7_stmt" uuid="cd05bebe-a619-4f4d-8b81-69900e91bfa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1287,10 +1287,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2b4a99e-9522-4573-befa-5d8488979f73" control-id="cm-8">
+    <implemented-requirement uuid="3b307e64-c650-4276-a4d0-c8ed972f20f3" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="babdbe30-66cf-4711-8604-d88bf3248051">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="39c0401d-3044-436b-a597-e343629dc545">
+      <statement statement-id="cm-8_stmt" uuid="18c51ee3-a770-4ab1-bbee-3980394252d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1298,10 +1298,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68470d63-d702-4204-9ecf-c178cd5eeaed" control-id="cm-10">
+    <implemented-requirement uuid="3bc27d95-ce5b-4e58-9770-3fbb02ec4c77" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="f8917c6f-64f7-45ca-86de-4e82d384f327">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="7f29d31b-1519-4052-9cc1-eb7203c81951">
+      <statement statement-id="cm-10_stmt" uuid="e13a24c6-d01f-4c5a-8c08-8c46900fc403">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1309,10 +1309,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6314a09b-13f4-433c-a223-a5a023d04e3d" control-id="cm-11">
+    <implemented-requirement uuid="fa0e44f3-2c7b-4054-987f-d444f3e19b9c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="1034c3fa-57d9-4460-922c-121e27b80420">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1af0a504-6675-4c23-b621-91140eb3e7b0">
+      <statement statement-id="cm-11_stmt" uuid="a274e760-9a2b-49a8-97d9-8f3fd4a919a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -1320,10 +1320,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5b0a4a6-f4c6-474b-a591-4ad1a9ac92f7" control-id="cp-1">
+    <implemented-requirement uuid="9b43dfe7-3d77-44cc-8441-be42c3c95fd8" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="073f7123-b137-4223-8b5a-d4d1e0701530">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="2c87dce0-f23f-46d2-b357-58006ead891c">
+      <statement statement-id="cp-1_stmt" uuid="850321e7-8708-47d2-8a69-b673e8e35e8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1331,10 +1331,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f2fbfc1-209c-4125-b695-027e348077b8" control-id="cp-2">
+    <implemented-requirement uuid="5bc6aa5e-a6d3-4ff9-88fc-f511a52e07e7" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="50a6ddc3-0252-4954-9299-09df4fc55c41">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="b5341317-636e-4a13-b56c-b46c525f4c62">
+      <statement statement-id="cp-2_stmt" uuid="321b56a3-e3e2-4f7d-afd1-95811c0ed14c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1342,10 +1342,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="199fb0ce-9540-41d9-bc30-016c46d0fd53" control-id="cp-3">
+    <implemented-requirement uuid="3bb16503-975f-4a69-a00e-ed061e343cc4" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="561425a3-44de-40fa-96d4-2f3a69276460">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="6c4aaed8-f77c-4363-9c83-dd673baa9591">
+      <statement statement-id="cp-3_stmt" uuid="edfe15fa-e205-462f-9592-ffe56fd32204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1353,10 +1353,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac4ecbd7-aa0c-45f6-a4ea-e21526453392" control-id="cp-4">
+    <implemented-requirement uuid="0b0e16bb-221c-4d77-9b07-51c08862fec6" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="cce60933-47de-41c8-869a-ef8c390cf7b6">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="48162a02-a6fb-4e56-aea9-94209bff9f1c">
+      <statement statement-id="cp-4_stmt" uuid="4aff4b76-0858-4d63-8284-04b56780c4a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1364,10 +1364,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df62f0cf-06c8-43bc-87ba-01cfc08bf36a" control-id="cp-9">
+    <implemented-requirement uuid="bc22a3cf-95d9-4b22-9112-6fc1b4ff81f6" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="bc40f77f-16b0-4b31-b286-a56d56ee8884">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="017968de-9852-4f5d-8cc7-a1930b20d941">
+      <statement statement-id="cp-9_stmt.a" uuid="b8249024-8595-4c8f-b43d-1877b1539f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a08f7f0-9663-4cb5-9700-734cf93d3a58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1383,8 +1383,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="1cea84af-a32a-49e1-b959-bc6b12dd4c80">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1a16f02c-4b04-401f-bd27-6b57b6edd2db">
+      <statement statement-id="cp-9_stmt.b" uuid="2de89133-ecda-472d-99c4-efa326e6714e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3753498-0e8c-4971-901d-2ae5853f8faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1400,8 +1400,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="acdd4a56-0315-4246-a2bc-61de1ada7273">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3bcb8442-f1a8-4437-ad95-744c74d54755">
+      <statement statement-id="cp-9_stmt.c" uuid="f9c08a44-9d5b-46db-980c-d64ee467af2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dba5d26-fcff-44e7-853a-fbd3e9d16a23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1417,8 +1417,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="4626f631-ac07-4b4c-9f96-c9ce16f98e31">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="8f1a327c-2322-4019-983f-152b0229d0e7">
+      <statement statement-id="cp-9_stmt.d" uuid="a8885751-e451-479e-9783-8cc776849233">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d827a66-3be2-4d48-9834-d5adcab4c487">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1434,10 +1434,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="356c0965-acac-444a-886a-b5c79e129f39" control-id="cp-10">
+    <implemented-requirement uuid="02f89333-b0c2-4c4b-b1e7-a38e1ffca80d" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="c56265b9-35dc-4a69-90d0-d4356eeae957">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="de288aa2-fca2-4144-9387-97be5e2967e4">
+      <statement statement-id="cp-10_stmt" uuid="d96de4d7-6285-427b-b6d3-27b06c7ee126">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05c68c3e-793f-4b6f-960e-cb0cad097f1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their OpenShift environment. A successful control response will detail
@@ -1446,10 +1446,10 @@ processes used to fully recover/restore the OpenShift environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb3abd4b-1212-43ba-ad31-40a94f95d730" control-id="ia-1">
+    <implemented-requirement uuid="1ac74505-b835-4d8b-9a65-0072731a1432" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="f3554bf1-8f66-47c7-a560-0009800b4f30">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="6598a251-3154-4450-a2e1-59f7dde852df">
+      <statement statement-id="ia-1_stmt" uuid="4a264b65-a3e1-4bbb-aa0c-6a39ee9a705a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1457,10 +1457,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa77432f-a6bd-4b89-89e0-c8ad99b4b1e0" control-id="ia-2">
+    <implemented-requirement uuid="d85437b7-d62b-4023-ae67-cbe3dca95dd6" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="5bad79a2-093f-4fba-989e-e6a840577ef0">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9dd6cb53-9dbb-4a87-8481-28f3437d0466">
+      <statement statement-id="ia-2_stmt" uuid="48880db7-6cff-4e77-8fe5-8522f4a8077f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad09895f-4ac3-43fd-b43b-8d04184ea227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -1468,10 +1468,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63601c0e-0c0e-41d4-9aa9-28b0adf4af82" control-id="ia-2.1">
+    <implemented-requirement uuid="b6207e75-1e9b-44fd-896a-744868a7ee3a" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="f8327fb6-895e-407b-bd28-48f626049a3b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="74638dcd-8979-4e5a-b1c1-7cd477dd4102">
+      <statement statement-id="ia-2.1_stmt" uuid="2c5aa764-2ef3-4ad6-8f03-acd8a22ac68e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be67a4f8-46f8-44a4-98fa-d862af3ead31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1502,10 +1502,10 @@ OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffa58c26-0c2a-4a91-8dbf-234fb0363f77" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="f23b1372-14e3-4a3b-9dc1-65224c7e5b85">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5bd1052e-fba7-46eb-b4f8-9d5919f8be59">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1518,10 +1518,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9c56f15-d700-41df-af40-9ea13c691b28" control-id="ia-4">
+    <implemented-requirement uuid="e21d6a2a-d400-4480-89b6-7f40b0c50ae4" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="9d15554c-833b-4447-b580-beeed1b87aee">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="998b7b53-2237-4a4a-8930-498049b40383">
+      <statement statement-id="ia-4_stmt" uuid="5cc82413-d164-4bb0-9b39-108524a03fd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -1531,10 +1531,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da848159-8255-4141-8fe3-76997573665f" control-id="ia-5">
+    <implemented-requirement uuid="82b7e251-336c-4f51-9d1b-dd1d2a18baf5" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="de3806fb-1491-4313-82b7-620082ba7a85">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9ebd7ef9-2970-4cb9-aa33-d98af9833b49">
+      <statement statement-id="ia-5_stmt" uuid="9b4c1651-4e00-46ed-9296-95d1bbf5af34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -1544,10 +1544,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51b8cd2d-b450-4370-b071-0905d20c2f9f" control-id="ia-5.1">
+    <implemented-requirement uuid="9ae4fc53-7521-4cd9-8d91-a1f38dd953ed" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="e17190c4-947c-47cc-9939-681b44963bd2">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ad894497-6e31-407e-953b-92b4e188aeff">
+      <statement statement-id="ia-5.1_stmt" uuid="7aaf7dd2-6511-408d-b902-bfa59d362c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -1557,10 +1557,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6214985-60ee-4268-8816-b88a80c62e32" control-id="ia-5.11">
+    <implemented-requirement uuid="0c8d9074-74b1-43e9-b7f2-588b07d91ac0" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="fb48489c-d87c-42a6-9717-0c53ed490a8e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a7faa452-4db5-43fd-b337-b87cf9137858">
+      <statement statement-id="ia-5.11_stmt" uuid="46876a3c-1392-4a20-abda-4720c149ba69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -1570,10 +1570,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3358fbfe-11c1-4c8c-8eb3-1c616b0a67d1" control-id="ia-6">
+    <implemented-requirement uuid="12498f82-cc76-4b1a-970e-b52e957da8dd" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="972ad157-e598-4402-8cef-8207e419c8a9">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="42f282aa-31ce-434b-8089-abacc49484a9">
+      <statement statement-id="ia-6_stmt" uuid="70f01749-e367-4d73-85ea-84c3a6c22764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3296420-39ec-4baf-b4eb-3c52f4535a3b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift natively obscures such information. OpenShift cannot be
 configured to be out of compliance with this requirement.'
@@ -1581,10 +1581,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18c8a660-24f1-44f1-a026-b654e4084236" control-id="ia-7">
+    <implemented-requirement uuid="d4e53f34-f8c9-4b80-a352-3b044bfd5837" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="543fc42c-a224-4e52-826c-4791c44df9fc">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="12da3f67-793c-4974-8516-d6fbfe65e59e">
+      <statement statement-id="ia-7_stmt" uuid="380e5148-4be4-4cd9-a28a-fc132df2e116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1ba60b8-1e70-4e76-b334-583c33bc5670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to OpenShift nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -1606,10 +1606,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd61bc04-ebff-436f-af95-8742ff4da51b" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="875f7724-2153-4b99-a556-631e8294236a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a97fddfa-7c8d-48b0-a267-d8206a8b4f46">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -1621,10 +1621,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="153985eb-ee67-447a-8837-301471dfd2ec" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="908adde8-7e17-4d54-b721-cca98b48c55d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="efe7dcba-176a-4870-827f-dc007d7aed81">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -1637,10 +1637,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="642d4c12-5155-4e97-bb16-eac87b9572a0" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="d5ee6ab2-aaa4-432a-9d88-06c46636677d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="54152327-4210-44ff-aaee-2d35e2169d4c">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1654,10 +1654,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba1142d5-6c74-4a9c-828d-aa5aad926b43" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="45d62627-1f00-4697-91b7-de23552e91c7">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="93ab493b-a774-466c-877a-b4b6e2998ff3">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1671,10 +1671,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e765f389-6c36-4e26-919e-3df19f666432" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="ab5b6c25-3e71-474f-a5c7-5994c469e61d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="baa52e97-fe2e-4983-9e14-d291b39be273">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1688,10 +1688,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d46ee988-3748-4dd7-b663-c6680f9ed58d" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="3f1daaf7-238d-4f24-bc28-a37784581b2f">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="4c4dd7da-fae6-42e8-aee6-9160e2d0d142">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1699,10 +1699,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56da9eb7-8291-46ea-be40-cb3ca9ea8b7f" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="2862d635-4105-4ece-8fca-6e4959df412c">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="25447403-faf4-4496-816e-16f1905370a1">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1710,10 +1710,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df1dc7cc-c756-4f3e-9126-06e8c4805c98" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="f71ec431-21e3-4019-bbe6-d41da817fd58">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5ae6ab75-bf48-45bd-a7dd-893b8d3e6006">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1721,10 +1721,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95e16489-6b18-4cdf-81b0-cec4d159cb86" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="abf670cb-a9ff-46e7-976d-c50734b537eb">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f5bd1a7d-2c3c-4d63-813d-ed3acf20b054">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1732,10 +1732,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1884cb3a-d60e-4819-8ce7-f5f6248a5c83" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="64decf92-d03c-45a6-a80d-27a7eeeaebbf">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="20d43727-075d-431c-86d1-cd28f7fc5e20">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1743,10 +1743,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19081b04-d21d-4c6e-a2b9-bb4ded6cccde" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="58396d6c-551a-4e15-aca1-4043b77af8fd">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a584d88f-fd7e-4b4a-8d22-b0816ffb6ec1">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1754,10 +1754,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c217095d-c304-4104-bfd6-7a9bf8dc1053" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="10a25013-b3b0-421f-a750-a1a41f53d878">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="074e64a3-c321-48e0-8f9a-5de19fc313e5">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1765,10 +1765,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff27c07f-3e2e-4155-9ff9-490b765270e0" control-id="ma-1">
+    <implemented-requirement uuid="ab96e205-f5ae-4f92-aeba-9d65d4089811" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="1bb8144e-f3d3-446a-bfa7-d3e6e2ad94a9">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="2a6a5c08-2250-4cfb-aa47-0380c9f6cfd0">
+      <statement statement-id="ma-1_stmt" uuid="cff15548-e6ea-47ab-bff0-ae27d840911f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1776,10 +1776,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="752f4e11-c188-4121-aaa8-907d70fa7eca" control-id="ma-2">
+    <implemented-requirement uuid="ac03a1fa-a125-4831-b841-a85b0d07e099" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="dc8d5bcb-676b-4090-85d5-b30411bbbb0b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e5626b96-3e88-47c1-ac73-6656ddcd520f">
+      <statement statement-id="ma-2_stmt" uuid="69953a5e-05a4-477d-b010-34cc2cd92d8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1787,26 +1787,26 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fae30359-744c-426a-8f53-8289ad53c4ed" control-id="ma-4">
+    <implemented-requirement uuid="1c8083fd-9c42-40a1-a265-ec2662dadab9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="204a1da7-d9a9-4c6b-9427-5db1868773d4">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="4a9f373a-6e6f-477a-83a4-f8de7de89fe2">
+      <statement statement-id="ma-4_stmt.a" uuid="8d3a7d1e-86fd-4ab7-8d6a-20abf4d58af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="5d8b3d45-ca94-4d60-ad34-4e1fd92774e9">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1a28c341-828e-4654-84ae-9fc4281d826a">
+      <statement statement-id="ma-4_stmt.b" uuid="424f393f-8bd9-49ca-b75b-972873f8a80e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="f4900776-1be0-42f0-8527-8783fd2bf8c0">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3df3f205-c853-4ee9-86a5-9f47c4fd30d5">
+      <statement statement-id="ma-4_stmt.c" uuid="55e15a38-efa6-4f16-8548-50432deac845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6aa2bb26-eb59-4d99-84cd-822805438767">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.
 
@@ -1818,8 +1818,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="eda6db37-5ac7-43b6-917c-7d877e0bf7f6">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="77828210-90eb-4fa3-9a63-7b24eeefd89d">
+      <statement statement-id="ma-4_stmt.d" uuid="755528dc-d98c-41d7-aa24-5e6e32ad6223">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ccef3b2e-7c65-495e-88dc-4ee72829f552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -1829,8 +1829,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="e901b4dd-1a84-46e4-a1aa-a33fd5a37590">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="56490c8d-3454-4e01-9240-d8eb6f619ba0">
+      <statement statement-id="ma-4_stmt.e" uuid="3937c74b-e19e-4c0e-890f-5cd9268105c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dcad0664-141b-4ab9-8272-91128053ab87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -1844,10 +1844,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4546e73-a36a-4a2a-ac8c-2fa4ca4d3443" control-id="ma-5">
+    <implemented-requirement uuid="7bae4cdc-5101-4916-9bd0-32097c3a5540" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="f0b499df-28c8-4417-b2ba-5031e9b08d5e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="cc9da8b0-dee2-470e-ae23-cecda5efd43e">
+      <statement statement-id="ma-5_stmt" uuid="4de28098-f4b1-4383-b6c7-d8cb36cb1ea0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1855,10 +1855,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="613bc4eb-6904-41c3-b78b-db901786d4d8" control-id="mp-1">
+    <implemented-requirement uuid="6e3641b8-d91a-4b4c-aed5-1d4b9fa8b9f9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="0074d309-e5d7-4bdd-ad5d-f3971f8a91ec">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ae8ab617-7fa6-451d-8da1-9ed4b1af9b2d">
+      <statement statement-id="mp-1_stmt" uuid="6a0d866d-901f-4cfa-b1d1-3dcdcfdba280">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1866,10 +1866,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5af94485-da9d-4fd2-b31a-a379319eed79" control-id="mp-2">
+    <implemented-requirement uuid="0b1de93b-94fe-4940-bd9e-2557cabb300b" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="219ebcba-e322-409c-ab38-30cfd6691a1e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5715d5d2-e127-4bf5-ab60-0faecd525207">
+      <statement statement-id="mp-2_stmt" uuid="4ca98bdb-106e-4c20-9b26-a7fbfe88bc72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1877,10 +1877,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c5b55d6-a76e-4d44-9fc6-c8b617522d99" control-id="mp-6">
+    <implemented-requirement uuid="80536df1-978a-46ac-a7d2-fb7be3c4fb15" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="bc3276ca-c4c1-498f-9580-de07cd038354">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ed814a8d-ada0-40f7-a48c-14a66da32d05">
+      <statement statement-id="mp-6_stmt" uuid="989e0404-089c-4307-80ec-eb9b5f6f0cc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1888,10 +1888,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25476a4f-89fd-4b93-8f79-87578f00a85c" control-id="mp-7">
+    <implemented-requirement uuid="07d86507-30da-4926-9f98-7b39d4efe030" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="e1c89aad-47e2-40ce-93f8-9e42a962ab8e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="0de5cac5-527f-41ee-8e6c-0222589e63b3">
+      <statement statement-id="mp-7_stmt" uuid="5624b235-5824-4baa-8814-03e6b6aaed21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1899,100 +1899,100 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccea4ce4-449b-419d-9aed-699645a015cf" control-id="pe-1">
+    <implemented-requirement uuid="efcc3344-7813-4729-8b4c-353c3b06428d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="cfe657fb-f582-4f49-b3ba-0f08ed974e8b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="4a62737d-efb0-47bf-9baa-9d628899101a">
+      <statement statement-id="pe-1_stmt" uuid="a69e0d62-407d-4910-ab66-18c03b168392">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f3cf72d-68db-4ad2-9dad-a453d03b2bff" control-id="pe-2">
+    <implemented-requirement uuid="92271e93-1df7-4bd8-ad4d-8ffd06fb2877" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="70ce5365-37a3-48bb-bc40-a6fb24f92287">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="df262161-54c0-40b0-95a7-899ecfa9878b">
+      <statement statement-id="pe-2_stmt" uuid="341520a8-ee52-4acc-ac44-4715de827f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e151c90-3907-4c84-a905-774958d35fb4" control-id="pe-3">
+    <implemented-requirement uuid="329c7586-aa2f-4ed6-aec0-f17c8d698026" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="453bab7a-3b47-4ad8-afae-668f49f8325f">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5399e5ea-2807-40f4-98be-e95114acedce">
+      <statement statement-id="pe-3_stmt" uuid="c14a9afe-deb5-43e9-9fdd-96cc22ecd1b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b66992f-33e8-4b33-aa57-af3e221c27ca" control-id="pe-6">
+    <implemented-requirement uuid="01f99faf-9f68-4c8a-8ad0-9b3d90c9b014" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="2f8b9401-a9e9-45e4-8e66-394ddf814414">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="d930a5d7-b195-47f0-a327-e59dddb66bcb">
+      <statement statement-id="pe-6_stmt" uuid="63fe7eb2-34c1-478a-a4b3-085ad3ba8a25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74cf7166-7d3e-410b-b8ae-450aa7f85ce9" control-id="pe-8">
+    <implemented-requirement uuid="242f3d8e-b3eb-4058-b1a3-bfbe712a1b15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="d6176a41-53ab-4b6b-9d0a-9ce9998c99e0">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="cf811389-42c3-41cf-a799-9e907033c10f">
+      <statement statement-id="pe-8_stmt" uuid="8eebb287-2309-4986-8ade-187dc4bdb8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0de282cf-0107-4a16-9498-73c49654bc11" control-id="pe-12">
+    <implemented-requirement uuid="7e18ab07-c4b5-4978-b6f7-370814ec6a6e" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="d011d8bd-1cf6-419e-8e00-c85692b47439">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="7119622c-2bb8-4278-ac84-2a013103bb5c">
+      <statement statement-id="pe-12_stmt" uuid="8b9427b8-b0fd-4c10-a090-a0fc02b43a7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f38868d8-d3ce-4ab0-b89a-25885b3a80c8" control-id="pe-13">
+    <implemented-requirement uuid="f2ef922c-3e62-493a-a497-cc8801cebcd9" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="20df1029-d0c7-4272-9579-99eafb09c658">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="422bd346-470c-4750-9247-b266e2cb7618">
+      <statement statement-id="pe-13_stmt" uuid="2af78162-9be5-41d8-a16e-89489da79133">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1989107-3fcd-4dbf-b91d-2b35ce9e0fcc" control-id="pe-14">
+    <implemented-requirement uuid="0b6ac012-3ebd-444a-8c15-179b449dd03e" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="866b4f53-d129-46cd-84fa-122aa0a711d1">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="0ea5646c-d259-416e-97d3-4cf841682ac2">
+      <statement statement-id="pe-14_stmt" uuid="2430b2c7-3867-4c68-9475-33402076cbd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="784e4672-0e65-4f3c-8e4d-2234eeb0c856" control-id="pe-15">
+    <implemented-requirement uuid="7fd52cb0-bc5a-4989-bd0a-e5edad6a6875" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="bd8750fd-0fd4-49fb-b46c-60043669a795">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="cf7da6bc-4f48-4c03-b103-100322901370">
+      <statement statement-id="pe-15_stmt" uuid="e280552c-8bca-4408-803f-85c89a04f109">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f459f63-063c-4c6c-be10-03987e6aec5d" control-id="pe-16">
+    <implemented-requirement uuid="a2a949e4-02f8-423c-9c40-5a7d49d329aa" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="6b9dcfd3-bfbf-4045-8d10-76a4ee978f0d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="d0b9fadd-969b-44c6-8078-b38ad6f13e7a">
+      <statement statement-id="pe-16_stmt" uuid="3c91da19-2cf3-4882-a0f0-35464a9c622c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2ad8d67-deab-4439-aae8-f4eef44c5f5c" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="8da5289c-022d-4967-9a2a-a8ac657bcea4">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="bb15c2a7-c118-47a0-82ad-ea2a0e3ee44e">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2000,10 +2000,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61cca4a9-ca81-430e-9661-ee9fb2303c6a" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="1909710d-7e5c-4893-a74d-bd996b727e7b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="09cc8e30-3522-4ad7-9bdc-a99373151b14">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2011,10 +2011,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38cffb77-69a4-48c4-8e40-bdaacf24e297" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="6b99e8a7-a0cd-4a1d-ace1-a71aa47a93f5">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e0fb5167-f20f-42bb-a10d-94a1a450d137">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2022,10 +2022,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1f92554-82b5-41b1-a097-c7743479cdaa" control-id="ps-1">
+    <implemented-requirement uuid="4d136db8-e7eb-4b3e-b037-381487f0532e" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="9efa1503-e412-4e5e-9825-9e0557d0745a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="214c2a7a-7cd3-4e99-99a0-0f0f6235deab">
+      <statement statement-id="ps-1_stmt" uuid="9af3ca73-229f-4538-abc2-efd626ea3055">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2033,10 +2033,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9439e784-2e4f-4d2d-bb77-dba7d453ce91" control-id="ps-2">
+    <implemented-requirement uuid="6023f53c-f1f6-461b-bc4c-59bf5bed97b4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="1e074188-a755-46a8-bc1b-15b1d1b75385">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="22baa592-7c96-4c44-a68d-c73dfbfae1d7">
+      <statement statement-id="ps-2_stmt" uuid="100d4a3d-c1eb-45a7-9e8c-0bc8dbb62d2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2044,10 +2044,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d576b9f-e8df-4084-9123-a77e021dea8e" control-id="ps-3">
+    <implemented-requirement uuid="ab01fa25-d8b0-4d7b-ae45-d2ab5d8b1382" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="0694bb35-1d05-483e-949f-1f60e1d47e21">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1c1a40b5-a2d7-430e-b8ab-19c9f4e9643f">
+      <statement statement-id="ps-3_stmt" uuid="1c3a8a5e-7e84-4341-abd4-3063ab3fb9f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2055,10 +2055,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="710abe12-c29f-4f40-8add-d89e2235a4e2" control-id="ps-4">
+    <implemented-requirement uuid="d59ce3bb-2024-4bc6-be8a-e4afb6334739" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="44096f5d-a22e-4947-a450-8a587c2b1c63">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="ac89644a-d861-4ba8-ac6c-9533b3833595">
+      <statement statement-id="ps-4_stmt" uuid="5298ca65-c410-4e9c-8825-e7bb70670a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2066,10 +2066,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfabde2a-4b63-4354-a9a0-b72c8b77d854" control-id="ps-5">
+    <implemented-requirement uuid="dbf6994c-27d0-4bc3-b60f-bc0958c0a878" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="406d8ac5-1e31-4063-8055-90b7575e5789">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="a8d97540-fc3a-424e-8c5d-80bb4847acb4">
+      <statement statement-id="ps-5_stmt" uuid="a92e9df3-3a63-4925-8654-7c596d51f667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2077,10 +2077,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a96fe99-2400-46a6-93cc-6e6aa4ef14bc" control-id="ps-6">
+    <implemented-requirement uuid="868fa3ff-5e6c-421f-9cc2-55267f6d9a46" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="a1d3e616-935d-4d40-ab6d-69a1df535a82">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="07871651-1c3c-4d06-adb2-f7b8a136dcc3">
+      <statement statement-id="ps-6_stmt" uuid="7a665411-ce9f-4cfc-8716-8f61343d8336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2088,10 +2088,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19dd43e9-6a2e-4e4a-b777-69ca15a4aaec" control-id="ps-7">
+    <implemented-requirement uuid="a95b32cc-6f69-4da1-a053-66b13b726e6b" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="30c8d54e-fdad-4d9e-9e42-e807de515098">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="446fdfba-3ae6-4dfe-9a60-ee15e100c92e">
+      <statement statement-id="ps-7_stmt" uuid="f1f9a6d5-9a56-4e67-ab67-93e63f5c593c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2099,10 +2099,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e750e78-d501-45a6-af67-d09f879ff30e" control-id="ps-8">
+    <implemented-requirement uuid="b32f79da-715e-4149-bd0f-e74f904b811f" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="89e31d60-1eda-4a79-99ba-feee9e2c6e30">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="df7b8c78-354f-4f15-8faa-3278b198b405">
+      <statement statement-id="ps-8_stmt" uuid="09459806-68af-4733-802a-aa394b87a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -2110,10 +2110,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aeb702f4-08f6-49e5-a0f1-a310ce50f79e" control-id="ra-1">
+    <implemented-requirement uuid="e37cfe14-b5fd-4d96-ac49-1a57863c6f72" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="a8ba43ca-cd5c-40e0-b2ad-23b9c4e1619e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="bd1ef3a2-9b6d-4adc-a8a3-96e09cf7cea6">
+      <statement statement-id="ra-1_stmt" uuid="2a1973bc-26a3-4d6f-93c2-dc280fe40b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2121,10 +2121,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe019cc4-dc11-4f9f-b9d4-c57ebb10663b" control-id="ra-2">
+    <implemented-requirement uuid="b330baef-38cc-404f-b2f9-cac39cb6bab8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="c36c0c16-c07a-4ada-ae3e-5d69c5d2032a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="6c6034f2-703b-4237-9ab2-368016b88114">
+      <statement statement-id="ra-2_stmt" uuid="fc8a77ad-f129-4504-a1c6-b4e72a971c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2132,10 +2132,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56767adf-31e1-4127-9a82-1f4ddc6ebd0f" control-id="ra-3">
+    <implemented-requirement uuid="ba31e6ad-7602-4a1a-a279-267f87ac58cd" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="50db9aa9-08f9-43a1-92e4-8e409bbbb812">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="efd55251-af25-4d71-afac-2271255a1618">
+      <statement statement-id="ra-3_stmt" uuid="3c5a3049-9ba4-4284-8163-0c6046d289a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2143,10 +2143,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ef568b2-4a7b-45ae-9330-c8e7e01a5dc6" control-id="ra-5">
+    <implemented-requirement uuid="3911668b-2301-41f2-a0e5-ff0d3f95db08" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="18a868f4-6731-4a85-83a2-224a8eb95e22">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="83cfd432-d981-4de2-9973-5af864549422">
+      <statement statement-id="ra-5_stmt" uuid="e68ebbe4-3b22-428d-9d9d-9eeee4865235">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2154,10 +2154,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31d8085f-0a63-4ee0-870d-3423e8e5ceb5" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="71e9868d-93fd-44ed-ac6c-e54477c2478e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e3ccffdb-a3be-4669-8c9f-567762def8a0">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2165,10 +2165,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17b637b6-7043-4934-b128-dd9c8c158d28" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="62aa2c5d-05ca-46a3-b158-72e2d017b9af">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="dd126b3f-c13b-4eec-9a44-cba488325c1d">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2176,10 +2176,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6fe66d4-6202-4aac-83e8-a8f337a0971f" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="9b92e9d9-0ed2-45ac-923f-7aa1b1a2eeff">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="af16b537-d7da-43a8-9791-cd7d0df559ab">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2187,10 +2187,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a0ae5bf-ebdf-46a8-9b14-6bf790440ee3" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="72c9adb6-dfb6-49ea-8d6d-bfa0d221e5d2">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9e748f22-3d58-4c58-b1f1-f1a34c6001b5">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2198,10 +2198,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5758b6e7-f5c3-4aa3-a755-26dec699bbba" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="1c2a87e6-1562-461a-af1e-7f016102095c">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="aa551471-99db-43ae-97fc-3bec85c44c48">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2209,10 +2209,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa122bf2-3639-4771-b570-cd8f467a6e08" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="115c21d3-30d8-4c1c-b2de-d422241b280d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="14caa182-b0ad-4268-bb91-5a9a5f6ec71c">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2220,10 +2220,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba5ee20d-05ca-41f5-b50f-30da5980e753" control-id="sc-1">
+    <implemented-requirement uuid="5651d80a-c6dc-48a2-a7d4-59d286b6168d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="c63c5744-0de0-4ec6-b236-0abc996be307">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="1db2943e-dea1-4486-8ef1-513b8dd0c18c">
+      <statement statement-id="sc-1_stmt" uuid="f95841a1-e7a1-45cd-8dbf-fb9f208730da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2231,10 +2231,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bc3f4ce-cf76-45f6-97f7-5b5cba9da522" control-id="sc-5">
+    <implemented-requirement uuid="f499ec6c-51d8-4b49-a2d2-5776775a3493" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="cb9c13f7-d009-4340-a880-9335825d7d90">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f475e272-368c-4dc8-85bd-7711c02f86ef">
+      <statement statement-id="sc-5_stmt" uuid="33eaa098-ca31-4f63-84d2-6138c7a098f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2242,10 +2242,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="643bd163-415f-42de-8b7e-b82d340338b8" control-id="sc-7">
+    <implemented-requirement uuid="3bad8fd3-057a-419e-847a-320c75185d9f" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="f9d7ed6e-18b9-4427-aa44-2908bdde6070">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5324c9c4-308c-42f1-96db-dd5f2c68e42a">
+      <statement statement-id="sc-7_stmt.a" uuid="3f72051b-6578-4787-97d9-6e4f8619b2e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdabd9ff-7ac0-464d-b4e2-2085625778c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Openshift can be monitored is forthcoming. This activity is being
@@ -2255,8 +2255,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="9a2d03e7-f22e-4f1c-aec1-077ca04f8725">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="0f632780-162d-40be-aeae-3e97472591e4">
+      <statement statement-id="sc-7_stmt.b" uuid="6fc0305a-c430-4dbd-ac33-7226cdb84d44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7519cc9b-c5d5-489e-94c3-d8233cc8a4f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -2266,8 +2266,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="600e4fe0-50a9-4060-b72e-d2aa7a493b5a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="208bcafb-d538-4f5f-b307-c67e5f0d6ea4">
+      <statement statement-id="sc-7_stmt.c" uuid="eab9b163-d436-4802-af0f-69f8986ad962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5494a31b-da22-49a8-b068-5b4d3b701e2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can route connections to external
 systems through a managed interface is forthcoming. This
@@ -2278,10 +2278,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97cda186-ec7b-4676-a67a-a7f6d965269f" control-id="sc-12">
+    <implemented-requirement uuid="7c88e161-ba05-43dc-ab5e-884b8dcb10bd" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="8c422821-d174-4c9c-9055-1cb89e8a148e">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="560a4008-1108-4c50-9286-74784d76f9ef">
+      <statement statement-id="sc-12_stmt" uuid="02134109-c5f5-45e9-a1d6-e052124ef3e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="352d0e88-8e3f-4f3e-9b22-26e69493b31e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -2292,10 +2292,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3de9dddb-4993-406c-ace6-0172c8ac5120" control-id="sc-13">
+    <implemented-requirement uuid="3f412236-08c3-4871-b71a-c5eabf00f94f" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="665e0f25-965f-4d40-ae31-25aee3a40607">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="924244ab-ffef-43a6-b0cf-5eb840602d3a">
+      <statement statement-id="sc-13_stmt" uuid="489f455c-5055-47cc-8e10-8437a43748e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f74300e-0237-423b-836d-8f145bac0762">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding OpenShift's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -2306,10 +2306,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46876e91-bd89-4628-83c5-020dc634af69" control-id="sc-15">
+    <implemented-requirement uuid="76ca3ea7-c2d8-410c-8ca5-4404d7072b39" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="313b2284-0426-42a1-9b52-6d18a066f82d">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="fe934b80-12c1-4ef3-91e9-fb9822040a53">
+      <statement statement-id="sc-15_stmt.a" uuid="65568e0a-645b-4332-a928-6fd568a15f5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2318,8 +2318,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="d354d092-8f3b-4b00-b5e0-c18a75dfaf40">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="4a5cb1c9-de0d-48e7-b115-233b2e34159d">
+      <statement statement-id="sc-15_stmt.b" uuid="5afe21bb-69ec-494c-98e3-bcdacfde5d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2328,8 +2328,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="4e56668f-a509-470c-979d-36954b464851">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="39a6a183-d75b-4f1e-99dc-169312bf4050">
+      <statement statement-id="sc-15_stmt.b.1" uuid="d65a4a16-075f-4578-aadc-d9a267ce2130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2339,10 +2339,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdc7e12c-77e0-45fc-bd83-ae4623da03fe" control-id="sc-20">
+    <implemented-requirement uuid="f8b830ff-57af-4e37-854b-788171e6accd" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="f565c949-815b-4b9e-9d81-3c7840a3721c">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5e66a56f-5e32-43ff-8a74-26b1d33eae9f">
+      <statement statement-id="sc-20_stmt.a" uuid="e5127dc4-3261-4308-8dee-f2d6a1836dfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8cd61eb-4c1f-4240-bf35-1ef4202ccd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -2363,8 +2363,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="64ab0a22-e852-4285-910b-a4e8489e5d82">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f5b76682-165f-4e22-bcae-17603e7da376">
+      <statement statement-id="sc-20_stmt.b" uuid="5801a7ff-229f-4f6f-bdc7-61ce7f4809c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a8570ee-bd65-41dd-9064-8453735ed2d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -2386,10 +2386,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4649eef1-03f5-4219-aa07-b5e33243d497" control-id="sc-21">
+    <implemented-requirement uuid="3bd8b52b-1b3a-4228-a4f6-f4a456a753e1" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="9618593c-1d5e-46e5-8ac2-dca96c36f34a">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3af8b5d3-3fba-4248-bf20-e77fc689cf18">
+      <statement statement-id="sc-21_stmt" uuid="121f52df-4b04-4051-97a3-d05a14dd503e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="289e55b2-eac1-428c-8f3a-d3a0e8a486b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -2408,10 +2408,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6992e695-49b5-4fa5-8018-731809fed6ef" control-id="sc-22">
+    <implemented-requirement uuid="c20eba14-fc75-48a7-b425-9d93b361f7d5" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="4c1defce-9df8-4e92-9e18-0f34e7c4a6b6">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="0d4bd5e5-d72b-455c-b1cf-bfa1e3ebb316">
+      <statement statement-id="sc-22_stmt" uuid="10885e32-cc85-40ae-bed1-b469620eab66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="808d8d96-a64a-433c-ad12-ccd41c1a4b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -2430,10 +2430,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bfa7495d-db88-47dc-9095-fee25b5fc84c" control-id="sc-39">
+    <implemented-requirement uuid="fc3dd2a5-0331-4978-ae59-af93cdadd306" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="ea9be4f0-207b-4fab-a210-7eaa5ced33f0">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="00670a24-b502-4fe7-a54b-ce8645c82027">
+      <statement statement-id="sc-39_stmt" uuid="0ebe79d3-820a-4763-b0a0-3bfa9bcd25b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18033792-c0d4-4b01-890f-9d7957b9c16f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When OpenShift runs on Red Hat Enterprise Linux, 
 OpenShift maintains separate execution domains for each executing process by
@@ -2447,10 +2447,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="839a4512-a664-415b-a1ff-af53b8419d72" control-id="si-1">
+    <implemented-requirement uuid="a61cc071-ecc0-458f-902e-f49cc09131fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="ed2cc692-8617-4f5a-a380-54d1d17eb382">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9e80537d-cbd8-471b-9f8a-a821372a86af">
+      <statement statement-id="si-1_stmt" uuid="e90085e3-09ec-4da8-8312-dd6fdd8d33ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2458,10 +2458,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d97ea49-9732-4bbd-92f6-b3fe2e3efc08" control-id="si-2">
+    <implemented-requirement uuid="51ff2fe8-0d0d-4955-8bb5-69d7e5140461" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="e4ffcff9-b524-4825-a8be-7e72fa2cf4dd">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f71d0bbe-89b9-41f3-8d87-9da575322c1d">
+      <statement statement-id="si-2_stmt.a" uuid="cc54398b-c182-42bc-882f-cdae56f230aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d014d8d-6355-4b52-878e-8d2d9125edec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -2476,8 +2476,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="8721f667-9b80-459e-9ecf-745aa063ca38">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f2317746-3ac4-43d6-8ba8-25f2754e23a3">
+      <statement statement-id="si-2_stmt.b" uuid="3e9e1351-2baf-48ae-a626-ec33a0b98eaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d5e34bd-e241-4c53-b67b-e398909b0837">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -2492,16 +2492,16 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="6d683769-d553-4542-82c5-82a1810432d6">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="e6c9540f-9b36-4756-8408-48e2bd0e82ad">
+      <statement statement-id="si-2_stmt.c" uuid="819d1252-34e4-4c59-9721-a280e31aacb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="c710d446-1be1-4c10-a00c-52903bf9da6b">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="88ce0797-dd1d-4664-873b-c26378c1747a">
+      <statement statement-id="si-2_stmt.d" uuid="0233489c-5aba-44f9-b7ca-a084496a95cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2509,10 +2509,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3429f5de-32d0-40c2-9a7e-af50414e31da" control-id="si-3">
+    <implemented-requirement uuid="a73549a8-4ef3-4e35-ae59-78a92edd5429" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="2b594c38-f431-4f1e-9b85-0cbfa2e3d6fb">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="5559b096-59d0-4238-85d0-456c05608166">
+      <statement statement-id="si-3_stmt.a" uuid="99ffeb16-9f41-4901-85cd-a64f801b69db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68c758ff-1223-4c00-ad94-b38ad58e96ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -2529,23 +2529,23 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="edcb5534-6a3f-437e-a2fe-920398c1a715">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="44ae15af-a41a-426e-84ed-e862084abb22">
+      <statement statement-id="si-3_stmt.b" uuid="4378e159-c248-484d-866c-616e57ae60cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="844170d4-44ba-4a4b-a292-9e8a3604fa30">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="2383dee5-1bb9-4142-b460-097974863603">
+      <statement statement-id="si-3_stmt.c" uuid="c3dfb7d0-4929-477d-8c51-72da41d4adf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f8d3c4-5693-46c1-b279-e6c96c419175">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of OpenShift, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="39f8b6f4-9010-41ad-8958-6bbcb3e83439">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="f56738c2-0697-4236-ad6c-6e4ea0369413">
+      <statement statement-id="si-3_stmt.d" uuid="7fd01259-94de-4af2-8c6d-f320e41c911a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2553,10 +2553,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59cffe30-f44a-400c-ad8a-80b2bd6955b4" control-id="si-4">
+    <implemented-requirement uuid="1a0b3492-5535-4428-a0a7-647598146b89" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="b60f9f5a-e18d-4a45-a6fc-5459c359d2b1">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="212af193-41ab-4956-abe0-fde327ef88c8">
+      <statement statement-id="si-4_stmt" uuid="8497c3eb-0eaf-42d0-aa8b-824b58f6096b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2564,10 +2564,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9db711fb-fa30-4f36-8dfe-c63dae69503e" control-id="si-5">
+    <implemented-requirement uuid="2fd16570-0cfb-4746-8964-2c214f8a6923" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="d6a4df45-b15c-468b-ac8e-6fbc225e5542">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="3388d5ca-41f4-44cf-b7ad-3e346c53804c">
+      <statement statement-id="si-5_stmt" uuid="21e36570-d66a-4acb-b429-693ab619cbf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2575,10 +2575,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e043e62e-b8eb-4a5d-81fc-a69ab8796b8c" control-id="si-12">
+    <implemented-requirement uuid="06214fcb-4a37-4659-be34-919e761ed58f" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="3d049cf8-a089-4db9-b61c-994d44d2793c">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="9187e109-fd6d-4154-b84f-a1cbf7eda130">
+      <statement statement-id="si-12_stmt" uuid="a54c2fc4-ed14-4568-988f-77430a6cbdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="703257cf-df00-492b-900f-ddaddf2efa2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -2598,10 +2598,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5237d475-7b4e-42a3-9491-778427c9128b" control-id="si-16">
+    <implemented-requirement uuid="ea08db6a-8104-4ede-b641-fcd2b014ff1a" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="305457fe-d824-4a50-a0ec-e20084b39c31">
-        <by-component component-uuid="f7cc88c6-5b2e-41b6-9f4c-0c34359c4275" uuid="7a6d30f3-908b-4284-9a02-06a9edf68003">
+      <statement statement-id="si-16_stmt" uuid="dcd7a2a8-e255-4157-90e8-2f52131197c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80f11f03-6cc3-48b9-9807-d8b86e5c0b07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-container-platform-3-fedramp-Moderate.xml
+++ b/xml/openshift-container-platform-3-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="972a005f-2a44-4e28-889b-02b8e9bb57b1">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="a2d4b743-b544-4551-a2df-37f3cfd5af5b">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.64+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.10+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="64868de7-b149-4827-873c-c5c41f6b42c8">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="36b521cd-e613-4f95-be87-6a8a24c24655" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,135 +484,135 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="e58df670-03dd-49a2-98c7-b6e5644e25bc" control-id="ac-1">
+    <implemented-requirement uuid="60708a04-b787-4584-88ec-b5a40233339e" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="8690478d-9307-49af-a9f6-d60995223c33">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2d7fc295-3dab-4e3d-af10-7a6acaf34c9f">
+      <statement statement-id="ac-1_stmt.a" uuid="a534b272-07f2-4dd2-b131-50e83c8b73c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d03e4f5c-c2b6-4321-ade7-720c3cc1f5b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="6e7e1a73-d10b-4b51-8e2c-ddf6a4a7663e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0c195f28-84c4-4938-bde7-b902d54408a9">
+      <statement statement-id="ac-1_stmt.b" uuid="39869e7b-fbd0-4a76-ba93-35f3b833a806">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2161802-26d4-4ab1-8795-f7c2627f5634">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c14b4555-ea68-4406-8c12-b8ce53ce5e58" control-id="ac-2">
+    <implemented-requirement uuid="59578d19-03b0-4491-8eae-26a04cc69a05" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="90d49bef-6a82-4c49-9742-b28e522cc8ec">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ca8f7dfc-e808-4513-8e8f-764dc7a787a0">
+      <statement statement-id="ac-2_stmt.a" uuid="f58c922c-f798-4fab-bdbe-a332c7e92d18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ad2c932-3725-4d99-82c3-df7432aac77c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="f3ace9e9-7e3d-48b0-8227-e7fbae1bc241">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f0752875-c673-4dff-9384-e59bea19b398">
+      <statement statement-id="ac-2_stmt.b" uuid="5457a123-995d-45d4-a9fd-5db514a88e2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2404e9a-93b0-4e58-9e38-0a9b968064af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="871cac05-8d2a-45b9-b3b6-b72f86d92474">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8e0f2a7f-6588-49f3-831c-2a5c82f14f23">
+      <statement statement-id="ac-2_stmt.c" uuid="d2d3de61-15cc-4a4c-9674-3846c86431bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e239287e-a985-4297-8c52-f51f408465e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="c27aa974-70a8-4da3-ab3b-e67a45b1fcbc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="529e4fa3-9944-43ff-bd9c-42a83d88d880">
+      <statement statement-id="ac-2_stmt.d" uuid="96aa180d-68b4-4e6f-9a73-ce5f84362742">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c68a103-5a62-4cda-b74a-a4b30fe404a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="cfbf45ca-5602-40cc-bc00-144540bc32e5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="37e672d0-1066-472c-bc5f-a7b4de1381a6">
+      <statement statement-id="ac-2_stmt.e" uuid="9e220f14-127e-4ad8-bee8-035b5f2f7a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b49cfe0-e9b5-4fd0-9e96-24822cf55507">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="90b6452a-af80-4ae8-b55e-1a5e9416b9b6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="545d1218-7b37-44ed-8f44-60cb27e014d0">
+      <statement statement-id="ac-2_stmt.f" uuid="daa02e58-fffe-431a-a6ff-9923736b876a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8b34df7-1b86-4cde-9eb7-1fde4cb7cddb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="a03304dc-f643-4de5-8be3-925af2f04460">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2c828520-c93b-4d1e-9b64-7bff4d8222f9">
+      <statement statement-id="ac-2_stmt.g" uuid="727f879e-69cc-46cf-be37-9006e8253d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed61ef3a-e2d6-4a0d-8081-5e8c8e72fc2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="c7930595-1432-4312-905c-50b37d9e99f3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="804e298a-df3a-4c28-ae7a-ff251c7cbccc">
+      <statement statement-id="ac-2_stmt.h" uuid="4c706ff6-f1d1-4442-a6f1-1835c98964c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="948375b2-e248-4d06-b3d3-f314aad054c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="3f745f7e-5a63-451e-8dd4-2fd7fadebf25">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="acf1e56d-816d-489e-8f9b-6c0bccbedcbb">
+      <statement statement-id="ac-2_stmt.i" uuid="d517b147-73a2-4415-944f-2eb3d12c90db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5056b50e-2182-4662-a649-7f1bca05a377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="252104f5-abb5-4714-9593-30af658fdbf1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b53a7a16-c7fc-433a-ab2b-c960ec0abd16">
+      <statement statement-id="ac-2_stmt.j" uuid="19d705a2-6ca5-4692-a782-04fc9c41a37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bff8c94-defd-4343-aeb2-065ebe0bd183">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="144df1af-2e91-4764-ae94-0a476b8d02d3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b7b446e5-03a1-463b-a5a7-a0c697d2bb09">
+      <statement statement-id="ac-2_stmt.k" uuid="6d13e74b-b22d-46d2-8000-b5c56699bd00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61e050e3-2279-4395-b0ec-05835ee60c2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b53c9e2e-0a0e-4347-b5a8-8dec6f8b4d34" control-id="ac-2.1">
+    <implemented-requirement uuid="dbefa979-2715-4023-abe1-dc7fd1103ff1" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="e9a3cded-4a2e-43dc-a404-448020c317d8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4d5f22c8-e215-463f-94bc-a7bf9f1872a2">
+      <statement statement-id="ac-2.1_stmt" uuid="3c3e099d-f873-4c99-aede-aa89c1d5bfa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="281ea8f1-b026-46fb-a5f5-9e2c29611be8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift components of the system support automated management through monitoring of accounts and system activity by logging of related information.
 While OpenShift can generate audit data, and securely transport the data to a SIEM, OpenShift does not provide automated mechanisms (e.g. email, text messages) after system events. This functionality would fall to third party software.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19e73d9a-9e7d-45b9-ac8f-29c90a99ad48" control-id="ac-2.2">
+    <implemented-requirement uuid="bbe1af05-a651-4f11-a41f-ae1e41f9e262" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="f1cdf1e5-8751-4310-bb1c-49786d1577b7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="812683ec-ece8-4b0c-8c33-513888ddbd95">
+      <statement statement-id="ac-2.2_stmt" uuid="e3babbb6-c300-4e61-8764-d1ef8530dc49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c27a240-2a8b-4b8f-ac1f-030322aa1aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the capability to create guest/anonymous accounts or temporary accounts. Any external emergency or temporary accounts will be inherited from, and managed by, an external identity service (e.g. LDAP).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c18f07e8-fb22-4c29-ba32-6893ef332c5e" control-id="ac-2.3">
+    <implemented-requirement uuid="00d46d8e-1fb8-45de-a5de-30365eae3277" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="8631f944-5bda-4a7f-9d1e-b264206333f5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ace5aca1-4a13-433a-91ec-1377f363ba62">
+      <statement statement-id="ac-2.3_stmt" uuid="d0eaefc6-97af-4294-94b7-c9bd78a4dd70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35edb55b-ec8e-4f66-9894-946287d912cb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift end-user account management is inherited from the hosting environment.Automatic disabling of these accounts must happen at the centralized account management level; for example, within LDAP, Red Hat IdM, or Active Directory.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="188b5517-4d45-4285-a49a-39530f84e32f" control-id="ac-2.4">
+    <implemented-requirement uuid="8708f73f-5233-4211-82d4-411bea1a4c0a" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="822ac4c8-a9ae-4673-8279-497e107bf570">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d77aa711-d398-4b85-bde7-1d1c28067fc2">
+      <statement statement-id="ac-2.4_stmt" uuid="1208642b-e08a-4373-9321-d7d810eff5fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c7fa6d4-f3ad-409e-8456-0a9299a8df6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet FISMA requirements, OpenShift must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -626,10 +626,10 @@ service.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="303644b0-1e12-41fa-b744-1bf3067c22ce" control-id="ac-2.5">
+    <implemented-requirement uuid="105d1fd1-5772-494b-9941-3867decbdc50" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="ed9a4093-0944-4955-8443-b70ed41cd67c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d1e3d351-ff68-4f6a-a619-564a5aa6252c">
+      <statement statement-id="ac-2.5_stmt" uuid="7263b83a-47f5-4af3-8c51-2a38686cc512">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="012c492e-9cb9-468d-acd3-5c7195e2fd4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Within OpenShift, the sessionMaxAgeSeconds variable in the
 master-config.yaml file controls when/if users must logout after a
@@ -638,10 +638,10 @@ period of inactivity.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f0d7dde-b6ce-4253-a419-9aac81c17396" control-id="ac-2.7">
+    <implemented-requirement uuid="2d879320-2d71-438d-82fd-a8efddee152d" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="dd84a390-0ea4-49c3-9922-6dc61f2375bf">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e0a753c7-b6b4-49d1-bcb6-b32950614703">
+      <statement statement-id="ac-2.7_stmt.a" uuid="1fa5180f-c0e7-4a36-b597-1a2d1528f975">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df8deefd-6141-4833-bff5-3c47ea28ed43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift roles can be used to grant various levels of access both
 cluster-wide as well as at the project scope. Users and groups can be
@@ -654,16 +654,16 @@ https://docs.openshift.com/container-platform/3.11/admin_guide/manage_rbac.html'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="dfc53427-ac6d-44b7-898b-32d2fcfae15e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="13c96c07-25c7-4611-92e0-083dc0f73a86">
+      <statement statement-id="ac-2.7_stmt.b" uuid="6e27cd28-4cfe-49c0-ad40-95d887f6ec11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fce24ac-a9cb-4c56-a9e0-cc2f658fd82d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control and not applicble to the configuration
 of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="73c04152-5772-47be-8a4b-50cff2da2186">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b388d1da-03fa-4c53-8abe-cefaeb797909">
+      <statement statement-id="ac-2.7_stmt.c" uuid="1cfc2d0a-2681-4fc9-89a3-cf7f69a845cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fce24ac-a9cb-4c56-a9e0-cc2f658fd82d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This is an organizational control and not applicble to the configuration
 of OpenShift.'
@@ -671,10 +671,10 @@ of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="553e62fc-8030-4272-b1d3-5a281f3cca8b" control-id="ac-2.9">
+    <implemented-requirement uuid="dc5698cf-558a-430a-b523-68fba567a124" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="b46d2360-4db8-4616-9a7a-21fb9b6c557b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b14dd15a-2bba-4b55-9a69-aeb3792b01c1">
+      <statement statement-id="ac-2.9_stmt" uuid="77669137-ea0e-42e8-8e85-57dd2da82fe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -682,10 +682,10 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a3011fe-8f4b-429f-adf4-f304f84e051f" control-id="ac-2.10">
+    <implemented-requirement uuid="788053ba-0c40-4273-a55e-58a115860315" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="889f361f-3e67-499e-9650-65c4eeb70ef1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3a6b4928-9885-434c-92ad-3489e34cead5">
+      <statement statement-id="ac-2.10_stmt" uuid="9099931c-f89a-4c51-beef-ba7a3dfdec63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d09d9271-4abf-4960-b408-7673e0a10703">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift does not have the concept of group accounts.
 
@@ -696,18 +696,18 @@ of operating the shared identity service and not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ca63e9-9cd3-4129-b837-25d4390c960c" control-id="ac-2.12">
+    <implemented-requirement uuid="86466902-6096-4cf7-99df-b4bfab460261" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="cba8306d-d793-4378-bce9-41029448aabb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4b71cd7e-dd2c-4a4f-a06a-22b908a5093e">
+      <statement statement-id="ac-2.12_stmt.a" uuid="cca33a0f-d39f-455c-9c64-896aec65c3f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="a064db09-a97a-441e-931a-238a57684f7a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="74c4b8cf-c5d8-45c8-927f-ba1247157696">
+      <statement statement-id="ac-2.12_stmt.b" uuid="2683ff06-15cd-43db-b511-2f8cd1037855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad43b0a-b255-46d1-981b-61ea8052f956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to the identity service provider,
 and outside the scope of OpenShift configuration.'
@@ -715,10 +715,10 @@ and outside the scope of OpenShift configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="909c2d2d-4c57-4295-936d-083cd6bf7dc8" control-id="ac-3">
+    <implemented-requirement uuid="d8db6759-def8-4339-bed8-ffc870482ca6" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="2caa9559-3836-4221-a12e-d1228d62a54a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0ca2e065-f3b2-4e83-9e9e-622b2d6ce0e1">
+      <statement statement-id="ac-3_stmt" uuid="8725b63b-97f4-467c-89ff-3ae6966d072f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47a19d86-79ce-46b6-90bc-f6ee32905688">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Authorization policies determine whether a user is allowed to perform
 a given action within an OpenShift project. This allows platform
@@ -742,10 +742,10 @@ configured.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c82d8312-3f13-47ce-9bff-b9251f81492e" control-id="ac-4">
+    <implemented-requirement uuid="22b018bd-c73c-47cd-b3d4-b7012b7ed531" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="a64e2f78-e010-4ef3-a48f-3a5ba02320b0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="773d35d3-b066-4be9-9333-6ad0301681eb">
+      <statement statement-id="ac-4_stmt" uuid="d047fabe-5feb-4872-93ca-0fa02155a9da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd16a7b5-4b2d-4002-baa9-dcfe261b671e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for controlling the flow of
 information within the customer application, and between the customer
@@ -762,10 +762,10 @@ https://docs.openshift.com/container-platform/3.3/architecture/additional_concep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4768daa2-d547-4531-9adf-e8bf983b9be0" control-id="ac-4.21">
+    <implemented-requirement uuid="294150a2-1120-4ce0-9561-b1c72c4fb24a" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="3f13c447-141b-41b7-9d3d-c9980c34d420">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6163a6f5-709b-48ef-add1-dd705a3414ab">
+      <statement statement-id="ac-4.21_stmt" uuid="f1d01aa6-f4e5-43b2-9265-e1f681f8c11c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5069b83-98d5-4b64-afdb-e769759dbe2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -776,10 +776,10 @@ techniques used to accomplish this separation.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7649fa85-d7bc-4641-a9a0-9a2ce64703af" control-id="ac-7">
+    <implemented-requirement uuid="ce816ee8-00dd-4a1c-b9f6-3b5cd0f8f33f" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="8bf311e6-424d-4e32-808b-0fe90e19e20e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b9bb891f-3590-4924-8f0a-01f5f7d8d207">
+      <statement statement-id="ac-7_stmt.a" uuid="24aa9850-e243-41dd-a61d-54f533d38f35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72873987-046f-4ee7-b2f1-546624878717">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -790,8 +790,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="fb4f7e37-f7fe-4af2-8a3e-33668c8a5725">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="409a0797-dc89-41f2-b144-ce7d32d86dc3">
+      <statement statement-id="ac-7_stmt.b" uuid="bd16ba30-0829-4fcf-b9d5-8c39a0ecdd9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c23be9c-70d3-46ea-80f4-312055fd2b2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for taking the FedRAMP required
 actions defined by the customer, upon account lockout.
@@ -803,10 +803,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba8fba5b-fca7-4569-9941-9f0d7c474856" control-id="ac-8">
+    <implemented-requirement uuid="0681d54c-f2d5-4a76-ae06-e309f36db328" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="0b27e0f8-64fb-436b-862d-b63ea7892d65">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="eb8537b3-1e63-4c7d-9b14-66057c6cc318">
+      <statement statement-id="ac-8_stmt.a" uuid="5959ee14-d888-43ac-bc94-2a1672d052ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a6982d5-2fe0-4a79-a9cb-0270677cf54b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -825,8 +825,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="879af0d4-988f-406d-b934-a43c2622634f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="59c9bf1e-42fb-4b66-94c9-fc2e57092ac9">
+      <statement statement-id="ac-8_stmt.b" uuid="8ab258e2-1c3d-4d32-a32e-eab24fbebd5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e75e0ed9-63a8-413f-9a6a-b36bdf2d62f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -840,8 +840,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="0583aa81-758c-4e62-afd6-70b7e44a4f05">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f2cd271e-68c4-481f-8148-5c1db66f3db7">
+      <statement statement-id="ac-8_stmt.c" uuid="d1a44f1f-f6bf-47ff-8dd3-c88ae2bfef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3123693e-d71e-4719-a6c8-fec6e9ea36be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'
 '//*
@@ -857,8 +857,8 @@ of the system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="8e8035eb-c26d-4f53-8f90-ee4cd969915d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="239e1c97-8171-48c7-ab93-5eaaf8bbc9c4">
+      <statement statement-id="ac-8_stmt.c.1" uuid="fea90977-1c02-4513-94c0-bf4662ec9e28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbd396e3-ea13-4211-82c2-ae7149526204">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for determining the conditions
@@ -868,8 +868,8 @@ conditions must be reviewed and accepted by the FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="ad3697f9-5d22-48d9-9132-e9e016c1a79d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="99708305-765f-47f1-9dd0-cdba4d8baf12">
+      <statement statement-id="ac-8_stmt.c.2" uuid="89d2ef17-0208-44c1-bdd4-1866797b04b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a631d91-5ab8-4a75-b5a9-5b055a4728b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for how the system use notification
@@ -880,8 +880,8 @@ FedRAMP JAB.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="37d042e1-28cc-4af6-84ca-85faae6c9890">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="aa43190a-97cf-48c4-b16a-ef9ecd99ba1c">
+      <statement statement-id="ac-8_stmt.c.3" uuid="e94c4031-2e2e-467c-b852-1842d215ee2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c3edbe-cbe0-43df-9b89-c7d7ce1ae00c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for verifying that the system use
@@ -894,10 +894,10 @@ review and accept the process used to perform the verification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd26599f-fb5c-4ba6-a748-013f4292a2eb" control-id="ac-10">
+    <implemented-requirement uuid="1070c906-98a3-4885-aeb7-b9878c1f03c4" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="d0f26a87-fbea-4f36-a32f-16c07cb45dbe">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="72bb3f04-7daf-4ddb-8bb9-92cf510e7140">
+      <statement statement-id="ac-10_stmt" uuid="0b6b8dbe-0946-48d6-a2d2-6bb987d3193f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd0fbe9b-14f6-4ef6-b059-99cb6103941c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -912,10 +912,10 @@ https://github.com/ComplianceAsCode/redhat/issues/616'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37e16e23-a847-4fc1-b23a-17a80a598cd6" control-id="ac-11">
+    <implemented-requirement uuid="b22123c1-5174-4ffd-8bb7-ef3aec2074d6" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="caa5935a-0ef8-41cb-ba0e-c5026e3f9a9e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9c475f0c-959a-4120-aef7-83ce8f9cb85a">
+      <statement statement-id="ac-11_stmt.a" uuid="abb16fdb-f7f5-4bce-ba81-f1f3f9228cb7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fd0cfc-fa17-4b42-b071-06c8855d57b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to disconnect the idle users
@@ -923,8 +923,8 @@ from the management console after 15 minutes.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="d1c4c0a0-ff97-41d8-909b-14b4ec5f6fff">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3be4b27a-2c41-42b4-b92e-564330f1aa23">
+      <statement statement-id="ac-11_stmt.b" uuid="38618eaf-ba46-4874-aec1-afde297cdb26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fd0cfc-fa17-4b42-b071-06c8855d57b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to disconnect the idle users
@@ -933,10 +933,10 @@ from the management console after 15 minutes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e7075f9-fe25-49ad-bc19-c0e45b12fbf2" control-id="ac-11.1">
+    <implemented-requirement uuid="74004b67-b127-447a-94af-b5997b3c674d" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="d3351ba1-7e56-4341-a6f2-97a1975d5645">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6b451aea-69fa-4147-8a9d-e016ab07182b">
+      <statement statement-id="ac-11.1_stmt" uuid="c9a6bc6d-5585-4f4d-84c5-0f0b66e1b733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6cfc7a3b-523f-47a6-89ff-34641ba30c13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 default behavior of OpenShift is to logout idle users from the
@@ -946,10 +946,10 @@ will be the OpenShift logon screen.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdcdde88-1fee-41a3-8dbc-0a34215ba0ca" control-id="ac-12">
+    <implemented-requirement uuid="8584d2b4-1dd3-4b00-9623-1e780f2922eb" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="53b1bc3b-1fe4-4aa7-a675-c7acb708a67d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="258ad355-24bc-436e-8014-f7a4824875e2">
+      <statement statement-id="ac-12_stmt" uuid="32aa90d4-9c73-404a-b0ae-8cc86b8c87e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0c64846-1e12-416c-a31b-f6fcef3ae688">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -960,10 +960,10 @@ or conditions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc441eb2-45ab-41f1-bc48-c980a7266f83" control-id="ac-14">
+    <implemented-requirement uuid="b1a2b672-e170-480b-817e-9f392a21bff5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="ef146220-37a4-4768-b5bc-3cc44cffe597">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3729540f-8a47-405e-9f7d-1e1337b57377">
+      <statement statement-id="ac-14_stmt" uuid="e7a01511-c0f7-4332-8e84-f809e32215cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63bf72c5-0fe5-4ffd-a6eb-ed61cbbe7a7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -973,10 +973,10 @@ non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d34291a-46e9-4b2e-a435-77b36e5757d5" control-id="ac-17">
+    <implemented-requirement uuid="a7fa4407-680e-468b-8503-6d1394a6cb1d" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="cd70f6e9-8bf6-4913-8516-790324337708">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4e962a74-8098-406f-adc1-c6d8d0d57b6f">
+      <statement statement-id="ac-17_stmt" uuid="625f3c93-8015-4643-85fc-92d115742ab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -984,10 +984,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac1a3aea-74f1-423e-bd54-02bd9c5bd1cc" control-id="ac-17.1">
+    <implemented-requirement uuid="493fbbbb-008d-4451-aea6-263e27816acb" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="b5c6f37b-d3b2-4658-8b25-fb1f317871fc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="93fd16bf-1f77-4596-9d74-f2b83c8b1a1b">
+      <statement statement-id="ac-17.1_stmt" uuid="6a02d385-1cae-4704-a601-21f3add78b90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="703c52e5-98be-4f0d-acf0-a720d55b8c72">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'All system events, regardless of local or remote, are captured through
 the OpenShift and underlying Red Hat Enterprise Linux audit subsystem.
@@ -996,10 +996,10 @@ This control is inherently met when auditing is enabled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e24c1151-f663-4263-91b0-1263a0cde052" control-id="ac-17.2">
+    <implemented-requirement uuid="429deebc-d20d-4be3-ab68-f7abadd9e39f" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="328d24e3-782c-4d0f-ad55-f95c9e8daeed">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="659ad767-68cb-4840-978f-d9ffe96dbb15">
+      <statement statement-id="ac-17.2_stmt" uuid="41e9e645-8eae-4be9-8a06-7707a7aad8a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94856d52-6948-4056-9a9d-e4b2d1615b9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Beginning with OpenShift 3.11, when OpenShift is deployed on Red Hat Enterprise
 Linux, and FIPS is enabled as a kernel setting, OpenShift will use OpenSSL
@@ -1027,10 +1027,10 @@ and integrity of remote access sessions:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="791a74b9-ac3b-468f-85a4-7e7423539ba2" control-id="ac-17.3">
+    <implemented-requirement uuid="5d17d406-b350-4806-acfb-8455a6cf57ce" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="59ced1aa-ebf7-4ba1-8ac6-89c8f9771816">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="251c15e7-e2ea-41b6-9ef2-c54d535042e3">
+      <statement statement-id="ac-17.3_stmt" uuid="08264ef6-255c-47ad-9bc0-9acc30ca3499">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8edcd83c-b250-4b8a-883b-e7541d0b5223">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1042,10 +1042,10 @@ to protect those access control points.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5be7495d-a676-4933-be83-6ce5bbdb2537" control-id="ac-17.9">
+    <implemented-requirement uuid="9870fc33-f39b-4f7b-b08e-3e88b42970ba" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="6a000924-13c1-4ab4-b7e2-c28134009d9c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="66198291-6825-4871-82fb-91121ae4b787">
+      <statement statement-id="ac-17.9_stmt" uuid="f40721b4-b50a-4459-8b5f-3212077a13de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ccf7378-9cbd-43d0-9b46-1c907fd7e0f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the firewall technology embedded into Red Hat
 Enterprise Linux. This technology, named firewalld, allows a system
@@ -1064,10 +1064,10 @@ for tenant applications immediately.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59395cc3-ca19-4152-a406-c832b4d275a4" control-id="ac-18">
+    <implemented-requirement uuid="faf889c1-c3e4-4611-b3aa-81ade0b60c72" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="0af4ad37-94db-4c4d-9000-195d0f146a71">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="cb6a2265-8cdc-4b68-9944-e48705942f48">
+      <statement statement-id="ac-18_stmt" uuid="1fa47f7a-07fe-4570-ac1e-4c7bf1746a61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1075,20 +1075,20 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd8d4d69-e889-4812-9d51-4d1b2874be76" control-id="ac-18.1">
+    <implemented-requirement uuid="53522277-cafe-4b95-98bc-a36e02ccd271" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="564f635b-48ac-4c75-a58e-440503ba9859">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5d589542-6c40-4338-a5de-12ddcba9d7c3">
+      <statement statement-id="ac-18.1_stmt" uuid="17dfe968-cf6c-4226-a456-242b6022e24e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba7c1345-e5c0-4242-9343-a6054f9cbfa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is confired by the host operating system.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c25c90d4-1e9d-475a-9760-474c33a69f95" control-id="ac-19">
+    <implemented-requirement uuid="5e70b3c6-335c-4757-ad39-72b66ec7193a" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="05de17bf-3ab9-45df-934c-bceb9dc3bd61">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a03189fa-f451-4091-b10f-7cfea584b6c0">
+      <statement statement-id="ac-19_stmt" uuid="d0cf94d2-2d0c-4b28-9bfc-007e463cf3fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1096,18 +1096,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="929c7a95-e029-43b9-ac6d-2cd6afe0e465" control-id="ac-20">
+    <implemented-requirement uuid="67fc136f-3487-46d0-b749-950f22cfed99" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="522a16b3-3567-494a-bcb9-316fb49d3bba">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="39e9356c-2182-44ed-a6c6-f2605770cda4">
+      <statement statement-id="ac-20_stmt.a" uuid="d852d7f9-5f3d-4fa7-94b2-623432ac3474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="5afa318c-b832-46af-a296-47a52c8351cd">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a02fc0fe-d949-47c8-bce3-92109bebaf25">
+      <statement statement-id="ac-20_stmt.b" uuid="50117407-a947-4180-b837-5df60acef77c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1115,18 +1115,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3136d4f0-5e8e-448a-8c2e-1ecaa9f44e97" control-id="ac-20.1">
+    <implemented-requirement uuid="2110df62-3c74-4a44-a75f-c7cedcfde146" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="7aa22ce0-bb40-49b0-beb6-ff0cdaa82469">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1440a9a6-e72d-41a9-9cee-ed56182b8494">
+      <statement statement-id="ac-20.1_stmt.a" uuid="df75ccd7-cdd6-40a0-87ad-98412f406658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="f989061c-7f9d-46e7-b8f5-52ad3067c323">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="13177ea7-7b16-4902-beb7-a3c069eeaaa1">
+      <statement statement-id="ac-20.1_stmt.b" uuid="1d938772-4ece-481f-a10c-9cfd11f59079">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1134,10 +1134,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c17cc15-0d87-4570-acde-38c86a2ccec2" control-id="ac-20.2">
+    <implemented-requirement uuid="c86b5405-7bd3-4f4d-bfe1-2ecd05cb59ad" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="15ce9e00-f92d-457f-89aa-5e9275041ef5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fefa5237-7405-4219-8a1e-de80b2ecb32b">
+      <statement statement-id="ac-20.2_stmt" uuid="3b896ffe-ca98-4f8b-9f85-f6b139a5f4d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1145,18 +1145,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed2f19c7-e2d0-41b2-9014-78ad78bfd4e4" control-id="ac-21">
+    <implemented-requirement uuid="980dfc0b-1962-44e1-8a0b-113be5e653d4" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="ecab2f46-5d2c-47a8-b03a-be738b070a14">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e4d9c028-23a1-4293-9e54-507e808cc55b">
+      <statement statement-id="ac-21_stmt.a" uuid="e9e80274-8948-45ca-aa95-3655bdbc99fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="5c4b56a1-0341-4ee5-b06d-727963ae34da">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="981f5fd1-085b-43c6-9f82-aacfe58028da">
+      <statement statement-id="ac-21_stmt.b" uuid="97952866-6afa-4069-a178-2b4488cdbeca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1164,34 +1164,34 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38dc437c-57dd-4324-9881-30123e496f2a" control-id="ac-22">
+    <implemented-requirement uuid="2e22dd86-a8db-41af-8b95-b169b4837f17" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="eab85586-9ebb-45e0-a5c6-a2476dec3f1f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3fcd58a0-d894-4045-bd71-c436547371e1">
+      <statement statement-id="ac-22_stmt.a" uuid="38377e70-0989-4f2c-b71c-91a4e3680228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="886a617f-2965-47d0-88ef-bd75516619d0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9a3ff40a-1949-433d-a4b3-f4fb4df6c593">
+      <statement statement-id="ac-22_stmt.b" uuid="68c4d6dc-9dc9-42c5-8f34-93d19c06153c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="87d213fb-9d4b-4671-8c8c-a6a6295722ef">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d3bfa3e2-bc08-47a1-8056-9978d087552e">
+      <statement statement-id="ac-22_stmt.c" uuid="7b8bfb09-8cc0-43ad-be77-ca0e1b177c4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="ff25d36d-3521-41ba-be70-861aa76031bc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4eca5dbb-e0d8-485a-abf2-ff6b27c6c311">
+      <statement statement-id="ac-22_stmt.d" uuid="a34f247f-0e09-4045-97dc-142c54d65da6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1199,45 +1199,18 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6b39072-b0b3-4010-b224-2e2499bb9ecf" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="ad1fc756-e1c9-4e2e-a498-748bf2b8ffe6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="db8e5f47-2414-45ce-868c-ce99f9e31e34">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="5a204e1c-71f3-4b05-8549-18ed37c33a97">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d18588bb-5c4c-4454-9a94-77394f643513">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="55d01c1e-1774-4f45-9348-089206a6b093" control-id="at-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="24d17b1b-1d9c-4dd6-b880-fc9e4b8a2e09">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="58cdecc8-dfd6-4c4f-849e-ac70725d9b6c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-2_stmt.b" uuid="e153e3d4-a6f2-482d-a3f1-4dd90b6f4121">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0756e280-4be6-4781-8c30-0be4b869f933">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-2_stmt.c" uuid="743b315f-db9e-4b53-97c4-43639cdacd1a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5993a600-01da-4c6a-b587-b20964ddceb0">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1245,10 +1218,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="867af53f-462f-44da-8a99-6b41136f4db0" control-id="at-2.2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="c8e482b3-82ab-42f7-9b1d-f37fd66781cd">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7a87c4b4-c1f4-46cc-831d-9485c94f1ba3">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1256,26 +1245,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f62df19e-0471-472d-a798-08e20d60ddea" control-id="at-3">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="0d6adbe0-23f9-4189-8e88-bbd56632a88b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a75e8b23-22f4-4919-a761-640f6f521283">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.b" uuid="c3d9eb6a-ad61-4db5-88ac-d48adf3150de">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d79be3e4-1687-41ac-8b50-5fb7cf9422d2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-3_stmt.c" uuid="70fe40b0-8e73-483d-9d2d-a16eed993972">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0b605da1-66ca-4f63-8485-d47f542f4be7">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1283,18 +1256,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3b59684-dcfb-431f-9e40-c066645c0745" control-id="at-4">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="090ac426-97e1-4fef-848c-979378612abb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="79147d63-7f29-41f2-9239-8cd84f85cfc7">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="bb7e02cf-1a07-4c35-9d7b-68f996c735ca">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1d1169b8-5ec5-49bc-93bc-4964967c508e">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1302,10 +1283,29 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8eba1eec-0f6f-4d52-8bac-9b5da54fb299" control-id="au-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="1c4b9ae3-f336-4c66-bdad-8b40dffcf920">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="be71ece0-b5c3-469e-9074-c8cf07017855">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ff356bcd-4854-4223-bf9e-e8ea3a310cdb" control-id="au-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-1_stmt" uuid="42ab131b-17cd-4db6-bace-aadded17e94c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1313,10 +1313,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4753cb92-c126-49b2-b369-1d14f3b7e6c1" control-id="au-2">
+    <implemented-requirement uuid="df0fc4ec-86fc-43d8-9709-a51f8882cc4b" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="d4a4b70d-c585-407b-9811-2133d4604759">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="431eb798-198b-460f-9a9f-c9ce12cf8be3">
+      <statement statement-id="au-2_stmt" uuid="f4a9622c-4261-405f-82b5-919e8d481c56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1ece91a-779e-4a5a-85d8-7b2c87fd0588">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -1327,10 +1327,10 @@ OpenShift through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74d07714-87a9-4b92-9e34-1d0cce786f89" control-id="au-3">
+    <implemented-requirement uuid="a1741e48-4de6-4549-ad9b-cf2088e4e2ea" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="c219c707-e448-4cfc-9040-2a9fbc527505">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3d15263c-dd50-4d53-8c11-848e7d9d64bd">
+      <statement statement-id="au-3_stmt" uuid="f8f48da5-0595-412b-a4f1-85231f500cc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6364b03-a0e6-4926-b96d-a03faf8e0cb4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift audit records contain this information by default. No
 additional configuration is required.'
@@ -1338,10 +1338,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ea91d65-46df-490d-a567-31801aafd7c2" control-id="au-4">
+    <implemented-requirement uuid="0885c7da-ffa1-40f0-9109-4b822dafab35" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="4463ab13-077a-40b6-b350-67e543afb79f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3bb2f8bb-7a93-4781-8248-aed97fba7dcf">
+      <statement statement-id="au-4_stmt" uuid="4fbbbe83-ed9a-4bfb-af19-ea8c8b7124d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef0522af-af8d-47df-a85c-dc20f28735ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift. This control is reflected
@@ -1365,10 +1365,10 @@ https://docs.openshift.com/enterprise/3.2/install_config/aggregate_logging_sizin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84fb71ac-ef44-4bb9-adec-744cc438a8b2" control-id="au-5">
+    <implemented-requirement uuid="f873dd86-9b68-473d-a5f8-df8df82df7aa" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="80cfe226-f255-4982-acb8-806635847456">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c69da4cc-b169-4597-aeed-25129dfd90d9">
+      <statement statement-id="au-5_stmt.a" uuid="391206f4-940b-474c-8d11-9edb3899a6f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dac2725-ee2f-493c-bfb4-5590df1386e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -1377,8 +1377,8 @@ when an auditing failure occurs.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="553679ef-410e-4487-aada-753d412999ba">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c7b54260-b377-4641-b792-96cd7a0f0947">
+      <statement statement-id="au-5_stmt.b" uuid="4e876cdf-c65d-476a-ac41-9617baa4928b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bda2746-ccb4-48f8-b7fa-23c91788498b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, OpenShift Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -1389,10 +1389,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c55b2c4-fd7c-4da3-82bf-f308a5f56714" control-id="au-6">
+    <implemented-requirement uuid="2fe84fb8-05ad-4cbb-b9fd-22da40910edd" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="c43461e7-c3e2-4669-94e5-0eedee4b8fa0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0dac92ae-0f2e-4310-adef-9dc680fc295c">
+      <statement statement-id="au-6_stmt" uuid="6c925364-79ba-40b3-8d16-7d0c218e7aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1400,10 +1400,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e16d58a5-3e30-4bf0-ae4e-852ada7d8897" control-id="au-7">
+    <implemented-requirement uuid="78fe86ba-7151-46b8-9514-e7088a584da6" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="54e73a22-bed0-461c-8394-562817beb427">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5afaae73-23b0-4da3-bf68-fac479058231">
+      <statement statement-id="au-7_stmt.a" uuid="f60782ae-416e-4e77-9baf-38195be249e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c5c7a8-2fb4-43b3-9a41-24fd7795f348">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift embeds the Elasticsearch, Fluentd, and Kibana (EFK) stack.
 This pre-integrated audit reduction capability aggregates logs from
@@ -1416,8 +1416,8 @@ may be setup to detect atypical use.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="e207329d-a8be-4a1d-8017-a2b8e2209428">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="11d1db67-f288-4759-8caa-052b0a5b78d9">
+      <statement statement-id="au-7_stmt.b" uuid="091243bd-bcc1-4809-855f-c2c82f5b51fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbb57050-cbde-4118-8ba0-6caddcb6fbb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift logging subsystems do not alter the original contents
 or time ordering of audit records.'
@@ -1425,10 +1425,10 @@ or time ordering of audit records.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02a3b3a5-0791-43ee-bb3d-99fe2777270e" control-id="au-7.1">
+    <implemented-requirement uuid="55eab158-fc49-4893-a95e-312b82183285" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="b06c595a-14bc-45b6-8d62-d5b7a6637b8c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="55df9a5d-9fb6-4bea-830e-9e86a80026c4">
+      <statement statement-id="au-7.1_stmt" uuid="fff83246-d10a-451f-becd-3187510fa3a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98a0b716-433d-4ef3-a2b1-591a621e0731">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are responsible for ensuring that the information system
 provides the capability to process audit records for events of interest
@@ -1440,18 +1440,18 @@ fields.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8069dc68-097f-4969-9413-e23318397e0c" control-id="au-8">
+    <implemented-requirement uuid="b0cc2985-4fa3-4643-b69d-2bc0e6b4891b" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="88be3369-e172-4ef9-8c77-c971d2be8b76">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8d48f221-1598-46a2-9a5e-a7b4c647cf7e">
+      <statement statement-id="au-8_stmt.a" uuid="1e983df4-6832-4b42-8841-4647c61d19a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eac111fb-f99a-4d90-8fc3-c3f2be4e07bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift logs are generated using the internal system clock by
 default. This is non-configurable behavior.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="38814426-6458-464d-8714-10848f1c7dc1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3dc260a8-f643-469c-9f6a-396987e4acaf">
+      <statement statement-id="au-8_stmt.b" uuid="1af2c1ee-5635-4ca7-a125-0193a83686dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f8c71d9-556b-47ae-83d6-f8354e7d5a7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift time keeping relies on the time services provided by the
 underlying operating system. When running on Red Hat Enterprise Linux,
@@ -1475,34 +1475,34 @@ https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Sy
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5447a92c-ae82-4086-a23b-e4edc95cc7b1" control-id="au-8.1">
+    <implemented-requirement uuid="0ca6b291-4a5a-49f4-af21-34b5d45081a6" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="8a694c76-8cf9-4892-bc2d-ff02adfca1b5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="37020e5d-dca3-45ef-a9dc-5c68d1569e27">
+      <statement statement-id="au-8.1_stmt.a" uuid="71bb68a5-1eda-4509-aaca-b70501447657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f57e9f3-fa29-463d-9bed-2c7c555b0c49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underlying operating
 system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="e6408d43-ff21-4d0a-9b29-195176dc724d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="aa665906-3268-4b9a-9dde-2739ac7dd163">
+      <statement statement-id="au-8.1_stmt.b" uuid="86c7f7f7-fe64-4367-83bd-9ce51dc193e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b.1" uuid="6d378a0e-cfcf-4da9-b140-4c1da7d072d6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d397bcc8-7804-41ab-9e61-a9bc0e424189">
+      <statement statement-id="au-8.1_stmt.b.1" uuid="3adb07f3-38ac-4879-8c86-5897180e448f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b.2" uuid="e05dd75c-0d08-4b26-8bed-46912b47968a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3875c47e-1710-4c56-92f4-782c73c859c3">
+      <statement statement-id="au-8.1_stmt.b.2" uuid="844aa359-4a5e-459f-b6ec-fa0a1664f55b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5572dfc-f9e8-4c74-906a-9eaca718d859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift utilizes the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.'
@@ -1510,10 +1510,10 @@ operating system. This control is not applicable to OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="904514d4-529d-4b89-8f8a-8d59cfc2f986" control-id="au-9">
+    <implemented-requirement uuid="25be9da1-c399-4518-a66b-b7420619381d" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="c868e36f-3654-4264-b496-58afe106a62e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="adb1575c-b676-413d-8aaa-6cc076ebbc21">
+      <statement statement-id="au-9_stmt" uuid="40dda508-78eb-47f8-af8d-7712aa8bb3a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859a0daf-8b78-4978-a3c8-6ed9377b5f0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -1529,10 +1529,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cdeb9ba-f00e-439d-9787-1ff8a4db3155" control-id="au-9.2">
+    <implemented-requirement uuid="45a664f4-ab35-44d9-bdcc-da46510a3c04" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="2370422a-ad33-45dc-ae09-8793c19660f1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ce180944-3231-435a-a43f-b7fc063d07b3">
+      <statement statement-id="au-9.2_stmt" uuid="e6086580-7c2d-4771-94c3-ff3671eccb8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04f2b951-f38b-4d1f-97f6-aacb16650965">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to back up audit records at least weekly to a
 physically different system or component than the system being audited.
@@ -1546,10 +1546,10 @@ audit records to a central service via AU-4(1).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b3b4eae-cc6e-436b-b9e6-b42ef15553cc" control-id="au-11">
+    <implemented-requirement uuid="20998a4f-4e1b-4087-8b46-810c9a4cda5f" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="5158b745-e50c-4835-babb-ce421669b570">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e4ceba27-9498-46ac-8e49-850f506572e5">
+      <statement statement-id="au-11_stmt" uuid="12b59756-4cf2-416f-98dd-68f2dd5cf8d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f45482a5-2b41-4044-8637-f7a8da5224f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in Jira:
@@ -1559,10 +1559,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aed5f51f-5147-4f1f-8d29-206d5ef76612" control-id="au-12">
+    <implemented-requirement uuid="ac5c7e83-3ce6-41b5-9a42-9004361d21a8" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="07da351e-894a-42fc-a3ac-f547c7c56c9c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="28af7d04-88ef-44be-bc3b-fecbcc15e5b2">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -1574,8 +1574,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="482db92c-96b5-4de7-ab34-b6ffde04ad2c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2960fcd2-4beb-4da3-bbc7-5741b2e9e03d">
+      <statement statement-id="au-12_stmt.b" uuid="0876f4fa-4a0c-4f9f-9e37-86ec35acdbb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a14957d9-85f7-4af6-bff4-e5b13f768c2f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -1593,8 +1593,8 @@ is recommended that OpenShift specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="ba72d862-2756-4c99-adf6-540ac7b6effd">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3694e97c-1867-4e32-bf8f-a30eb049a060">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -1606,10 +1606,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdc71cc2-61c8-4392-a036-84778784b67c" control-id="ca-1">
+    <implemented-requirement uuid="137a1bb1-2be5-4792-8402-b452ebdc8289" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="5d44ab00-cd9e-4cb4-b7e1-ca3192d096ff">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="29a07a73-1688-484d-b83d-5bfe8babd6f8">
+      <statement statement-id="ca-1_stmt" uuid="82ebbeae-39c1-4a32-8ace-cfae81e476d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1617,10 +1617,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf074edc-d222-45f8-ad8b-5f376254bd89" control-id="ca-2">
+    <implemented-requirement uuid="92f26f75-6eeb-4bc8-9686-ed1d8181854f" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="fb4c0e83-9747-4fe7-ad29-8486426bd0b4">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5bb39bd6-9bd1-4051-abf7-a9cce50a692c">
+      <statement statement-id="ca-2_stmt" uuid="8340ac1d-6c63-41e0-8926-68ab5c1ae749">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1628,10 +1628,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f429159-d867-4a38-afdc-d59da3f525e2" control-id="ca-2.1">
+    <implemented-requirement uuid="66592cdc-3f3f-4577-8e34-34002c14f287" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="e193dfa3-23b9-42e9-a66f-ae5a5b9e425e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e482dc08-a0f6-481f-be13-9f357323623f">
+      <statement statement-id="ca-2.1_stmt" uuid="4c836022-5b78-4150-8ec3-61d6b865e198">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1639,10 +1639,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fef7523b-9b37-43cc-bb17-68978aa691aa" control-id="ca-3">
+    <implemented-requirement uuid="deb63227-f2a7-4ccb-a8f4-c3daf16b1b00" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="28cbf3df-85d8-423b-8aef-b86714d06d33">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="07bcca9f-737d-4a24-b7f2-df3569ff213d">
+      <statement statement-id="ca-3_stmt" uuid="4515c02d-a038-4872-b604-333eb17af574">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1650,10 +1650,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e72bb1a-7683-468a-8709-a07232154bcb" control-id="ca-5">
+    <implemented-requirement uuid="461cac5d-4510-49e7-8996-a044e976ea00" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="d2a3398f-341f-420f-bfd6-a1a9a8c8b724">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d9b726d8-d30f-42de-85ee-05eae85f01e9">
+      <statement statement-id="ca-5_stmt" uuid="75a60994-46b3-4a2b-b437-8a8ade88dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1661,10 +1661,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d248f9b3-23a8-4a25-9801-4f79dbc1c86c" control-id="ca-6">
+    <implemented-requirement uuid="91eec0d1-f1ca-4478-bc79-1cdbb27fe7bb" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="74b936d9-5a7e-4175-933f-77d10cf2ef2d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c4f4d7ba-9a79-4a18-a56e-dca4062adc19">
+      <statement statement-id="ca-6_stmt" uuid="fc00e0cc-b43e-4250-be0d-0a9cfeed4bf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1672,10 +1672,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a25c4bb-5358-41df-a053-f1b470c84b90" control-id="ca-7">
+    <implemented-requirement uuid="e64d358a-f134-4e34-9117-5d6767731abe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="2d04a66c-7591-45a5-831e-9e6bee3d68b9">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="75843ca3-68ae-4bcf-9dc0-5f4924e07504">
+      <statement statement-id="ca-7_stmt" uuid="1361fa12-ec53-4f6e-b5a9-517e3e7eca7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1683,10 +1683,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="794e43f7-eda4-49e4-ba2a-b9f873e6433b" control-id="ca-9">
+    <implemented-requirement uuid="229eadf1-80c0-4c84-a297-4cafca0aa898" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="969a15b9-2dac-4420-bdbc-cdc91673fb93">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0cfc4616-fcf0-4849-b7fb-f0253ba54daa">
+      <statement statement-id="ca-9_stmt" uuid="58b1d545-6ac8-40c0-bfaf-7fb6d3d1d6ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -1694,10 +1694,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="244a8aca-a025-49da-b9cb-fae37efefbec" control-id="cm-1">
+    <implemented-requirement uuid="6db18908-efb6-400b-8ff5-6c6425f4a511" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="60ea1616-7403-49ca-9743-b98eb28e83c9">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3b90f68c-79b4-4daf-8948-3dee91dbaf45">
+      <statement statement-id="cm-1_stmt" uuid="3d140bf0-9c1f-445d-9da3-0f4f78994802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1705,10 +1705,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc7f2079-d13c-4e89-a610-b3c65768255f" control-id="cm-2">
+    <implemented-requirement uuid="03633224-a901-4b5e-8a83-9f11fcc66564" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="8d68497a-158c-4ccf-9bab-6f9d2f78a74a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d88ecae2-e640-4ae0-98c9-2e659479d198">
+      <statement statement-id="cm-2_stmt" uuid="a179fc74-d550-4122-9846-c936bd97eba3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1716,10 +1716,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fb798a5-3d82-488f-b619-4e0a0c287786" control-id="cm-2.1">
+    <implemented-requirement uuid="cbf42a12-ed9e-4209-a4ce-e4c4f16bd500" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="01dad550-68c2-45f8-b059-c1387140143a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5c2c1fec-2e00-43d2-b3ae-42baecae024e">
+      <statement statement-id="cm-2.1_stmt" uuid="99ef247e-b28d-4cc0-aa97-a7c66fc541cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e0af131-9823-44ea-bce0-b7fae6cc158a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for reviewing and updating the
 baseline configuration of the information system as a part of
@@ -1730,10 +1730,10 @@ configuration as a part of installations and upgrades.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25bbeb4c-7d4f-48c9-b8d6-cd6962a5bd12" control-id="cm-2.2">
+    <implemented-requirement uuid="18e30419-e9ef-4760-af0b-008b07d96c77" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="d114ebf7-1989-4df4-aaf2-825a02bd8937">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fcd67d57-e412-43e9-90c8-1aebe4e446d5">
+      <statement statement-id="cm-2.2_stmt" uuid="69e642ca-f24c-4a81-b377-d53d1d258dfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81f190ff-6802-44ef-bdb2-354e9c6cd692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing automated mechanisms to
 maintain an up-to-date, completed, accurate, and readily available
@@ -1744,10 +1744,10 @@ help maintain the baseline configurations of the information system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab3ed43d-297f-4ff7-9c76-be429af39dce" control-id="cm-2.3">
+    <implemented-requirement uuid="46b94187-e85e-4d7c-8ef9-29c5ec81558c" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="14ae31b7-f3bf-400e-b848-50a04e8f852d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3b40871c-81ea-496a-968a-30f8e9a62e7a">
+      <statement statement-id="cm-2.3_stmt" uuid="b9f34dee-fbad-4dbf-8f34-372c22e1d24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4e6d314-6951-471c-86ea-442d2de3e471">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for retaining previous versions of
 baseline configurations to support rollback. A successful control
@@ -1758,27 +1758,27 @@ version.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33299f3a-9e46-4054-a912-577d9f683ff0" control-id="cm-2.7">
+    <implemented-requirement uuid="7b848231-284f-44d5-8639-b7eb19397f8f" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="6b861fc1-a220-444c-b8c2-f9d6ad26151b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f68b7576-582b-4b76-b118-79467163d11f">
+      <statement statement-id="cm-2.7_stmt.a" uuid="afabc90a-9a85-4e1a-a2e0-adfa85a37ceb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7422da5-e491-494d-ab20-460f4bf1cac0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="9a8d6978-c560-4ff5-a050-1ba34343f220">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="77149272-8b2b-49c5-be90-b666d27e4fe1">
+      <statement statement-id="cm-2.7_stmt.b" uuid="e42c3a5c-b46b-4c95-85b0-13665548e268">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7422da5-e491-494d-ab20-460f4bf1cac0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab84fc0b-fa87-469c-9a29-4f49577efb56" control-id="cm-3">
+    <implemented-requirement uuid="6b730e13-852a-4faa-b6aa-2c4ad228c566" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="a3546e4a-d8ae-4132-9018-cbc6b000b182">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="da20bb2f-f055-4094-baf9-79f79dd507f1">
+      <statement statement-id="cm-3_stmt" uuid="e256ede3-9788-4b8d-b138-a7478aefd573">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecce0170-2439-4ff6-b241-0274cea1e1e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing approved
 configuration-controlled changes to the system. A successful control
@@ -1789,10 +1789,10 @@ implemented after approval.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4297114-6302-4d91-847c-ac287e333bf0" control-id="cm-4">
+    <implemented-requirement uuid="7d9cae12-888d-449d-8d98-a97f9953cab2" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="63e692da-4c7f-45d2-86af-3b84ef916021">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a5fc933a-3a72-420b-9985-dfd974491b73">
+      <statement statement-id="cm-4_stmt" uuid="e8ad8b2d-ba3c-48c8-8103-a1ca0da104a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1800,10 +1800,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f22dd7b8-b269-49f9-82d4-0bc8dea3e05b" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="cc8de5a9-fa0c-425f-a450-5e24a5adf15d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e9118f61-cf1c-4e41-b8fc-957a425ac1aa">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1812,8 +1812,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="e37e9c60-f659-40c8-8442-3efd2976003a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b345a9a7-a230-4530-a93b-e91acb3b7eec">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1825,10 +1825,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a273b4f-7f16-454a-b197-8ea325cf5b6a" control-id="cm-7">
+    <implemented-requirement uuid="470be975-e9e3-43a3-8eea-dca908192731" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="b59f7f88-b808-4237-9ee9-e86e929cf662">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a0a4daf7-4a00-43fb-a3cd-9bc86cf3a208">
+      <statement statement-id="cm-7_stmt" uuid="cd05bebe-a619-4f4d-8b81-69900e91bfa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1836,10 +1836,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb9ecfbe-a2e5-4c78-8870-a6e2ddb2203e" control-id="cm-7.1">
+    <implemented-requirement uuid="e3b9edbf-fdfe-4343-8820-b5c720f1ec99" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="67b7f6fe-0b44-4b8e-a68b-434d77dd3a2d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f6fda274-f8fa-4cf6-a16e-708b2b55fd93">
+      <statement statement-id="cm-7.1_stmt.a" uuid="8c47a1c6-c2b9-46b4-b536-34cc016b073f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a7baa6c-52d1-4cb8-b448-762527c19c84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for reviewing the information system
 at least monthly to identify unnecessary or nonsecure functions, ports,
@@ -1848,8 +1848,8 @@ how often functions, ports, protocols, and services are reviewed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="ef8f19fc-1cb6-4142-9057-8a82cecb69e1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a597ef4c-1616-493e-b9ed-8406b89d3a1e">
+      <statement statement-id="cm-7.1_stmt.b" uuid="3a34ef9f-664e-4468-95b7-b673f0081b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88c4f1a4-2b9d-4d4a-8b98-e515518eea60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for disabling functions, ports,
 protocols, and services that have been deemed to be unnecessary or
@@ -1860,10 +1860,10 @@ process are disabled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="239bbd60-0c62-42bf-9fc9-810a4f11b1c2" control-id="cm-7.2">
+    <implemented-requirement uuid="d2420728-51f3-4640-9294-eb10afd9fad1" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="3e25a482-efc0-4147-96ad-da800231a15b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="76b3ca53-3f74-45cd-b72f-732edf415d05">
+      <statement statement-id="cm-7.2_stmt" uuid="f7ed7fa7-bea1-4a5b-ba2f-07b7d7aedab5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9141925-6989-4263-8ee6-65bce0d81e0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for preventing program execution
@@ -1881,10 +1881,10 @@ said trusted registries to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21abadce-31b7-46c2-95c0-9ee59cc95ede" control-id="cm-7.5">
+    <implemented-requirement uuid="ba99eda2-e418-4708-857b-840deca1e407" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="58dd7b2f-7ce2-4fb1-aeac-e698f7601d07">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6a6dc4c2-cc1b-4174-ae9d-20068f6b1443">
+      <statement statement-id="cm-7.5_stmt.a" uuid="7f8b45ec-3f43-4aca-a6bb-d5b6a529262c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a33b96cd-a3f0-42f5-bb8e-d7a7443a8e96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for identifying software programs
@@ -1902,8 +1902,8 @@ https://access.redhat.com/articles/2750891
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="cb67584f-d724-4f3e-95b7-4e6cf5cc0111">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9a411097-0533-41c5-8dc1-69e28cecaf22">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a40b6918-43ca-4fbc-8ef7-a6d855c57dcf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43c7eab-230e-4e52-b17b-622d05b857d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for employing a deny-all,
@@ -1915,8 +1915,8 @@ information system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="9b59959a-de6d-4263-a49c-444b1251ba1b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="49c39460-4f9a-4d0b-b66e-0afa96a5a914">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3c2af6c1-3279-4193-98ad-2ef9c5af5024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f755ec40-6e8d-4e33-acea-b13158a010d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for reviewing and updating the list
@@ -1929,10 +1929,10 @@ least annually and when changes are made.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9cbbcf9a-458e-40b3-8312-18cd3078a2c5" control-id="cm-8">
+    <implemented-requirement uuid="3b307e64-c650-4276-a4d0-c8ed972f20f3" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="4b9a9297-d575-4c81-a563-346c415b841d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e00a76a1-aa9e-47ce-9075-26fb5025839c">
+      <statement statement-id="cm-8_stmt" uuid="18c51ee3-a770-4ab1-bbee-3980394252d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1940,10 +1940,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74073f2c-291b-49c1-b4c6-f69c4af2da38" control-id="cm-8.1">
+    <implemented-requirement uuid="4360872b-bba4-4302-8824-9ee4495f7b22" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="f6b8cae4-8846-4291-90f6-7cccc6f93488">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d4b82ae3-a15c-4615-a9b2-cffea52b6117">
+      <statement statement-id="cm-8.1_stmt" uuid="37b54ce4-be5b-4f8a-8930-b2180b131405">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1951,10 +1951,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96a62004-498d-42ce-ae4d-136fdb389d40" control-id="cm-8.3">
+    <implemented-requirement uuid="a07a949e-2c93-48a9-9fa3-9de2d836c7e6" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="bf79967c-7645-4d8e-9d44-9948b6c27f00">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="94a30f7a-5194-480e-bf8c-ffafecfe9899">
+      <statement statement-id="cm-8.3_stmt.a" uuid="9d25e150-95ef-4c7b-bf47-dcbaa9be7e9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9db15659-5eca-4c26-ba11-2f8497e0f5dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for employing automated mechanisms
@@ -1966,8 +1966,8 @@ on the information system.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="379fb1f0-5970-4440-bc9b-c0faecc8388e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="64cc2257-c099-48c0-861f-1032ea54cf92">
+      <statement statement-id="cm-8.3_stmt.b" uuid="4bcd3838-705b-4b9e-976c-84d4be55930d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b7ff5f9-c1f1-457a-ba36-b6fd8b1011e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for actions taken when unauthorized
@@ -1980,10 +1980,10 @@ to that system.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e38069dd-9731-447a-80d9-88664787a98e" control-id="cm-10">
+    <implemented-requirement uuid="3bc27d95-ce5b-4e58-9770-3fbb02ec4c77" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="ea1a5968-d762-414f-99aa-45371678fd37">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="928cd018-851c-4611-9787-efa39ab43707">
+      <statement statement-id="cm-10_stmt" uuid="e13a24c6-d01f-4c5a-8c08-8c46900fc403">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -1991,10 +1991,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59a4965e-5122-4287-b445-ad08beaae56c" control-id="cm-11">
+    <implemented-requirement uuid="fa0e44f3-2c7b-4054-987f-d444f3e19b9c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="47c1bbfb-3843-412c-8291-918cfec79377">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d4a2f6f4-68a1-464c-bd57-798f24ab3e2d">
+      <statement statement-id="cm-11_stmt" uuid="a274e760-9a2b-49a8-97d9-8f3fd4a919a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -2002,10 +2002,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93a632c4-fc0a-4485-9864-2559f8444880" control-id="cp-1">
+    <implemented-requirement uuid="9b43dfe7-3d77-44cc-8441-be42c3c95fd8" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="9b5ac1a1-5032-44f6-b690-f777d13d4624">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e5194270-db28-4332-9dcc-4fd173b60d99">
+      <statement statement-id="cp-1_stmt" uuid="850321e7-8708-47d2-8a69-b673e8e35e8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2013,10 +2013,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3770e90c-2f02-4790-9f1b-af1de5f1e691" control-id="cp-2">
+    <implemented-requirement uuid="5bc6aa5e-a6d3-4ff9-88fc-f511a52e07e7" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="d4d949e2-0158-45c7-8f11-76a1102bad2c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="eeb85576-f96d-4b2c-bc15-09bf555ead96">
+      <statement statement-id="cp-2_stmt" uuid="321b56a3-e3e2-4f7d-afd1-95811c0ed14c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2024,10 +2024,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d9ab766-e753-4872-8ca8-54070dab221a" control-id="cp-2.1">
+    <implemented-requirement uuid="53ebacd2-f8ba-4f80-bf61-38185fa54e56" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="fd66f41b-67cc-4bbb-b733-5aa5dc0fb9ed">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="acc0f120-066c-4971-bd2f-085f73bc5d64">
+      <statement statement-id="cp-2.1_stmt" uuid="6529d16a-eb54-4f30-9cc3-7dff40657627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2035,10 +2035,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2837fa5d-103e-469e-b7bc-97a001bff131" control-id="cp-2.2">
+    <implemented-requirement uuid="11a1fff1-b22e-4abd-9a88-c41d6d7b6740" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="ab73169c-d904-4d27-b0d3-ca38ac215637">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ab9f15df-4a5b-49d3-9283-84283af934e4">
+      <statement statement-id="cp-2.2_stmt" uuid="38043c5c-757e-4d2f-a714-0c3ff20d3388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2046,10 +2046,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c78a665-2383-48ad-a2d0-82984b12d326" control-id="cp-2.3">
+    <implemented-requirement uuid="fa4c13a9-12eb-4413-a7f7-3bedd032122c" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="41229ade-76c8-4d13-ae7a-b2159a1978cf">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="85de12b7-7beb-425b-bcac-cce771a698f3">
+      <statement statement-id="cp-2.3_stmt" uuid="f83767eb-b395-4597-81c9-ccc0506c3744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2057,10 +2057,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ec84c6-e832-412a-801e-872e3f3925e8" control-id="cp-2.8">
+    <implemented-requirement uuid="1940d06b-6b33-4cbe-85fa-bcbf53449aef" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="d823d341-4f77-4529-9eaa-394b236bf83a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="83ece957-b863-49ef-9c9b-99f464c969f8">
+      <statement statement-id="cp-2.8_stmt" uuid="84da0c5f-f1d3-4598-9d8b-b9e2ec5ba264">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2068,10 +2068,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a417baa3-acf0-4044-b787-7dfe90c9e6e4" control-id="cp-3">
+    <implemented-requirement uuid="3bb16503-975f-4a69-a00e-ed061e343cc4" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="52dfa48d-0f03-484e-a220-07846fe7e87c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f13188b1-667f-43af-85f8-f88b5bdd4544">
+      <statement statement-id="cp-3_stmt" uuid="edfe15fa-e205-462f-9592-ffe56fd32204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2079,10 +2079,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d83f700-5e72-4ee9-b2b8-725aeaf5c67d" control-id="cp-4">
+    <implemented-requirement uuid="0b0e16bb-221c-4d77-9b07-51c08862fec6" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="9baaa73e-20c7-49e3-aa77-55463b5bd1f3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="bb2e86d2-dbe0-4a34-a82a-793bdf103c1a">
+      <statement statement-id="cp-4_stmt" uuid="4aff4b76-0858-4d63-8284-04b56780c4a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2090,10 +2090,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d91180ac-4fe8-4067-a23c-b75312aaf5ea" control-id="cp-4.1">
+    <implemented-requirement uuid="61457040-7b61-4e0e-9938-5488f8f8e30e" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="b81ba387-25a8-41e7-976a-32abc4a64a35">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6c1cf158-6c9e-4c52-8aa3-01fcde93d3de">
+      <statement statement-id="cp-4.1_stmt" uuid="9735ea7c-0632-4604-94c3-4ee147a2ff79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2101,10 +2101,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7cb626a-9544-405c-9615-ceff9b86bb46" control-id="cp-6">
+    <implemented-requirement uuid="a66e6296-58a0-4726-93b7-a549896a6738" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="71227fbd-ed90-4588-b566-efbc7dad6b19">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fca4107c-31c2-45c7-b9c0-c23e1a298f8e">
+      <statement statement-id="cp-6_stmt" uuid="160aaa1a-93a2-433a-8ef8-6c4672264ad8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2112,10 +2112,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01219b89-768f-4171-b8b0-a0e8dd41a227" control-id="cp-6.1">
+    <implemented-requirement uuid="99b83a59-32f6-48ee-9fcd-ec9ffb531296" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="bac089dc-fb78-4746-bd1c-02f71f2efd13">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="eced9682-efde-439e-9d89-d025cbaefc13">
+      <statement statement-id="cp-6.1_stmt" uuid="1a1af641-21e8-4817-b8aa-67bf997fe8f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2123,10 +2123,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df61d087-f4e6-4695-96cf-40f30d08f4f9" control-id="cp-6.3">
+    <implemented-requirement uuid="4124987b-d89d-42c6-bed6-eb84e1d841d4" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="bed44346-1fed-4974-93f1-a32afa88a7c2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="795e15e6-293a-4964-8e9e-cc72bfbd3fbf">
+      <statement statement-id="cp-6.3_stmt" uuid="8cdc8375-15c7-4e54-90c5-6de5788f2627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2134,10 +2134,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe7aec2-9bf3-4501-91a3-d31a89e91f60" control-id="cp-7">
+    <implemented-requirement uuid="3054c2ef-1c61-4d1b-8ced-280632da8fec" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="7b220f27-933a-4737-900a-c41cb697c138">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="255971fc-3d62-4f6c-893d-cac28661511e">
+      <statement statement-id="cp-7_stmt" uuid="590ac16a-9627-436c-af05-a0ead357275a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2145,10 +2145,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f15a6710-24b8-4fc4-85a6-5f39886922e0" control-id="cp-7.1">
+    <implemented-requirement uuid="6c0df842-e0d6-43c6-b13e-1b1d697a9313" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="de81e733-7762-4140-a6e2-f972feaf8bc8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="736a6159-2714-4783-ba58-8f8e49b446ea">
+      <statement statement-id="cp-7.1_stmt" uuid="992dbd8e-c091-4f53-bc1c-11a0ec69a5ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2156,10 +2156,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f09ab5f2-7b40-4c5e-a765-b69e0b7ea464" control-id="cp-7.2">
+    <implemented-requirement uuid="1673da4a-1268-4c3b-8b17-38f8f6ddd3a0" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="0bbe1224-dfa6-4b50-a973-3249b85a4367">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ed61d9fa-efa1-44b5-b9c4-3d6157187168">
+      <statement statement-id="cp-7.2_stmt" uuid="4e68b95a-319f-46a7-a8df-a0b0c7e05446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2167,10 +2167,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f3f83d4-2ce3-49a3-97ca-d576a113dcfe" control-id="cp-7.3">
+    <implemented-requirement uuid="a77f4e3f-1dc9-424e-a1c5-e8f2b48fde1e" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="c6c394d3-bc5c-4b27-83d4-d789968b3ffc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6eb2d93c-c55d-46d0-b7fb-8f3a1898eb22">
+      <statement statement-id="cp-7.3_stmt" uuid="a7f5a540-576b-4b9f-b193-ad006d9f51a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2178,10 +2178,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8f95851-554a-4622-8d34-b43fd4cf360d" control-id="cp-8">
+    <implemented-requirement uuid="fbd871f4-43e1-47d5-9302-cd7a852e3e9e" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="7b4cd1fc-f38c-46a9-82c4-d4259f16b68a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f1233d17-c2e1-4b5d-9c9a-d5f4a5ff058a">
+      <statement statement-id="cp-8_stmt" uuid="ed1526c5-658e-4280-a3b5-3f7affc00674">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2189,10 +2189,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fe208d2-fc84-4a23-b027-a12889061a6c" control-id="cp-8.1">
+    <implemented-requirement uuid="ccc9aa45-abff-4056-b521-b92198d7eb00" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="48d457d9-3698-4ee7-9a2d-8b9dfd66c6e9">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2685dd2b-3726-4211-8f93-0cc3d1642459">
+      <statement statement-id="cp-8.1_stmt" uuid="95bbd4b7-6b9a-44ae-a1ba-1304ace33ea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2200,10 +2200,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de0bedce-3553-49aa-b103-9358e18ecdc1" control-id="cp-8.2">
+    <implemented-requirement uuid="c93439ba-4314-4f20-b70c-3186e61de945" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="0205d756-2096-4354-8964-334aa02312f2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="34136f7c-1db9-4bbf-be4f-124cca0c7c55">
+      <statement statement-id="cp-8.2_stmt" uuid="0e95fdc6-26e8-438a-9605-7a1d81cfea1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2211,10 +2211,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17ea16e5-3dc4-401a-8911-e88d5aa82afd" control-id="cp-9">
+    <implemented-requirement uuid="bc22a3cf-95d9-4b22-9112-6fc1b4ff81f6" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="26a71035-17a2-4f78-9075-9c141ee02e61">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="57190e19-511a-4f30-aec6-b95a2174c10b">
+      <statement statement-id="cp-9_stmt.a" uuid="b8249024-8595-4c8f-b43d-1877b1539f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a08f7f0-9663-4cb5-9700-734cf93d3a58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -2230,8 +2230,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="4d468cdb-82d4-45d1-99a8-dd084944b4c6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="bc002f6a-604a-4c7f-bb0b-048f49697541">
+      <statement statement-id="cp-9_stmt.b" uuid="2de89133-ecda-472d-99c4-efa326e6714e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3753498-0e8c-4971-901d-2ae5853f8faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -2247,8 +2247,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="9535e583-2bab-4d25-9286-66d99f0627f2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a11985ca-249a-4814-a602-ba407c1a660b">
+      <statement statement-id="cp-9_stmt.c" uuid="f9c08a44-9d5b-46db-980c-d64ee467af2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dba5d26-fcff-44e7-853a-fbd3e9d16a23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -2264,8 +2264,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="514890c8-e5a2-463e-afb6-5c2fc7d91846">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="66cda22b-605e-4d50-8890-85dc03b3d6c2">
+      <statement statement-id="cp-9_stmt.d" uuid="a8885751-e451-479e-9783-8cc776849233">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d827a66-3be2-4d48-9834-d5adcab4c487">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2281,10 +2281,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dde715f-1c54-4dd8-9e29-cb4c366d8519" control-id="cp-9.1">
+    <implemented-requirement uuid="01074291-dca3-46e3-a8a2-c45cf9e3a3c2" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="4f2b3cb8-89dd-4afd-8613-ec517f767ae7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="cf86225a-15a3-4670-a8f4-827f9af157f1">
+      <statement statement-id="cp-9.1_stmt" uuid="bc93c8f6-96fd-4247-907d-9c22e22ba948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2292,10 +2292,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce300f31-14ea-47c3-9ef3-6b11703e30e5" control-id="cp-9.3">
+    <implemented-requirement uuid="1a44a893-e374-4449-a5f3-1aaf3e9650ce" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="52bd4058-0059-44fd-b61e-18ef2864bd05">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ea1d13e9-2a46-45e3-ae02-53da79822ab7">
+      <statement statement-id="cp-9.3_stmt" uuid="6d4386c8-1e74-4d0a-928f-c614329f00e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2303,10 +2303,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71c0665a-6c70-483c-9706-a6017713132c" control-id="cp-10">
+    <implemented-requirement uuid="02f89333-b0c2-4c4b-b1e7-a38e1ffca80d" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="1c704842-8ba1-4773-a501-4af7caaecba9">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="98b44761-63a0-43b1-9100-c3f977bc39b5">
+      <statement statement-id="cp-10_stmt" uuid="d96de4d7-6285-427b-b6d3-27b06c7ee126">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05c68c3e-793f-4b6f-960e-cb0cad097f1d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their OpenShift environment. A successful control response will detail
@@ -2315,10 +2315,10 @@ processes used to fully recover/restore the OpenShift environment.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="085e2671-01da-45a8-a91d-13c17ee769e9" control-id="cp-10.2">
+    <implemented-requirement uuid="1720f0b1-6202-4c8a-8e3e-889266d2db3d" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="none"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="867ecd20-8b87-4e34-b57c-62cbf2378d3a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a102d19d-6b5e-4b34-941f-f2ea5425ffd7">
+      <statement statement-id="cp-10.2_stmt" uuid="c6e19b08-a73b-4a7c-9cb3-383e92bc7174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="688c2729-55ce-48e0-8647-94d6e4cd0f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for implementing transaction
@@ -2330,10 +2330,10 @@ the case of failed or conflicting transactions.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23637e55-e402-40e0-98d0-9ea128ab4c52" control-id="ia-1">
+    <implemented-requirement uuid="1ac74505-b835-4d8b-9a65-0072731a1432" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="f701f92e-344b-4335-841d-b18f9b08f70b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f0aa513f-bfbf-4b4d-b012-768487921665">
+      <statement statement-id="ia-1_stmt" uuid="4a264b65-a3e1-4bbb-aa0c-6a39ee9a705a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2341,10 +2341,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ff13c52-a884-4d38-987d-456ad7e97a91" control-id="ia-2">
+    <implemented-requirement uuid="d85437b7-d62b-4023-ae67-cbe3dca95dd6" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="a1f51eba-d5d2-48b9-8e69-b129d1d92c70">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b9486bb6-5ff6-4273-8f05-1b6f293df0d1">
+      <statement statement-id="ia-2_stmt" uuid="48880db7-6cff-4e77-8fe5-8522f4a8077f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad09895f-4ac3-43fd-b43b-8d04184ea227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -2352,10 +2352,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b312d0e4-d7ef-477e-8290-c93e43ac8943" control-id="ia-2.1">
+    <implemented-requirement uuid="b6207e75-1e9b-44fd-896a-744868a7ee3a" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="95786afc-38af-4454-ad7a-a51cc5c1f101">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4e0cc1ab-c815-4a0c-bc14-74b6aee70ff2">
+      <statement statement-id="ia-2.1_stmt" uuid="2c5aa764-2ef3-4ad6-8f03-acd8a22ac68e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be67a4f8-46f8-44a4-98fa-d862af3ead31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2386,10 +2386,10 @@ OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f51a4c28-735f-41eb-8f15-c7e93514a095" control-id="ia-2.2">
+    <implemented-requirement uuid="b20e807e-447f-4f60-bab0-abcf80ce1b16" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="8773555b-3d31-4259-8eb6-fb21f891dd24">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="689a48f5-4cf7-4a43-8ca4-92032f7becac">
+      <statement statement-id="ia-2.2_stmt" uuid="eb39e647-8766-4855-8b0f-b8924bdf20b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f02082bc-c604-452d-9d17-42181e8f1412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to non-privileged accounts.
@@ -2400,10 +2400,10 @@ multifactor authentication is enforced for each.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fb51d12-3b25-4f10-a402-f5ea31ee7db3" control-id="ia-2.3">
+    <implemented-requirement uuid="4a611d8f-eba4-455d-b134-4174c2ce9a4f" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="e49822ce-429a-4c2f-b5dc-fbe8b325ce56">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fdd84405-6fa2-4af3-b48f-2494bfd2eaf0">
+      <statement statement-id="ia-2.3_stmt" uuid="aa9ead1e-a7a7-42f9-9ff6-d847e6801260">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37f0bdb6-1840-425a-814e-366fd45da66b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to tenants of cloud computing
 platforms, such as OpenShift administrators.'
@@ -2411,10 +2411,10 @@ platforms, such as OpenShift administrators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42de330b-71d7-4a80-aa8a-fe37f84cb063" control-id="ia-2.5">
+    <implemented-requirement uuid="0cf74701-7838-45ad-8c29-7a3719147fd8" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="6067796d-65e3-4122-89a5-7cd7c9d82541">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="15ef4394-0493-47e8-b045-9a4f6a48ac4e">
+      <statement statement-id="ia-2.5_stmt" uuid="36c07a99-a75b-4752-b345-544ddf1e77df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e156758-4269-4c10-87c1-78bd4ef29fe1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift requires individuals to be authenticated with an individual
 authenticator prior to any group authenticators being employed. This is
@@ -2426,10 +2426,10 @@ authenticated, group access/privileges will be granted as applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1246980-4aff-470a-80a7-ab2dfae4fbff" control-id="ia-2.8">
+    <implemented-requirement uuid="b4dd3658-3599-401d-bb60-840216e51eda" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="1015a55c-6337-427a-b105-faa50b78cfea">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6b827473-44b1-45df-814d-152a6da74aaa">
+      <statement statement-id="ia-2.8_stmt" uuid="5004b172-e82d-42bf-b037-4ecc39c4a274">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03f28c95-2188-4c2b-ada9-b13aaf594206">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing replay-resistant
 authentication for access to privileged accounts. Microsoft AAD and MFA
@@ -2440,10 +2440,10 @@ replay-resistant authentication is required for each.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fb30007-e214-4fe4-b644-ebd1216da396" control-id="ia-2.11">
+    <implemented-requirement uuid="07da1097-875d-4ef7-9dd8-938a112602ed" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="97c9b5c6-cb6f-4a73-89ea-58e9bf352350">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="868d3b7e-4f80-467a-b0ca-33f4d035de17">
+      <statement statement-id="ia-2.11_stmt" uuid="d8dead12-9d75-4ff6-8f2a-f612a984c021">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f50fdae5-0fe7-41cb-abc2-452270b5308b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication such that one of the factors is provided by a device
@@ -2458,10 +2458,10 @@ solution.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fa18621-03a3-4e0e-8b1b-b48357b947e4" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="7aca8eb1-db78-4eda-b215-b10222004b44">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3bf64900-6b82-45e2-81c2-3adc2a9693ba">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2474,10 +2474,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f89d6a4-ed09-49cf-b54f-c1bcf82efabf" control-id="ia-3">
+    <implemented-requirement uuid="17ecbece-8e0a-417d-adea-f82e3ec022a7" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="91070075-08c0-4932-9171-ac0851c3c7ff">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="25202155-bceb-4f77-b288-a98036960e8f">
+      <statement statement-id="ia-3_stmt" uuid="78a34ad0-b977-4a39-aae7-aea1bb756afc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95e0a535-e1ec-4e09-afc6-4b7b15f8a692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring that customer-owned
 infrastructure is  properly authenticated prior to establishing a
@@ -2492,10 +2492,10 @@ will provide identity of the machines.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf75ebce-2304-418d-bd66-8b66eb495677" control-id="ia-4">
+    <implemented-requirement uuid="e21d6a2a-d400-4480-89b6-7f40b0c50ae4" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="dee50cf4-f90e-4b98-8418-5821558506b0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="17439617-3393-46e1-8a3a-5c577d01d0d4">
+      <statement statement-id="ia-4_stmt" uuid="5cc82413-d164-4bb0-9b39-108524a03fd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2505,10 +2505,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbe70c96-4226-4c9b-9e96-ca57fe8a18db" control-id="ia-4.4">
+    <implemented-requirement uuid="a4c50edb-200e-490f-9bda-660c2feb689a" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="97aede46-e892-4dec-8ca9-20f3dd494906">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e4e578fd-3e2d-4697-8ef0-cf7fdcc6b616">
+      <statement statement-id="ia-4.4_stmt" uuid="2786021c-8862-4dd8-9eb4-18f064af13f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0fdb38a8-add6-480a-b5a8-bb33347a30eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for including contractor or foreign
 national status as a part of individual identifiers. Microsoft AAD
@@ -2520,10 +2520,10 @@ into the individual identifier.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4a697b1-1518-453a-b744-5a342efda80b" control-id="ia-5">
+    <implemented-requirement uuid="82b7e251-336c-4f51-9d1b-dd1d2a18baf5" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="db715d5f-dbe3-4ad3-b715-fa7dcdd3fbb0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d15cfc4e-98ec-4bfd-a98b-881ec73626e5">
+      <statement statement-id="ia-5_stmt" uuid="9b4c1651-4e00-46ed-9296-95d1bbf5af34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2533,10 +2533,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcb70b49-921f-4285-914c-450eafa2aea0" control-id="ia-5.1">
+    <implemented-requirement uuid="9ae4fc53-7521-4cd9-8d91-a1f38dd953ed" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="b4303873-41c7-4924-af16-17fa72d2a7ae">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ba5b1720-fe82-458f-b08b-35f3142f0317">
+      <statement statement-id="ia-5.1_stmt" uuid="7aaf7dd2-6511-408d-b902-bfa59d362c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2546,10 +2546,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5fb86fb-9e2f-433b-bc63-2f18a2112d85" control-id="ia-5.2">
+    <implemented-requirement uuid="7c40ed9c-69e4-4303-b1d0-e499d81994ca" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="a6d5a8e5-d624-4f62-9e2b-e60d19293d6e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d9913474-d6b0-4975-8112-22875b645a4d">
+      <statement statement-id="ia-5.2_stmt.a" uuid="8ee288fb-da30-4a24-87b4-518a90bcdd10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f04ddaad-c8ca-4af0-a857-7eb406ac2956">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for validating certificates used
 within the customer application. Active Directory Certificate Services
@@ -2558,8 +2558,8 @@ to address the mechanism used to validate certificates.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="f4df02d6-39be-491f-9ee5-91e0cab9e547">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ed6a5151-92cb-426b-86da-971cd04b8b50">
+      <statement statement-id="ia-5.2_stmt.b" uuid="1142e1f6-aef9-4d40-9595-4083f196a56f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44fa2414-ba77-4d7e-8f2b-a032cf71511b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for the enforcement of authorized
 access to private keys associated with certificates used within the
@@ -2569,8 +2569,8 @@ address the mechanism used to restrict access to private keys.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="da904c30-62ea-48fd-abae-0b6406f38bd3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="58c058e8-40a8-4196-9b67-3de59d932517">
+      <statement statement-id="ia-5.2_stmt.c" uuid="014c6d68-100d-4fb1-9cca-32361c3a25e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4ec1356-ea47-4e3b-a267-e3ef8e25e0ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for mapping the identity
 authenticated by a certificate to the account of the individual or
@@ -2581,8 +2581,8 @@ certificates and accounts.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="2afc6d86-ee4c-4b94-b05a-07e9a88fbbd8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9a88104d-58a7-47d5-ae11-3f272f46de73">
+      <statement statement-id="ia-5.2_stmt.d" uuid="31080905-d7cb-4a4b-a958-1e99d8b51614">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bccdc38-799e-43e1-94cd-45e1345889de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing a local (i.e. within
 their subscription) cache of revocation data. Active Directory
@@ -2593,10 +2593,10 @@ populate the revocation data.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfc39f3f-1560-42df-a72f-629ae269a2e1" control-id="ia-5.3">
+    <implemented-requirement uuid="4bdeb903-68a9-4110-85c5-b5824149fd94" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="0f940446-ad5c-42d9-8664-bf75841f446c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e3a6c4f3-dd58-4bd4-8a54-26919efcc75a">
+      <statement statement-id="ia-5.3_stmt" uuid="aa18ec7e-04f5-478f-b2df-4dcc177c8ddb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b682d871-f7a5-4f95-b244-88377d365c2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for distributing
 authenticators in person with proper authorizations in place. A
@@ -2608,10 +2608,10 @@ authorization for distribution of the authenticators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb7fa650-a609-4aff-a01b-7de8ddd3576a" control-id="ia-5.4">
+    <implemented-requirement uuid="e2176a2e-1b27-4529-8607-7d3beb4c9210" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="26bd2683-bbb3-41e6-afd7-2b5bc79b38c1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9a80d668-b488-414d-859f-7f0042ff951e">
+      <statement statement-id="ia-5.4_stmt" uuid="be8079a5-6d92-4bc6-a2b1-e14e864850e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42170b86-81ae-4aca-a9fe-5f35f2f9e130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing automated tools to
 ensure that password authenticators meet strength requirements.
@@ -2622,10 +2622,10 @@ enforce password strength requirements.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="039c4b72-f717-4337-943c-1d6cd52735b5" control-id="ia-5.6">
+    <implemented-requirement uuid="698df71b-53ce-464f-a1c1-56e790b28067" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="b8e37d96-ac2c-40de-bb24-931c538f151d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="131becea-d25a-41a1-86a3-751103a6754b">
+      <statement statement-id="ia-5.6_stmt" uuid="26fc0646-a774-4b2d-8b6c-dfdf58458259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38c79c30-7a15-4e3b-8464-57c79dff95e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting authenticators.
 Microsoft AAD solution may be used for this purpose. A successful
@@ -2635,10 +2635,10 @@ tools used to protect authenticators.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05af5f8d-c078-4127-a05d-3a19e9c83fa1" control-id="ia-5.7">
+    <implemented-requirement uuid="562238bd-4063-4ddf-b042-ec969ce76847" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="a90b9de5-fb98-4793-a7dd-43620f41a17c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="93ab0dec-d30e-437e-ac9b-2974709c38df">
+      <statement statement-id="ia-5.7_stmt" uuid="7c818933-0a51-488a-ba95-bfe132fdff5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3875aa2b-4008-47ae-8bb7-8f4278e96140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift does not embed or store unencrypted static authenticators.
 OpenShift cannot be configured to be out of compliance with this
@@ -2647,10 +2647,10 @@ requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be944651-e539-44c5-a8ef-234197316ef0" control-id="ia-5.11">
+    <implemented-requirement uuid="0c8d9074-74b1-43e9-b7f2-588b07d91ac0" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="87364e6c-0f6d-4bd1-b68a-e00632ba7549">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9b91e7ac-ed8a-44af-9c98-420871a1e6ee">
+      <statement statement-id="ia-5.11_stmt" uuid="46876a3c-1392-4a20-abda-4720c149ba69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64e455c4-4873-4213-8e59-8cba6670e48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, OpenShift
 must be configured to use an external identity system (such as Red Hat
@@ -2660,10 +2660,10 @@ identity provider, not OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32894de0-48bd-4184-b594-927ef13b900b" control-id="ia-6">
+    <implemented-requirement uuid="12498f82-cc76-4b1a-970e-b52e957da8dd" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="b55c9747-fe54-4d66-9182-079e63be86ef">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c85571e8-b4cd-4b10-9063-13ae35e94e75">
+      <statement statement-id="ia-6_stmt" uuid="70f01749-e367-4d73-85ea-84c3a6c22764">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3296420-39ec-4baf-b4eb-3c52f4535a3b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift natively obscures such information. OpenShift cannot be
 configured to be out of compliance with this requirement.'
@@ -2671,10 +2671,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40e17439-73ea-4231-8010-7674c09f0900" control-id="ia-7">
+    <implemented-requirement uuid="d4e53f34-f8c9-4b80-a352-3b044bfd5837" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="0d372e80-595d-4cff-8526-92b231d1a4e6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f9614002-7740-4ad0-b6c9-428b7d17f881">
+      <statement statement-id="ia-7_stmt" uuid="380e5148-4be4-4cd9-a28a-fc132df2e116">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1ba60b8-1e70-4e76-b334-583c33bc5670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to OpenShift nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -2696,10 +2696,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bda56ea6-a466-47b5-823f-c0fc57f02778" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="7254c878-44e3-4351-98bc-58b4ae19ef60">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="216fefa2-bdb5-43e4-aa87-df03833bfcfd">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -2711,10 +2711,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="664412c0-9e59-4bd0-9127-8524783a12e8" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="7703e82d-d6e9-433f-a54d-1dddb653658f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5b24ff24-4452-4902-94c6-0d27329acc39">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2727,10 +2727,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4556f13c-5423-44a2-84d3-7a6ea5374131" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="7222e242-bbb4-4981-8cd8-6791d9c28999">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1e7d176f-7053-4db5-9ef0-39feb809d26a">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2744,10 +2744,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd1b3110-008e-4f90-8734-ae13cf38e6f9" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="6366cc14-a7ca-4515-ba32-a1e4fc464914">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7458681e-b6aa-4587-9d13-949da7ea4f42">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2761,10 +2761,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="faf59ab6-c79d-4e5a-b765-e342cd37884e" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="ce375cd4-8f2e-4485-b6b3-2a2c56b9e5a8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="cfcac929-7f06-4202-a66f-32a51a96575d">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2778,10 +2778,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dec17afe-d8ef-44da-8f3b-c8994cc80c11" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="d066c8a8-bcfb-4057-9079-76bb9731f8a3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1f668382-f0a5-4167-a33e-0c53cd267d4b">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2789,10 +2789,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8325189c-f37d-43d0-8779-31b11de147cd" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="ff4e48fc-83cd-4bed-a54b-d04722e27457">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="301679cf-256b-4cb4-bc2f-0c2445d74c0d">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2800,10 +2800,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="580c6b1c-b6c4-4136-9043-53063b662e84" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="f6fff713-c1d8-4255-bf85-53269ade6f7f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="31b06920-2546-4dbd-8bed-1f8e63e57210">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2811,10 +2811,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ba0351-8195-4bf4-8da3-4937b12303d7" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="5f918878-4c00-4257-9b1c-f3103d1042d1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="413c3a9e-0590-4d33-bbc1-967e8dd8392f">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2822,10 +2822,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="264a5515-ebdc-45ce-9b80-23df8272c1af" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="43c89701-7ad1-4b7a-b710-e2c28afb3396">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b1112821-25d6-4daf-89be-fe1f3f350057">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2833,10 +2833,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d23173c-915b-4394-8251-199064b6adb6" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="5f470ff1-f1f9-4ad1-a857-b2c839457fca">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e1198086-a75f-4a9e-b617-05272c85d50b">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2844,10 +2844,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd75d1d9-6bc5-4ade-9d18-a4959b44406c" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="5d204184-e1a0-41e3-8fab-7d2654e5e6bf">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="dfd9e575-051d-411d-a6d2-ee460203ca23">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2855,10 +2855,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="839647a2-9e16-47b4-9e4d-46ca144e9510" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="94314a3c-079f-4ed9-b37e-efa6357ecb28">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="82283a17-8bc7-4643-871b-69e5990cb890">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2866,10 +2866,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c51063d-d1b8-4da3-951e-b23ba74afb7c" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="36e724da-171a-4d88-80b5-3fc38def94af">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ba9ea2e9-3380-41e9-a8e4-96d5e3d0bdda">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2877,10 +2877,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcbe55cb-712e-444b-bad5-872841c2871f" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="1ed0de88-bbbb-4d92-8920-4b5839fcc011">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="67f0ffe9-0c01-481d-bc3c-3673173ca970">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2888,10 +2888,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85aad470-134f-4664-ab77-1a91e805e67b" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="1c7e5c8e-7337-4f1d-bd0e-117615a6cf28">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7141715f-8f05-43ea-af51-284d89e69546">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2899,10 +2899,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="203262c2-7670-4f1a-a797-279865d2cd02" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="edf06c91-cb73-4fb0-ba9a-5a141933b76a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="40ce3468-9185-4fec-b01c-db77dd62e713">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2910,10 +2910,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d012bb5b-eb82-4ab1-b251-2a8c6831e8b0" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="013eb692-e49c-4fe5-a5d3-af0d021b55d3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="12cb14f5-c97e-4652-9f7b-58590354814b">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2921,10 +2921,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50568229-3528-42f0-a013-a0964f90b2bc" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="51a26f0e-ff74-41c8-b9bb-cf7ec4971e9e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5f06abb2-a3e5-43eb-8607-d4cee0421580">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2932,10 +2932,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab7597f7-274d-493f-a621-ff73edccd9c0" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="43f2b28c-a0ce-4ea3-b9e1-19365e4d4c70">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c45911cc-f236-45ca-be4b-767e0ecc45fe">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2943,10 +2943,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="551c55ed-b7a1-458a-ab4f-7df9f2de4b75" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="768b9205-1889-47ad-a3b9-bac41cf91b27">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a7ae0105-0736-4d6c-b669-858408d59e10">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2954,10 +2954,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8be79a6-2ee7-42f9-9fe8-8843a3442a5d" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="30021839-444d-49c0-a7bb-5b78984bde59">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e9f07d85-a039-4689-a98c-8a0984ab6a1b">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2965,10 +2965,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecf89acf-3f95-4164-a368-394be1fc047e" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="326ad39b-c501-48e9-9024-1bac0476af84">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="57643dd4-b4f8-4d01-ab0c-ada947c00f10">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2976,10 +2976,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c0f2e00-b4e8-466c-9d67-3e4bdc4fa1d7" control-id="ma-1">
+    <implemented-requirement uuid="ab96e205-f5ae-4f92-aeba-9d65d4089811" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="9e8d798e-229b-496f-9dc6-05778acd299c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="173a6e4c-0821-48fa-be9d-91e2364c93c7">
+      <statement statement-id="ma-1_stmt" uuid="cff15548-e6ea-47ab-bff0-ae27d840911f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2987,10 +2987,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d625a1d-5eb8-4464-94fc-d724d874378b" control-id="ma-2">
+    <implemented-requirement uuid="ac03a1fa-a125-4831-b841-a85b0d07e099" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="657044ed-e903-4247-b4a0-3333ebebd57a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d5ce171f-aaa6-412a-af88-4c56cb7b2975">
+      <statement statement-id="ma-2_stmt" uuid="69953a5e-05a4-477d-b010-34cc2cd92d8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -2998,26 +2998,26 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de41ca5d-da4c-4edf-8aa1-634a961587ee" control-id="ma-4">
+    <implemented-requirement uuid="1c8083fd-9c42-40a1-a265-ec2662dadab9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="27f58573-b98c-46c0-8a1b-448df90936f2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6ccddb79-ebef-4d0c-a838-20f8a6909ef6">
+      <statement statement-id="ma-4_stmt.a" uuid="8d3a7d1e-86fd-4ab7-8d6a-20abf4d58af1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="2340d78b-5324-4ef8-aff4-9db5b2d78d37">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8475410c-a0e4-462c-a54d-cbb719c88467">
+      <statement statement-id="ma-4_stmt.b" uuid="424f393f-8bd9-49ca-b75b-972873f8a80e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="67b3a0d0-3c0e-4fad-b903-b2779605994e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="29b60300-aa2f-4493-ac8c-d6a9428a3a46">
+      <statement statement-id="ma-4_stmt.c" uuid="55e15a38-efa6-4f16-8548-50432deac845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6aa2bb26-eb59-4d99-84cd-822805438767">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to OpenShift.
 
@@ -3029,8 +3029,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="e2348a78-d664-44bf-a6b4-6060a8c91347">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9a523f04-46e1-42d1-9534-3166e17c2f3e">
+      <statement statement-id="ma-4_stmt.d" uuid="755528dc-d98c-41d7-aa24-5e6e32ad6223">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ccef3b2e-7c65-495e-88dc-4ee72829f552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -3040,8 +3040,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="e40982cd-832d-423b-9618-2f924c0ceb17">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f848ec49-2388-4554-b47a-9fef355435ed">
+      <statement statement-id="ma-4_stmt.e" uuid="3937c74b-e19e-4c0e-890f-5cd9268105c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dcad0664-141b-4ab9-8272-91128053ab87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -3055,10 +3055,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6246283d-68c3-4090-998c-98b11657a398" control-id="ma-5">
+    <implemented-requirement uuid="7bae4cdc-5101-4916-9bd0-32097c3a5540" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="645597d9-ecee-452a-bef8-48a8edf6a4b0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2b35d88b-9d78-42bc-be98-a2996ef43c1b">
+      <statement statement-id="ma-5_stmt" uuid="4de28098-f4b1-4383-b6c7-d8cb36cb1ea0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3066,10 +3066,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e13e428-f08d-4e03-848a-149d8332f688" control-id="mp-1">
+    <implemented-requirement uuid="6e3641b8-d91a-4b4c-aed5-1d4b9fa8b9f9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="11885f2f-26d0-48d8-94d9-ce60e91caa85">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6ccfefc7-ea9a-45dc-b216-142e6c118f43">
+      <statement statement-id="mp-1_stmt" uuid="6a0d866d-901f-4cfa-b1d1-3dcdcfdba280">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3077,10 +3077,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f432f546-c925-42fa-abe5-704c81830369" control-id="mp-2">
+    <implemented-requirement uuid="0b1de93b-94fe-4940-bd9e-2557cabb300b" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="8cfecea8-cd97-4054-b1ca-44e5833fa3b7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f87e55cb-2d68-401d-8e2d-7455b63af316">
+      <statement statement-id="mp-2_stmt" uuid="4ca98bdb-106e-4c20-9b26-a7fbfe88bc72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3088,10 +3088,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9aaa48fa-6e89-41be-9764-99ebd3cfd725" control-id="mp-6">
+    <implemented-requirement uuid="80536df1-978a-46ac-a7d2-fb7be3c4fb15" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="a5d2e01f-2143-4c97-a792-b2849db44a77">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="aadf050e-5737-4520-8231-280d70bde1e3">
+      <statement statement-id="mp-6_stmt" uuid="989e0404-089c-4307-80ec-eb9b5f6f0cc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3099,10 +3099,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef1c70c2-9542-4cf8-b654-722da163d0a3" control-id="mp-7">
+    <implemented-requirement uuid="07d86507-30da-4926-9f98-7b39d4efe030" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="4b13ec82-d89a-4c3d-bed0-2298dfd4b950">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d49c9d25-e21c-4c1b-a53d-1fc6400c5426">
+      <statement statement-id="mp-7_stmt" uuid="5624b235-5824-4baa-8814-03e6b6aaed21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3110,190 +3110,190 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bd48cce-b566-4417-a654-8226e2dedaf2" control-id="pe-1">
+    <implemented-requirement uuid="efcc3344-7813-4729-8b4c-353c3b06428d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="f86209c6-e7cd-4a12-9f39-87c8a5a3581e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="eab1b919-12eb-4300-80e5-98bcb70060f5">
+      <statement statement-id="pe-1_stmt" uuid="a69e0d62-407d-4910-ab66-18c03b168392">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ddd832a-3a62-44a7-8493-626212fce039" control-id="pe-2">
+    <implemented-requirement uuid="92271e93-1df7-4bd8-ad4d-8ffd06fb2877" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="aae734a2-09eb-422b-bb1f-5a3f3af276e4">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c4f6bddd-82db-4df0-be99-7dff9163e19a">
+      <statement statement-id="pe-2_stmt" uuid="341520a8-ee52-4acc-ac44-4715de827f34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfa5e2c2-8bce-4b6e-b4e0-1254aea46173" control-id="pe-3">
+    <implemented-requirement uuid="329c7586-aa2f-4ed6-aec0-f17c8d698026" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="e6844187-01e7-4aab-8423-8dfcc4f9581f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="17d5e071-760d-46dc-b001-a07228c8a7e3">
+      <statement statement-id="pe-3_stmt" uuid="c14a9afe-deb5-43e9-9fdd-96cc22ecd1b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29c99dbb-af84-4051-b55d-97d039f7fe86" control-id="pe-4">
+    <implemented-requirement uuid="8083e64a-83f1-470b-847d-494c1a3fdb0e" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="8bb9564d-bf9b-46b7-b49e-0410083e5072">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="79093610-2df3-4f95-961d-6d1a2172fd2b">
+      <statement statement-id="pe-4_stmt" uuid="8f899cea-0cd3-40de-8fdf-764d248e83dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32e8c409-b459-485e-8ba8-445ed444d50e" control-id="pe-5">
+    <implemented-requirement uuid="de758ed1-4b71-45fc-8221-880bc9ac1e4d" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="097472e6-ea08-49d1-ad2e-b0b9dcac965a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="da022e20-4350-471d-81a2-6200cd292d49">
+      <statement statement-id="pe-5_stmt" uuid="c68b2bed-84ae-40a1-a30c-f98ed3cf9a35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d6c40dc-f052-4627-bb9b-54fa0f3aa4dc" control-id="pe-6">
+    <implemented-requirement uuid="01f99faf-9f68-4c8a-8ad0-9b3d90c9b014" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="a19ee691-3a41-4638-9f98-4c95f12dfde2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1f3c0b1d-0be5-4335-ad0d-299fe782c0fc">
+      <statement statement-id="pe-6_stmt" uuid="63fe7eb2-34c1-478a-a4b3-085ad3ba8a25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cf6d94a-efc4-4ec7-a5f9-0d1bb82c10fc" control-id="pe-6.1">
+    <implemented-requirement uuid="24829d55-bb86-408a-aeb6-9ce69948046d" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="a94fba06-3081-4ea6-9aa8-0079a1ada97f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e89c052c-77bc-4013-988e-832cc1213e61">
+      <statement statement-id="pe-6.1_stmt" uuid="1f4e403d-0995-4eb7-a723-2e0d380f0e68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="795daa72-a2ab-4d3d-a83b-aecf098f45a6" control-id="pe-8">
+    <implemented-requirement uuid="242f3d8e-b3eb-4058-b1a3-bfbe712a1b15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="9954e35f-fc70-4559-a30d-4b78ca556408">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a56d437f-0eed-4311-b409-a6afe010cb9e">
+      <statement statement-id="pe-8_stmt" uuid="8eebb287-2309-4986-8ade-187dc4bdb8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a4e728b-0596-4894-add9-be3463235b0e" control-id="pe-9">
+    <implemented-requirement uuid="b87ebbc9-80c1-4c38-a9da-50a6a208afc8" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="251f17e0-b2d1-40ba-966f-22af309cd866">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="69ca0fde-8923-4ff7-9405-54da43152f16">
+      <statement statement-id="pe-9_stmt" uuid="fba9f39d-2894-48f5-bfcd-c08770a0820f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5cd5e06-735e-4677-9be9-aac6e4b9ecca" control-id="pe-10">
+    <implemented-requirement uuid="960caf3c-e746-4500-a2ef-a6070c2c6f0f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="8acc456d-6705-4045-9b4a-42302878a763">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d8ced457-7870-4df9-8e46-29bfb2ccf0b9">
+      <statement statement-id="pe-10_stmt" uuid="e90c7233-d86c-4f97-917b-af27de2f277e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="515ffb53-4996-4cca-bd45-f132b186868b" control-id="pe-11">
+    <implemented-requirement uuid="f921eb9b-4410-4723-98ba-e64ef7098585" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="284aa28b-891b-48dd-b4f8-8cab124db009">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0900a7a3-6ae6-4245-888c-05d7c92bd861">
+      <statement statement-id="pe-11_stmt" uuid="e69acfac-306c-48de-a0c8-633b6ff40d61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f08118f-5248-4a67-b2e5-5019ea085ccf" control-id="pe-12">
+    <implemented-requirement uuid="7e18ab07-c4b5-4978-b6f7-370814ec6a6e" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="8d94d557-a3f4-41fc-85f2-559a462a4673">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="246c4324-3016-4a86-8437-545b84cc5219">
+      <statement statement-id="pe-12_stmt" uuid="8b9427b8-b0fd-4c10-a090-a0fc02b43a7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8e9dabf-ed63-4970-a1de-5ba580d7d32e" control-id="pe-13">
+    <implemented-requirement uuid="f2ef922c-3e62-493a-a497-cc8801cebcd9" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="e48e25cb-f44e-469c-9964-be98a315617b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8121d754-ce90-42a7-9649-e7c9840fedfd">
+      <statement statement-id="pe-13_stmt" uuid="2af78162-9be5-41d8-a16e-89489da79133">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4c447d3-e679-4db3-8c96-fe6c1876319f" control-id="pe-13.2">
+    <implemented-requirement uuid="a8b37e1b-9aff-4181-9f21-165f65a2838c" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="9c789e19-4e5d-4192-97b8-266fe3eea9aa">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="32adeea7-584a-4f2e-b876-247186621b44">
+      <statement statement-id="pe-13.2_stmt" uuid="8f514ea6-42f7-4b73-80bd-e4f3c7a5d30e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69dd7942-b306-4670-8ef9-18e8546d172b" control-id="pe-13.3">
+    <implemented-requirement uuid="35ab7bc0-d210-4edd-9357-0a0009a3614e" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="3438c60d-d7d0-41d6-98a8-6cb96981c69a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5449205b-0a1c-4f32-abc5-9e7a5fbb7896">
+      <statement statement-id="pe-13.3_stmt" uuid="22407131-9365-4076-9059-98b185e0dabd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef136452-cbb7-4495-95a0-53494740aafb" control-id="pe-14">
+    <implemented-requirement uuid="0b6ac012-3ebd-444a-8c15-179b449dd03e" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="3f0fcb23-ace7-4c7b-8001-24d041d23284">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7aafd614-503d-475b-8ee1-2251ffc27930">
+      <statement statement-id="pe-14_stmt" uuid="2430b2c7-3867-4c68-9475-33402076cbd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="630e68f6-127f-47d2-8bf7-32f214856565" control-id="pe-14.2">
+    <implemented-requirement uuid="76fd6216-6bdb-4757-94bd-09455569b009" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="c8cfae2d-3d8b-427f-b0d5-f6bc1d4ef96a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="daf67ed7-71d8-47f0-ada9-2acd07bae153">
+      <statement statement-id="pe-14.2_stmt" uuid="7b7d786f-adb0-4b21-82ed-39527c26e5bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01f1fd28-4095-4368-a56f-6e89e81485f1" control-id="pe-15">
+    <implemented-requirement uuid="7fd52cb0-bc5a-4989-bd0a-e5edad6a6875" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="08f5a0a9-45e1-4822-80d1-a43e20bab9b8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3fc1092d-6118-453d-9d05-006f3a4db6fd">
+      <statement statement-id="pe-15_stmt" uuid="e280552c-8bca-4408-803f-85c89a04f109">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2a09c2a-8e6b-4b6f-8568-26c02973a9ad" control-id="pe-16">
+    <implemented-requirement uuid="a2a949e4-02f8-423c-9c40-5a7d49d329aa" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="8fc83e97-c113-4906-b49a-95b713e011fb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6b4e32f8-8d93-45b2-8a94-2d25b833341b">
+      <statement statement-id="pe-16_stmt" uuid="3c91da19-2cf3-4882-a0f0-35464a9c622c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73dc6142-475c-4c4f-869a-5674a2632ebf" control-id="pe-17">
+    <implemented-requirement uuid="10588914-a432-4ccf-8761-1fbabbda47f9" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="f703aced-d5cf-4a28-9d47-589ed3864357">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="aeb91af6-bfc4-44a9-ac36-a497fe8a6bb3">
+      <statement statement-id="pe-17_stmt" uuid="2e9d2e39-9ff6-44d6-bcad-2d17a6cd9c8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba37111-64a5-4596-b8eb-fe45c3719ec9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2b15aca-ff2d-494b-8af8-fa2550cd0c69" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="7b6ae1b0-3979-4bcf-91e9-e467a22a55e8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="95ef9231-bb2d-4bf0-96b4-ae676d3e8bd4">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3301,10 +3301,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d0fcc3e-179f-4750-ae8a-d2723582dfdd" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="8772f789-7c26-4b76-9162-1c8176e64438">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4467572f-531c-41ab-8d0a-0166c308415d">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3312,10 +3312,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="093c3605-9e2f-4de2-9f3a-cd37a4c38ff6" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="719afa45-a0e2-4987-a6b3-5235f0198df5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a98a8f16-c60c-4df4-8488-8e7d673e21f3">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3323,10 +3323,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f1f94cc-8232-4a93-9102-83ffe5dec4cc" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="f9163730-229c-486d-ba83-d6800b4580a2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0647520a-82e7-49fb-8fde-80ec666aea95">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3334,10 +3334,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="454182b0-593c-48fa-b684-7e74adcd4f98" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="5d761b02-e93c-4df4-a84c-e03377b82521">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3935c954-b7ff-4f93-8bcb-5e89039dbf4d">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3345,10 +3345,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b76f9bbd-0989-4da4-af86-fabbafbc8099" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="327686f3-0a1f-46e5-b288-d32447d05b0c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3b9c1d00-f995-412a-87a1-6c4da2a0a6b2">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3356,10 +3356,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="145fe9f0-cbb1-4685-9f68-c0a96e48134d" control-id="ps-1">
+    <implemented-requirement uuid="4d136db8-e7eb-4b3e-b037-381487f0532e" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="87f0d48d-5334-4095-8abd-275a0bbe6e26">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3bc1cfe6-2a0e-45d2-94fa-cb4cb0659a19">
+      <statement statement-id="ps-1_stmt" uuid="9af3ca73-229f-4538-abc2-efd626ea3055">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3367,10 +3367,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7120b04-475f-4c14-8730-aba6c5c55f22" control-id="ps-2">
+    <implemented-requirement uuid="6023f53c-f1f6-461b-bc4c-59bf5bed97b4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="cebbe6e9-42fd-4592-af8f-57804fe3dae1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2e4d948f-3a8b-4c9f-9720-f15509c023bb">
+      <statement statement-id="ps-2_stmt" uuid="100d4a3d-c1eb-45a7-9e8c-0bc8dbb62d2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3378,10 +3378,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd820a7d-353c-48ec-ae88-52c977bd03b7" control-id="ps-3">
+    <implemented-requirement uuid="ab01fa25-d8b0-4d7b-ae45-d2ab5d8b1382" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="0949529c-11f3-414f-b678-95f5e49fc51f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="39b0f096-35cd-49bc-b59d-21937739a98d">
+      <statement statement-id="ps-3_stmt" uuid="1c3a8a5e-7e84-4341-abd4-3063ab3fb9f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3389,10 +3389,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a676fed-5c2c-4200-b6c0-991b5b22e0b1" control-id="ps-3.3">
+    <implemented-requirement uuid="b63d44b9-6723-4059-b6a9-b511cc880ce4" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt" uuid="ffce630a-06c3-4212-8e85-4da1fb3073d5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b5772ef2-fd28-488f-97fd-df00a7fcecfa">
+      <statement statement-id="ps-3.3_stmt" uuid="c04a351f-987e-4ab0-86f9-e053b86080ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3400,10 +3400,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d53d25f-16e4-4ad7-9556-a807b43246c9" control-id="ps-4">
+    <implemented-requirement uuid="d59ce3bb-2024-4bc6-be8a-e4afb6334739" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="6f4d1369-fcdd-41ef-a59a-616642a68320">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0ad834fb-4a0e-4352-bcb5-35f303c625ef">
+      <statement statement-id="ps-4_stmt" uuid="5298ca65-c410-4e9c-8825-e7bb70670a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3411,10 +3411,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acd536f7-b091-400a-88bd-009c307b892b" control-id="ps-5">
+    <implemented-requirement uuid="dbf6994c-27d0-4bc3-b60f-bc0958c0a878" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="ae8db677-015e-477d-9020-68e2fee7cebc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2064c292-c92e-4e45-8f9f-1fc8f83d989d">
+      <statement statement-id="ps-5_stmt" uuid="a92e9df3-3a63-4925-8654-7c596d51f667">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3422,10 +3422,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b510ac57-df99-4a12-ba5b-f63f35453df9" control-id="ps-6">
+    <implemented-requirement uuid="868fa3ff-5e6c-421f-9cc2-55267f6d9a46" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="6397b120-6b5b-4df9-9197-05e8b098219d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9ec07028-2c3e-4d67-bdb5-db2c5d655b96">
+      <statement statement-id="ps-6_stmt" uuid="7a665411-ce9f-4cfc-8716-8f61343d8336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3433,10 +3433,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fdc4405-c68e-4d4c-ac1e-d145574d45ec" control-id="ps-7">
+    <implemented-requirement uuid="a95b32cc-6f69-4da1-a053-66b13b726e6b" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="60632366-9621-4880-ab8b-aa30e12f8ca7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5bac00e2-3bdc-4343-866c-984d9a470d6f">
+      <statement statement-id="ps-7_stmt" uuid="f1f9a6d5-9a56-4e67-ab67-93e63f5c593c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3444,10 +3444,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77efc500-cb78-4a5e-8a36-8fdd1abf8e43" control-id="ps-8">
+    <implemented-requirement uuid="b32f79da-715e-4149-bd0f-e74f904b811f" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="75f2e3dc-93a0-4cc7-a12c-e4cc05946cfd">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e82a1ba0-d66b-401a-ab41-eeacfa105566">
+      <statement statement-id="ps-8_stmt" uuid="09459806-68af-4733-802a-aa394b87a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3652fc67-d97b-46ef-b59f-272caa0873c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'##
@@ -3455,10 +3455,10 @@ applicable to the configuration of OpenShift.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b715bb82-33b2-4e47-aebb-4e6088bf1c9d" control-id="ra-1">
+    <implemented-requirement uuid="e37cfe14-b5fd-4d96-ac49-1a57863c6f72" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="91009a77-f688-4540-b469-48a611a01652">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ba1c9e10-eb95-44df-a23c-6dc326648ff4">
+      <statement statement-id="ra-1_stmt" uuid="2a1973bc-26a3-4d6f-93c2-dc280fe40b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3466,10 +3466,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="320b604e-a13b-412a-8d96-b2a824481542" control-id="ra-2">
+    <implemented-requirement uuid="b330baef-38cc-404f-b2f9-cac39cb6bab8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="6fc4e782-82f3-464d-9f79-78810abe9971">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="de48c48f-84fd-4b7d-a312-d4c9282f297a">
+      <statement statement-id="ra-2_stmt" uuid="fc8a77ad-f129-4504-a1c6-b4e72a971c1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3477,10 +3477,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc93b68f-9e1f-4f6c-8a5f-ec3a6b19f06c" control-id="ra-3">
+    <implemented-requirement uuid="ba31e6ad-7602-4a1a-a279-267f87ac58cd" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="e366788c-dc4f-4f8a-aa24-9b68eaf6d367">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="afb720b3-058a-422a-a163-7b3c2da68baa">
+      <statement statement-id="ra-3_stmt" uuid="3c5a3049-9ba4-4284-8163-0c6046d289a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3488,10 +3488,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7d2a8f5-7b73-485d-a43b-35cbe852a28e" control-id="ra-5">
+    <implemented-requirement uuid="3911668b-2301-41f2-a0e5-ff0d3f95db08" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="56522ac1-1c97-489a-bce4-b13206684972">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ad2e28e7-683e-45d9-b6a2-f9ed0c4aa462">
+      <statement statement-id="ra-5_stmt" uuid="e68ebbe4-3b22-428d-9d9d-9eeee4865235">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3499,10 +3499,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30c43cf9-d39f-4bbf-aea5-d7c8ce0cf058" control-id="sa-1">
+    <implemented-requirement uuid="1c7eb645-a1a0-4380-aa0d-4186c741b0ea" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="8764c148-51d3-4c89-b403-28060f29c783">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="055f96a1-dfb6-48b2-ae47-e7bd2deb2847">
+      <statement statement-id="sa-1_stmt" uuid="b2300217-ce75-4247-b6f9-aed171e941b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3510,10 +3510,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21cee5be-3ea0-46ec-aafe-50414870583f" control-id="sa-2">
+    <implemented-requirement uuid="c40e17b0-3f8e-4a54-bd90-da5d6f399405" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="9bf40dc2-bbd6-4c63-a5ee-dcb43dcd0c12">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0e0ddf9a-9fec-4425-b224-fc6bd3d2a748">
+      <statement statement-id="sa-2_stmt" uuid="0faf40b0-125c-4fb0-a6ef-f4c8b1d0b6c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3521,10 +3521,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="136b287b-f8cb-4c3b-b4ac-f88f73d435f2" control-id="sa-3">
+    <implemented-requirement uuid="1ef638ed-63b0-4546-afd4-646a4e489d4d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="1449357b-b74e-4693-a566-f21c1e5b2555">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="85b75383-c883-4037-a7b5-43af24b76523">
+      <statement statement-id="sa-3_stmt" uuid="1f7b9240-7f05-43b2-af6c-32398ab4c7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3532,10 +3532,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ead7232-298e-40bd-95f8-d497afd7820e" control-id="sa-4">
+    <implemented-requirement uuid="11827e8c-21e5-4a36-baa6-675f27dbb43e" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="2842e470-a374-4175-9acb-02a591818fcb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="19230739-cd72-46cb-af04-cb4f621b47c0">
+      <statement statement-id="sa-4_stmt" uuid="44a5b31e-b2b3-46dd-a778-878a6d050e46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3543,50 +3543,50 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b37e16dd-c9c8-4630-b1d4-467cbae3fb85" control-id="sa-4.1">
+    <implemented-requirement uuid="3c6a4791-f30b-4e95-88b3-474afc477b61" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="3624cf01-d28c-4201-be9e-4227babb79f5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="bfb339a9-4f75-4686-a92d-f837dda54907">
+      <statement statement-id="sa-4.1_stmt" uuid="f43eff80-86b9-4186-a3c1-255d3ad95047">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="304d0a93-ec22-4a5a-8573-48495351dcc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01c2b3d1-b674-4fd0-a51e-d2ac19049101" control-id="sa-4.2">
+    <implemented-requirement uuid="abb05047-05c1-4fdb-bc9b-02cbaa271846" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="a48c5222-0081-4b7a-9c9f-e0c0a5000e89">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0a021765-f641-4543-8cc2-283e50285b6a">
+      <statement statement-id="sa-4.2_stmt" uuid="fa0145ca-6267-4fd7-a7bb-8b719e2e67d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ce3ca6d-c078-4736-ad0b-64c903ef7b8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (2) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a24cbe6-1a48-4c0c-8c0c-b6beed27f1ef" control-id="sa-4.8">
+    <implemented-requirement uuid="446d2acf-6a0f-4a7c-a2c6-aba47061b3ef" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="9cded8e2-48ef-4ad5-823b-1d9b74ed8a56">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f4bb2552-8a0b-44d6-b81a-9df9f9408075">
+      <statement statement-id="sa-4.8_stmt" uuid="7e8f756c-33a2-458b-a08c-15ef02481b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="03206e2e-2e26-4a79-b888-2504d14b2ae8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (8) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79b37a93-9f21-4cb8-bf71-c517b5d142dd" control-id="sa-4.9">
+    <implemented-requirement uuid="acd30502-67a6-4df7-91dc-df675c46b69a" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="afd90a34-4adc-4ece-af01-8a6fdb19ed92">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7561c8ca-46ae-4797-85cb-38a1b1361275">
+      <statement statement-id="sa-4.9_stmt" uuid="d67b30f1-ef60-443e-96a9-6727a3cea522">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3ddc9-7078-45d8-9425-2281b700ec3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-4 (9) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b1a7d47-91c1-4a84-888d-9f9a016a753b" control-id="sa-4.10">
+    <implemented-requirement uuid="e62c435e-724e-4c11-9be8-4b0b224cc02e" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="11a9f236-7846-4979-b4c0-f588dbca304a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6db7da5e-b7b8-4a14-9e3f-01331f960a44">
+      <statement statement-id="sa-4.10_stmt" uuid="b348d1ad-da91-498b-909d-f765990f6b02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3594,10 +3594,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="748613dd-9cff-49de-a768-c5cdb003a565" control-id="sa-5">
+    <implemented-requirement uuid="3698244c-73ab-42f7-9147-487f4edb33f8" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="1dbe88b8-933e-4006-8d25-763b11f155b5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="2578c429-e224-4695-962b-64a0f848c500">
+      <statement statement-id="sa-5_stmt" uuid="ee3039a9-2177-4e5d-9ff3-730f3ba9eacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3605,10 +3605,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cedca09b-7ff9-484f-bd74-06a050843a71" control-id="sa-8">
+    <implemented-requirement uuid="5e5a6a8d-afb2-4525-a1c4-d5b4997cda15" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="0b4506a3-6bfc-44a9-80d2-6327eae874b5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="db0bb674-0a4f-46f6-aafb-88006f597be5">
+      <statement statement-id="sa-8_stmt" uuid="24258998-f733-4988-87c3-984059b24a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3616,10 +3616,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8a81ad4-4a45-4ddf-9cac-3e2f251f0a82" control-id="sa-9">
+    <implemented-requirement uuid="6586d595-a660-4279-a7fb-107e57cffad2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="f550272e-b001-42a0-9472-4fcf4d6a6b39">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ea4037d0-06be-4cb1-86c9-29610187b53c">
+      <statement statement-id="sa-9_stmt" uuid="f4994f59-399a-42ca-9dc8-eae7a2ec5423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3627,10 +3627,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ef85c8b-8d07-4048-8e2d-36c240e6d2ef" control-id="sa-9.1">
+    <implemented-requirement uuid="eeb641b1-d0c3-4939-a03a-39a1c54304f8" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="3de10d07-7408-4c9a-92af-3d60f13b216d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5efb6719-0798-4517-8efb-62d4376ba367">
+      <statement statement-id="sa-9.1_stmt" uuid="61c934d4-2de2-496a-b86c-103538a58e8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3638,10 +3638,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd8357c4-128c-4546-91dc-cbae3dd8a77d" control-id="sa-9.2">
+    <implemented-requirement uuid="63ffe205-b15d-49c1-8ce9-56d11de37d2e" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="3a1bcc8f-a462-4bf8-b389-267f4f1c7d84">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="85062710-b2bc-44a6-b354-ff58a4ec91c5">
+      <statement statement-id="sa-9.2_stmt" uuid="69e24e2f-1d2e-4256-9d9f-4c26684e09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3649,10 +3649,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d61b1f2-97f8-4b05-96e5-053c4afec473" control-id="sa-9.4">
+    <implemented-requirement uuid="8c8ed702-4dd5-4489-bc2b-10ef0c9cb73d" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="74b851af-266e-478d-b4c3-bb24080e1d66">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7063dc4b-046c-43a5-af17-0b92c417c4aa">
+      <statement statement-id="sa-9.4_stmt" uuid="f3d832ca-eb99-4f60-8148-d165cae3ff41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3660,10 +3660,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c226ce19-8881-4b26-a407-346da10c1cd2" control-id="sa-9.5">
+    <implemented-requirement uuid="69277f74-99df-4ac3-87d1-304f17348d64" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="a1a9dede-fd48-4a16-bc87-220628f175c1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="73dff292-681b-40dd-aa93-1289ae409319">
+      <statement statement-id="sa-9.5_stmt" uuid="d2b42ef4-08aa-4010-b9f3-0b1257c1bba4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3671,58 +3671,58 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8b8e9d1-e2b6-4595-9c9f-d02d48ea47b9" control-id="sa-10">
+    <implemented-requirement uuid="382ae9b7-82c9-470e-9997-3ad0050546ed" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="f6df21c4-7458-4a6e-9914-709b69eeba68">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="377ac1e6-db7b-4b0e-b579-d2d009dd89cf">
+      <statement statement-id="sa-10_stmt.a" uuid="05dd316a-60d4-4d6c-ae99-36cbf5c2111e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a65db07-8bd5-40be-9483-0cf5002480dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (a) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="7ba5b938-590e-4fcb-94e6-4ceb6898f08f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f36fdf6f-f2c2-4ca8-80b4-6775a499c76d">
+      <statement statement-id="sa-10_stmt.b" uuid="dbbefd25-7602-4961-9b8d-7016a2778ba1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e45b040-490c-4601-9108-6b62b8c8bed8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (b) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="13613a4b-c034-4dba-bd52-d47f5a54b6da">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7d211ed2-5390-4095-8a8d-d7d729891854">
+      <statement statement-id="sa-10_stmt.c" uuid="9a5f7710-a238-47fa-8826-ca06056dde50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a064e7db-cd84-4330-850e-f194754b26a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (c) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="793c9d4f-5f2d-4d39-9d64-fa17ff770a01">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6a1e5d87-2898-4eb5-b82d-f91ab3bfbc3e">
+      <statement statement-id="sa-10_stmt.d" uuid="348563e6-5445-420b-9e54-2bd67cb3b09f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6196b269-89e6-4028-83f0-53e0620b51ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (d) is planned.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="2fbafbb2-a527-4ad5-91ba-fa8af81dfe06">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="282a799e-3f99-41a1-843a-3419eab747a5">
+      <statement statement-id="sa-10_stmt.e" uuid="1c6d415d-7ed8-4775-aa2c-47443b26ceaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40cd38eb-8089-4482-86dd-8b14865b13b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (e) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f9a6524-90ae-4722-8f8d-711f61550ee3" control-id="sa-10.1">
+    <implemented-requirement uuid="31f19912-792e-45b4-8466-c842b5fff63b" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="d5875289-9dfa-4001-9216-0faffd1733b8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="37d8a33a-dea3-42ce-bc34-b34b439386c8">
+      <statement statement-id="sa-10.1_stmt" uuid="610f4bc7-7c74-4ad5-93f4-ebba3ba91ee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c87c57a2-c06d-4802-b91c-8fdd243f3cea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A control response to SA-10 (1) is planned.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74d30e89-ef06-4801-b331-1940f685618a" control-id="sc-1">
+    <implemented-requirement uuid="5651d80a-c6dc-48a2-a7d4-59d286b6168d" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="62e3283d-2049-40bd-9d15-489da4f03cdb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c08accb6-4f5f-4d12-99d9-738acfc33bc1">
+      <statement statement-id="sc-1_stmt" uuid="f95841a1-e7a1-45cd-8dbf-fb9f208730da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3730,10 +3730,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="353e6135-997a-453d-a1de-61dd5ee00f85" control-id="sc-2">
+    <implemented-requirement uuid="45184a65-ac16-4ba7-8370-1b3d059f73a3" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="71015c88-cd18-4183-a979-be54452d718c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5f3dd240-6bff-4cf0-bcba-a2b324d3a911">
+      <statement statement-id="sc-2_stmt" uuid="676e19b8-f19f-45c8-b57e-3e55be805135">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f886952-6505-477c-897f-a16f051d5e0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -3743,10 +3743,10 @@ and management functionality access is separated.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc0d4b3c-4da2-4559-9883-dc7cb8976187" control-id="sc-4">
+    <implemented-requirement uuid="1ceea3d3-3782-4c64-8e55-4178aecf31be" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="de80a4e7-6b03-4a70-8f4a-c850a0d20c4a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="e561c0ce-8876-452e-b395-2ff933fa8553">
+      <statement statement-id="sc-4_stmt" uuid="bffdbbcc-af07-4296-a380-38d3e96ddf1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea85ab0c-4c54-4353-bfe0-eaed665e08a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -3755,10 +3755,10 @@ successful control response will discuss how this is prevented.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e1f1e1a-a01e-4fa8-8284-cc80cb149a12" control-id="sc-5">
+    <implemented-requirement uuid="f499ec6c-51d8-4b49-a2d2-5776775a3493" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="aa59d280-4c41-49c5-bd0f-9a8ecc7830cc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="703b6ec8-bf1f-43ec-813b-6526193422d1">
+      <statement statement-id="sc-5_stmt" uuid="33eaa098-ca31-4f63-84d2-6138c7a098f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -3766,10 +3766,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c60bc264-f475-41e5-bb77-a06d5e224808" control-id="sc-6">
+    <implemented-requirement uuid="145e3693-4b5c-4687-aa01-06faa69d027e" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="e1b98aa0-364c-4137-888e-fed221cd9947">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f8fd7573-0988-49ed-bcb6-049d67cd7ab7">
+      <statement statement-id="sc-6_stmt" uuid="cdaa6955-af96-4ded-b044-651ce8e5951c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98311916-bff5-4d0a-907c-d0e8a6c7e5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible to protect the availability of
 resources by allocating processor and memory resources by process
@@ -3779,10 +3779,10 @@ discuss how resource availability is protected.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a59098f-c85b-4114-b9ab-c81cdba22a2f" control-id="sc-7">
+    <implemented-requirement uuid="3bad8fd3-057a-419e-847a-320c75185d9f" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="5daad82b-79ba-4170-b231-2b489220445d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c4198f10-c6c6-4491-8943-5f1f5b02857a">
+      <statement statement-id="sc-7_stmt.a" uuid="3f72051b-6578-4787-97d9-6e4f8619b2e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdabd9ff-7ac0-464d-b4e2-2085625778c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 Openshift can be monitored is forthcoming. This activity is being
@@ -3792,8 +3792,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="e7f403e2-54fe-4dce-b7e3-6a69a40e0b33">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="1a0f9458-7ae9-4814-9284-c82a4254a61d">
+      <statement statement-id="sc-7_stmt.b" uuid="6fc0305a-c430-4dbd-ac33-7226cdb84d44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7519cc9b-c5d5-489e-94c3-d8233cc8a4f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -3803,8 +3803,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="1597c0c2-89a1-426d-9c01-2eabb0926996">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9671797f-31ee-4b87-9f02-89cdbf89e62b">
+      <statement statement-id="sc-7_stmt.c" uuid="eab9b163-d436-4802-af0f-69f8986ad962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5494a31b-da22-49a8-b068-5b4d3b701e2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift can route connections to external
 systems through a managed interface is forthcoming. This
@@ -3815,10 +3815,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87d4d2f4-5f2f-4fe4-ac90-bfda5fbf8c83" control-id="sc-7.3">
+    <implemented-requirement uuid="1b8306d1-b23a-444c-a90f-b6384351098d" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="2a58fe38-8fe2-42b3-ae04-0958ddf47a04">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="90d28541-ab23-406a-b4d2-51bdaba66a2a">
+      <statement statement-id="sc-7.3_stmt" uuid="f5a6d0ce-ba0e-4ce6-b0b1-be3f546c100a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10d1d997-e522-435d-a550-05ced6eebbcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -3828,48 +3828,48 @@ enforcement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db3dfa13-e181-48ba-b3da-fa344403c1eb" control-id="sc-7.4">
+    <implemented-requirement uuid="40b05aa6-c8d1-47d5-b5f7-65cf07004596" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="19d7696c-f9ec-4647-b0f0-f272f2b6b6ab">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8d3c3192-16a0-4a6e-a46f-ef4561cb8b96">
+      <statement statement-id="sc-7.4_stmt.a" uuid="ff5f8537-02cb-445b-a1cb-d37293e742bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="ec5b3b8d-561c-45ee-b7a9-f1b13130b4f3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c9398942-f13b-4700-8288-3509766fbc96">
+      <statement statement-id="sc-7.4_stmt.b" uuid="9be0639a-8be4-47bc-ae2e-4359af0794ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="d4b2e0de-efbc-4ec3-95bd-6d81a7c9dd7e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9da61b81-2b60-419d-b2dc-1ebd674be3c9">
+      <statement statement-id="sc-7.4_stmt.c" uuid="78435ec2-e899-46c7-8b36-778aaf1c867e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="5a033f4b-3b80-4335-9a79-1be0fe1921ad">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5086052e-d1f8-4d60-815b-a374017a4db6">
+      <statement statement-id="sc-7.4_stmt.d" uuid="4240e31d-db4a-481c-b00a-5e74bc7b3961">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="8ee6034f-92b1-43f8-b4e0-f638ff9274d8">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="cff2cd02-3fae-47e9-a485-7d20c87c5f22">
+      <statement statement-id="sc-7.4_stmt.e" uuid="e8b6561b-d8ad-40e8-a6b6-f3d1192981ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff9269d8-2ca2-48c5-af6f-c37f3f541419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited from the network and IaaS provider.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe33d807-fe95-4484-823c-fb2dce768064" control-id="sc-7.5">
+    <implemented-requirement uuid="02e34c4e-d275-4ce6-83ab-aa52bfb3cf82" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="e6e328a3-94e1-40eb-afeb-01dfafa6e694">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b6597ddd-3d34-4ae2-8ac8-4d34326e9f9b">
+      <statement statement-id="sc-7.5_stmt" uuid="8df5ea74-cbae-4161-b62a-fb5cce809979">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba6f5e62-9e53-413a-8956-3ac4fab17cba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -3878,10 +3878,10 @@ by exception (i.e. deny all, permit by exception).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff371e53-7b86-494d-a7ae-89486c27674a" control-id="sc-7.7">
+    <implemented-requirement uuid="a73a61b0-42a6-47c2-af43-30ca614dd309" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="15949bd2-cdef-4b41-8687-934bbdbe7448">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="53045b74-0bcf-47b5-ba44-9136a97e77a4">
+      <statement statement-id="sc-7.7_stmt" uuid="269d30c7-ab78-4404-afd0-5d61e1a5a6d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42fed431-933a-486e-aec1-ae00744cbd36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing mechanisms to
 ensure OpenShift nodes to not act as proxy or relay servers between
@@ -3890,10 +3890,10 @@ internal and external networks.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f261d771-d15f-4f5c-9c74-214d83b70b73" control-id="sc-7.12">
+    <implemented-requirement uuid="fd9e6b7b-a1b0-4d03-8372-b5c90491186d" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="88f54775-8819-477b-89ef-94ba2c953263">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="11364f02-7311-4529-a522-32a68f4efacd">
+      <statement statement-id="sc-7.12_stmt" uuid="e7f26f01-e38a-4229-a5e9-d05c5a3ab47c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bcae28b-c686-466b-9537-914db5b23547">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -3902,10 +3902,10 @@ local firewalld and SELinux policies.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2f366bb-d741-4a0a-9868-8cde5eeaa996" control-id="sc-7.13">
+    <implemented-requirement uuid="395df344-6436-4c37-af8c-101052db6073" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="e1e7a133-eff8-4970-b9ef-a2485ae4893c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d910ebb5-fd37-43cd-bf44-fbc496713e5b">
+      <statement statement-id="sc-7.13_stmt" uuid="ff75535e-3178-4875-b64d-b3fcfa26aa97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5fe9fd7-6ec7-461b-8b81-7a81d9cb6a0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for ensuring that OpenShift is
 isolated from other internal information system components by
@@ -3917,20 +3917,20 @@ control.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6dbe935b-7803-4894-9b03-f4b50a3340cc" control-id="sc-7.18">
+    <implemented-requirement uuid="f6a1d6dc-5556-429f-84e0-9522b0efd320" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="b0d2a873-4f54-4d87-948a-6576c3a92b6e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="f930ca88-add9-4e5c-880c-25e27b80bea0">
+      <statement statement-id="sc-7.18_stmt" uuid="f5c35cf5-b700-4e5d-b405-77a19cd7267c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="baa2cef2-011f-4e6c-9be1-5e650016ed64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited through organizational network services.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69dbc1de-9aec-4521-8b80-4beae7579b92" control-id="sc-8">
+    <implemented-requirement uuid="dbb58d1d-24a2-40eb-8223-1874cf17736f" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="370e7f31-7d55-4780-8eb3-c19867fe556a">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5acbefa8-7129-465c-9dc1-7c312dc2549b">
+      <statement statement-id="sc-8_stmt" uuid="b4ccb602-816d-43fa-9615-899936dc596c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6de910e-149e-4a43-913f-5f6c531617b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for configuring TLS for transmitted
 information.'
@@ -3938,10 +3938,10 @@ information.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0ef5a91-dbf1-44dd-8495-4afd7997cf1a" control-id="sc-8.1">
+    <implemented-requirement uuid="309ecd34-3d20-46be-a07e-846a1fe45f27" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="70fa843d-8a46-4d19-999d-72af55ce5070">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="da8551ad-858e-4950-a23b-31b347b0179b">
+      <statement statement-id="sc-8.1_stmt" uuid="09048457-8308-4541-8769-d1219ef438f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4a7f402-aad1-4175-b5c1-f0d7545dcc23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -3952,10 +3952,10 @@ network communications that carry customer data.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7e28291-0b0e-427d-bfbe-2bb2fc3b3657" control-id="sc-10">
+    <implemented-requirement uuid="bfce6633-b22c-48d0-9e5a-72b19040d678" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="ea73d3c8-1314-4f5d-8f56-52eda5916040">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="a6852af0-6da4-48c6-a4a8-359c21b9a7b2">
+      <statement statement-id="sc-10_stmt" uuid="2f812c81-df98-40d8-8293-788cb91deef9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c67d9a1d-74c1-4612-9056-3c368ac37a2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -3965,10 +3965,10 @@ means on how this is established.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8795b1c1-0e27-42f1-8e71-d43a2f997918" control-id="sc-12">
+    <implemented-requirement uuid="7c88e161-ba05-43dc-ab5e-884b8dcb10bd" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="f8942490-d25a-44a1-8654-be1c9a0a59b5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8ed0e927-e204-4d3b-9e1e-a977c3120f8c">
+      <statement statement-id="sc-12_stmt" uuid="02134109-c5f5-45e9-a1d6-e052124ef3e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="352d0e88-8e3f-4f3e-9b22-26e69493b31e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how OpenShift generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -3979,10 +3979,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0b28ad6-07db-42d5-8b77-141d224fc4db" control-id="sc-13">
+    <implemented-requirement uuid="3f412236-08c3-4871-b71a-c5eabf00f94f" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="a39ac16f-dcc1-4ccd-8b7c-37e0272ca6f7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0a3a6d2c-4118-467c-9cea-e208efb2abdc">
+      <statement statement-id="sc-13_stmt" uuid="489f455c-5055-47cc-8e10-8437a43748e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f74300e-0237-423b-836d-8f145bac0762">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding OpenShift's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -3993,10 +3993,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d83dbb61-0a7e-4126-a0ba-970cd1d0b8eb" control-id="sc-15">
+    <implemented-requirement uuid="76ca3ea7-c2d8-410c-8ca5-4404d7072b39" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="39c9dbdd-9cbd-4b2e-8477-b8e208743b6d">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="eb01b0a0-bf55-401a-b057-67b8bc049400">
+      <statement statement-id="sc-15_stmt.a" uuid="65568e0a-645b-4332-a928-6fd568a15f5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4005,8 +4005,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="fab3f813-060b-492f-9124-9f757b772121">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="ff754e62-cdc4-4390-b860-0df2f3fe4aaa">
+      <statement statement-id="sc-15_stmt.b" uuid="5afe21bb-69ec-494c-98e3-bcdacfde5d24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4015,8 +4015,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="35476b1d-ad57-45e6-82b7-15949141e807">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="61968946-dd0d-4755-bcc6-693e7fbd53d0">
+      <statement statement-id="sc-15_stmt.b.1" uuid="d65a4a16-075f-4578-aadc-d9a267ce2130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afdd5fd-c693-47e9-9485-a3f17706bb5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4026,10 +4026,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e9f19f9-94d0-4b4a-87dc-9034f1645e25" control-id="sc-18">
+    <implemented-requirement uuid="e632bdf6-9def-469a-9f51-f787715c8d51" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="1f1cefd9-9961-4be2-a757-92c3fa618e91">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5d337efb-ca4f-46c7-9750-38b78e5d60e0">
+      <statement statement-id="sc-18_stmt" uuid="e4cf3bca-cc87-4d2f-bca1-9a6e873b7c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b076ca-9681-445c-8b71-37fcecf9b185">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -4038,10 +4038,10 @@ with organizational policies defined in SC-18(a) and SC-18(b).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09cb20d5-25d1-462a-81ac-99dd4a8c5ecb" control-id="sc-19">
+    <implemented-requirement uuid="a333d58f-a031-4846-986b-65403531f85b" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="43410548-bcb9-48ae-8ade-c6b2e0b05ca4">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="be477a43-e625-4d26-a5b9-6ae045438414">
+      <statement statement-id="sc-19_stmt" uuid="99a38163-d7a5-4f40-818f-422bf601fcb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a02f55cf-9d87-4641-abcd-91fb726b65a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -4050,10 +4050,10 @@ organizational policies defined in SC-19(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba00db24-53c7-4b2b-8843-be2529491f49" control-id="sc-20">
+    <implemented-requirement uuid="f8b830ff-57af-4e37-854b-788171e6accd" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="663a4c81-f550-4908-a69e-33ab75e8951b">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4fbad248-d75f-46dc-bca0-2373bd063d05">
+      <statement statement-id="sc-20_stmt.a" uuid="e5127dc4-3261-4308-8dee-f2d6a1836dfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8cd61eb-4c1f-4240-bf35-1ef4202ccd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4074,8 +4074,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="06db29ff-83e3-454b-bd44-833aecf1ea7e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3eb85b70-c30f-4cfa-bb23-015d362059fd">
+      <statement statement-id="sc-20_stmt.b" uuid="5801a7ff-229f-4f6f-bdc7-61ce7f4809c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a8570ee-bd65-41dd-9064-8453735ed2d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4097,10 +4097,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cb73937-2332-4414-babf-df6505ac1292" control-id="sc-21">
+    <implemented-requirement uuid="3bd8b52b-1b3a-4228-a4f6-f4a456a753e1" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="44eddaea-39ec-44af-b956-4c51b5566fe7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="82a93814-4d45-4182-ad9e-a6cfa7bdbcdb">
+      <statement statement-id="sc-21_stmt" uuid="121f52df-4b04-4051-97a3-d05a14dd503e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="289e55b2-eac1-428c-8f3a-d3a0e8a486b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4119,10 +4119,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97fa6e61-f0cc-400d-9183-df7dac70a8f4" control-id="sc-22">
+    <implemented-requirement uuid="c20eba14-fc75-48a7-b425-9d93b361f7d5" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="399f3d81-00a6-4eaf-bdc1-7edb2dfda9fe">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7cfe80f2-29ea-4ce3-a206-6fc19a77509d">
+      <statement statement-id="sc-22_stmt" uuid="10885e32-cc85-40ae-bed1-b469620eab66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="808d8d96-a64a-433c-ad12-ccd41c1a4b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenShift has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. OpenShift supports
@@ -4141,10 +4141,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90f1b7de-48b7-4896-a11a-0550e673ec88" control-id="sc-23">
+    <implemented-requirement uuid="8c4987c8-a619-49a2-8c27-4d6a68cf9c0e" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="e600964c-38c8-4d63-b1e4-955fb7cfd2cb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="772c6292-1e51-4b57-ae1f-a0c2d4f0cac4">
+      <statement statement-id="sc-23_stmt" uuid="0a5b40f2-5655-4ca3-8c38-81c3d33f5504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f7cfbc5-f939-47d6-a7e3-44377d12ec68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -4159,10 +4159,10 @@ the authenticity of communications sessions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6177eb55-2460-4ae9-8bea-883c87328533" control-id="sc-28">
+    <implemented-requirement uuid="97c63d21-0394-4cc1-a9a5-6eca1aa05b33" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="cd788f7c-b616-425e-a50b-61bce4a69d94">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b6eec016-eb1f-4cc2-9714-071c15d58d4c">
+      <statement statement-id="sc-28_stmt" uuid="d79a9a88-b123-4dfc-a893-b36de54eb28e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f69f9f92-e028-44fe-baa3-9712e7949912">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'A successful control response will need to address the means by
 which data at rest is protected.'
@@ -4170,10 +4170,10 @@ which data at rest is protected.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c73fb62-76e4-4656-bea8-0828541ac906" control-id="sc-28.1">
+    <implemented-requirement uuid="a5b59816-840a-4297-ad03-1ec2f09f2ff3" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="84bde2f0-99c6-4a0e-b5c4-08421d4549d0">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="598aef22-c7a2-4f2b-9426-357ca3f8372f">
+      <statement statement-id="sc-28.1_stmt" uuid="58dcc4e2-a2b7-456e-8f96-0049fa3be1f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c8e01f8-d1d8-40b8-a6e5-1b60b89fb596">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -4189,10 +4189,10 @@ protect confidentiality and integrity of data in transport.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72bb2cbd-d3d6-4593-abac-7ae67738184a" control-id="sc-39">
+    <implemented-requirement uuid="fc3dd2a5-0331-4978-ae59-af93cdadd306" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="ea08147b-82bd-4c24-8647-35fec1e3c124">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="989a3e6b-6674-43e6-98df-e0883b710123">
+      <statement statement-id="sc-39_stmt" uuid="0ebe79d3-820a-4763-b0a0-3bfa9bcd25b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18033792-c0d4-4b01-890f-9d7957b9c16f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When OpenShift runs on Red Hat Enterprise Linux, 
 OpenShift maintains separate execution domains for each executing process by
@@ -4206,10 +4206,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a19f6de4-b5d8-49de-9bc6-a0a1c937c72e" control-id="si-1">
+    <implemented-requirement uuid="a61cc071-ecc0-458f-902e-f49cc09131fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="edfe0524-558d-462f-9ed9-b81cbd311035">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="bebcae47-36ae-42be-b936-997ee35a591d">
+      <statement statement-id="si-1_stmt" uuid="e90085e3-09ec-4da8-8312-dd6fdd8d33ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4217,10 +4217,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d896ec4-0033-4563-bf4a-856484ed000c" control-id="si-2">
+    <implemented-requirement uuid="51ff2fe8-0d0d-4955-8bb5-69d7e5140461" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="c1e7a923-f1b8-4681-a023-bd92113c51a5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="60f125d5-0630-4af4-8e89-af999fe24e17">
+      <statement statement-id="si-2_stmt.a" uuid="cc54398b-c182-42bc-882f-cdae56f230aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d014d8d-6355-4b52-878e-8d2d9125edec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4235,8 +4235,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="2ec24ab1-6fc2-4e68-ba6a-8a71f292d2dd">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b2e8bcdf-125b-4c7f-9882-7cc504c2c4bb">
+      <statement statement-id="si-2_stmt.b" uuid="3e9e1351-2baf-48ae-a626-ec33a0b98eaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d5e34bd-e241-4c53-b67b-e398909b0837">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -4251,16 +4251,16 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="f864bfa1-5900-4e1b-a6f4-5dbfa9dc223f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="6d86a94d-1fca-4901-bfb2-808f6ee1e007">
+      <statement statement-id="si-2_stmt.c" uuid="819d1252-34e4-4c59-9721-a280e31aacb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="eb5e34d7-06f1-4f20-a6db-8b605ce3e98f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fc83e1bb-c508-454e-836a-5ba094a7bdf7">
+      <statement statement-id="si-2_stmt.d" uuid="0233489c-5aba-44f9-b7ca-a084496a95cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4268,10 +4268,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c52cf84-8b36-494a-aafc-218e390c2c59" control-id="si-2.2">
+    <implemented-requirement uuid="9a5cfa9f-0693-4234-ae47-92ce1f7dd379" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="81891dc2-a168-4264-b127-3e63468011b1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8e19df2d-73ae-4007-9c86-98343c9fa39b">
+      <statement statement-id="si-2.2_stmt" uuid="58c9edd8-bda5-4e73-a634-2f55dd4e2746">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0df12449-b791-47ce-968f-a15fd77929a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be required to employ automated mechanisms on a
@@ -4286,10 +4286,10 @@ the state of system components with regard to flaw remediation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87eab111-b4bd-4e32-8e45-2c69a343c23a" control-id="si-2.3">
+    <implemented-requirement uuid="9cab4d15-649f-42b6-84a7-ea91d7fbcba8" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="b7bd6448-5c05-4c31-a785-700aea1d0ac3">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="690384a6-efa8-4cba-a656-bcaf6945d50a">
+      <statement statement-id="si-2.3_stmt.a" uuid="b688cbad-d425-4f78-ab3b-fd4deb9ae645">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8778d770-db90-4f5d-9c90-2c388459b19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer is responsible for scanning for flaws in their
@@ -4302,8 +4302,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="f46b3c7c-1939-4715-905b-9e97a2cf9da1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8a28b091-4eb3-4db1-aad0-cae92a6868a6">
+      <statement statement-id="si-2.3_stmt.b" uuid="73c6a5c3-bcf3-4cd9-9d14-bce099d237cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27ea413-c18c-42b0-b5e7-9c7dd7985ae9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 The customer will be responsible for scanning for flaws in their
@@ -4317,10 +4317,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b931c546-be8f-4d7d-ad68-714e2e56e0f7" control-id="si-3">
+    <implemented-requirement uuid="a73549a8-4ef3-4e35-ae59-78a92edd5429" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="ac9ec321-f08e-4f42-bac0-729fefb175c4">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c6fb209a-06d3-4b9e-8ed6-acb6533f5247">
+      <statement statement-id="si-3_stmt.a" uuid="99ffeb16-9f41-4901-85cd-a64f801b69db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68c758ff-1223-4c00-ad94-b38ad58e96ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4337,23 +4337,23 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="50c4af42-beb6-40b3-8d6d-f2fdcc8cf06f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="794b78b1-798b-4996-a6c9-f6ceb40da568">
+      <statement statement-id="si-3_stmt.b" uuid="4378e159-c248-484d-866c-616e57ae60cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="89ab2110-880d-453b-b0e3-e7b0c706e4ed">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="13a617e8-eccd-4aba-9699-09a2208a3bed">
+      <statement statement-id="si-3_stmt.c" uuid="c3dfb7d0-4929-477d-8c51-72da41d4adf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f8d3c4-5693-46c1-b279-e6c96c419175">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of OpenShift, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="3c239645-c114-4985-9e63-35a4e02d0adb">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="83d5f868-ff6c-4a6d-ae83-a5a034eff04c">
+      <statement statement-id="si-3_stmt.d" uuid="7fd01259-94de-4af2-8c6d-f320e41c911a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4361,10 +4361,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f122c572-878d-4e29-872d-c3ce9a8bd4dc" control-id="si-3.1">
+    <implemented-requirement uuid="25e9e8d7-8802-4d20-8337-c9e71f14b3be" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="9931881f-2751-401d-b352-1e1a592d9dfc">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c2d3b698-9994-46e8-b617-adf49c260498">
+      <statement statement-id="si-3.1_stmt" uuid="a6a982d4-20fd-433c-9572-58f50789bd1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18991304-6891-47d4-992d-b5041cbe24d0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -4375,10 +4375,10 @@ protection mechanism is centered in one location.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c5073a8-d898-422d-8209-0380063e9f84" control-id="si-3.2">
+    <implemented-requirement uuid="f8c3f7f6-df8e-4dbf-a40f-4f32a2933d05" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="cbbf808b-976d-4612-8a8e-d398a42cf738">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fe59d5ef-941a-49ee-8257-e63363957057">
+      <statement statement-id="si-3.2_stmt" uuid="94de5dc7-a75b-46c2-8c98-8cd9804687ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe606ac6-77ea-4087-8fc2-91a8ec937fa7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -4389,10 +4389,10 @@ mechanisms definitions are configured to be updated automatically.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41d20ad8-c7c0-4a70-adaa-794c116aa1b3" control-id="si-3.7">
+    <implemented-requirement uuid="4e714453-dd81-4590-b826-1c2bb0dcb62f" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="eaffe136-96e7-4498-8a8f-6031e40547a1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="02b97d8e-a68a-4202-966d-77914357cc60">
+      <statement statement-id="si-3.7_stmt" uuid="367bf051-09ab-4d20-9684-b74507109378">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64dc97f4-62a3-4e8a-88f5-7c1695cfaba2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -4405,10 +4405,10 @@ do not yet exist.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac8aa2e6-6c2d-4e31-b4e4-e004ca856443" control-id="si-4">
+    <implemented-requirement uuid="1a0b3492-5535-4428-a0a7-647598146b89" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="3b1292b6-2c67-4be5-b1b2-c21b4f9d1779">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="30d415af-3a5a-4600-bf2d-549c84551b24">
+      <statement statement-id="si-4_stmt" uuid="8497c3eb-0eaf-42d0-aa8b-824b58f6096b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4416,10 +4416,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5aa95fa-a30a-4cf7-a43b-5bc2d270399d" control-id="si-4.1">
+    <implemented-requirement uuid="d53b1333-fa4e-4669-822e-63db227ec10d" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="1be8b7d1-877a-4b45-9de0-677800c9c7ee">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="65b460d0-2942-4049-8bfc-3a2e63470aee">
+      <statement statement-id="si-4.1_stmt" uuid="c5f2f43d-5cfa-4d3b-b099-4883f976e8ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2020ec2-9be5-454f-bf0b-9068e8dac025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for integrating intrusion detection
 tools into the OpenShift environment, and documenting how this
@@ -4431,10 +4431,10 @@ systems.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="251a3f7d-98bb-4c80-820a-5fd7356bf631" control-id="si-4.2">
+    <implemented-requirement uuid="6e20e0eb-e7c1-484f-a633-f37c9f4a1ff2" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="62ca5176-5f6e-49f9-a9c4-088a7c94f8a7">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="71358cf2-48a5-44e6-be9a-ba79801ac293">
+      <statement statement-id="si-4.2_stmt" uuid="223935ff-f4a3-40d6-a42f-add4fefe2475">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d20beca8-8fc6-4991-99a0-7a9e75cd7e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -4448,10 +4448,10 @@ analysis of events.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84935417-c6b9-43e4-bab2-11ce9de5841e" control-id="si-4.4">
+    <implemented-requirement uuid="297237c1-5d71-4fee-9c8e-7aeff55ba236" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="1d51a088-e677-4bda-acd8-9a913b7e0ad2">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="9fe3074d-c640-4f8a-a7c5-5304ac83bf50">
+      <statement statement-id="si-4.4_stmt" uuid="60189981-962d-4567-a3e5-59dae8dc7554">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee591d3c-02c1-46ee-b641-7bd52c931aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -4463,10 +4463,10 @@ not, how network traffic is continuously monitored.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb8388c8-020b-46fc-a319-d1716deca279" control-id="si-4.5">
+    <implemented-requirement uuid="c5b122cc-64d1-4cbc-869d-8ae2f0be1d11" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="a5f3c0c5-517f-4cbb-9cd5-172ed1ab024e">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="67ac9996-cc79-443b-b26b-5c0dcc4655ba">
+      <statement statement-id="si-4.5_stmt" uuid="9ffd0a22-36f0-4373-b488-c6aad26578f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eea7dca3-3df0-4e0b-8984-df260c203e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -4478,10 +4478,10 @@ the notification.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="801c9f2c-8908-4236-a508-471ad99249c8" control-id="si-4.14">
+    <implemented-requirement uuid="d8d89aec-fdab-413e-bb22-e8b2fb64f912" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="636f20ba-9bd0-4828-bd18-32430437cbf4">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0f39056d-e713-491e-a2c3-ba9dfaa48d62">
+      <statement statement-id="si-4.14_stmt" uuid="445ba79b-c8a5-455c-aa8a-67d35426b09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ea8a35d-d1b5-4012-948c-5daf8cde1bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'An OpenShift infrastructure does not have wireless capabilities. This
 control is Not Applicable.'
@@ -4489,10 +4489,10 @@ control is Not Applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc8e6379-3c31-4ee0-9a8a-32a1e90b16b5" control-id="si-4.16">
+    <implemented-requirement uuid="9cd2ac9f-ed6d-463b-8be5-79b53f0381c4" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="5aac05f7-e05a-46a9-87e6-02b70d21e60c">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="fcc0f437-e508-463f-92b3-4212b26c2125">
+      <statement statement-id="si-4.16_stmt" uuid="725cc6b3-bb59-4f54-b171-73848a6b89e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2922f053-40db-44dd-95ee-14eaffe76810">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -4502,10 +4502,10 @@ tools.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46c1eb1c-4c7f-462f-86a4-d58594a2dbdb" control-id="si-4.23">
+    <implemented-requirement uuid="33c28549-42b7-4698-af7d-b40674518e04" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="291a8ac5-8226-48e9-a7eb-ed2f2e2f3fbf">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="701a6f66-0582-4fc3-864f-48776158d538">
+      <statement statement-id="si-4.23_stmt" uuid="f4b89be2-1c8e-4cd7-9eb2-276c39d2ea70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="56298acb-1788-4933-a8a7-da0d96406a13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -4514,10 +4514,10 @@ various elements of the OpenShift infrastructure are monitored.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0433a5a-ed27-4c75-9f17-9bca6e911a9f" control-id="si-5">
+    <implemented-requirement uuid="2fd16570-0cfb-4746-8964-2c214f8a6923" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="1fdec571-f8e9-4004-b977-18787dc90674">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="09291620-6a6d-4c0e-8ab1-03ac432eed85">
+      <statement statement-id="si-5_stmt" uuid="21e36570-d66a-4acb-b429-693ab619cbf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5f1b731-a871-4be5-ab5d-32f5dc12d2c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.'
@@ -4525,10 +4525,10 @@ applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f5762d7-3be3-48c5-b72b-b26dfc08b082" control-id="si-6">
+    <implemented-requirement uuid="09ebcd4c-e600-4a27-be86-3bc3ca19d9a0" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="5d24037b-49fb-4e57-84b2-277917f7ce88">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3bd1a4da-b90d-4ebb-a162-340718d528ce">
+      <statement statement-id="si-6_stmt.a" uuid="9f9f4cdb-9814-42eb-951e-ae802d477502">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5de98c5-bc8d-4e49-a6c7-a0c0ec6e77e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -4538,8 +4538,8 @@ for testing the correct operation and resolving any issues found.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="2caa5570-b44c-4be5-80aa-ff888f5615c1">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="b80b4eee-25b3-4a29-954d-74efa6305574">
+      <statement statement-id="si-6_stmt.b" uuid="682f7c94-eeeb-4d66-9387-2fa5d2b4702f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7062c134-d97a-4089-b445-4566ce4f47dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -4550,8 +4550,8 @@ of security function verification.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="fcd36c87-e343-4191-b95e-e41577b78ede">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5608103d-85c4-4973-a41e-6686bf6542fb">
+      <statement statement-id="si-6_stmt.c" uuid="49484c73-0f61-4ba3-996f-99c3f95b1edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99aea6d0-89f2-4318-978d-10b4cd4c47ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -4560,8 +4560,8 @@ system administrators and security personnel as required by FedRAMP).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="8124cfc8-5731-458b-b1b6-7390fd33c916">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="7de871bb-19a1-40eb-b88c-10fd1aa9bd19">
+      <statement statement-id="si-6_stmt.d" uuid="079b2480-3826-4fda-bdc3-514bbbac2736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d710cccc-b0f9-49df-8ac8-7a3fefa99a5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -4573,10 +4573,10 @@ actions.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a300260-1c6a-476b-a648-8377d6798ad9" control-id="si-7">
+    <implemented-requirement uuid="31231978-1139-4dad-9bbf-07a6ce92ed0f" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="5e1e27e6-4514-4107-8f68-f3158d0ce601">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="c3c3e14d-5164-4135-ae42-47a2378eb7b7">
+      <statement statement-id="si-7_stmt" uuid="af4c246b-3dea-4eb4-b12c-cd205a006755">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="526bb75a-1ee8-4aa5-82a6-eb372d5f335f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -4586,10 +4586,10 @@ the integrity-checking mechanisms these tools employ.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ff369a9-0a4b-4e7c-898a-64021d571903" control-id="si-7.1">
+    <implemented-requirement uuid="e158fe68-a21e-4e68-9259-38cce9525912" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="a4fae34f-dfe3-44b9-95a2-567420283db5">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="d099d517-760b-4ca1-ba95-96dafe11f1b5">
+      <statement statement-id="si-7.1_stmt" uuid="2ea053d9-f748-4174-bc59-e02ad01501a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48215e55-046d-404f-b076-dc7e726ecab6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -4601,10 +4601,10 @@ for selecting those criteria.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5429953-2cac-44b9-9c6c-7320b38704cb" control-id="si-7.7">
+    <implemented-requirement uuid="dea939b7-9c10-46bd-b840-3ea8ff8dc36d" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="28516179-3e02-4045-84b3-3ce2a45bc1fe">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="07cfa8aa-2290-4d04-95f1-bedf17262475">
+      <statement statement-id="si-7.7_stmt" uuid="0704b7a3-aac1-4815-82b3-933f7128bef5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79ba709b-7d3e-4f22-99a2-9c69bb10afbb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -4616,18 +4616,18 @@ capability is invoked when needed.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b4d576c-5ed5-48fa-a238-fee78c8e993c" control-id="si-8">
+    <implemented-requirement uuid="a40414d4-81a5-443d-9225-15a536a6574c" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="8de76373-50dc-4246-ac0c-6a055ef1735f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="5b2071c0-2d0c-4b04-89c4-68fd7245b87d">
+      <statement statement-id="si-8_stmt.a" uuid="88fee8fa-447e-439b-8c26-486a649ce9f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="7b71f873-46f9-47e0-9f77-414e7a811149">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="8f861374-0ed0-4bad-abac-c42ae4d699a6">
+      <statement statement-id="si-8_stmt.b" uuid="fefd44a3-1622-4e1a-9713-2f3363ff0502">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4635,10 +4635,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7835f6c0-3bbe-4902-a5e0-99b98ad4ce75" control-id="si-8.1">
+    <implemented-requirement uuid="3612cdf8-22b7-448a-ac06-e1de0743fdaf" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="504931f1-437b-49ed-8328-0beed3db061f">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="15813ff3-1e76-4bdd-b37b-59124b790181">
+      <statement statement-id="si-8.1_stmt" uuid="723b5cd5-ee8b-4d82-b30b-3e19cba30e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4646,10 +4646,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0897c75-a414-40ee-8fe6-dd9a42b99844" control-id="si-8.2">
+    <implemented-requirement uuid="95a31156-d8ff-4c33-9205-548a95c14f9a" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="1ddf0ade-dee0-45d8-9cb5-3215787687e9">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="0b447d8b-91c5-42e6-b4dd-2873b9da6f7a">
+      <statement statement-id="si-8.2_stmt" uuid="57cd2400-1e11-428f-815b-d7dedcaece48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4622a66d-f185-452e-b5e8-4c02cd2f12c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.'
@@ -4657,10 +4657,10 @@ are not applicable to the configuration of OpenShift.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b789af0-c770-4b6d-88b6-68817d70fedb" control-id="si-10">
+    <implemented-requirement uuid="ae9dd3f8-7cd2-455a-a57e-f2459f1c2f79" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="fc29f27a-b379-499c-b89c-e965a7551013">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="823d53e7-47b6-40f8-aded-6abd5875ae6b">
+      <statement statement-id="si-10_stmt" uuid="79d9a7ec-bd65-4269-aa02-ef39d9bd6c69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ad60ae-977a-489e-bb5e-4ce317aee27d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -4672,10 +4672,10 @@ taken by the system to invalid inputs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6eb7f037-9dd1-49f4-acd7-e8d0a941e6cb" control-id="si-11">
+    <implemented-requirement uuid="81b6555d-b189-4501-897e-b9c7c701241b" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="fde55369-9cc3-4ad1-97d3-a159a6ce3a20">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="3d63db78-aa93-4a19-9f49-9f2ed612e3a0">
+      <statement statement-id="si-11_stmt.a" uuid="4cc8c111-af1c-45f1-a298-f78ef7ce09a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdb9ff34-317f-4d79-8e38-2dbe2dd33022">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -4686,8 +4686,8 @@ messages are created, analyzed, and corrected when necessary.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="b77294ee-cb79-41a5-b1ac-c5d1069cde15">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="4b3ecbe0-eb49-463b-87dc-82a0354994cb">
+      <statement statement-id="si-11_stmt.b" uuid="e97305e4-bcf5-42c1-85a0-577fe12ca489">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b44b58a-2baf-478a-aaf7-ee2501a05615">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -4697,10 +4697,10 @@ to error messages is controlled.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c81d30b3-1be3-40a7-a0cd-2e93a5e09f78" control-id="si-12">
+    <implemented-requirement uuid="06214fcb-4a37-4659-be34-919e761ed58f" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="d302a60f-deda-4893-ae24-5ac7e37b88f6">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="64f02eb7-5858-4150-9148-d33b1d3ad8e8">
+      <statement statement-id="si-12_stmt" uuid="a54c2fc4-ed14-4568-988f-77430a6cbdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="703257cf-df00-492b-900f-ddaddf2efa2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -4720,10 +4720,10 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=3&amp;pro
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a31f4a4f-a772-45c5-b351-2c8e7f763331" control-id="si-16">
+    <implemented-requirement uuid="ea08db6a-8104-4ede-b641-fcd2b014ff1a" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="1675ce15-7fcc-4425-b069-85cccb83b806">
-        <by-component component-uuid="36b521cd-e613-4f95-be87-6a8a24c24655" uuid="02ec573b-870f-436d-87d7-fae3a66b7a8b">
+      <statement statement-id="si-16_stmt" uuid="dcd7a2a8-e255-4157-90e8-2f52131197c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80f11f03-6cc3-48b9-9807-d8b86e5c0b07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-container-platform-4-fedramp-High.xml
+++ b/xml/openshift-container-platform-4-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="f538cd6b-7e02-4207-97e2-551d6962e327">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="db231842-e6de-4c30-8a26-5b0c36eaaded">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.89+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.50+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="c37f9266-2b91-4115-a189-c79dd0229d80">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="bcf22859-b1e5-41d1-8fee-081044584e96" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="a2c60645-a7a0-4ea7-adbf-26d65d9356d4" control-id="ac-1">
+    <implemented-requirement uuid="e0198023-c291-420f-9859-85e195c4faa9" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="e62d7127-77a9-47a3-af9a-cadeacb7b046">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8c0402c2-6586-4972-b68b-89fca89d9e6c">
+      <statement statement-id="ac-1_stmt.a" uuid="2971b853-d916-4401-8ca5-c8fa0924d237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd3fa9f6-4df1-44c0-b3fa-59a4ce506b87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="3d2e7c6c-1167-4ee7-a120-e85c77f685f4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="15836424-1f26-4c5f-b395-22c5c067d2aa">
+      <statement statement-id="ac-1_stmt.b" uuid="ed757c19-aed5-476e-842a-a09178430b8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b47f666e-0fe4-4bf8-808a-5666b837c0d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6eb455d6-9444-4832-8853-e6b62cf88509" control-id="ac-2">
+    <implemented-requirement uuid="2c5581cf-ef35-49a4-9a0a-9debda8e77d1" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="28c57b28-ed24-4416-98e7-26347e28b3db">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="15794733-8889-4615-ae48-c292e6b4ac8d">
+      <statement statement-id="ac-2_stmt.a" uuid="fdc1d0c5-014f-4605-ab9e-babf06ad410a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ad7a627-339a-44a7-a584-ee8b8d28daf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="8a68edda-f7a6-4c2b-8918-7316550daaa3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8038cfdb-108b-433c-b262-3fcb18158ee2">
+      <statement statement-id="ac-2_stmt.b" uuid="3bab5523-04da-4a6f-a9a9-df415bf5d095">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61f14919-d2bc-431e-82da-3134faaa614b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="6ec3fc1e-a7be-4ab2-8b44-21cb577eff70">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3cc62d56-479a-48b5-9684-2e28da0133ad">
+      <statement statement-id="ac-2_stmt.c" uuid="893b989d-5db1-4129-8350-081bed59bba2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4956345-f525-4925-bf7b-4908b5097170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="6355b7ad-644f-4b15-b358-de09abd18616">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5022843a-e69d-4c09-a558-075eb05426bf">
+      <statement statement-id="ac-2_stmt.d" uuid="4c9b242e-3572-40d2-9a44-0b1219ea99e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3850f91d-0960-42bf-9630-d79d395190f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="86f11bdc-9222-49e0-b679-645d998f8f44">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e90480b8-000d-4581-bd89-f120bf1acb1c">
+      <statement statement-id="ac-2_stmt.e" uuid="969844e3-6d0f-49f6-98c1-391254329da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07456e22-883f-406c-84f4-b2f5e919cf08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="7399a395-6074-4865-9f13-bdd1e2c90d69">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f6ec5762-792c-4715-937c-b330a53d3404">
+      <statement statement-id="ac-2_stmt.f" uuid="832a1208-b86c-45e9-9f3f-b9bd4af97c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e347cefd-92b9-4f50-8968-cff93aaa856d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="7d439df7-08fd-4b10-aec7-acb74854d23d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ec7ce1b0-f17f-40c9-bd36-86de95b36134">
+      <statement statement-id="ac-2_stmt.g" uuid="e80a0cfa-b390-46b1-b9cb-8ea18cbc29fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31bfd818-2e8b-4eed-83b3-cd0eea10bfe8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="2ecd75d3-1afe-43f5-af8b-6ad897406850">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="488e3724-2508-4db5-82ff-195d8a2573b5">
+      <statement statement-id="ac-2_stmt.h" uuid="309b0bbd-c4aa-49a7-8bf4-1e6be2c3cfda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e691baac-1b31-4922-9a1b-6c3f31555beb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="89c8fccd-f604-4bd6-a485-7c78da87fa6a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ae10ddfc-ad11-44a6-9e8a-7536931620b8">
+      <statement statement-id="ac-2_stmt.i" uuid="f7ea5464-e9d0-4cfa-9fe0-56c99573928c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4190dc05-462b-44fd-a76e-9a018866b323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="e5204b0a-aadd-47ac-82a8-156d3e426785">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fd6791e1-51a7-4ac6-b4fb-84c0339e1ded">
+      <statement statement-id="ac-2_stmt.j" uuid="8bb6d26d-039f-4fe5-96e2-7fdce209c1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8ee0649-d86f-421d-a490-1e5d81031674">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="32f5b31d-166d-4c56-8d2b-10575a7209ff">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dfdb4538-e63d-4aa3-9a31-67c6ff13ed9f">
+      <statement statement-id="ac-2_stmt.k" uuid="23489861-614e-405e-b5c2-17662d7768c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e35086b3-4628-4ffd-9fb4-439a4ba21532">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b239ddc6-0ab6-4832-bba1-e04dc820b015" control-id="ac-2.1">
+    <implemented-requirement uuid="71608a8a-d089-4954-b51b-2221f505ec2c" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="a5dfc4d9-c817-4a75-8c11-0d3cecdeef38">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5695054d-327d-4fe1-a087-5b89ce5f78db">
+      <statement statement-id="ac-2.1_stmt" uuid="d810afaf-6285-4d35-b93b-dfaaee5a334a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1564796-d940-43cf-a045-b462f51cee98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift components of the system support automated
 management through monitoring of accounts and system
@@ -601,10 +601,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20ad5d5b-9ca9-4444-bb58-5ee7480c6b20" control-id="ac-2.2">
+    <implemented-requirement uuid="15663a5f-9548-43f5-90fa-9a9ee651356c" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="86f66319-1115-4eb9-98c7-b9f570412909">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5b3e7dc8-81df-4a3c-84ab-1b4d57842edc">
+      <statement statement-id="ac-2.2_stmt" uuid="eb582557-e0f9-48af-9d91-00a0842824b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91d5bc1e-6bdc-4f6d-9322-c41a68573f5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the capability to create
 guest/anonymous accounts or temporary accounts. Any
@@ -616,10 +616,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e68a7260-8fec-40e2-b91d-059c381b0982" control-id="ac-2.3">
+    <implemented-requirement uuid="e20a5a38-dec4-4fec-b76f-cf4e06a8ba5f" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="d7796382-a098-40d0-a4ed-d1df35b49a1e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="92351f78-0cc1-45b2-ad04-94dab2b64070">
+      <statement statement-id="ac-2.3_stmt" uuid="721acfa4-a4e8-4359-8975-ef95f0549b8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81b3fad1-f504-4d3a-9cf6-a871edafda17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the ability to automatically
 disable user accounts. Automatic disabling of these
@@ -631,10 +631,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="627c2e58-5789-4c86-871e-f4120d4ce142" control-id="ac-2.4">
+    <implemented-requirement uuid="ab1bfdb4-b28e-473f-8f0e-7fca979a658e" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="f1cf8128-785b-476f-8a30-5406e2323445">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="79260fe6-5cd7-4da0-81b3-542994a03c7f">
+      <statement statement-id="ac-2.4_stmt" uuid="ff9934b1-570a-4ace-9514-3a96da164797">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6937e246-fb33-4df9-9dc6-e93b469a1250">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To meet FISMA requirements, OpenShift must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -647,10 +647,10 @@ service.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="112f51e4-9599-4d4d-a23f-720556e1b6ee" control-id="ac-2.5">
+    <implemented-requirement uuid="2e0d4e7a-3946-4faf-bf32-e7b97b978e7b" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="bd0cf7fb-78cb-4dfc-95f2-2fd92efbea20">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d68f7a98-42b4-46c2-ac1d-6403f2c4e730">
+      <statement statement-id="ac-2.5_stmt" uuid="b0d83af7-15be-479a-bf3d-c1ad429b569c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6cd6beeb-9176-4ef1-9609-6a0442dc4046">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2 (5) is planned. Engineering
 progress can be tracked via:
@@ -659,10 +659,10 @@ https://issues.redhat.com/browse/CMP-82</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1259239f-667f-4705-989e-f3623a59f1ea" control-id="ac-2.7">
+    <implemented-requirement uuid="215d4c67-0389-4250-8a9d-94e5768dc97c" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="c92b6718-340a-4c03-ab72-4c9a6659316c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f49e681c-8173-461b-a419-d7f09178f153">
+      <statement statement-id="ac-2.7_stmt.a" uuid="cb087f11-2c7b-4215-9494-6f2d577fbafa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21350fe2-0e01-4b99-894d-c42aa132f9d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -686,35 +686,35 @@ More information for SCC can be viewed at:
 https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="65d058d4-422f-445d-b917-ffa0f255230e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dee41219-4f36-460e-9bc7-0cc983e69a7b">
+      <statement statement-id="ac-2.7_stmt.b" uuid="164abe78-f231-4e48-93d2-89c799431201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d55ad9bb-4055-47a7-bffa-a324310cc8a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="507b4f37-c15e-40c4-8f98-b152e27a1876">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b01e07f2-d348-4c40-a499-c2c2f07b0017">
+      <statement statement-id="ac-2.7_stmt.c" uuid="49cd45ff-f358-431d-81f6-a3a6729aae6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c2073a3-6634-4c7a-be8d-8272d954bdba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63d7228d-2667-48a7-909b-8da8c7d4c3fb" control-id="ac-2.9">
+    <implemented-requirement uuid="2a6b5a09-c3a0-4009-9f0f-edeca0282466" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="539916a1-89e5-4e25-9159-85907abc0cc5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5609d35e-f395-4be8-893d-f21af638c665">
+      <statement statement-id="ac-2.9_stmt" uuid="088f54b2-99bc-4179-b6fb-62a409ca203e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e243f06-367c-4ba3-8ef9-12959c75d0b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd100d5d-5d77-489c-b3e9-804047d8e823" control-id="ac-2.10">
+    <implemented-requirement uuid="75e3c63a-6cb3-440b-8d80-e09bf7200e6a" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="ba59ebd5-c30c-48ce-9d83-b4faa65381f5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="561e2ba3-cbbe-416e-8206-fd82178cd558">
+      <statement statement-id="ac-2.10_stmt" uuid="f39028f7-2123-499f-b93c-893d702db421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49fc7330-de6e-4102-9900-72f2af447fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the concept of group accounts.
 
@@ -724,10 +724,10 @@ of operating the shared identity service and not OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31451702-220f-4248-bab1-b829587fd2fa" control-id="ac-2.11">
+    <implemented-requirement uuid="b38f0f43-bc35-44b4-ae9f-07ea53c08456" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="af4c0a4f-9842-4418-acec-7463bd3c179d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3a93accb-5120-4267-8473-e9d57c5d93a3">
+      <statement statement-id="ac-2.11_stmt" uuid="d85ba742-b7c9-4eeb-bad5-6613996c1b0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ac0abd9-717a-4aea-bd6a-21fa4d54e86e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcement of organization-defined circumstances and/or usage
 conditions is the responsibility of third party identity
@@ -740,10 +740,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1920ae6-3050-4163-939a-3bc7a1a6b8ca" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="663c61ef-9e5c-4496-8928-5d259be77a53">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c276894c-5231-4558-ba4b-9eb075b51a97">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -751,8 +751,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="0a196fd8-e254-4275-8ef3-ec0a057167ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b1d1645f-779e-4483-8bbe-4a00f2f59288">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -761,10 +761,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="233a1061-20d4-4e3f-9eab-684af4273538" control-id="ac-2.13">
+    <implemented-requirement uuid="9acf0cc8-f955-4bdc-b6ba-168f06052b5e" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="c7e7d58f-2ce4-4d9a-8d65-728ddbb71610">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4bc0e2cc-91ed-4ccc-aafb-c3a2c3f72cac">
+      <statement statement-id="ac-2.13_stmt" uuid="f102a128-ddfb-41e6-b2d0-93af2e08babd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74cf5a18-ead4-4dc2-a5ef-b0e174d6435f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(13) is planned. Engineering
 progress can be tracked via:
@@ -773,10 +773,10 @@ https://issues.redhat.com/browse/CMP-211</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="438a376d-de8e-4109-a3b8-935851c6e966" control-id="ac-3">
+    <implemented-requirement uuid="8ed60360-91df-45c9-bae5-82a7bc31a7b3" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="bfa5ca04-fac8-49d6-92fe-b1a99bef39b2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ffb709ba-1dd6-41f7-9fe0-80c836a8744f">
+      <statement statement-id="ac-3_stmt" uuid="f0bb86a5-90e9-402d-b977-53a357f35912">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3144d8bb-1a8d-444d-809e-f38d4290dad3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met through the use of Role-based Access Control
 for an OpenShift user. Namespaces should also be configured to
@@ -784,10 +784,10 @@ sandbox users and resources to only the required projects.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7106d0c4-fb5a-4f2b-8124-0430ce531f7a" control-id="ac-4">
+    <implemented-requirement uuid="52d4a6ad-af88-4e7d-92f8-effe11d5f363" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="b69489a4-ab05-48fd-83ef-8881c90383b5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="adb4630f-039a-43be-b53c-20672f5604b3">
+      <statement statement-id="ac-4_stmt" uuid="d22b8559-ef87-40a0-96c1-9b10c8adb3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6345764-c22c-4e76-b06a-f8c1d20537d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -795,10 +795,10 @@ https://issues.redhat.com/browse/CMP-98</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="031993d9-1d16-40c1-8b65-06ea8bf4d8ee" control-id="ac-4.8">
+    <implemented-requirement uuid="721e36ee-4972-4f66-917a-f0a50e5b2e70" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="608ad4bf-0733-48f8-b5e7-fa13adcca77d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4848b632-d698-4058-a6b5-56c1a15c2ee8">
+      <statement statement-id="ac-4.8_stmt" uuid="8709ed06-0aa5-4116-8e96-797cfaf6a239">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="312139bd-3d1f-41d7-bad3-93d576adf533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -807,10 +807,10 @@ https://issues.redhat.com/browse/CMP-103
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2efb310f-8998-45f0-8fb6-1aee0e0354e7" control-id="ac-4.21">
+    <implemented-requirement uuid="013bf472-055f-4057-a9a7-67e12094efbf" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="52817995-6708-4704-bb16-98fc36d64efb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cf930671-442e-40db-80f9-b966e07f645a">
+      <statement statement-id="ac-4.21_stmt" uuid="726b5013-677d-483e-8063-362924525d43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58c793a2-66e5-488b-bdd8-eb09cd4d03c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -824,10 +824,10 @@ https://issues.redhat.com/browse/CMP-113</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ada232da-2f0a-441e-b140-6ca33d984c59" control-id="ac-5">
+    <implemented-requirement uuid="f2764d74-68e7-4097-9afe-4af33f58ebce" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="7aea685c-8005-467f-8985-522435f6dabe">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="edaf0cdf-b5f9-4c3e-b09f-64d5f3aa90fa">
+      <statement statement-id="ac-5_stmt.a" uuid="4f9794ad-e884-4617-8ae1-a5dbfd8173a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c7839c5-1a22-4bcc-8f60-a3bb9edc75a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of OpenShift configuration.
@@ -840,8 +840,8 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="d3185616-2d9a-4872-87e6-a0c028047548">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="43cf5110-2358-4957-882b-47db39091aae">
+      <statement statement-id="ac-5_stmt.b" uuid="56c7bb04-452f-4526-8868-bddaf9d9072f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffa33246-5de2-4462-b5eb-0e156fa0bc87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of OpenShift
@@ -855,8 +855,8 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="191791c6-2def-47f5-8fbc-f10cba22016e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3975cbe1-cc31-4f86-8364-79fe9b9e7b77">
+      <statement statement-id="ac-5_stmt.c" uuid="a7b31cd4-647b-46a2-97c8-dcd939af4ffc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0bbfdca-fada-4c60-844f-97352e49b8cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -871,10 +871,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3892e14d-5868-4cc1-b2a1-f3ff1c9ef70c" control-id="ac-6">
+    <implemented-requirement uuid="88abbdda-8e98-4645-80b9-5595e5f7d2c3" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="93a54c0b-4fee-48f1-80c2-50a6d607268f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="227d6f51-a756-4720-8549-d0a4a301adc1">
+      <statement statement-id="ac-6_stmt" uuid="2919dd72-8813-440e-95aa-eb4a48e9292a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f513ea4-777c-4021-88e1-d944a78e84d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -883,10 +883,10 @@ https://issues.redhat.com/browse/CMP-115
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d66870af-9fd0-4729-a772-ef0210b26927" control-id="ac-6.1">
+    <implemented-requirement uuid="be17b2e2-832e-40b8-8b3f-ecfca434f4cb" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="9491f903-8d1b-4db3-b0ca-aa83290ac8ae">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4b4171f1-2b1e-4b93-bde6-9ec8dc984827">
+      <statement statement-id="ac-6.1_stmt" uuid="3d1ce575-6e16-4e36-a4ba-c376990f21c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d844c0-1c7c-4fb3-a161-cf80cdee6df3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -895,10 +895,10 @@ https://issues.redhat.com/browse/CMP-219
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbfa8d33-73a2-4df2-9278-dddec40b4a5f" control-id="ac-6.2">
+    <implemented-requirement uuid="2f88947c-672c-42df-9318-6837c2af234b" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="038f0d88-fe6d-40b7-ac13-92b1a3807bd5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a37bdd43-069f-4d77-8a97-377ecbe14f28">
+      <statement statement-id="ac-6.2_stmt" uuid="3c9f06ea-c341-4363-a3b9-10d98fb1db5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2aeeba05-5891-442d-8182-60a5a0389867">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 OpenShift configuration.
@@ -921,10 +921,10 @@ https://issues.redhat.com/browse/CMP-220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fb500f9-c2d2-4510-bc6e-1aed62ab4fb5" control-id="ac-6.3">
+    <implemented-requirement uuid="4100a8f8-1f78-4407-b795-bdf0701c0f12" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="787bba9a-f528-481a-b454-266867e23e44">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="671b26e3-f4e9-4ace-85ef-1a5a13784ed8">
+      <statement statement-id="ac-6.3_stmt" uuid="499aa97e-3b1e-420e-add9-8448f116f6cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818e1642-8cbf-4280-a5ab-8144eebf9490">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -933,10 +933,10 @@ https://issues.redhat.com/browse/CMP-116
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb638bf4-bfb7-41a4-943a-fef2b8615c70" control-id="ac-6.5">
+    <implemented-requirement uuid="e3e3efab-5461-4dd0-8720-65773f2e5379" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="98785f13-14d2-4325-bc83-2c042c4d8414">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="71693bda-4ca6-4792-ad6a-f391f8713618">
+      <statement statement-id="ac-6.5_stmt" uuid="6582b7a1-0f0e-4d84-98f3-ebe259e0b29d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626ddc47-b7c5-417f-9610-19c21a97cfcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -945,10 +945,10 @@ https://issues.redhat.com/browse/CMP-118
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f468050-299e-42b8-8545-0b8fbb71b940" control-id="ac-6.7">
+    <implemented-requirement uuid="2a68cc68-51ca-4be6-8b16-f1502d1cb844" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.7_stmt.a" uuid="e630554c-9ace-4cd8-b0cd-18bd6f1a4f81">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f67b8eea-8abc-48b9-982b-eed128f3e22a">
+      <statement statement-id="ac-6.7_stmt.a" uuid="99469d77-e2ea-4e2d-ac5e-8dbb5dbd9a01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fc363e0-de94-43fd-867c-525b51ed2a6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -956,8 +956,8 @@ https://issues.redhat.com/browse/CMP-120
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-6.7_stmt.b" uuid="401d998a-acb8-4f00-bebd-d09d08c01a93">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4953f9ca-6c16-405b-ae95-e2d871570b73">
+      <statement statement-id="ac-6.7_stmt.b" uuid="a9c46f7c-06d2-48e6-aea5-ec2587b9034d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fc363e0-de94-43fd-867c-525b51ed2a6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -966,10 +966,10 @@ https://issues.redhat.com/browse/CMP-120
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38a6c695-ac28-412b-97b7-dab5bb4a0636" control-id="ac-6.8">
+    <implemented-requirement uuid="4df7c521-e3cd-4eda-bdc8-16124c4e954c" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="08935f83-48ea-4817-87d6-5c809dd395eb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6e864f91-2d3a-4dc4-8a7e-272eae3971ce">
+      <statement statement-id="ac-6.8_stmt" uuid="7e007e2d-0b19-4f3f-8b9a-213513d71f65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e00fda25-a5ed-47ed-8e6f-3a356934e6af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -978,10 +978,10 @@ https://issues.redhat.com/browse/CMP-121
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d34385ff-ae24-4e98-a418-a6f449718d91" control-id="ac-6.9">
+    <implemented-requirement uuid="a46cc993-69c0-40a9-b1c7-3b51a8170ecc" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="3723b71e-b83a-40b2-8c75-8fcd41a91e76">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eb1932a2-c3a0-44f0-b16d-f915f92c0cc9">
+      <statement statement-id="ac-6.9_stmt" uuid="1b950782-4ef9-4f2f-aa12-d01c6885456e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7754724-50c8-4d11-b4a0-d4235cb8ef81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -995,10 +995,10 @@ https://issues.redhat.com/browse/CMP-122
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98d50dee-2c26-4003-b35a-f986cf728043" control-id="ac-6.10">
+    <implemented-requirement uuid="3e6efe21-9357-46fb-9506-c930ed1c9bd1" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="c3847af6-443c-413b-b373-8b7f0a93d89e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6f3b7b5c-9f7a-48f7-b680-3e2a038be733">
+      <statement statement-id="ac-6.10_stmt" uuid="fcec7506-27c3-45a4-abc8-25e198fd2ca7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f817e29-325b-449e-9120-08bf8dc62dca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -1013,10 +1013,10 @@ https://issues.redhat.com/browse/CMP-123
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5ca4ae8-b8b7-46fd-996a-303fe45ea164" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="05698fa3-b3be-46d1-92e3-2abaa608dbdf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="778b9aa8-18c8-49ea-9947-710bdc3c0aa9">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -1027,8 +1027,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="86bfd257-12a4-4693-965c-b02b841b452b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5d8db6dd-454b-4cf5-96f6-5dda5972d7ff">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -1040,10 +1040,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16de0886-2a0a-45e6-aabf-98b683cc4dfc" control-id="ac-7.2">
+    <implemented-requirement uuid="08586364-c958-4a7f-b6f4-ff7fb2d072d1" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="f373b1fb-8d90-4cf0-a2f9-012b5ad62355">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="853905bf-a510-404d-8a02-037db1d1ee78">
+      <statement statement-id="ac-7.2_stmt" uuid="40df52ad-3607-4303-aba2-b61267d9b288">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="822771c4-a630-4c20-9407-2569b57309a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Management of mobile devices is outside the scope
 of OpenShift configuration.
@@ -1051,10 +1051,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d1ea174-779f-4741-b140-a812e88939a9" control-id="ac-8">
+    <implemented-requirement uuid="1871ab2d-f550-4a44-abf0-755904c32987" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="64126eb4-d445-413a-b742-5e01ec25bc27">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b5b69f5f-1199-4057-ab47-cecf9ce8f7eb">
+      <statement statement-id="ac-8_stmt.a" uuid="81fee283-7ebc-4201-8c6f-6c842d1258ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbaba125-1dff-4fe4-a089-3bbbfa1485ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -1074,8 +1074,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="48272ef5-9aa2-46ef-81b6-3c735110bf06">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3b2991d0-e1d4-472b-8bee-516a3647a592">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -1090,8 +1090,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="3970b475-cedc-4153-a6f1-4bdc179ea4db">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="01f28dc6-8630-4360-b58c-baef285e88fc">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1109,8 +1109,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="d28f56db-0f82-4c09-b4b6-89a66efae653">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7c7481a8-47f7-46f4-b8f3-ea8497eb2d42">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1123,8 +1123,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="edd962c0-e9db-48d2-97d9-8e66a7d1c238">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b2fd604f-9d37-4975-8468-9000018f62d1">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1138,8 +1138,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="b912ea2f-31da-42ce-981e-f2e885c0711e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bd5b22b6-dc37-4389-930b-743ae863b3e7">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1155,10 +1155,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02f726b5-ddab-41f5-b2e8-e8c40f68831c" control-id="ac-10">
+    <implemented-requirement uuid="317d48f2-c463-4fd9-a033-49c4ef0fa7d0" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="0667443f-9044-4992-89e9-bef78dae015b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="345d8fba-2fdf-48bd-967f-b516052359ad">
+      <statement statement-id="ac-10_stmt" uuid="3f970970-cbef-4fb6-a9b4-26b91e499a28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aed70d9-b8b8-4e83-89c0-337f33551afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1172,10 +1172,10 @@ https://issues.redhat.com/browse/CMP-131
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe1e0d0c-1b80-45d5-a910-1407f9943444" control-id="ac-11">
+    <implemented-requirement uuid="e915b154-d306-4240-b477-551192bcedc5" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="6c52a359-8059-400e-9f65-370c27a0fd8c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fa6bf250-89f4-4397-b60b-e701673d593e">
+      <statement statement-id="ac-11_stmt.a" uuid="ddde43f0-56b3-481b-96dc-95b0befdff3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1183,8 +1183,8 @@ https://issues.redhat.com/browse/CMP-222
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="d6e1e742-cb82-4f69-a7cc-268349990c62">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="442ae1e6-ee53-4951-9cb0-2a9c6f4f5a12">
+      <statement statement-id="ac-11_stmt.b" uuid="9cfa0153-ccc7-4fad-baac-e5e5beee1046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1193,10 +1193,10 @@ https://issues.redhat.com/browse/CMP-222
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d08aa1f-84b3-4140-a665-1e417c236537" control-id="ac-11.1">
+    <implemented-requirement uuid="ab6903c4-8a5b-4507-ad07-184780da55aa" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="8a1180db-a0cd-4ef3-bd28-844d4fecd370">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="78797c83-bfce-49dd-850b-adca91a15cfc">
+      <statement statement-id="ac-11.1_stmt" uuid="e16650c5-8d95-4e15-bc8e-5d3e7457ba56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09896195-8492-4293-a137-628ef9ab4ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1205,10 +1205,10 @@ https://issues.redhat.com/browse/CMP-221
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c196ad4-58a2-448a-b28e-a474918e238d" control-id="ac-12">
+    <implemented-requirement uuid="80d9fe3f-ec91-44e1-8c30-69b9aaf4e472" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="52604199-4c7e-4844-a612-171424eafe4c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c29e9ad7-e56e-4164-a5c1-c85de1521bd1">
+      <statement statement-id="ac-12_stmt" uuid="fc0fc943-da69-4c4e-946a-4d377389240b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="292db0d7-a6a2-4127-a9b1-4efb2359e579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1223,10 +1223,10 @@ https://issues.redhat.com/browse/CMP-132
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a12f891-a876-4e1e-93fc-7f2a77863a95" control-id="ac-12.1">
+    <implemented-requirement uuid="edcfc5d5-054c-4603-ba23-fbb6e12a7953" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="b8566991-023e-4ae4-9cf7-7318b725a415">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9ab3c3e3-90b8-4cb9-ae49-0d972252fb78">
+      <statement statement-id="ac-12.1_stmt.a" uuid="ef94f017-ef31-4e14-8be6-7ddb45ce7650">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea329058-ee40-4d53-9f8c-a69dc05d21d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1234,8 +1234,8 @@ https://issues.redhat.com/browse/CMP-223
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="c754a520-49b2-44c3-b573-ecfe5d6ebeb9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3bfb905d-37cf-4907-8fb8-39c681685e6f">
+      <statement statement-id="ac-12.1_stmt.b" uuid="090cba7d-410b-482a-a704-1618cd44d50a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea329058-ee40-4d53-9f8c-a69dc05d21d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1244,10 +1244,10 @@ https://issues.redhat.com/browse/CMP-223
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2763474-a73a-40f7-be6d-d970ec306ca9" control-id="ac-14">
+    <implemented-requirement uuid="2292ced5-1bda-494f-aa51-ef64228072a5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="f86b12f5-a876-480e-8db9-6a0944e28a54">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5d8dfe19-5a55-4358-9b5b-1c1aef2bdb7f">
+      <statement statement-id="ac-14_stmt" uuid="627160b9-85a7-4e24-9beb-643788ea9fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10130008-0803-4042-898f-872c8464d34f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -1257,18 +1257,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c6cceb5-82a8-4452-a265-892740341bad" control-id="ac-17">
+    <implemented-requirement uuid="5a29a780-d78e-4632-ab61-dc00a1cb0cff" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="e674e4f5-804e-49aa-aa15-e40dd83b11f7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bbe9b2ee-6312-4099-90f4-beb1874fa302">
+      <statement statement-id="ac-17_stmt.a" uuid="f3fdfb30-0212-4348-a5ad-ab13c5acb066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="34b33b6c-6b32-46b3-9594-c3f238034de0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9c8554b9-6bd9-44c0-97dd-fbbd222c407c">
+      <statement statement-id="ac-17_stmt.b" uuid="b2e75aa9-b2f3-4990-a770-899b2be99b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -1276,20 +1276,20 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70efd034-4a0a-4aa0-8695-7a510ff0bd45" control-id="ac-17.1">
+    <implemented-requirement uuid="e8186e42-4077-4a1f-8d78-734534553a2d" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="e0206e80-4f00-46d2-b8e1-8010d464dc0d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a61d27eb-485d-4d52-b169-50eba83c3fb5">
+      <statement statement-id="ac-17.1_stmt" uuid="b27603fc-b7e2-49a2-99f6-2ae0836e0d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32c2c705-2546-4bef-9f35-b858913689b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c241a5a-9e1d-4794-8ffd-4ac7cde50e1d" control-id="ac-17.2">
+    <implemented-requirement uuid="88b90b9a-fb15-4e92-9fc6-1fa52e43892c" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="152c07c7-97f6-485c-9f32-c2558957a005">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="830cf186-f46c-4632-a0bf-673747d11efe">
+      <statement statement-id="ac-17.2_stmt" uuid="f3d9d92e-2e38-4824-be78-32ed9cf94460">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36668d5a-b24d-47f1-9ae3-69c368fbb2c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Beginning with OpenShift 4.3, when OpenShift is deployed on Red Hat Enterprise
 Linux, and FIPS is enabled as a kernel setting, OpenShift will use OpenSSL
@@ -1321,10 +1321,10 @@ https://issues.redhat.com/browse/CMP-144
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2d9a3c6-ec66-463c-a8bd-efd3b8b5721e" control-id="ac-17.3">
+    <implemented-requirement uuid="39d48f16-1d4f-47cd-a477-ddb3574cdf02" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="cd54ed26-ba29-4a32-9f4f-8203e8c9d2fd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1c372104-5d71-4377-bd2d-7877a537e7eb">
+      <statement statement-id="ac-17.3_stmt" uuid="7967ae9c-1cd4-42ae-bdcf-f84c036ae938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09af0121-32d6-4b5b-8587-b4c4adeea806">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1351,10 +1351,10 @@ https://docs.openshift.com/container-platform/latest/networking/routes/route-con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55a509ed-3186-4b70-a48c-7bfb4ecfb342" control-id="ac-17.4">
+    <implemented-requirement uuid="2b7ceece-2a8a-4c2b-8f5a-d14e43c96d30" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="1b40586e-9f3b-49f2-9864-ec5d648dc6e4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4c38cf92-f2f0-4631-92e5-3a98bd7dec30">
+      <statement statement-id="ac-17.4_stmt.a" uuid="2fac32de-656d-4642-bf78-e1cf164fc928">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62f34e74-45a1-484f-8492-9f54561aaef5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to security-relevant
 information via remote access only for organizational defined needs is an
@@ -1362,8 +1362,8 @@ organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="e4100630-54f8-41f9-94fb-24b25db8a213">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b67496b4-2e21-4607-905a-fdfceae891d9">
+      <statement statement-id="ac-17.4_stmt.b" uuid="2a3800a5-ea81-426a-9eed-8686d02c572c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69ea0dae-a55a-45a6-bed8-76192aeac67f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and access to
 security-relevant information via remote access in the security plan for the
@@ -1373,10 +1373,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1da94148-61b8-4be5-8355-1f37ca560972" control-id="ac-17.9">
+    <implemented-requirement uuid="6d39d74d-7cc9-4300-95e0-18776a3bb79a" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="796e6373-c777-45cd-83c6-8be446fd5238">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9da78189-fbdf-4161-9fcd-a23fdd990a24">
+      <statement statement-id="ac-17.9_stmt" uuid="0f860f1f-ebb3-4506-af67-3a93ecc11ef4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7de19c9-673d-4a6d-8e4d-796b592c1787">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift utilizes the firewall technology embedded into Red Hat
 Enterprise Linux. This technology, named firewalld, allows a system
@@ -1395,18 +1395,18 @@ for tenant applications immediately.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7cd83b5-9510-4de1-ab2c-a74ad415bb0a" control-id="ac-18">
+    <implemented-requirement uuid="a137be9b-db9a-4432-b346-697717b883de" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="70e0ad29-78c0-411e-b92e-5154bbfa1515">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f3ca873c-6745-426a-8cf6-41fd589fc95f">
+      <statement statement-id="ac-18_stmt.a" uuid="ce5ee22d-7d86-436c-bed8-98ba87480aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67017357-816e-48d8-ad67-84ca7d5d9d24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="6f5bf2cf-3dc2-42a4-b9c9-0ba1b3c4d5cd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5ee89c28-3f0c-4f5c-bc44-5d45904bcdd1">
+      <statement statement-id="ac-18_stmt.b" uuid="506e53cb-dc82-4df4-8615-623609005745">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e370990-461a-4d3a-a840-d0ca212cde3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of OpenShift configuration.
@@ -1414,10 +1414,10 @@ system are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="415f3b81-48b1-437f-8eb5-4c26e8216079" control-id="ac-18.1">
+    <implemented-requirement uuid="56c8fc13-85fd-4f4b-b7a2-f8823dcbc13a" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="eff33798-16a8-489c-a55f-91a39f82bafd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0369dd34-091d-4b33-bc3c-1ca00d60ead7">
+      <statement statement-id="ac-18.1_stmt" uuid="659e3e0a-5917-4d36-adce-d7fd342315a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1ceb27e-635d-442f-b219-3e1be8d30867">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 OpenShift configuration.
@@ -1425,10 +1425,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93f3ceb9-bc64-4e6c-99bd-3683624e2178" control-id="ac-18.3">
+    <implemented-requirement uuid="51261dbe-afe8-46ca-bf6f-ab1c681b2524" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="3a6f8a09-00dc-421b-a695-e84b25a0e345">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e4caa60a-b56a-4a34-88d7-78c18a19d400">
+      <statement statement-id="ac-18.3_stmt" uuid="ce9621a6-530f-468f-8072-6b7c3ff17079">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc76a2f2-8b79-4470-83f0-d2449fce262e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The configuration of wireless networking is accomplished at the
 OpenShift node / operating system layer and is not applicable to
@@ -1437,10 +1437,10 @@ the OpenShift Kubernetes layer.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddf26c8d-b4dc-4b83-833e-29a83904cfa4" control-id="ac-18.4">
+    <implemented-requirement uuid="bbed9704-30f7-4639-abac-d348cbdbf691" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="d6270640-2703-4d34-a416-a1e7510a3638">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e21fce2a-dd69-4db1-844d-e7bf339be655">
+      <statement statement-id="ac-18.4_stmt" uuid="191b8ab3-eb22-4fdf-a2b4-5083390aa2c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ec82b54-7830-424c-a8a2-f043de69f6f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1449,10 +1449,10 @@ https://issues.redhat.com/browse/CMP-149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d007f859-444c-41bf-8c33-07562195553f" control-id="ac-18.5">
+    <implemented-requirement uuid="fa84436a-a684-451d-b45f-af11df137574" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="12b1af4c-774d-4a9b-99f0-cf144631ea3f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f99611c1-9354-4156-bad3-f51877ad89f9">
+      <statement statement-id="ac-18.5_stmt" uuid="0fc553b9-137b-406e-9750-7ae6c58d1b97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb61e54a-f505-4fef-a1c1-1c2c91b06993">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Radio antenna selection and calibration is outside the scope
 of OpenShift configuration.
@@ -1460,18 +1460,18 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e73cc7d-fd70-4811-b5ab-065d83637429" control-id="ac-19">
+    <implemented-requirement uuid="86ed2bac-7994-444e-aa3b-062de041b71e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="c2968810-7431-417e-a252-f900efbb8501">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b4be14d3-9762-4a80-ab09-ba8a48a0134d">
+      <statement statement-id="ac-19_stmt.a" uuid="179cd8c9-3d7d-4984-b992-f75b748a5622">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1426997b-7d52-4dba-b9d5-84fee93f7d8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="95536433-8ba0-4423-8a5e-0118067981f5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4007f263-d3b9-403d-bf9b-aed14142e3cf">
+      <statement statement-id="ac-19_stmt.b" uuid="58260cd8-1853-4758-8827-2d7b8fe2e9d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="296305da-52b8-4adb-bc00-f2d04345bc9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of OpenShift
 configuration.
@@ -1479,10 +1479,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f83fde36-3954-4efe-9c9e-965ccde6f57b" control-id="ac-19.5">
+    <implemented-requirement uuid="dd752582-728f-4f6c-9caf-fe4bd2fd4422" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="b898cd14-712e-4422-aa80-55346e7a0242">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2abc8baf-79a4-4328-a0e4-05873d3a52aa">
+      <statement statement-id="ac-19.5_stmt" uuid="4f1455e4-2691-4587-bc33-3cc15fbf181c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4549175-08d5-4dce-9837-a98c69cb0694">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of OpenShift configuration.
@@ -1490,10 +1490,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98c90fcf-95ce-42e0-9379-138fb835c4fc" control-id="ac-20">
+    <implemented-requirement uuid="0794e2f3-0316-4600-987b-57769e6091d3" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="9bfa7d31-9c81-4617-bb26-28791c650081">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="52c9c7b9-3a9b-4bff-a01b-89d91b5b8831">
+      <statement statement-id="ac-20_stmt.a" uuid="c3ceb797-40c9-4c32-88da-bc2c3d02557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e2635d7-0d90-45f7-ab07-a72f837f9950">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1501,8 +1501,8 @@ systems is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="0ad8bb63-7326-4d87-b5e8-7f1dce525bd3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="855c59fb-a10b-4735-8fc1-5f99ce4fe941">
+      <statement statement-id="ac-20_stmt.b" uuid="0de55e9f-7322-4e3e-8934-b0ba825f62a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5372dc5-f754-4f92-85af-1a52d9aa9a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1512,18 +1512,18 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48347ff0-c826-4802-8c55-1cefa464d603" control-id="ac-20.1">
+    <implemented-requirement uuid="a02d662d-2d0d-413f-a040-1a2400dc933c" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="eefc8928-ae43-456e-8371-b78c1a0ca422">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="64c7d780-af27-4c6c-9a0a-927b6072df27">
+      <statement statement-id="ac-20.1_stmt.a" uuid="3b390916-7af6-4ede-9787-392e09e4cf1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86d7739f-3888-4a20-8cd9-c17683414ca5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="fedd39e7-17e5-4b44-b102-42bb0dbb3975">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="146446d2-9d0e-4375-8991-528bb032e16e">
+      <statement statement-id="ac-20.1_stmt.b" uuid="cffcb9b7-ad0a-43d7-94ad-3aebe0650ed0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d21ed88-81a8-4e27-9806-4dbce94289f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1532,10 +1532,10 @@ information system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="731f04da-80a3-4149-9ff6-7587c9f769c5" control-id="ac-20.2">
+    <implemented-requirement uuid="738af087-76f9-4aa8-ab3f-a1bb09c19568" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="da425cbb-8cdf-4ea9-9651-e53064fac4bc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="adb46d06-aaa9-4a9c-9020-3886073c60e2">
+      <statement statement-id="ac-20.2_stmt" uuid="8d0ca122-e016-4d26-8c98-dc10bdc3af88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16969b66-25bf-4ef0-8fcb-f65b8f820f02">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1545,18 +1545,18 @@ systems is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a91f530-959a-4f2c-8ff9-1ba6f99b86d1" control-id="ac-21">
+    <implemented-requirement uuid="61a0e15e-4c16-43aa-a234-4d335e4ce619" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="4b710919-766b-4617-8292-be542de294f1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0cfd20a2-1d80-480f-9849-d44d77cb6493">
+      <statement statement-id="ac-21_stmt.a" uuid="7e54743e-5a48-414c-9276-b5c5d341b28d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bf8c9ef-3cdd-41ba-93a1-5cceb69f17d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="e2a8b2a6-ca57-4e6a-8186-803d27d49cc1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c1ec4631-5270-4c4e-9635-d17ccc2ce734">
+      <statement statement-id="ac-21_stmt.b" uuid="ebdf4603-5832-43c0-a84e-a8da8858ddef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5635039-936c-456c-8f6d-5f3b83b3cadf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1565,10 +1565,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad02f3c8-32e1-4e8e-baff-57ada796d5c3" control-id="ac-22">
+    <implemented-requirement uuid="f6ef3a84-58d8-4513-aad4-89f3f6a90990" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="0d4af3d7-31a9-4a24-a6bd-8d13e2e4f238">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a7def9e3-2d21-4dea-8382-5857d619e10c">
+      <statement statement-id="ac-22_stmt.a" uuid="c7e11f37-7e67-4880-bc3a-b57dba50840b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="376f4ff8-c17d-40df-9517-a104d6234154">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1576,8 +1576,8 @@ system is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="94e4de3a-4f4b-484b-b519-a888c88562f9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="34b25788-1c21-4b0f-b2c3-d0f0dab9c929">
+      <statement statement-id="ac-22_stmt.b" uuid="3fefacff-d1d5-45e2-91a1-3bcec05feab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec07b4f-b422-4324-8342-a8a0a2d4082e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1585,8 +1585,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="83bd8b14-6d9d-45ba-b7ee-598f3dd595b9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d788c043-a21a-4ffe-8592-2eefe673ef99">
+      <statement statement-id="ac-22_stmt.c" uuid="74b40455-dd6b-4af8-a62f-6be80b7b921f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2009a919-1675-4f79-9e2b-92ef86ab360d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1595,8 +1595,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="4cf596a8-c2ed-4285-8f3d-65a24498ff95">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c1f9cafd-291c-4ec8-96b6-75d6c109dc5f">
+      <statement statement-id="ac-22_stmt.d" uuid="78333f22-f26a-43d3-84ef-4fd62a7fc128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="179f843f-79fd-4d99-91e7-a6276487bab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1606,18 +1606,18 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33d3259f-f313-4db2-b5de-355d937cd36a" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="d32d9258-5d22-4f43-88ea-9c213d03641e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c3691176-4308-44b8-83e2-d6519228783b">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="1418de77-367c-46db-ba81-84e54b9c67a8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7041a7a8-029e-443b-9789-546a4534edf4">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1625,26 +1625,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35a2c0e6-e57f-4b90-b5f3-eabca665a1cb" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="f79b2d84-41be-443f-b0f4-6d9b063f6686">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="046c4e1c-d4b0-4dfe-93a9-c4459e723e1d">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="97080273-8db1-4351-957f-9c31e2cb7f4a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="07e12d9f-7570-4e66-bcce-c24f9ba92f9c">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="47046c4a-054e-4c8c-ba78-c5679560069b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c901a3ec-54f7-4e58-9b73-f1c29405a03d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1652,10 +1652,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be9e94f0-35e2-4ab3-9eca-650e90e7dbad" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="98bc922b-cff1-4218-a858-7bb77fdbdf32">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cd48f937-7d07-4696-ab2d-cd79d9651347">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1663,26 +1663,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4088e110-b469-48bc-ac7e-188c30241e9f" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="ef11b366-1e73-4f9a-85b0-f606b60e97d1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3abcdae7-2f08-48ef-8db1-a13ff944fe36">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="70b4cd6f-b7de-4c5f-943d-36919a89309b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7787792b-6875-46a7-b866-127aa4c4bc35">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="db4be22e-31a3-4724-9236-9dedde92b7d7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="06584385-bd5d-459f-b8ca-7859ee5ce2a8">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1690,10 +1690,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5979caa-3716-4c74-87fd-6f1ccf852d5c" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="94a24bfe-2f57-4229-982c-f80aa934da8c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="83174d12-d402-4433-973b-2c578cd56bca">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1701,10 +1701,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f925b06a-267f-4fbb-a98c-66f8efc7eefc" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="6c924ae8-972d-47a6-9ef4-b54f420d6bca">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a70f0dd0-c298-4879-956d-e1742996026b">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1712,18 +1712,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89151902-bd37-48bd-b69e-0ca03af343e4" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="50bb1a01-049b-4d24-8388-4e5c90dac8b6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b72f9f48-026e-4594-97c5-6f3814c40a7e">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="85bae29b-dabf-46a6-8105-d13d2cb8645e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="29899bbd-ca68-4b5a-927e-d9660dd1459c">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1731,18 +1731,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e88981f-3383-4b92-8b73-d18cb6f8bd62" control-id="au-1">
+    <implemented-requirement uuid="ef0a9955-e6e6-400a-b0c2-4c90a3572de1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="7b288725-754a-4990-a770-e332ae30ffb4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c61aa842-ebb9-4ab0-978d-d1f1ab6b0f78">
+      <statement statement-id="au-1_stmt.a" uuid="a62838df-3f8d-4562-bab9-7c3fb3901ef9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f02538f5-6b4b-47ad-be64-68cde7e322b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="df52b2c3-064b-4a84-ab0a-2ba4db8537ad">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="69acdfdb-29d2-4dad-b22e-936e383d18c3">
+      <statement statement-id="au-1_stmt.b" uuid="1a981643-a22c-4097-907f-183a4a6c69ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="896963fb-9a31-41f0-b128-3d133586df01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of OpenShift
@@ -1751,10 +1751,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2fbda21-44f0-443b-b6bf-b8ab3a82dcdf" control-id="au-2">
+    <implemented-requirement uuid="7be12d88-184e-400b-9fa3-52fd68eacaca" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="8053d733-c430-4372-8213-50b55e1f4956">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d8080957-da9a-440b-a887-8a959d4ac94e">
+      <statement statement-id="au-2_stmt.a" uuid="4d421c20-31f0-4ce1-ac50-b99c88342ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1762,8 +1762,8 @@ https://issues.redhat.com/browse/CMP-155
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="8c503fe5-b21a-405e-a8b9-b9f223bd338b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d40ec509-0880-45e0-aace-b466f9fcc307">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1771,8 +1771,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="32cacc0c-f412-4871-8176-c2f901b51c9e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8b61f255-6520-4a24-9239-d14d9bd71e1f">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1781,8 +1781,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="d156b9c4-0429-4c03-bf84-f2ad904b49d9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d5521ce9-f2c9-40ab-ae6d-7df64c3b616d">
+      <statement statement-id="au-2_stmt.d" uuid="5888b387-1140-4214-85f2-a70baffb4734">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1791,10 +1791,10 @@ https://issues.redhat.com/browse/CMP-155
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99334c24-f2ed-43bd-b97d-f29913ff85cd" control-id="au-2.3">
+    <implemented-requirement uuid="a8714d40-4409-4029-970f-b6db4119d80d" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="a1fff5bb-8b9a-4db2-95ae-3ebd493f4647">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="98797aa3-07e6-4594-8fe8-cc840a223173">
+      <statement statement-id="au-2.3_stmt" uuid="4c57f753-4a67-4f30-8406-64b13510536f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe2ca5ac-2ed2-4808-817a-dc1fb2d7cdc7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of OpenShift configuration.
@@ -1802,10 +1802,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4b1b47e-8055-485d-83a7-a9fc4fe65a6f" control-id="au-3">
+    <implemented-requirement uuid="a8aa07c1-977c-4acf-ab95-7b1304cd50db" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3_stmt" uuid="040f8969-5e85-438b-bac3-522f5a7d3114">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="12b338f2-260e-4d28-88d9-4bfdcc5ad0b5">
+      <statement statement-id="au-3_stmt" uuid="c9bdcd27-57a5-4c8d-9187-b9b44e8aedd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86a2f7e-3776-48bf-b89d-a341ef18bb87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1814,10 +1814,10 @@ https://issues.redhat.com/browse/CMP-156
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="666ab419-247a-46fe-aba2-f2c9be15a0ea" control-id="au-3.1">
+    <implemented-requirement uuid="c1e0e21f-dcd1-496e-8035-c390c79d8ee5" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="fb891259-d27d-4b4c-a49d-f4c10c3de90c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9cf82daa-3430-43f3-9503-c101944f88dd">
+      <statement statement-id="au-3.1_stmt" uuid="75fb7866-11a8-41b8-bad1-b9155c8ffcc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dc50397-62c3-4794-9b21-da85086bc5ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1826,10 +1826,10 @@ https://issues.redhat.com/browse/CMP-157
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="beeecdee-5533-4e88-a0a8-2a014f71039f" control-id="au-3.2">
+    <implemented-requirement uuid="25e3d638-55ab-41e3-8419-8af242870322" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="3dd44a96-96a1-4862-a614-ac5092490ce7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="97b05471-e493-4fd2-8adf-63dac6adb68d">
+      <statement statement-id="au-3.2_stmt" uuid="e2d7f1db-1330-40eb-92f5-7d3684aaea29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac67f87f-a691-499e-b0cb-ca3480061d70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1838,10 +1838,10 @@ https://issues.redhat.com/browse/CMP-158
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53c5d989-9c2b-49a6-ad8f-5401fe452cec" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="ab246993-ba0d-498d-b37f-73e991c39660">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3d84dcf7-ef64-43f5-9792-70abff3ec1be">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1850,10 +1850,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20fda11a-c01a-4a90-88d6-6c7d82a5bc1d" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="e32deb58-2e94-4147-82c9-9ff1ac31dfd4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="da2054d5-07ce-4cda-bf03-f6da51ede8e0">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1861,8 +1861,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="2482c434-52b6-464e-a826-53d2a2456729">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d54e0b67-8d96-419b-8458-654d5950564e">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1871,10 +1871,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90d7de02-9cb1-4bcc-8161-8beb6830c44b" control-id="au-5.1">
+    <implemented-requirement uuid="2e89a770-e938-4cf3-9f8a-7420bd9fa4e9" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="5353d3bd-eab2-4c34-9899-effccd007f9d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a1ed513-e587-4e05-859e-3e00b027d69b">
+      <statement statement-id="au-5.1_stmt" uuid="dcd1a857-b0c8-4703-b66c-adf58cdea558">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6af428a-7963-4178-9852-66a5bd50c9fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1883,10 +1883,10 @@ https://issues.redhat.com/browse/CMP-162
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53e2ac3e-c28e-478f-b1e4-0d653c537cb4" control-id="au-5.2">
+    <implemented-requirement uuid="6a79d009-e381-4bbb-8e52-8060b292bd61" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="5a9046ff-8db6-4d4b-a0fb-95cfdb10723f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2ae717c4-8e25-4031-9961-3cbdc28f09a9">
+      <statement statement-id="au-5.2_stmt" uuid="d7d48242-d792-4c50-84cd-19e48829b55c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="274573cc-54ec-4bf5-8e71-e5eea86312eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1895,10 +1895,10 @@ https://issues.redhat.com/browse/CMP-163
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4097de46-f4f4-470a-920f-3c92b295e1a1" control-id="au-6">
+    <implemented-requirement uuid="b8f5d492-d89a-47a8-8100-8d3467acfd32" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="0bfde0c2-3511-48d7-a8be-286acb322424">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ec707169-410b-4a38-ae20-3519c3494cb5">
+      <statement statement-id="au-6_stmt.a" uuid="08063edb-8d74-4477-818b-b829fbd5dbd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a88cb0f4-5871-49b9-9199-2ed0b21e10cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1907,8 +1907,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="e3fb96af-655e-4132-83e6-36d58c4439e5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0dcd4931-6f66-4ba5-bc59-e42f89eb613f">
+      <statement statement-id="au-6_stmt.b" uuid="1a73feb9-9aa3-4bbc-b713-e4094e86ea4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eca14996-d7f3-4ce1-bdf3-addb2bb13ac1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1917,10 +1917,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8014320f-622c-4d74-bef1-35490721f8bf" control-id="au-6.1">
+    <implemented-requirement uuid="8f3651de-9640-4a2c-85b7-11ac36329a38" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="427c7ecd-9eb6-4276-9972-c6168ffadbc6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="437a7b04-f7c6-49d4-a0d9-31e7b7bb05e9">
+      <statement statement-id="au-6.1_stmt" uuid="17f07aaa-cd19-4907-b660-672d4014657e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0829c1f9-bba9-4e1c-a268-31bdcebefe36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 https://issues.redhat.com/browse/CMP-167
@@ -1928,10 +1928,10 @@ https://issues.redhat.com/browse/CMP-167
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb074d88-c824-4da8-aaa0-9173a9083d62" control-id="au-6.3">
+    <implemented-requirement uuid="bf22437c-7619-499e-9d5c-94a487cb035a" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="7e16ab5a-11e3-4b87-b04e-0031ab8be2e3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="abbff0f5-57c5-4b9a-8f73-2c7f6206f5b4">
+      <statement statement-id="au-6.3_stmt" uuid="e0ef9471-ce63-420e-ad27-c678b3f9f0ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eaa9b62c-fbb9-4a23-ba48-c729771c4471">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1952,10 +1952,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17b91361-220d-4fb5-9beb-c7dcdc3564c6" control-id="au-6.4">
+    <implemented-requirement uuid="b52803c4-028e-4068-905a-fcbb50e6f55c" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="ea23bd88-17b9-4d21-9769-6859c71371d0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0e80ebfd-f5fd-42a0-b040-f36d68aa0f4d">
+      <statement statement-id="au-6.4_stmt" uuid="bb7cef9a-0dd3-4c4a-b38b-5029e4c7af88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="959f02a7-a674-4051-b750-416dfa4607c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to centrally review and analyze
 audit records from multiple components within the system
@@ -1972,10 +1972,10 @@ applicable.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="124b2f80-3196-4582-9536-85fe73b77e01" control-id="au-6.5">
+    <implemented-requirement uuid="d0a3f259-d28e-4cce-8b40-0233e64539fe" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="fb185d9a-273a-4bba-adeb-73bdda0a10e1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2e5a6feb-a4a4-4f91-8550-0227552c9350">
+      <statement statement-id="au-6.5_stmt" uuid="b475dfcb-e949-469b-95ce-d1315af1765a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f43d4e88-eb5e-4bdf-a18a-5c248bd14e7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to integrate analysis or audit
 records with analysis of additional organization-defined
@@ -1998,10 +1998,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8c23974-f9fe-41eb-b7c0-6ec8b62c99ea" control-id="au-6.6">
+    <implemented-requirement uuid="f2aec883-8a98-41da-a6a1-c01dd804bebd" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="ebc45345-524f-4aeb-9b05-a4298726a93e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a79473c0-7c22-4522-b0a0-d5104c766f17">
+      <statement statement-id="au-6.6_stmt" uuid="8593dfda-cc51-4d93-922e-4decd352f600">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3618fd5-f43b-46d4-9e14-d68724a155c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to correlate information from
 OpenShift audit records with information obtained from monitoring
@@ -2024,10 +2024,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85ec072e-a1e7-47f5-9acf-ae407794a2b5" control-id="au-6.7">
+    <implemented-requirement uuid="9c616f83-3475-42b2-9707-d6cf49a91080" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="a0604026-ea8d-4b15-a26d-870e64281a41">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9e0121d1-d2de-497e-8d6f-ed33a1ebe760">
+      <statement statement-id="au-6.7_stmt" uuid="e7525856-b34c-4320-a781-5fb698637fb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4942b253-2a47-4d9a-bf1a-c4cd6119a318">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational specification of permitted actions for
 information system processes, roles, and/or users, associated
@@ -2037,10 +2037,10 @@ information is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60d32538-2658-408f-adcd-7b3224b50c61" control-id="au-6.10">
+    <implemented-requirement uuid="743865b5-06d7-49e6-add4-0a0c83e3ee63" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="883d83a9-32d9-42b3-9397-3472f89c6323">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d40420b7-96c8-4c8b-967a-50e1952060b3">
+      <statement statement-id="au-6.10_stmt" uuid="9d89d27a-fd63-478a-a2dd-f71077d08076">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa6e06a-44ce-4cc7-83e1-94a7c7ba93dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational adjustment of the level of audit review, analysis, and
 reporting within the information system when there is a change in risk
@@ -2051,10 +2051,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81bf7d40-93ec-426d-8112-ae0513613197" control-id="au-7">
+    <implemented-requirement uuid="06a7191c-ddff-46e4-ab94-e82663e33249" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="f73a8b54-6cb3-40bb-a8cf-7696102f8d45">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="96994460-97ca-4d55-874c-a8d6ac39e35f">
+      <statement statement-id="au-7_stmt.a" uuid="6bcc436f-7317-4689-bff0-acbf2c50aaa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0cd3cf46-dc7e-41eb-858a-fdb5910d3822">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -2072,8 +2072,8 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="97022f2e-d212-4c75-8bcf-089691b8c2c4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="82bb80b5-52a4-482c-801a-06f1850a565f">
+      <statement statement-id="au-7_stmt.b" uuid="c6f0bb72-36c3-4761-9a5b-c40627d0a446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9b3215f-331a-4fb7-9067-a704d26e888f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When OpenShift's Cluster Logging Operator sends OpenShift cluster logs to a remote log store,
 the operator does not alter the original content or time ordering of audit records.
@@ -2081,10 +2081,10 @@ the operator does not alter the original content or time ordering of audit recor
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2df985d6-202c-4a5d-b8d3-adf6a8f97f6d" control-id="au-7.1">
+    <implemented-requirement uuid="058aed75-8622-4dfa-ae99-2c359885e02f" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="ed05d588-b371-419c-a631-fe5455587c7d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eec49325-e5d8-4eab-929d-87ff6921c09a">
+      <statement statement-id="au-7.1_stmt" uuid="720c614a-f263-426b-bd33-2363ad574369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="258ecfda-b77b-46a4-af8e-0970feb52488">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -2103,10 +2103,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04bcd107-1c6a-42bd-87e3-c4597a70de35" control-id="au-8">
+    <implemented-requirement uuid="9c2388b8-6ef5-45cf-93d2-cd87d4f39794" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="32e409ae-4287-48fe-82d6-5bf8c7668dd7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="95e73922-23d5-4c52-9751-3c0e7fc9c974">
+      <statement statement-id="au-8_stmt.a" uuid="7edb6f5a-e08e-4faf-a375-bad11b80aa7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3e4e1da-469f-42f2-a0e1-2c8ffaeae1ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API uses the internal system clocks to generate
 time stamps for audit records. At the code level, the OpenShift API
@@ -2125,8 +2125,8 @@ which really is a time.Time value which comes from the standard golang library:
 https://golang.org/pkg/time/</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="1d4cdf72-0099-4d75-99f2-7074c6404b39">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6d32b866-d6f0-4e62-850b-2b8f4dd3f7ee">
+      <statement statement-id="au-8_stmt.b" uuid="8199e4bb-c82f-4ace-9317-6db96229ad0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca64871d-2677-4674-8c06-a118a56ef997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -2142,18 +2142,18 @@ for more example of audit records.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b83459f-9155-4edc-84ed-ba607b0f50e1" control-id="au-8.1">
+    <implemented-requirement uuid="8f844c3b-c8be-427a-b5e4-de865825d22f" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="f2c6c4ea-1844-4d17-9fbe-ed75f3f3029f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e58357b0-fcdb-454e-8871-a50fa1e4f688">
+      <statement statement-id="au-8.1_stmt.a" uuid="0f7774f9-7015-46ca-8049-12d0303a4e3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce43980-d680-4af8-8d74-231f0e325343">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift synchronizes time by utilizing the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="45558c42-8abb-43c4-a59a-07204db7b272">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2669821f-ee1b-4cc5-ba8f-a3cc8be33713">
+      <statement statement-id="au-8.1_stmt.b" uuid="d10df678-a2c8-4dfd-a581-f78c81b4d714">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce43980-d680-4af8-8d74-231f0e325343">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift synchronizes time by utilizing the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.
@@ -2161,10 +2161,10 @@ operating system. This control is not applicable to OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9061b2a8-573b-4467-9481-b4dc81416360" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="9dec6d7f-e8c6-4aac-ba4a-42b2ef0fff89">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="19a02928-d99c-48ac-9030-6bace3b15b70">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2173,10 +2173,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf0bfbba-fe73-4ae8-b566-d5799d1e51e0" control-id="au-9.2">
+    <implemented-requirement uuid="3b44ab3b-34bf-4526-88f1-7558a0573638" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="4a41d560-1a5b-4bf1-88c9-c5b24fcf5822">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9c89f266-9b64-424c-a0ee-019c01cedb16">
+      <statement statement-id="au-9.2_stmt" uuid="78874635-1b1d-4ad9-b505-8c833b1126a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad51bfc3-0766-4dd0-8936-c1e95143c52f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2187,10 +2187,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62f55cba-1780-404f-8bd2-46181428345a" control-id="au-9.3">
+    <implemented-requirement uuid="d9af3243-40ce-4013-919a-34fa861da6db" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="1a036782-61ac-4e35-81fd-10d898c50af9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eecebf22-a4f6-4d8f-8c2e-88d80592810b">
+      <statement statement-id="au-9.3_stmt" uuid="83a67435-1fc0-48cf-923a-6c164b999990">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3439f73-d646-4d3e-808b-8c6cbe8756fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2199,10 +2199,10 @@ https://issues.redhat.com/browse/CMP-236
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acf2645f-8822-495c-a8c2-5bf2f12deb39" control-id="au-9.4">
+    <implemented-requirement uuid="2e936dfa-c426-4c14-b9bf-b4a2585f877c" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="38e27c37-f565-4e69-9c34-61b785ff93a7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="85826d34-205b-4e14-a731-c64672212eda">
+      <statement statement-id="au-9.4_stmt" uuid="67384918-d292-4ecf-907c-a9a006bd813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c316f2ae-f82d-4182-a625-9ce6bf288afb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be tracked
 via:
@@ -2212,10 +2212,10 @@ https://github.com/ComplianceAsCode/redhat/issues/863
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7429cdef-a503-48d8-bbc6-04916c78a6a1" control-id="au-10">
+    <implemented-requirement uuid="a8912fe8-a2c0-440f-a252-d977dfa1f0bc" control-id="au-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-10_stmt" uuid="297f66c8-23a4-4089-922c-4b747d704bda">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d4e6847f-459e-4fe5-b2f8-79a39c0fc178">
+      <statement statement-id="au-10_stmt" uuid="c2f0541a-5d78-4cb2-ae65-2579c4173d2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2224,10 +2224,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00d42dae-1d9f-4f7a-9793-7c5edbb6242b" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="30cb43df-3210-4af7-a2ba-2ce5b380fdea">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fbca05c5-e1ac-4684-b493-e161e82c92f7">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2236,10 +2236,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="352b0272-adcd-4194-a94d-92f2e4fcbdf6" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="d3f09bb5-15ff-4962-bf6c-21cbe27a5bc2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="16194119-3015-4269-a94c-b2f2b66fdac1">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2247,8 +2247,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="3adfdbfc-5e4c-4bfd-a200-71bc49ed5092">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cee1574d-dfd6-4fb7-8742-9e5e3fec847f">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2256,8 +2256,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="75758d8d-7665-41c9-9f26-9f319fc5b223">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4fe06761-bb78-460d-8bcd-c7173bee6f0e">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2266,10 +2266,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b969e0b-a5cb-4dc2-ac73-b31602ca5a47" control-id="au-12.1">
+    <implemented-requirement uuid="fb1002d1-76a3-48d5-8b34-e6b6fa126fac" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="08c50760-b284-4c46-a967-47b348a46fcf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="aaffa5e1-2d03-4f23-9692-9d222e90aadd">
+      <statement statement-id="au-12.1_stmt" uuid="a7e4e309-6e3b-47bd-9c7b-1edb4051b33a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c016671-eaf2-44de-b4e8-65772fb0d46b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2278,10 +2278,10 @@ https://issues.redhat.com/browse/CMP-181
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6323802-011f-4ea0-b839-2596108e2ab9" control-id="au-12.3">
+    <implemented-requirement uuid="68e7eab1-370a-4a93-9585-646848d58228" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="0b4ebf32-0eb8-4110-b6b4-8326460acf9a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d1294ead-a942-4e97-937e-d5391c9f9b4b">
+      <statement statement-id="au-12.3_stmt" uuid="4f1962f7-8e80-4e22-9dd0-d14292e79638">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f777ccd-7ad1-4d71-8151-788d6f6ba024">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2290,10 +2290,10 @@ https://issues.redhat.com/browse/CMP-247
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9e3f542-a046-48ae-9225-a5b29be710ac" control-id="ca-1">
+    <implemented-requirement uuid="fb9e823f-f30a-49cf-8e64-8b12563d512b" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="499c2733-0cc8-4b2d-946d-1bf92c461732">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5d030ea6-44dc-4642-b41f-056f6afb8082">
+      <statement statement-id="ca-1_stmt.a" uuid="e4ced95c-04ba-48ca-9570-5ec802f01701">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2301,8 +2301,8 @@ the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="3c71d333-8858-469b-a9f5-2ec98c50459d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="74614dd2-e3f6-4b89-8553-806edc54e128">
+      <statement statement-id="ca-1_stmt.b" uuid="a65bb5b4-db69-495d-8756-9d322f94c158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2311,34 +2311,34 @@ the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f4b28e9-ce12-41e7-b6fd-74486f22fb31" control-id="ca-2">
+    <implemented-requirement uuid="8d8afad9-0508-45b9-ba76-18768cd27aa7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="71042c9f-fc3f-4bdb-9bfe-b31c7ece8673">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5ed8df68-4ab5-4c5f-952f-0b37885ae4ad">
+      <statement statement-id="ca-2_stmt.a" uuid="5edc8cc8-7dd1-473d-ab0f-070f2f4287b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="54dc2dfd-7135-4174-9131-e732898bd95b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e61675b9-da2d-4507-a35c-f74cefa390b1">
+      <statement statement-id="ca-2_stmt.b" uuid="0dd59305-6612-44cd-9bb8-3983326a6dd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="7144bd49-88ce-4129-8f16-bc08878c92ac">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="51d8a797-7d50-452d-ad95-a4db4c62ba6e">
+      <statement statement-id="ca-2_stmt.c" uuid="fa943605-14cf-456a-ad67-8eac021ab68c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="43d8c843-7259-424c-a397-6be9429ff448">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3c955406-652a-4e03-90dd-917b42b66556">
+      <statement statement-id="ca-2_stmt.d" uuid="8540655a-6e76-436d-8513-3723a102553d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
@@ -2346,10 +2346,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e654e312-acda-4838-aa33-81549a9f6e3a" control-id="ca-2.1">
+    <implemented-requirement uuid="08d49c7b-953f-4cd0-9813-50874951537b" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="fc8f3db7-9f6d-4e04-9b60-b9de787abf2e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5824b33f-3fea-4e79-95a6-365fcb6be053">
+      <statement statement-id="ca-2.1_stmt" uuid="38aa23f1-4422-402a-924a-ec395b6a768a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3b9dd57-eac9-45a8-99ab-907dfa329afe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of OpenShift configuration guidance.
@@ -2357,10 +2357,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0b04e68-d640-47bb-9470-f383c9e69a59" control-id="ca-2.2">
+    <implemented-requirement uuid="db5a2907-c1fd-4e4e-a6eb-61559c12003e" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="2cbf3184-0c6a-4ff9-b89d-32c4e3b1ef52">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="00a9ad22-5791-435a-afd9-210bad7972d6">
+      <statement statement-id="ca-2.2_stmt" uuid="3fe6f2ca-381f-497e-a072-33027570ea25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f9a999f-dbf5-46ff-a007-43b2c21ab3e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of OpenShift configuration guidance.
@@ -2368,10 +2368,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be82e689-6b05-4f69-a798-7c1e7477705d" control-id="ca-2.3">
+    <implemented-requirement uuid="58a67648-ba68-4415-974b-61de7dc1c5b5" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="7887fef6-424e-494f-94bd-b58c3dd12b82">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c92a1352-6d33-4405-b5d0-5d451238d40c">
+      <statement statement-id="ca-2.3_stmt" uuid="11147258-cf14-4f88-a31f-b75bcdd421d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab0e3099-0268-4610-80d3-04805390b90c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of OpenShift configuration.
@@ -2379,10 +2379,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09195365-aae9-4b40-8fcb-7c35977cc088" control-id="ca-3">
+    <implemented-requirement uuid="d852491f-4160-48e1-afb7-2e2ec47b7d99" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="51826ff8-a55e-4d44-bea3-4a9520449e4f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="33e3b4b3-7d4f-4a5f-9fa2-1482b2cc472b">
+      <statement statement-id="ca-3_stmt.a" uuid="2c3ee9df-91cd-437a-82c9-864e15531e98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2390,8 +2390,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="aa99e6dd-186e-4419-99cf-9833245d6b55">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9ab191e2-97b1-4a1f-ac45-a3e38d82728b">
+      <statement statement-id="ca-3_stmt.b" uuid="4eb00eec-a9ed-4ee3-a6c7-484b670b8529">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2399,8 +2399,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="9ded3483-8fa9-4258-a444-77be7d772c38">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="642f8856-e5f3-4196-9d6f-00db5cd832ea">
+      <statement statement-id="ca-3_stmt.c" uuid="b11f5bcb-6d01-4308-8993-e1f6c74da678">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2409,10 +2409,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="363760f1-33bc-4efc-b490-65c1c08abad7" control-id="ca-3.3">
+    <implemented-requirement uuid="85595d4a-3f82-4cd4-ae40-c9e1bece56df" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="e779c571-3076-4924-83ed-45957bd0b8f0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="557f5655-79ee-4fcc-b70e-e0185d6a31a9">
+      <statement statement-id="ca-3.3_stmt" uuid="ff516853-42f1-46e8-aed8-dbc22157fe12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="558d97f8-5d6a-4aee-8a12-912b5f070589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 OpenShift configuration guidance.
@@ -2420,10 +2420,10 @@ OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c888b8f6-7e5f-4e16-91ed-6a0ac9dba3af" control-id="ca-3.5">
+    <implemented-requirement uuid="80d92939-b566-45ea-acd8-dad9640c46cb" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="b0f7d69b-10b6-48da-aefe-bb39d6059fdb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2f3fdef1-874b-4937-93ea-d800d8ad1025">
+      <statement statement-id="ca-3.5_stmt" uuid="25e4fad0-540b-4190-a0a4-0009d55b70e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbfd7e30-455d-49ee-9888-3853ccbfd5e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to OpenShift and applicable
 through host-level firewall rules.
@@ -2435,10 +2435,10 @@ https://issues.redhat.com/browse/CMP-253
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f1bc915-3a68-464c-8108-838b6dcc42e4" control-id="ca-5">
+    <implemented-requirement uuid="4d507723-069b-4eec-b5c5-97cd3e94d334" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="0f4f9d4e-2551-4087-a29d-4a53af7259a6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d4d2a272-c9fb-4537-96bb-2214444a57af">
+      <statement statement-id="ca-5_stmt.a" uuid="89655419-75ed-4ec2-bdc4-07f88fe99933">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7da1eaef-58ea-4508-bf86-2095cb61dfae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of OpenShift
@@ -2455,8 +2455,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="712e8a5a-f2e0-4ae4-adef-fe64bdf693f0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e061673c-1276-46b3-8204-45c44e5ba1c4">
+      <statement statement-id="ca-5_stmt.b" uuid="8e8f321c-48f5-4ff6-8654-76986b9774e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd5cdde-ec46-4ca6-b2c7-ba5f7fd31de2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2470,26 +2470,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf6554da-9595-4950-8db2-37438b05ab0a" control-id="ca-6">
+    <implemented-requirement uuid="f62731c0-3032-42e8-8694-31c841118669" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="ea881d2e-e669-4d83-a47e-f9434b137295">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="927b0f5d-a9b6-4f29-9ae4-f1a1a7720418">
+      <statement statement-id="ca-6_stmt.a" uuid="fe0d6c95-f1a6-4353-968c-b520c4853cb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="3c593940-3798-46f8-875d-75a7c61439d4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8e27217e-ed10-4310-9c65-8e28c9037dc8">
+      <statement statement-id="ca-6_stmt.b" uuid="4029322f-8f15-4f57-a0c7-70c8654c0505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="a74d02ad-198c-47e3-8050-9cefda06f5c2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="24260834-1ce5-4c01-93e1-18e5ce5f8d49">
+      <statement statement-id="ca-6_stmt.c" uuid="f0742c71-cd50-4fb4-90bc-bc7b6839f689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2497,10 +2497,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcb56af9-722c-430f-80d7-bdd4d09ec666" control-id="ca-7">
+    <implemented-requirement uuid="55addee1-b8b3-4109-80b1-b8227770eb8b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="b2405916-8932-42c3-8313-ab6b8b93ebc1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c0c5123b-a2ec-48a6-a039-dc1dc36a7793">
+      <statement statement-id="ca-7_stmt.a" uuid="d6a330d2-df2e-4d92-9cd0-1956cc3c7781">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7b1e437-6967-48fe-bbfa-c7cd030c0de0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2509,8 +2509,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="989f9dc8-5927-4d1b-80d4-fff59a8f3d46">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a7152c86-a264-4cc6-927d-9d6eb9f5aba9">
+      <statement statement-id="ca-7_stmt.b" uuid="c4ca4be2-e8e3-4f6b-a10d-d7cac01ab064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="033b0fa8-776d-4796-bffe-cd824557b80b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2519,8 +2519,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="3c1b1abd-b889-478f-9dc5-f00957a40ba1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="74c7c654-9d6b-4dab-8fc7-868ee792be11">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2528,8 +2528,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="cdb9a908-88e5-4627-ad15-21244f9c49eb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a0450537-a8c5-4c3e-81b1-b08d3f75bf2b">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2537,8 +2537,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="7496a829-01b9-4099-a920-55abb12b735a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="901df0e7-e99b-4071-9862-dc6df56063b6">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2546,8 +2546,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="45c41d17-b10e-41e9-9b7b-cce819670793">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7596a090-cc91-4f13-be2c-37175a8b82d3">
+      <statement statement-id="ca-7_stmt.f" uuid="b09f9aba-1b28-487c-997b-fd2a7ce6c033">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="291a33c4-ec9c-4387-bba7-db910c86c7a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of OpenShift
@@ -2555,8 +2555,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="ec4e9f63-c749-4ca2-b72a-cb4fdae55f75">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3dc319fd-ae8d-4d05-b12e-6a069c75213c">
+      <statement statement-id="ca-7_stmt.g" uuid="a32b68f0-5ca4-43dc-aee3-8bf1d9e27165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c50876-9275-40f2-bc33-4ee44dcf13f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2565,10 +2565,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fcb818c-c6dd-4249-a7f3-4580c009a7e8" control-id="ca-7.1">
+    <implemented-requirement uuid="624d74b3-1731-42e7-8baa-7f3e97270e66" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="fcbde844-9334-4c7c-9df3-e705f1632899">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cd592352-1960-423b-8867-ccbc9e1d651c">
+      <statement statement-id="ca-7.1_stmt" uuid="e47b699c-612e-4f18-9c35-f1d70ae60f37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ee7afb1-daf3-4bdf-b139-e274fa0c1f1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of OpenShift configuration guidance.
@@ -2576,10 +2576,10 @@ scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bb903e1-6a73-43da-bf4b-e31c754aa4d4" control-id="ca-7.3">
+    <implemented-requirement uuid="3af3c047-c59d-441b-a7bd-a5d699ad1036" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="c39deb5a-b34f-4b84-a470-53428cc37e28">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7dda98b7-5840-45f3-b32d-910078f804b4">
+      <statement statement-id="ca-7.3_stmt" uuid="9b80c78d-e726-48cc-80f5-b1132480c276">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ce18f0d-f78d-4a8f-b168-f380c6fa0b1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational trend analyses processes are
 outside the scope of OpenShift configuration guidance.
@@ -2587,10 +2587,10 @@ outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0059d2f7-4893-4105-861d-69ea1d7b0e53" control-id="ca-8">
+    <implemented-requirement uuid="b716fb4e-3373-4b56-bfab-5a619dfb7650" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="4a0bbb1b-653b-40e9-9f24-82886aa8486f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7fa2f0d5-c7a6-4074-98cc-7701352a6c87">
+      <statement statement-id="ca-8_stmt" uuid="e09a8895-1ef0-4139-a6a7-85714c2c9a97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a354f5f-f6a4-4922-9746-a7e30df42f31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 OpenShift configuration guidance.
@@ -2598,10 +2598,10 @@ OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="546d22b9-303c-47b9-8238-1c87ed8c82ae" control-id="ca-8.1">
+    <implemented-requirement uuid="3cd4469d-5efa-4a03-bb53-9e10f9cdc180" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="849e448d-6b00-423f-9d40-c7517bd7bbf4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9b28f944-1129-4819-8874-eee9e07b32ba">
+      <statement statement-id="ca-8.1_stmt" uuid="4faa1b9a-6f58-4e69-bc7c-23c69dcc3e05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29136789-b5ab-4c39-9dd5-db08bfe1e3ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for OpenShift configuration
@@ -2610,10 +2610,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3e2829f-5543-4a6a-bc56-d7e60de2c061" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="e0194393-5f8d-4dee-90c0-1c887f2dea1c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="125762b2-fac3-4424-b63f-0e7bfb05c404">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2621,8 +2621,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="f85b6251-5104-4f05-9ab4-1cdba8865874">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5f5bb56e-b58e-4e03-abab-19c151464ca5">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2631,18 +2631,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b79b3ce-e50b-4755-b433-d4b85b18e66d" control-id="cm-1">
+    <implemented-requirement uuid="53b3abac-4a28-4161-959b-fa09347080a4" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="db3de51f-b72a-474f-b553-1668766b1c03">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8c30f3dd-97c3-4cd5-8bbc-113e1bf9d181">
+      <statement statement-id="cm-1_stmt.a" uuid="0e08d61c-98ad-4d8d-9cef-ca802b007cc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77ee3a9b-63d6-4f8d-bf3e-f10feb7ec653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="13921317-7754-4cb1-99a5-173b6e2db874">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="154bd8ec-4bbf-470b-8873-0118a8de59da">
+      <statement statement-id="cm-1_stmt.b" uuid="13dfc8dd-1b1f-4f8f-a824-fda32a269ecc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6eccf7c-0437-4523-a842-44769fdd2ae4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of OpenShift configuration.
@@ -2650,10 +2650,10 @@ management policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16d35b26-a826-435d-8b28-1c1a687e952f" control-id="cm-2">
+    <implemented-requirement uuid="7ec7cc47-526c-4739-94f5-5362151297e2" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="8f21262b-2223-4492-8c7e-3da5dbc5fcd1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="381b4c73-3925-46b1-8371-8228b491d4e8">
+      <statement statement-id="cm-2_stmt" uuid="6aaa5474-1312-44d0-a614-bbcbc95a220f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e95a42-d853-44e4-8693-3cc9f20747c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management in the OpenShift Container
 platform is to implement the principles and patterns of GitOps
@@ -2682,10 +2682,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcc5b1ee-2b24-41ba-b86f-f4ec7649ed20" control-id="cm-2.1">
+    <implemented-requirement uuid="15c843e2-7b5e-4cab-925c-949ff806ea4f" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="2a2c7f9d-6b0a-431e-81a8-76c7548be0ca">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="661b5fae-82d3-437c-a59e-ab4caceba68f">
+      <statement statement-id="cm-2.1_stmt.a" uuid="b8bff285-b306-4a1f-a2c1-339246cfcc10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="120e9e6d-bc52-43ce-8533-674d957d6795">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift per an organization-defined frequency is outside the scope of
@@ -2707,8 +2707,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="0a21705d-c47f-4560-8243-7831b4e0a06d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5a5e71ef-4493-4e1b-bfe7-024e283f504e">
+      <statement statement-id="cm-2.1_stmt.b" uuid="3d12c2a9-9322-41c1-9e81-3bcc2bfb0e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95bbb4ef-965c-450e-93d0-3f0b25b55679">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift when required due to organization-defined circumstances is outside the scope of
@@ -2729,8 +2729,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="be5ff3ab-85f7-4a22-bd7e-5d9df05e1d4e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2a05738d-a590-4635-a77e-0c76a8c1ad27">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5a93b6d5-ea2f-400c-861d-e393ddedb528">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e03918ea-9597-46d0-b685-77696fc48515">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift as an integral part of OpenShift component installations and upgrades
@@ -2753,10 +2753,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8077aa6c-6b56-4306-8e8a-17de28cc17af" control-id="cm-2.2">
+    <implemented-requirement uuid="9811f427-cb9f-4959-839e-c1ad0e3b1f69" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="ad31bd22-b9cf-4a4a-b863-3b950228b442">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4b1d1262-4f50-4ca7-82be-88f8f1e1e1e8">
+      <statement statement-id="cm-2.2_stmt" uuid="1a85e226-7846-458e-87aa-daabb3024acb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbf585d-7073-4272-9b00-0e9a10603a48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2766,10 +2766,10 @@ https://issues.redhat.com/browse/CMP-262
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a68d325-6eed-413c-9013-99019f8b093f" control-id="cm-2.3">
+    <implemented-requirement uuid="68ad0e12-a096-4067-a971-c389177b7034" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="ebb831de-0fa6-42aa-80cd-a91347ca4e30">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4bc2ef65-cd9a-4b45-93fd-b51f5242037c">
+      <statement statement-id="cm-2.3_stmt" uuid="11312c94-dc55-4ed5-b885-e600694b3b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2045b012-4c73-4e3c-b73c-37eaf05d3dae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2792,10 +2792,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dad1933-0773-41c6-bd8a-771a515d4cb4" control-id="cm-2.7">
+    <implemented-requirement uuid="6459ecfa-b910-43e7-8965-3b3415c870db" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="8bfe6436-bbdc-4422-a40a-2f933e34180d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="40edb9e7-f8e5-4e5e-979a-bb378a743f9c">
+      <statement statement-id="cm-2.7_stmt.a" uuid="4c10504f-e039-4f61-930c-576645e31828">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9178f438-9fed-4b72-8bce-95c1b53c7d2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2805,8 +2805,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="16e4c8ac-0256-40df-b7e2-435271b4cb9d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6d45bb6c-4755-4a5c-8f05-94507a0d29dd">
+      <statement statement-id="cm-2.7_stmt.b" uuid="47b6c5a0-4926-423b-a81d-a279fde17855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d750095f-9a35-42fe-a0f7-57f49ced611f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2815,10 +2815,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b714668-0456-4411-adc6-e281a3d09ad5" control-id="cm-3">
+    <implemented-requirement uuid="d5803f5d-c744-42be-8dc1-112e58561dac" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="70c6a8e6-3b36-4318-b9b7-1f94e505cfb3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b227c2ec-497e-410b-9df9-a39d1e59d900">
+      <statement statement-id="cm-3_stmt.a" uuid="cd86af9e-b2c4-42f9-bd08-622642ee246a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2827,8 +2827,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="c6d8ab1d-b035-4139-bedb-b2d8402dc58b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2aa33c72-cd32-48d0-babb-b2f3dd481632">
+      <statement statement-id="cm-3_stmt.b" uuid="55b2e92c-81f2-4fad-b3dd-456c93a1fbac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2837,8 +2837,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="87d60695-0d7c-4b5d-aa37-a981c7c1e731">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="40d6ff94-4567-48ec-ad08-75e2db6b5af7">
+      <statement statement-id="cm-3_stmt.c" uuid="684a0521-4ea2-4b94-b6b7-7b7a50b3f2aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2847,8 +2847,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="5824208d-8e2f-411a-9101-f41439b4772c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="aa8d3df4-5ef2-48b2-847c-92f8de9ec2df">
+      <statement statement-id="cm-3_stmt.d" uuid="b1245fb4-2e87-497b-9ad1-8332e3854425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2857,8 +2857,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="af7d2269-f621-4977-9b6e-d7a65f5fc7f1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="948cdc00-85c8-4694-a418-9054ae64efa9">
+      <statement statement-id="cm-3_stmt.e" uuid="2a387d15-e1e8-4940-bce5-98bf905dd8d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2867,8 +2867,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="c599e325-c8f6-4651-811d-d29d0064d8b0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a31cbac-feff-4133-9da2-b56bdf5a1f2a">
+      <statement statement-id="cm-3_stmt.f" uuid="dfaa0f29-9d3f-4979-97ec-a7128d6afa16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2877,8 +2877,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="ed2e4c08-780b-4cfa-a460-0bcdee009bdd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="015c31f3-d95d-40fd-a17f-b90f6f970eb8">
+      <statement statement-id="cm-3_stmt.g" uuid="f81d2b69-26cb-40d2-bd0a-e160c2e867d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2886,50 +2886,50 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0ac6b63-8967-404c-9255-a5657ce32c12" control-id="cm-3.1">
+    <implemented-requirement uuid="b2160e5f-d047-40d4-bbb1-28eacd42e078" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt.a" uuid="4301822f-c2f6-4307-ae3a-052c859af456">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9d3cf660-0c77-439a-8844-56c979c83dae">
+      <statement statement-id="cm-3.1_stmt.a" uuid="d86a9135-2388-4a23-9f22-64266a0bbd31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.b" uuid="6937035e-7030-4bcf-9d53-c478766136e8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f6779d4b-4aa0-4183-866c-5b6b0fe1a3f3">
+      <statement statement-id="cm-3.1_stmt.b" uuid="19b4321b-5cc2-4112-9bfb-830b85754cb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.c" uuid="4a8ac491-c2d6-4e06-925b-81b5f2f6887a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="04f9c592-53a7-4ace-b0ec-79005ea16ba1">
+      <statement statement-id="cm-3.1_stmt.c" uuid="d0b1ef15-a252-4024-bee8-3bb0354920c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.d" uuid="9cc97a40-e908-410f-b56a-c9f698c1fdaf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="010dab33-679e-430c-8f72-3b55e4d40593">
+      <statement statement-id="cm-3.1_stmt.d" uuid="e1d42f1c-164f-47c8-b6c3-41157072e380">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.e" uuid="3c8f1aed-9af6-42de-a42d-13203346ad41">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2fee93c1-8ff2-4a0b-99e4-ad503e3201d8">
+      <statement statement-id="cm-3.1_stmt.e" uuid="7689bcf6-9e63-453d-be08-e88cfa4c3a41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.f" uuid="2e144d77-9e2e-456d-817d-98419a94909f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c56d4aed-2be1-4e80-b99a-1be9afa9ccc4">
+      <statement statement-id="cm-3.1_stmt.f" uuid="c25d7f4e-9101-4394-8364-0aea227d4093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2937,10 +2937,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a70b7d1-14f5-429e-94a8-a05971990f6d" control-id="cm-3.2">
+    <implemented-requirement uuid="ce518cce-4125-43ab-8d14-20e411dd1fa4" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="f06ac249-4af1-4378-9dbb-a4b5d850ddc2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="01d5b8e5-d5d1-4b51-a7a6-6b4590fd4ed2">
+      <statement statement-id="cm-3.2_stmt" uuid="182f9585-cde3-4854-94ef-374099416cf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2948,10 +2948,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc1cc7b8-046d-4d59-9440-88b97c5ea9e2" control-id="cm-3.4">
+    <implemented-requirement uuid="c4d2d769-2338-4f3f-a322-a99b421dfb6b" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="482a7c5b-9208-4630-9213-54750663f8c3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7c57425a-9d63-47e8-9040-e5f947cf217f">
+      <statement statement-id="cm-3.4_stmt" uuid="358b4208-13ad-4dd0-ad14-f165194b2f3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49569198-f252-431a-9013-108d8e183d9c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The requirement for an information security representative to be
 a member of the organization-defined configuration change
@@ -2960,10 +2960,10 @@ control element is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a27ca25-fc1a-435a-b854-28d987e1020b" control-id="cm-3.6">
+    <implemented-requirement uuid="61cd825a-b1ee-4f88-9902-7584c461ed98" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="a1c95c5e-5c89-4be0-bd83-c434de2a63d9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bb081045-c864-4e5a-bd1b-ea849f4c03d9">
+      <statement statement-id="cm-3.6_stmt" uuid="6c95e840-d4ef-443d-a25b-f24944fe2d09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93e4280-05f0-43a2-a4ea-eba2203f78f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2973,10 +2973,10 @@ https://issues.redhat.com/browse/CMP-268
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bb0614f-22b0-4548-9179-8e9a62fc4af2" control-id="cm-4">
+    <implemented-requirement uuid="bf7559c7-c3f7-4b66-a683-9209b935cc2b" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="d51dcb53-bbf7-42b4-91f0-fd742b5f3b59">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4bef4a08-5fab-4885-9ffd-a12bbbef4ef3">
+      <statement statement-id="cm-4_stmt" uuid="07305a6a-1193-4962-8b48-f144f31e60c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbc8a0c6-4b3d-4773-98b0-3a137e065b28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2985,10 +2985,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88a4d5e4-a983-457e-8ede-6364d5b8b462" control-id="cm-4.1">
+    <implemented-requirement uuid="7213bfcf-1142-4a7a-92b4-f64c64bcc968" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="3fe6b6a3-4712-47c2-ba54-96ffd7c61dd0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3a55f383-1a6d-40b6-ba48-fde2473db417">
+      <statement statement-id="cm-4.1_stmt" uuid="4b753d1e-4a6d-4be6-8daa-023b12fb7c06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d57d518-18b4-40a7-a11a-53e3639e476f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2998,10 +2998,10 @@ https://issues.redhat.com/browse/CMP-269
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e511b20-426f-4215-be1c-c5a44b6707cc" control-id="cm-5">
+    <implemented-requirement uuid="62eb973a-3540-44cd-b719-682e2649a54c" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="bfbdc1b7-9a69-4ee8-b889-e29964b60af6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b6bc4f51-b888-4396-a3eb-1db16eafea3f">
+      <statement statement-id="cm-5_stmt" uuid="781f8580-6098-441c-bc1a-43618deb6255">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21a2ade5-e577-4721-ad53-a1546e1d1b11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining, documenting, approving, and enforcing physical and logical access restrictions
 associated with changes to the information system is an organizational control outside
@@ -3019,10 +3019,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b31ed23-27e3-4438-a150-e9ec5961b92f" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="0750803f-c86e-43cb-a8c0-f6b1ddb27875">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2be23716-3c50-46c1-b654-caf1587dd4a0">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3032,10 +3032,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3947d26-0312-4eb2-b028-6fa0ef1ab241" control-id="cm-5.2">
+    <implemented-requirement uuid="916f8863-0506-4342-a5f9-e7237ea1ae1c" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="00b27463-76c8-4f4e-9e4e-61d49efa22f8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eaf8811c-023e-4105-8be7-29138ee16026">
+      <statement statement-id="cm-5.2_stmt" uuid="ce57b888-27e8-4fc8-8bf1-396d38f790ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -3043,10 +3043,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8561f223-a8c2-48c6-8303-98fe47cfc3f6" control-id="cm-5.3">
+    <implemented-requirement uuid="49523066-b7d9-4d77-a2c7-59366937787a" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="a7a3b920-ff91-4aac-8a60-c92e51a67d01">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="495c668d-ed4f-4783-a024-20660dfc88cc">
+      <statement statement-id="cm-5.3_stmt" uuid="84764f58-0c4a-4051-bc47-08d6a39f7317">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca577a36-3847-4240-9bff-912466fccf24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3056,10 +3056,10 @@ https://issues.redhat.com/browse/CMP-187
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2485dc7-8644-47ca-8a16-6186d4e066fe" control-id="cm-5.5">
+    <implemented-requirement uuid="10d3143c-c783-4b4b-b538-995e6714f707" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="6172efef-d97d-4a6f-a177-db336977531a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7d5292f3-b0ee-4ee8-84ae-39b6265b5595">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3dae2524-5241-4fdd-978d-beb381490964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d823359b-250c-49fe-954d-f6be6ba9d33a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3068,8 +3068,8 @@ https://github.com/ComplianceAsCode/redhat/issues/901
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="9c038238-f1eb-4290-bdbd-463f17731223">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2f5927b5-c038-4b2e-8fe7-e35976e6d351">
+      <statement statement-id="cm-5.5_stmt.b" uuid="e1618798-a68b-4c5f-9a6f-c9bc608ebd80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -3077,10 +3077,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="433f21cb-12cf-47b6-a5b6-19a06fe0be00" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="85dce977-cad8-402c-b5bf-c3e3ca30f48b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="32d5a5c0-89d9-423a-ba29-5b6a550182c9">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3089,8 +3089,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="6b0e825e-f27f-42db-bd78-43b1607c65cc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a3dcab48-81a2-426c-b253-fa5eadeb0207">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3099,8 +3099,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="3a19c44a-67b0-4d11-ada3-3a33e8a676c9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2d453c44-fbb4-4e3c-a1d5-99554ef68b52">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3109,8 +3109,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="27073e5e-4d08-450a-bdeb-81c1977430c3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9c94dfcd-f02e-4f32-8f7d-f0417e27648f">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3120,10 +3120,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4597262e-5286-4c23-b18f-d64b9268d59a" control-id="cm-6.1">
+    <implemented-requirement uuid="23adbbfd-9d1e-417f-934e-fedba07890ae" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="200f5ffa-7bf4-481b-ab00-ecd303649704">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4c549314-662f-4e51-9821-17a9baa66f3c">
+      <statement statement-id="cm-6.1_stmt" uuid="2f1e18cc-ae8a-42f4-b1af-e6941dd5209c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4551de61-8db5-440c-bfab-68c6bcb8968e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3133,10 +3133,10 @@ https://issues.redhat.com/browse/CMP-272
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f71db1d-ea11-4770-ada6-c5b2117ca4ae" control-id="cm-6.2">
+    <implemented-requirement uuid="726b397f-a208-45d4-ab8f-af16be623e39" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="9fa91f23-65ee-4bbe-bf95-50a0b0fc2ea1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="06db3eb4-3739-47a1-bd0e-d0e15eb959ef">
+      <statement statement-id="cm-6.2_stmt" uuid="eeea7e00-721e-4964-8799-7d623657d647">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -3144,10 +3144,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="706dbbd3-f3d9-45ac-a9f7-9f48c2ceccb2" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="3ba714f6-5004-4d0a-b20d-38833abc7681">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1eddbc87-49a1-4d43-8e60-5c6fe6bffeff">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3156,8 +3156,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="91423c8d-6c84-439a-98d2-d8bbabbf31ba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8eb5c079-f747-4c7d-9624-15d16b3a9850">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3167,10 +3167,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54d4a7c2-5adc-4dcd-bd91-ea457ee64ec4" control-id="cm-7.1">
+    <implemented-requirement uuid="681bbf04-881f-448a-b207-3183b7066a64" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="86bf598d-fd1c-496a-8d5c-c71e1ab981d7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5f229273-e7f1-4f5b-8343-5b2f9f31c71a">
+      <statement statement-id="cm-7.1_stmt.a" uuid="712afed5-3de9-4f0b-a3cd-93267d37b136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3179,8 +3179,8 @@ https://issues.redhat.com/browse/CMP-274
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="818a435a-32f8-4626-83b7-f0945a51f543">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0f760647-e336-4ce6-945b-d4b90a22f24c">
+      <statement statement-id="cm-7.1_stmt.b" uuid="ec980658-104c-4e52-8631-2d923aff4c85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3190,10 +3190,10 @@ https://issues.redhat.com/browse/CMP-274
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="496b3ed1-ed74-41c6-b940-56b5066faa4c" control-id="cm-7.2">
+    <implemented-requirement uuid="2045f042-6725-4305-b4d5-dfab9f16e180" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="ccc51885-c2f3-4102-a649-573c3a32d2d4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0d21e5ef-2764-4616-9a21-8a00eb9dda34">
+      <statement statement-id="cm-7.2_stmt" uuid="70ab7b0c-c1db-4c82-b9b6-f464a23a1371">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76bedc11-066b-41c5-b5b0-8b40dc36c3c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3203,10 +3203,10 @@ https://issues.redhat.com/browse/CMP-275
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a795d223-1c77-48b4-932f-12cc0062743b" control-id="cm-7.5">
+    <implemented-requirement uuid="afeb82d5-0753-4ca1-90fd-3866f47e1b51" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="1a411fba-cc96-47a4-902d-338f6aa7b519">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e00a41cd-1e58-417f-8d5e-a712ce31f6e6">
+      <statement statement-id="cm-7.5_stmt.a" uuid="664d44d4-5274-4bcf-b887-31cd4a5ac1d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3215,8 +3215,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="6195b9f5-6fd3-4d12-b8a6-d9c6eafc67fd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="83bc6d83-c0fb-4629-bf51-d561071a9e56">
+      <statement statement-id="cm-7.5_stmt.b" uuid="76448ea7-3d83-415c-add0-9cb8a842af1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3225,8 +3225,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="fc95ea87-16e9-4af7-889f-0270559ad8ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="035eff5f-9860-4887-9bfc-e6b5a1993bd5">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3b3a6030-4ee2-4050-95a8-c28aaaa8e862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3236,10 +3236,10 @@ https://issues.redhat.com/browse/CMP-205
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6100de4f-4932-4fbb-b4e5-96ea817b2119" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="d7b9c356-d09e-49f9-9c19-7333a6d777e0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="093d372d-ec12-4177-b26a-f581c6abfb9a">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3248,8 +3248,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="c47fa7b6-1439-4b7f-9de0-c8d2ee600a27">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="39f656fe-d179-4e7e-a359-414bc481f6f2">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3259,10 +3259,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18385d53-f126-4dd8-b822-597b74198955" control-id="cm-8.1">
+    <implemented-requirement uuid="a2d7594d-e346-4274-9265-d46540911822" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="ddcd82d5-6926-44b6-96d6-be3e6c657d1f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="30b941a8-5666-4f2b-8c54-20756350b491">
+      <statement statement-id="cm-8.1_stmt" uuid="e8f890bc-f312-4f4a-b859-d8ae6b11b6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8df6da4e-b135-43b9-86fe-b966c8589097">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -3278,10 +3278,10 @@ https://docs.openshift.com/container-platform/latest/updating/updating-cluster-b
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9958449-6a8e-4953-bd14-af5b5711d382" control-id="cm-8.2">
+    <implemented-requirement uuid="efec02dc-a7f3-4c26-8c97-12a768d47a8d" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="85221476-3a03-42dc-b45b-242fa42c5c33">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e44e1a0b-8ce8-4bfb-9573-edccdc5a37ce">
+      <statement statement-id="cm-8.2_stmt" uuid="fbd5169e-c8cf-454c-b310-f9ceac64689b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96f30624-9ae0-4a5c-8987-728732b902c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3291,10 +3291,10 @@ https://issues.redhat.com/browse/CMP-279
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c5462ce-c34f-4bb7-8240-f83abf9d4c99" control-id="cm-8.3">
+    <implemented-requirement uuid="9f65e091-76eb-4b8b-a90d-01dfcf2d492c" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="dc5c8c1d-b090-4ad3-b67f-be18496ca6b5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7890f094-a1b7-4779-b838-d6ff86907286">
+      <statement statement-id="cm-8.3_stmt.a" uuid="23171812-48fa-443e-9266-3902cb35ff08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3303,8 +3303,8 @@ https://issues.redhat.com/browse/CMP-280
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="5887444d-4564-4e1f-8a57-68d57c3a856d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bc00034d-cdc8-4486-a5e0-5445eade8368">
+      <statement statement-id="cm-8.3_stmt.b" uuid="7af95e64-9f75-464f-86de-26378e862fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3314,10 +3314,10 @@ https://issues.redhat.com/browse/CMP-280
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f03c4f3-628c-4490-8f50-0c9f47c3589b" control-id="cm-8.4">
+    <implemented-requirement uuid="db41c18b-5ec4-4d2f-9dcf-78c97dbc680a" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="73d06418-4f6c-4a02-9267-1c85436825f7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c5c93db1-9c06-4da2-977c-153223b32d54">
+      <statement statement-id="cm-8.4_stmt" uuid="b28bfa35-6364-4fb4-904b-772dfa7b02e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef2afa79-0923-4a7c-9750-cd595ab18752">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include in the information system
 component inventory information, a means for identifying
@@ -3328,10 +3328,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6652c11f-a495-46ea-8fbe-45c1bd22c262" control-id="cm-8.5">
+    <implemented-requirement uuid="fb999865-9705-426c-b663-06b8c59c0c14" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="b34a3771-4ac6-4dcd-97f0-6d1014233a90">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5150df24-7c5a-4b59-b71b-3ad7484bfeeb">
+      <statement statement-id="cm-8.5_stmt" uuid="00f44a70-1aee-473b-a536-43025be1335e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48b8fbc3-de2c-43d2-8a07-e28a178041df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3341,34 +3341,34 @@ inventories is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="450e93d6-cf61-414b-8a92-4745a9b0d98c" control-id="cm-9">
+    <implemented-requirement uuid="7d29b633-bf7d-4c8d-a07e-e7da6bd0597d" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="6158bc23-6915-4e11-9bb9-7503966fff80">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6756ea9a-4fae-4370-8962-f601a499dc65">
+      <statement statement-id="cm-9_stmt.a" uuid="4c2757ce-0736-4639-aa56-1445684f0852">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="adbaa9c4-681d-47b5-b8b7-aad650b48bcb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8a7eaf84-3303-4a4a-a098-90c95d786d33">
+      <statement statement-id="cm-9_stmt.b" uuid="ed8ce88e-7264-4d89-bf53-28942768311f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="fab90b9e-8dc6-401b-a485-f210df7b0e02">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="119f3d9f-4fe3-4b50-a21d-c23cbe9dd439">
+      <statement statement-id="cm-9_stmt.c" uuid="a54380f1-364a-4c9f-8240-adb67f10c541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="33c95f6d-b638-4618-9aa7-e143c85e3d96">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a7bdc8b8-d778-4fa3-8aa4-a7345f5484c4">
+      <statement statement-id="cm-9_stmt.d" uuid="f654475c-4631-419b-a63a-b6cd676d4b52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -3376,10 +3376,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0595863-e9e5-4f71-8cd3-7e933bd45899" control-id="cm-10">
+    <implemented-requirement uuid="7f6e0d1f-9540-4672-9ea2-87bc92bc1ba7" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="1d0ab58c-0fce-4301-bfab-3d94a5512c29">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7aaf3c91-a075-4497-bda4-70e590ff780d">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -3391,8 +3391,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="819aa1bf-4d1f-4980-9150-3821ff915e57">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3b38ada5-b82e-47b9-9dc1-f0d0b6822517">
+      <statement statement-id="cm-10_stmt.b" uuid="d39f780a-b0cd-4641-993b-431a62e3c29a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be79d021-c2a3-4c06-b5c0-f455be84026b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -3413,8 +3413,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="aa2c7a7c-0380-40cc-b184-4e81e485771a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eeea7dd6-916b-4702-a991-194dfbf7e5e0">
+      <statement statement-id="cm-10_stmt.c" uuid="26789b14-6c9d-47c6-88e9-ddc4e67722bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b094128-1abc-4616-8b9e-00eee0d19af3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -3425,10 +3425,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50d3fb83-9977-4936-a88b-8830624f3881" control-id="cm-10.1">
+    <implemented-requirement uuid="9f8336a3-a24d-4ddb-8263-d39ba3eb5517" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="fc899c1f-d0f6-4d09-a0f9-8ac3ab192ff0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c43fbaff-dd8d-4509-ba1e-2d1799936f67">
+      <statement statement-id="cm-10.1_stmt" uuid="fe7b30a3-83ec-4fc7-bfa1-e26d1e9460a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f6cfd58-cd70-4d96-9805-94191f4b1f49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of OpenShift configuration.
@@ -3436,10 +3436,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77bf6a79-2a2e-4496-9c25-2ff41894f40b" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="3e9ec220-e043-44f4-82d9-efdf3bcc2f62">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="16c80150-f0ee-42ce-9aec-1778be5306bc">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3448,8 +3448,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="b5621e8b-c27c-4445-827b-aee4c1376e8a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f3ea0ee6-8c5c-4a04-8e20-d0136a9dd389">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3458,8 +3458,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="678fac88-3af2-4d9c-a45f-54a9a4fd4998">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5345ae00-2d78-4814-aee0-0d2e857ca550">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3469,10 +3469,10 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf392505-39ba-4280-a9e9-7611bdb1872d" control-id="cm-11.1">
+    <implemented-requirement uuid="05674185-3d02-4342-9837-b98cbb249e81" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="f750a665-1fcd-4f81-99ef-75dbccb82dee">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b8a3d0ea-37c7-4a61-8cdc-f09e35395006">
+      <statement statement-id="cm-11.1_stmt" uuid="28d0535f-885c-4b5e-a73a-588c7cafa5ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677b360d-fb1d-4552-8436-63f7a3e58923">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3482,18 +3482,18 @@ https://issues.redhat.com/browse/CMP-286
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53d05493-db4c-4b8a-88fc-8e001b793b7c" control-id="cp-1">
+    <implemented-requirement uuid="771b728d-1714-4fd3-b5f5-a09573598f06" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="79d42416-a8d2-405c-bf89-5d95c96b008b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4216dba9-9b75-451c-9c5e-3b152ac8fbe6">
+      <statement statement-id="cp-1_stmt.a" uuid="66819085-e959-469f-bd11-b640883f4a9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5292e97-ef74-4234-a89c-9a4db072d285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="53d44fcb-c381-4df5-a94e-93b5782fa596">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5a24e940-2151-4887-96ad-09b83921bfe4">
+      <statement statement-id="cp-1_stmt.b" uuid="a502aa27-f4c0-48cc-aee2-a763691a788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b9fab65-b3f1-4cb1-a823-f55077e3378e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
@@ -3501,10 +3501,10 @@ policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5254a8d9-e5ed-440d-87a9-79a8966fcd2c" control-id="cp-2">
+    <implemented-requirement uuid="b9394721-3b8d-40cc-b02e-69fad58f7c0f" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="1cf06eb5-f7ec-4441-a220-ebccdb244445">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="44b4478e-5b34-424f-92b2-0c5ad6b3b256">
+      <statement statement-id="cp-2_stmt.a" uuid="8a136600-d66e-4ae9-bfd3-b15b9507039c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2aa923a-7992-49a6-84d8-d04470b30ac7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
@@ -3516,24 +3516,24 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="56e8491f-f854-4457-a6cb-015521cec603">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f86857fa-4915-48fe-ad7f-7e9f81536376">
+      <statement statement-id="cp-2_stmt.b" uuid="20c9cde0-812d-4c04-b472-bc27cfe4350b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="331d8009-959d-4fb9-8fe3-3b2a69179d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="1d85c50a-8c06-4ed9-8f34-cb118db6711f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="583f93f3-67ab-4db5-a2ad-80124c808281">
+      <statement statement-id="cp-2_stmt.c" uuid="54d178ce-a421-4486-9ce2-3d35d8e2a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe6802b4-1a91-4382-baab-2f3d7a1630f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="8a53d302-d266-4a49-aceb-97875830fea8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c055f376-3b4c-47c5-925e-5268e3dd04d4">
+      <statement statement-id="cp-2_stmt.d" uuid="9dfe91e6-60a2-4fc6-a292-26a3ca28cb37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6ef3bce-d733-47fa-a032-756fd0e81257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3541,24 +3541,24 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="4cb6a9d5-290e-43a7-a92c-f416a9411f03">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="493322b3-ed9f-4fd9-a05d-fbd3dce5e7bd">
+      <statement statement-id="cp-2_stmt.e" uuid="12e03d0f-7239-43ff-8511-42826295c45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8ffbee2-6b43-413d-9e41-723756839798">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="c053dc57-17fc-405e-a996-c59da5b99f38">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ed02db87-be77-4281-8d83-b74daff9ca24">
+      <statement statement-id="cp-2_stmt.f" uuid="3953f722-8d58-4b44-8f87-62d3a9186cc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="263af822-5945-4071-b329-b0064d3a15f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="b91565b2-c451-4fcf-a09d-ccf4053eb17d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="72f4e0d5-a39c-43d2-9177-a8f64b891c39">
+      <statement statement-id="cp-2_stmt.g" uuid="80043547-0078-4f6a-8e9c-cd6eeea6ccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa9f95a9-c72d-4dbf-8f27-c6f8493a27ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of OpenShift configuration.
@@ -3566,10 +3566,10 @@ modification is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c2e8e52-b4e1-4b0d-b819-1dd6bd9f6409" control-id="cp-2.1">
+    <implemented-requirement uuid="68fcb3d9-e3fa-4f21-8c0d-4dca3070f58b" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="1f6cfd52-62a7-4856-afd7-9a35e121511f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="511847e9-30af-409f-a76f-50a2f8b79bb9">
+      <statement statement-id="cp-2.1_stmt" uuid="71aae42e-fd99-437a-8439-fccb5ca10dc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3396a14-d559-4528-a017-03f6b3c5c178">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of OpenShift
@@ -3578,10 +3578,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb01ea6c-3db4-4a24-a7ff-56051bcaaf69" control-id="cp-2.2">
+    <implemented-requirement uuid="7e03fae0-bd13-44da-9203-e5fa39f3d61c" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="d29e7dac-a2d6-4f5f-b6b6-b7fc1f423eeb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d69f1f27-8b2b-443e-9de7-09fa909d7422">
+      <statement statement-id="cp-2.2_stmt" uuid="68dd278b-6ed2-4ffe-8b6d-7b3ebcc9ad00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3589,10 +3589,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc27c4d6-678c-4783-88c0-bd6df4351bde" control-id="cp-2.3">
+    <implemented-requirement uuid="9406b199-8f5e-485f-9269-cb66e3116867" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="c0976ce3-f308-46d4-baa8-f000755fa693">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4b2e8439-4a39-4dfa-a535-5142b3a758ef">
+      <statement statement-id="cp-2.3_stmt" uuid="10ab1719-eb47-4cd3-8405-36b41446ce45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84850209-159b-4f57-9829-7b4fffb823f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3601,10 +3601,10 @@ plan activation is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e61881e-404e-4ab0-8195-334ed28ab9ab" control-id="cp-2.4">
+    <implemented-requirement uuid="88e94465-9802-4189-b3e5-06fe631cf75a" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="09e6c6ad-f951-4692-b7bb-8107f9dd4910">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9509732b-31e9-4332-8227-1ee9683aaafa">
+      <statement statement-id="cp-2.4_stmt" uuid="75b3ba70-f066-4738-ac5c-8220cb2b5c41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f36c61-d5a9-4687-bed5-6effc28469bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of all missions and business
 functions within an organization-defined time period of contingency
@@ -3613,10 +3613,10 @@ plan activation is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6dcd27f-bd3a-46db-9351-b05ff0dc10ca" control-id="cp-2.5">
+    <implemented-requirement uuid="9bae2fc6-f6e5-438e-b704-28aba6f56f39" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="b2855e09-2dc5-4624-b2b2-eef4a495c365">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1d65c466-c285-4329-83a4-0f6e2ccc818e">
+      <statement statement-id="cp-2.5_stmt" uuid="c36acfec-e716-4fa5-9e76-cb79fc0db434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7885aa74-67f1-4912-b113-e4128b9a021b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the continuance of essential missions and business
 functions with little or no loss of operational continuity and
@@ -3627,10 +3627,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecab4da1-b457-4338-b73f-0324c28a6aa6" control-id="cp-2.8">
+    <implemented-requirement uuid="b2b31d8f-c254-46c2-99fc-b70a66da07d5" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="6abfe6a8-e775-4fcf-9960-dde27422596e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9770ccdd-341b-40f2-86d6-c756cf3bc4f7">
+      <statement statement-id="cp-2.8_stmt" uuid="cdd60955-5d53-4dfc-9362-923094a064b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3638,10 +3638,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b837662-5dbf-43bf-abb9-479f1b735bec" control-id="cp-3">
+    <implemented-requirement uuid="f8334ecb-8969-46c6-9bd2-85a7c4939117" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="8d365aba-69b2-4d99-9223-5a267615a6cb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="36a61f02-6421-48a5-be71-c76f363fa8c1">
+      <statement statement-id="cp-3_stmt.a" uuid="eacc635b-d7be-45c0-b1e1-a8c0caab0f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c46d9b50-b074-4b05-ad17-52cbefe2a778">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3650,8 +3650,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="7a1bab18-8ec6-44f9-86a4-f5478ec53993">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e374bcdc-6216-4e64-88b8-768938dd2a90">
+      <statement statement-id="cp-3_stmt.b" uuid="55d0cf39-d41d-47f2-acf1-9611c9cd28d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e2deff2-ef78-4842-a130-31d1f96ef3c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3659,8 +3659,8 @@ system changes is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="de125675-6520-4b8c-8c37-fa83ce7e90f1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="585ed930-2034-43ed-8610-38fc245fff30">
+      <statement statement-id="cp-3_stmt.c" uuid="84c463aa-dba8-43d3-9028-eb8251c5d259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5aadb256-2286-47f9-b444-493b37edbc52">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3669,10 +3669,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebdce152-7c5c-49b5-a671-3c4326ab691b" control-id="cp-3.1">
+    <implemented-requirement uuid="9d8ee492-786b-4d2b-ae22-4f489269d4b8" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="4f88d65f-7313-44ce-a1cc-fe99f1344834">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bcf8a1d4-b2c7-40e8-bde1-b7b94afe990a">
+      <statement statement-id="cp-3.1_stmt" uuid="91aaf8ca-18a7-4d7c-8b60-6e72209aa7c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8bf222d-f6c0-456d-918b-4c183a1ce94c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into contingency training to
 facilitate effective response by personnel in crisis
@@ -3681,10 +3681,10 @@ situations is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6ba712e-f617-476b-9c03-5791e1b99a2a" control-id="cp-4">
+    <implemented-requirement uuid="37f1ec1d-eca4-4821-832e-60470f2ed2d9" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="658e03a9-c600-4ab5-99a1-7590eb0b9549">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="37858fd2-cecd-4de7-b39d-797c0f504b18">
+      <statement statement-id="cp-4_stmt.a" uuid="a0121166-a8d6-4542-9a77-458b36f5fff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2d078574-7f68-43e8-860c-e009ad734355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3694,16 +3694,16 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="fa44eb5e-de5b-4706-a2b0-95315402463c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7b897ee6-b2f2-4e87-bc3c-87b4195790ec">
+      <statement statement-id="cp-4_stmt.b" uuid="cf743a34-3cfd-4fa9-a58c-07c4d34a9250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c86cbed-d193-4e6b-b255-6d100e78a57e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="93c8482d-6813-4baa-a1de-3ff2e40d20a0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="933ca61a-52dd-4761-b6d7-c78ec185dc5f">
+      <statement statement-id="cp-4_stmt.c" uuid="1f36412a-d485-4a3b-978e-d823b0c049be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8788b75-6ab4-44bc-b7fc-63dec92b1fbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of OpenShift configuration.
@@ -3711,10 +3711,10 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23c2d7fb-06b8-481d-9155-16070592e4d7" control-id="cp-4.1">
+    <implemented-requirement uuid="050446bf-fbd4-4e3d-9d30-0c8aee859401" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="2fcf5d4a-067f-4cdc-9838-447f0757b36b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="76b83363-2478-4e58-a251-366955b78f04">
+      <statement statement-id="cp-4.1_stmt" uuid="d18006e9-04d5-4afa-8fc5-e264bece5f99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e91bf2c8-c7fc-4ec1-ba01-eba54ef8f238">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3723,10 +3723,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7d5f233-b7fb-4936-9e8e-4c6dd082f9bf" control-id="cp-4.2">
+    <implemented-requirement uuid="4f3ce37b-49ae-437b-8dd8-d3375851b873" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="635db16b-67a5-45c0-abd7-7df4825054e6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b7f612ab-b89a-4fdf-bdbb-7fc310f72e52">
+      <statement statement-id="cp-4.2_stmt.a" uuid="abecfc2c-ceaf-45f9-83b1-f086b3f275b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ceef2030-c057-4bd8-857f-8cd7fae4171c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to familiarize contingency personnel with the
@@ -3735,8 +3735,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="541b2170-1bbf-4edc-94a3-f59d605f3b0e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f188d59c-b230-4c62-8d76-abee0f78e864">
+      <statement statement-id="cp-4.2_stmt.b" uuid="1e3e296d-fb52-4499-8c99-0e52944ee8d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90d68b01-c8db-47b4-974e-03ab046346b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to evaluate the capabilities of the alternate
@@ -3746,10 +3746,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7966de5-1a5e-40c8-bf79-50fe94acce29" control-id="cp-6">
+    <implemented-requirement uuid="50813791-4bfa-43e6-aac2-ae13162ae225" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="42126757-4a1d-42e2-92e3-1d272c284f7d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9718c607-d3e1-4c02-87b1-43c3f07d13ae">
+      <statement statement-id="cp-6_stmt.a" uuid="dc5c0f70-4f4e-4c18-a997-ef9147218854">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9deee0a-874a-49e7-8410-4ff3290a8975">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3758,8 +3758,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="a17963d1-71f2-4c26-ac1a-a2c293c833a1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="29da4528-7043-4309-a8f0-bf1213c8a323">
+      <statement statement-id="cp-6_stmt.b" uuid="a82fa0e9-77fb-4cb3-9a23-d5aeb13c5ffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="85d3cd83-fd2e-4d38-a918-2b3c029a6c38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3768,10 +3768,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73815af4-7144-442c-9db9-74783d26e1c8" control-id="cp-6.1">
+    <implemented-requirement uuid="2f93c5cd-a5b8-4408-9f8a-92d665f353a9" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="528a7bd2-5aa0-4cc3-aff4-71ab7b239726">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="464546aa-e63d-49b4-8f5b-165819adc8af">
+      <statement statement-id="cp-6.1_stmt" uuid="2a4ba549-5501-462d-a560-9996fb05de30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3247ec60-93f0-4ea3-ad3e-a4d626f687d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3781,10 +3781,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1bbd4f0-0bcb-4cce-b32b-1d7f4a6cac78" control-id="cp-6.2">
+    <implemented-requirement uuid="fcc79e58-91d6-440e-ac9d-f150bc185516" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="170389fb-6c59-44a4-b10e-ee58f991e607">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e3bb295f-6f77-4fbe-b73d-12335562d66f">
+      <statement statement-id="cp-6.2_stmt" uuid="107855ba-a343-4538-97e5-c439191f2aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3792,10 +3792,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8263dc31-6167-4f61-8190-b4b8fdcdfe51" control-id="cp-6.3">
+    <implemented-requirement uuid="81f7ebdc-7eda-44dc-940d-0038c9170894" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="610a33ea-8f44-4d53-9b26-d61875167615">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="efe9420d-b563-43e4-a294-a6e4f6c58c95">
+      <statement statement-id="cp-6.3_stmt" uuid="a20d4a43-8cc0-4ae5-bff8-8d97aa5e3957">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="231963f2-2910-4d08-b37b-9ada727c3578">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3805,18 +3805,18 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9369753b-06e6-45fe-85c3-ccb0f2e1255b" control-id="cp-7">
+    <implemented-requirement uuid="5b1e832f-e657-4fa3-8390-1fa1ed85c210" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="b7d19f7a-7a54-4027-9ca6-be41a0c35c5a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ddd02d92-8e7c-4939-a2d7-8286a82037e6">
+      <statement statement-id="cp-7_stmt.a" uuid="a4d95e39-d657-4a14-a24e-2f29804706f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="78f3445e-8b35-4a3b-8b9c-98091071af07">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="72c4bfd4-186a-4d68-9b60-d04a74823052">
+      <statement statement-id="cp-7_stmt.b" uuid="29a3c8f2-edcf-4336-a4ee-cc886ee3e60a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cef4bd19-d779-46ee-9794-575e3583566d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3844,8 +3844,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="e3a9ecac-f9c6-4777-a402-14844775bf44">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b69e1f8f-c3f2-4ece-9ceb-325e63695f40">
+      <statement statement-id="cp-7_stmt.c" uuid="8df8a76e-df2c-4ecc-99f0-f61d76d50ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3853,10 +3853,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef20ad87-bfc5-4ba8-8780-2304f71f9b0a" control-id="cp-7.1">
+    <implemented-requirement uuid="12045a31-1c7e-4694-b3db-ec5a872e954f" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="c0a31526-cfe1-4959-80ff-67cef7bc2afc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4ea17ef7-a395-44d9-8e27-8572cda8a8e5">
+      <statement statement-id="cp-7.1_stmt" uuid="f747f946-4067-4172-9e95-c3633e70e611">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8a07e0d-b993-4ff4-a806-f495649250ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3866,10 +3866,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83c05cf6-1faa-4470-8e03-f6f4a626cec8" control-id="cp-7.2">
+    <implemented-requirement uuid="c820dad3-a791-4dd9-a00e-3d6dd5d77077" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="3d7058d9-cd93-41f8-8556-1bd752f0bbb9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3e2ece8b-f54f-41eb-b09c-832ba7be81c1">
+      <statement statement-id="cp-7.2_stmt" uuid="deb477d7-3a25-4735-82fb-f9dbcc57ca46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fa3e2f6-646d-49ea-91d2-2759f78287bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3879,10 +3879,10 @@ actions is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="518f27d9-c3e2-4728-be36-2af98286a312" control-id="cp-7.3">
+    <implemented-requirement uuid="6984c5c8-08a3-4be0-8275-625e98ccc022" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="c3af39d3-594a-4fef-b327-a2de217e5d78">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9e699650-cfa2-444e-a18b-5d1013a9ea01">
+      <statement statement-id="cp-7.3_stmt" uuid="2f1230e1-a882-4798-bfce-e3408837c3af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b00e22d7-881d-453a-b04f-9c548c765bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3892,10 +3892,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57678ffa-6657-4667-b31f-22fa6940d64b" control-id="cp-7.4">
+    <implemented-requirement uuid="87d008d1-d0da-4d96-876b-82c0b5ba0427" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="0ff97737-c334-4ad6-ba51-d8bd9a2afc58">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="503477d2-cc2e-44e6-b834-c3504cdda709">
+      <statement statement-id="cp-7.4_stmt" uuid="8aec65e0-1820-4127-8f3f-20ddd0b39802">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3903,10 +3903,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e97c6b49-bed9-4ce9-84e1-93ef2e40197f" control-id="cp-8">
+    <implemented-requirement uuid="cbed8a82-ee85-48ec-91ad-b1db2679462d" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="6ab6f94b-7de7-4068-9a51-527f5b769930">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="87faba22-5c23-43a3-a7d7-d14d4891e130">
+      <statement statement-id="cp-8_stmt" uuid="49fb40da-a709-401a-a4be-84aa59502424">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5078176d-b1cd-4ba6-b420-33f93f20dee9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of OpenShift configuration.
@@ -3914,10 +3914,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a17eb06-5b11-4ef5-8765-ee5323b7483d" control-id="cp-8.1">
+    <implemented-requirement uuid="52236894-a4ae-4f0f-b025-b19d4e0b017d" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="5395871c-b4b5-446b-91a8-d46f2516c758">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a62047a8-a985-49e8-a86d-b11bf9e50e50">
+      <statement statement-id="cp-8.1_stmt.a" uuid="7222ff8d-4b03-47d1-805f-1ab4c66f5703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f7769c6-f2c6-488e-b9b4-a4f9538314db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3926,8 +3926,8 @@ time objectives) is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="d8f98c17-9210-457f-9bd6-e1da4657f005">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="38a87048-beee-4966-b266-2f7ac374aab9">
+      <statement statement-id="cp-8.1_stmt.b" uuid="e4a5ec7e-e81f-406b-ab83-4862700d0a7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ff082a8-f0d4-43fb-b6ff-3ed080e8d7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3938,10 +3938,10 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a295273f-c979-452d-9b39-e0d24ff4f247" control-id="cp-8.2">
+    <implemented-requirement uuid="01062b08-cd1a-4b58-993f-faefc16c0206" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="d252cad2-c4fa-479f-a744-9c6abc883fbb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="01551ff7-9f91-42fe-b630-ba7a61fc2ec9">
+      <statement statement-id="cp-8.2_stmt" uuid="93f2e67e-599e-43fc-a131-9fc9c848cdc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a39e3b0d-95c1-4bd2-921e-7e7f3b156405">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3951,10 +3951,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="764fcb7b-8412-4a1e-a917-52c56677a009" control-id="cp-8.3">
+    <implemented-requirement uuid="af0b69c2-5371-4f4e-81ed-a1438994f1ce" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="25885db5-4b91-4f2f-b9e6-f59f185ca5cf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2822ee80-e225-494b-b61b-1110d9231ea2">
+      <statement statement-id="cp-8.3_stmt" uuid="db90d3aa-d682-43b0-b3ac-4837a42242d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6411cab9-5afe-4654-8d04-695e411f8668">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services from providers
 that are separated from primary service providers to reduce
@@ -3964,10 +3964,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="411d88dc-8c7f-4b13-aa75-e6c0aec1f886" control-id="cp-8.4">
+    <implemented-requirement uuid="fe4f7722-8509-4685-a60a-e323d5a20cbd" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt.a" uuid="702328e8-aec9-445c-ac49-efda016500dd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3f12cb01-d683-4d5b-b4e9-a18b61692271">
+      <statement statement-id="cp-8.4_stmt.a" uuid="fd56fb25-3369-4e29-ac1a-8f1c69223435">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17da368c-1402-4bba-a056-38cb4c30371c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring primary and alternate telecommunications service
 providers to have contingency plans is outside the scope
@@ -3975,8 +3975,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.b" uuid="38fc1491-438b-4af4-be56-7a573e8daa86">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="258ce3cf-7f52-493d-aa21-4bf86f519b7a">
+      <statement statement-id="cp-8.4_stmt.b" uuid="6793587c-9782-4f9c-9fa7-db795d51dc11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23845c5f-8017-4cd4-9f21-603056da6d3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing provider contingency plans to ensure that the plans
 meet organizational contingecny requirements is outside
@@ -3984,8 +3984,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.c" uuid="553bccd3-08af-4958-b81c-684a42c70c94">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b5cb30b4-dada-4f1b-87c7-1246bf0061cd">
+      <statement statement-id="cp-8.4_stmt.c" uuid="ae3ca629-dc1c-4a13-a5ae-c3cd9d3283dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6aa3018-a56b-480a-ad01-a4ba2f2a1a49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining evidence of contingency testing/training by providers
 at an organization-defined frequency is outside the plannedscope
@@ -3994,10 +3994,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c08994d-fc2c-4b78-b4f2-f2b4d9dfcb52" control-id="cp-9">
+    <implemented-requirement uuid="b8ed0b80-8f2f-482a-9ecb-036cfc41ec26" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="24ef204b-0f23-4fec-b977-43746882cf91">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="903d16f0-f423-4c68-8766-d6fde41c8d0f">
+      <statement statement-id="cp-9_stmt.a" uuid="baffa994-23ab-4ef5-a98e-935efbb3a03e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91111cd6-ceec-4076-b4db-2f7432fbe684">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -4018,8 +4018,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/backing-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="ceada060-b036-4d89-977e-020170063024">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="57e19563-1e4d-4507-b31d-509162667fd7">
+      <statement statement-id="cp-9_stmt.b" uuid="5c32e132-5d18-45c1-9044-08de5dba08c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4e1dc78-ba58-44a8-b06e-7e3bdd228353">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -4040,8 +4040,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="3577566f-f35d-4a2f-b8cf-57efce06a73c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="35ee6c09-efb7-4876-b41a-42b825923244">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -4052,8 +4052,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="a4a600cd-e65d-4f19-94b7-771661b9c9cc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2215ddcf-4b16-49fc-819c-453dcd7d8bfe">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -4070,10 +4070,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5eaefdb6-940a-46f6-93bd-2a2966076fd8" control-id="cp-9.1">
+    <implemented-requirement uuid="2028a7bb-9a66-4854-931b-e4645f62f474" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="34734984-dcdc-4adc-80ba-8bf1cd05f5c4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="99126fc8-57bc-4d2a-9d48-76bd99e3c839">
+      <statement statement-id="cp-9.1_stmt" uuid="4ab62c86-5c04-4a4a-899d-ef04a43c3f6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19ed4134-a2ff-47ca-8b6a-f1646595bb99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -4082,10 +4082,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60ef97b2-e608-4c88-8c59-04897de40c08" control-id="cp-9.2">
+    <implemented-requirement uuid="beed14e5-9fe7-4843-96cd-13f050d7f29d" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="764438e4-dd1b-45fd-887e-ccedca65e1d4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="166d0e3c-10af-4681-9c12-8cb6a58f9ede">
+      <statement statement-id="cp-9.2_stmt" uuid="197b8749-9b90-4d18-b628-d1af270aa6a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7767ca0e-d302-45c7-964a-1fb0ff2021e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -4095,10 +4095,10 @@ https://issues.redhat.com/browse/CMP-293
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01478562-4875-4ba6-b85b-1f117424f5e5" control-id="cp-9.3">
+    <implemented-requirement uuid="373ffff3-37fb-4fba-b48c-39ee152839b4" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="7a5a1bec-1deb-4d9a-830b-eea97ac3eaf8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a085fbbd-3a85-41c8-9db9-57f70196ce05">
+      <statement statement-id="cp-9.3_stmt" uuid="e20bb8aa-12ad-4f56-98c1-246c171c7d8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b74d6d9c-72f5-4449-bdeb-4e8e12738eec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -4108,10 +4108,10 @@ operational system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6157c73-d0e9-4c0d-aada-84251b8bba5e" control-id="cp-9.5">
+    <implemented-requirement uuid="90751658-149a-4fb0-bedc-50ea6252154a" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="b5708406-d005-462b-8ced-e9b6ff228a85">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="acd0191b-c917-486e-9007-d87e5c943d9c">
+      <statement statement-id="cp-9.5_stmt" uuid="acacbfe3-18e4-4685-a916-af961872daff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4119,10 +4119,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="210fcff7-5204-4d8d-9796-1232c5eabc4f" control-id="cp-10">
+    <implemented-requirement uuid="60c05e35-8cbb-431e-be0e-7298fb2e3885" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="a09f8052-74e4-434b-a489-55993ecdd222">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="487d59a1-34a4-4528-99e1-2cab4a4841b4">
+      <statement statement-id="cp-10_stmt" uuid="4cfec696-2533-43e2-8cd4-d83034a25b0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc615e64-aa2a-40d5-9bf5-f9fec7b0860a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their OpenShift environment. A successful control response will detail
@@ -4137,10 +4137,10 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3fc992a-cb48-49a5-a2cf-f672e3e2a9be" control-id="cp-10.2">
+    <implemented-requirement uuid="f38b682d-5a68-4e3a-93ea-77d208867808" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="13dc8737-abcb-4801-8619-b95ba284a89f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1fe4472f-0181-472c-9078-a7b2c5bbe13d">
+      <statement statement-id="cp-10.2_stmt" uuid="1e5bdebd-7dc2-4315-954d-3e911ac29edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4148,10 +4148,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d242b9d-2341-4097-b2b8-36116a55103c" control-id="cp-10.4">
+    <implemented-requirement uuid="b3a13834-7f0e-4d08-a644-bb096e6adbb9" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="ec330a8a-0c86-47d6-bb6f-29be0e4abb83">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="13bc8cb6-43c6-461f-8e11-07b7bc361d3e">
+      <statement statement-id="cp-10.4_stmt" uuid="82de4f15-493b-4b9a-8aec-50193435726c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4159,27 +4159,27 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66b110f3-3107-45d5-beb7-6db2d8be9a54" control-id="ia-1">
+    <implemented-requirement uuid="7a63474b-62ca-479d-964b-d58bce457f95" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="43700ec4-fe7b-4ea7-8d1a-acb1b6d97f06">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc2e5da3-180b-41f3-97a8-98707e8d0d25">
+      <statement statement-id="ia-1_stmt.a" uuid="a36fe514-78f8-4e92-a6f5-ffbdbac40098">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a33d8b8-0bdb-4d23-8859-0363adaacce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="91a11e58-5985-4bd9-834a-e9e3f8f141d5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0465741f-7043-4d1a-8973-35cd50e52eec">
+      <statement statement-id="ia-1_stmt.b" uuid="1ad8b1ab-65d9-4977-9a6a-3dd415e440ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe0d32dc-7657-41d6-8617-03d01c8d0590">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="844f6604-b8ac-45cc-8dcf-d843267d01db" control-id="ia-2">
+    <implemented-requirement uuid="d5bf1824-63d0-459f-8124-139f199c926a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="9dd41d5f-ddd5-41bd-bede-e3813c7b22de">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d576f072-39c7-4eeb-9075-541055cfa319">
+      <statement statement-id="ia-2_stmt" uuid="69702027-98b2-432d-9be3-8816afa66b86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e572a34-7d36-430a-acde-f6d4ece3a6b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Unique identification and authentication of organizational users
 is deferred to the organizational identity provider (such as
@@ -4198,10 +4198,10 @@ container image, is provided by correlating system audit logs.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18bac594-ab32-4520-9cf9-83f2f794c805" control-id="ia-2.1">
+    <implemented-requirement uuid="31ff8a91-b777-49fb-b8a8-89cb0b4aae44" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="0e8874ce-dcc9-4550-9350-7c14261ce111">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4f01dac5-6fd9-482f-b2cc-43b045014efe">
+      <statement statement-id="ia-2.1_stmt" uuid="eca3dba3-92b6-4796-8f9f-3b9c961260eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11288f65-ae11-479b-8f16-163d14246986">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementation of multifactor authentication for network
 access to privileged accounts is deferred to the
@@ -4220,10 +4220,10 @@ needs and requirements.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce36ff0a-3bc6-45e9-aacd-4a9cd9bf5aaa" control-id="ia-2.2">
+    <implemented-requirement uuid="cf7c767f-0055-41ca-a1da-6d732b6a37e8" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="8594900b-59c1-41b8-a071-766b7e4e39e3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5ae6bf21-d805-44e6-bea8-3e46ab952e73">
+      <statement statement-id="ia-2.2_stmt" uuid="1fb52b9e-61c3-4c51-9616-d746b5dde22a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c7f868-8a40-432b-85d7-a6dda1c95ab3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing multifactor authentication for network access
 to non-privileged accounts is the responsibility of the
@@ -4238,10 +4238,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a90d26e-b83a-47e6-8802-350047ccca30" control-id="ia-2.3">
+    <implemented-requirement uuid="3d3e27ed-6394-4013-886b-40269120234d" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="2422e5b9-b739-4b36-a1fc-732b884128a1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4d226bf4-aa8c-4075-8338-b97fb0389c15">
+      <statement statement-id="ia-2.3_stmt" uuid="d683d036-9850-47a6-a23b-a45c5f4db720">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2319b2df-e057-43dd-9df2-f329809aae78">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift has no concept of local accounts and was designed without the use of local accounts.
 OpenShift relies on a centralized identity provider rather than a local identity provider.
@@ -4255,10 +4255,10 @@ is not applicable to OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7036759c-93cc-4084-bbdb-5d48ee40ca6b" control-id="ia-2.4">
+    <implemented-requirement uuid="95f67be2-45c2-48d5-b2d0-7306b9a94942" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="071939dd-5432-427f-bd5a-e1eb35bae000">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="14582219-4507-44f7-a972-0acec3dc2230">
+      <statement statement-id="ia-2.4_stmt" uuid="7922a873-f6bd-4403-9252-9486544ef088">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b36e937-b11e-4fd4-a3dc-52c49395a8d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift has no concept of local accounts and was designed without the use of local accounts.
 OpenShift relies on a centralized identity provider rather than a local identity provider.
@@ -4272,10 +4272,10 @@ is not applicable to OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd917bc3-3458-4622-be13-975169fc4485" control-id="ia-2.5">
+    <implemented-requirement uuid="70fb0a1f-4d52-4d3a-8bd2-76bad2982a11" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="994038fd-7110-4ba0-9ab9-d6fa6da42d08">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="12b27335-53b9-4747-a028-7019ad27be6d">
+      <statement statement-id="ia-2.5_stmt" uuid="171afaa9-5c54-4280-b995-6a326913f866">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8db01236-9ba8-4e4d-89f2-befea2e69992">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4283,10 +4283,10 @@ https://issues.redhat.com/browse/CMP-314</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc51af81-00f1-46ed-ad33-c8edb14a1711" control-id="ia-2.8">
+    <implemented-requirement uuid="58b65007-7944-4515-ac3b-eb32c8217053" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="f0d3f3a3-19a7-4b50-a0de-6fb819cacfe7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="825e5ddd-cae7-4bd8-b950-ade245cfe487">
+      <statement statement-id="ia-2.8_stmt" uuid="44133dc6-7f85-4bd5-8e92-7c3503592a8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befd7201-c418-44f9-b539-54f1d723941b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4294,10 +4294,10 @@ https://issues.redhat.com/browse/CMP-573</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ee4737e-1dfa-4bda-b8cf-5338e1212bc2" control-id="ia-2.9">
+    <implemented-requirement uuid="1ae78fa4-5f2b-45e2-aa71-a08e1fafa49a" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="4779ff50-58a6-4e49-b041-5a31891a22dc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3b96cc5a-0197-42e9-806a-34332e144f9a">
+      <statement statement-id="ia-2.9_stmt" uuid="e730c5e2-609d-40a2-add2-c42b0b4c1ae7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bf7bc4c-ad71-495c-bab6-5576d6c48875">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4305,10 +4305,10 @@ https://issues.redhat.com/browse/CMP-574</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a30967c-0bf3-4113-8cb7-33787d47cddb" control-id="ia-2.11">
+    <implemented-requirement uuid="362d4418-8240-461c-96e4-ef5fa30ad4dd" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="38d0ce2d-bfff-42ba-8149-443c18a0cd19">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8bec714d-b8f1-48ae-b3aa-ce0e710157c6">
+      <statement statement-id="ia-2.11_stmt" uuid="e6bd6d01-26be-45fa-914c-f0a6287cda05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d93e23f-8b49-4528-960a-997f4e43f8c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a separate device from the system
 gaining access to the information system using multifactor
@@ -4318,10 +4318,10 @@ guidance of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9febbb4-5306-4637-b872-a6c5a40c39c6" control-id="ia-2.12">
+    <implemented-requirement uuid="cd277188-f18d-4c2f-81d1-52b4f05d4850" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="26b337e5-2cf7-4118-a857-9df78310fbcd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f523263b-6e6b-4f77-94c2-bc6cafe92106">
+      <statement statement-id="ia-2.12_stmt" uuid="c8df24aa-90fc-40ce-8b44-eb61bf261d49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8a27df5-d2b4-454c-9d33-ff6bf5108270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronic verification of Personal
 Identity Verification (PIV) credentials is the responsibility
@@ -4336,27 +4336,27 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87d710d1-6fda-4dcb-9452-83f0522e799e" control-id="ia-3">
+    <implemented-requirement uuid="affb7bbc-ba2d-4d82-81ee-3b12c82a0240" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="124f0b66-d4c9-47a2-bc68-ea8ec0755491">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="78b2c61a-a867-4d2c-b575-6d3e05ef23e0">
+      <statement statement-id="ia-3_stmt" uuid="b0106689-c877-4dd2-b7fb-48be934113bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4094f41b-39e5-4be9-a5c0-2b03948cd290">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26d4e031-19a1-47b7-a496-15e002de42d4" control-id="ia-4">
+    <implemented-requirement uuid="f8c650c8-2244-4408-8c43-b7d628cddbf9" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="03d24e61-b485-487f-bd78-b253679e2c47">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6f21ac66-25a3-4299-8dd9-14850ae3a228">
+      <statement statement-id="ia-4_stmt.a" uuid="af77be7e-e7ac-43f6-838e-93a7def235f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ae35092-d4b9-46fc-8151-a7c985b0cf73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
 requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="b04235c6-cdf7-456f-8114-2a0386ca61f3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f1a7cb82-a1a5-42d7-875d-9dbea581847e">
+      <statement statement-id="ia-4_stmt.b" uuid="d4c31b6a-6158-43f2-8271-7bbe4f914cfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae5e68fd-d86a-4fa0-8600-a3560f6361b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift
@@ -4369,8 +4369,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="d678b670-b6b2-49cc-9737-c2d124ecd5c3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4210e6e9-8d36-46fe-a950-eb925aa22a93">
+      <statement statement-id="ia-4_stmt.c" uuid="4cadb32e-e9a0-46fe-9a9e-2b5198cf8dc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23c9fe46-b3b5-49ac-9dbd-091b95caffa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4382,8 +4382,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="636aa30b-4ea0-4296-bbb3-d9fbd7597d3e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="69fd4b82-ae53-4ad3-a9d2-2bfa48ca6a41">
+      <statement statement-id="ia-4_stmt.d" uuid="c1c3dfe5-dc9c-4795-b8f3-d4781b33a61d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b50a8422-1e67-4289-beba-bfac3b80e45a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of OpenShift configuration.
@@ -4395,8 +4395,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="249957ab-3859-4a45-9565-b1d868c358fb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="60d5aca5-1769-48a5-b875-10f88746578f">
+      <statement statement-id="ia-4_stmt.e" uuid="1ef28ca6-a1b3-4310-99d3-4d5b9d555331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78d3d56d-9076-495a-9b79-451d78c74481">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of OpenShift
@@ -4410,20 +4410,20 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d7c5e87-bba2-4a15-b5ae-c3486cd567e1" control-id="ia-4.4">
+    <implemented-requirement uuid="ffc6660f-49c7-48d6-ae0d-e730ffe55e55" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="dd6e980e-3993-46c8-afa2-00a3438b858b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ce3edda3-7158-441f-ad25-b4fb17e4faca">
+      <statement statement-id="ia-4.4_stmt" uuid="fc0b706c-b313-47dd-b2b7-ed57cbd810c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d818cc45-a56b-48ea-95ff-0dd9de956381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f51a594-27c2-4343-9afd-badb2180954e" control-id="ia-5">
+    <implemented-requirement uuid="f45786b2-8ed7-4ee6-9977-1cbfd8439463" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="8ebd5fd5-5819-4d84-a1a6-9923f0a6ef48">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9d00520d-1310-4fb6-be53-1972b87b86dc">
+      <statement statement-id="ia-5_stmt.a" uuid="b77b381f-73ee-45d2-b1ee-6dbd2a271b05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="035e502e-7530-462b-af9e-ef68b2c1e6f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -4431,8 +4431,8 @@ is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="a742b4f7-c6ee-420c-b593-38f03e8f98bb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3c49972a-e869-4260-aa59-b807652d9d70">
+      <statement statement-id="ia-5_stmt.b" uuid="9edf37b0-e399-4984-80d6-d022fb4db90f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bf9a1ed-032c-440f-9e8f-68b7c4658645">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4444,8 +4444,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="00408635-99e5-43f8-81f8-97eecad404d7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d6f029cd-ff2c-4c44-be3b-488241e1cb78">
+      <statement statement-id="ia-5_stmt.c" uuid="a5fbcaf4-4a96-4c7a-86e8-1cc7eb2bdfb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f524611f-505a-4fff-9a00-9f2e38d9fecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4457,8 +4457,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="65c3046d-73f7-4fd7-84c1-9b7f5fbddacf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ea9b2667-eabf-4c93-bfe4-08aa4bddf765">
+      <statement statement-id="ia-5_stmt.d" uuid="fdc6a0b9-914a-4099-9357-a8cd1607a7a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f6ba12d-0e6c-4f30-b8ed-d623e84a01c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -4471,15 +4471,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="dfb455e5-344d-47e3-b5e4-19d746e64579">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c4f4f705-1c15-4fd4-9784-92c1e98f3cc9">
+      <statement statement-id="ia-5_stmt.e" uuid="a8b479e6-63c8-478a-8ff7-d4d29749603e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c4e68b-fded-4a39-87a1-bb4af4c888a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="a4158a6b-b12f-45a2-8d10-420a1675199d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f74ed4fb-0e6d-4592-9a44-491ff9f17a9f">
+      <statement statement-id="ia-5_stmt.f" uuid="21d07f6b-a8a0-45f8-a9fb-77e8c140557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b95f8b1-9bc1-4f9d-a602-132c9801e281">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4491,8 +4491,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="b710a030-160b-4d04-b072-df94c37751fa">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6ad978e2-803f-4de4-be8e-6642b6673f45">
+      <statement statement-id="ia-5_stmt.g" uuid="f196ad36-8645-4831-be4f-7284660a97e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5be5103-5818-4050-861f-4c8878a5535e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4504,8 +4504,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="79c093b4-6eee-4990-a972-56d2859be11b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7565585c-b440-4a85-8982-fde36ae54e8e">
+      <statement statement-id="ia-5_stmt.h" uuid="ae312eb9-a9b1-484e-837e-55213c542bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3253f21a-52de-4279-81f7-050827a480a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4517,15 +4517,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="214205fc-4148-4018-9b21-8aefb96a419e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9101c598-4a0c-43db-8063-bc6270fad0d1">
+      <statement statement-id="ia-5_stmt.i" uuid="1103eb61-2511-4e4e-9dc8-ae2e27ee4fcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="858b0f18-ca29-4ecb-9da4-ebe49a3ddf8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="2d9051ed-5ecf-467e-a998-f87e1560081d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="28d655af-4c29-4b69-9ed8-5e870e256fee">
+      <statement statement-id="ia-5_stmt.j" uuid="0d9d2135-b850-4062-9382-e6e1435da287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="171d97d3-9690-4d1b-849a-ae505ebd52d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -4538,10 +4538,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ca0146a-b6a9-4a8f-9bd6-c405ef8a133d" control-id="ia-5.1">
+    <implemented-requirement uuid="c840dd2d-2134-4106-b0e1-cdbdf942e3ee" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="3387da40-c9bf-456e-99d3-d07b9b2b44ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="137c9c70-ca48-4626-943c-5da2e5da40a0">
+      <statement statement-id="ia-5.1_stmt.a" uuid="5494089a-1a35-4115-88e3-cf817fa662c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0080de48-f09f-4e25-84a7-d8fdc5704bb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -4555,8 +4555,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="ebadf17e-73d9-4ec1-ba99-5da399efe296">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d33f518a-d4a8-4103-9e3d-8c731cdd16e4">
+      <statement statement-id="ia-5.1_stmt.b" uuid="af6af93e-ea08-4c92-ae76-993187816f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="affed9b7-8fe7-49f0-92ea-6d594ebc48ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of OpenShift configuration.
@@ -4568,8 +4568,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="4b08d330-5522-4345-a1a4-5d8f25f0255a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="986743ca-eccf-4b42-835d-af388dc582f8">
+      <statement statement-id="ia-5.1_stmt.c" uuid="3ecfcdf9-1a50-42d6-b687-328fb6f3d17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e124b321-8080-4d56-a14d-45aef97161fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of OpenShift configuration.
@@ -4581,8 +4581,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="07dd6056-61aa-4958-abe9-1923ae8c104d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eb2bc00b-568e-46a6-93d7-92863f09191b">
+      <statement statement-id="ia-5.1_stmt.d" uuid="59ef1f9e-aba7-4b83-b9f3-9e580162fffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67102d51-3421-49c3-8272-98e08992dca4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of OpenShift configuration.
@@ -4594,8 +4594,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="076a680b-8418-4143-a455-dcdc684fae2d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e54b6ac8-22e8-48ee-a363-0e3092dca4bd">
+      <statement statement-id="ia-5.1_stmt.e" uuid="a1ebe259-90ce-47a3-89b7-3a836ba771ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eaf0053-9ecf-401c-8c93-a735e11b7306">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of OpenShift configuration.
@@ -4607,8 +4607,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="effdf3ef-8997-498d-9561-dd3868917257">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bdc235b8-9926-4ecd-bdf5-ef33935ebc9e">
+      <statement statement-id="ia-5.1_stmt.f" uuid="256c38d6-45fa-443e-907d-ff06e549ccf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f4d75ab-40f3-4890-97bc-bd148fe15e9c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of OpenShift configuration.
@@ -4621,34 +4621,34 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="450a1019-bad9-4301-a99b-40834e28cbe7" control-id="ia-5.2">
+    <implemented-requirement uuid="3d445664-31ad-44c3-9a73-e966b555a4e1" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="f35226ff-3b77-42ab-ac41-0e0002c384a8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bc22e407-6439-455c-90bc-78a2a982dfc1">
+      <statement statement-id="ia-5.2_stmt.a" uuid="a2b1037b-32b1-48d7-b633-f389aba90736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="d921923c-6609-41a2-9256-0f9c841e0c89">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5e9c71e5-fa3f-4766-800c-dd8399448110">
+      <statement statement-id="ia-5.2_stmt.b" uuid="e0bce06b-3ca7-4c6b-b737-8f7b277f03ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="6b224597-fbab-4bad-989e-6645f7545155">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c1d26752-bb5a-48d7-a5bd-3bf2c011f93c">
+      <statement statement-id="ia-5.2_stmt.c" uuid="0bc48b29-44a3-402f-8bf4-891ed7bfaaeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="18ab659d-488f-4642-a3cd-6c3017c8ef1b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="60b975eb-b4ec-4119-aacc-7a413402a12d">
+      <statement statement-id="ia-5.2_stmt.d" uuid="e6f5339f-55ea-49b8-8b36-6ca9d24cbd37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4656,10 +4656,10 @@ https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb566f45-df13-4eb0-87d1-ca742574bed9" control-id="ia-5.3">
+    <implemented-requirement uuid="087b0337-b603-49f3-9da4-561f46d5a5fb" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="f48a5c8e-b415-4557-85f7-2f6c3c5c44af">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2afeecce-cbc7-459f-b5ee-fda7cbfcd9ad">
+      <statement statement-id="ia-5.3_stmt" uuid="a788ca9d-d74f-4362-872e-c0972bbd9917">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="847c4dff-2b19-46c8-a1c4-14fde9fa7f1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4670,10 +4670,10 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1862000-cbbb-43f0-8ac7-ce162a1260a8" control-id="ia-5.4">
+    <implemented-requirement uuid="a0eca32c-d306-4f23-8e9e-96b6402ed104" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="fa9f183d-b2c9-44ab-a8f9-cf94fa6fb40f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8edd2af9-4726-42f5-b282-3ae292eba507">
+      <statement statement-id="ia-5.4_stmt" uuid="9ffddd5e-d96b-41df-b35b-8dbf74ca432e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c609ea35-e7b3-4483-9223-aa8bc09e7ff0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4681,29 +4681,29 @@ https://issues.redhat.com/browse/CMP-328</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c2d6728-619d-46cd-ae91-f4a2dcc3f517" control-id="ia-5.6">
+    <implemented-requirement uuid="571b39b1-f0a6-4dc9-a6a1-760fe8f05b3c" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="b7ea6fd2-075a-4fed-9323-52f2607da3a4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0713588c-3d01-4bb6-836a-14f696bb41e2">
+      <statement statement-id="ia-5.6_stmt" uuid="1db6648f-b34c-453e-a1a7-ada8b0930096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d818cc45-a56b-48ea-95ff-0dd9de956381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a35ef1aa-ac33-466a-bc12-43d063876218" control-id="ia-5.7">
+    <implemented-requirement uuid="a80217f5-2e7e-492e-b63a-d015ffb4b031" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="73a12328-ac1b-4fbf-b2bf-9af81e246a8b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cb60f540-9518-4be9-843c-2917b94874fd">
+      <statement statement-id="ia-5.7_stmt" uuid="dab7d254-8dfa-4536-9227-25dc1a71046f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3422ee35-1c97-4e63-b358-ad7a35d6837b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-5(7) is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea260ba9-5752-4e4b-be82-ca1aebf6ed7b" control-id="ia-5.8">
+    <implemented-requirement uuid="b31dfdc7-d04c-4f11-9301-4065d42c2638" control-id="ia-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.8_stmt" uuid="92e40f47-4a8f-417d-8b64-99587e2f4eb2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9c774842-2dbf-418e-9121-12a14d1fce59">
+      <statement statement-id="ia-5.8_stmt" uuid="b29d223b-6f88-4776-85f1-5ac1c5fbaee6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="871db668-f70e-46b4-a932-afc550709739">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational implementation of organization-defined security
 safeguards to manage the risk of compromise due to individuals having
@@ -4712,10 +4712,10 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4e834f1-01bc-4021-8dd7-f4900d908d31" control-id="ia-5.11">
+    <implemented-requirement uuid="aba44873-a665-4cf3-972c-4bb448283d71" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="ac33568f-5d97-4351-90e8-690a9f4ba9f0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a3445a4-e826-47d4-a40d-734a5f7c0817">
+      <statement statement-id="ia-5.11_stmt" uuid="dc253871-14d6-47f5-8139-0a58bffbc0c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98b4157c-f7dc-44e4-b6fa-2621e57af0de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -4723,10 +4723,10 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b5e6240-6fa7-44b0-b764-4af78dbcdfad" control-id="ia-5.13">
+    <implemented-requirement uuid="19c8cc63-a729-4e74-8147-8ec4c686b08e" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="5a67cd1f-9ffa-420b-ab7f-e76c1792429e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="052b5060-82fb-4c9c-b520-3c4840f42133">
+      <statement statement-id="ia-5.13_stmt" uuid="cd05784b-a067-4639-9277-ab983a44d826">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68814518-7f2c-4627-8cde-5041c22bd72e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4734,20 +4734,20 @@ https://issues.redhat.com/browse/CMP-331</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c08846e-b309-4c74-a5eb-5b07c93df0c9" control-id="ia-6">
+    <implemented-requirement uuid="d82ede4e-b4c6-4df6-8637-06ea271f4988" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="c9d98de7-50ac-4113-bcd9-8a9e57d6d7f2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e7d4fc02-d2df-42c4-8c2e-263ef2685207">
+      <statement statement-id="ia-6_stmt" uuid="954333a6-db59-4363-84ff-4a093276cc26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1de62daa-6d58-4197-b444-1f300cfa16bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, OpenShift Container Platform session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a5111ba-48de-496a-9465-e2ee6c22da5d" control-id="ia-7">
+    <implemented-requirement uuid="15f30ea6-ea07-4a5e-8f4b-911b2b9913aa" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="f1575203-7e3b-487f-ac38-e9c092b1e467">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bbe72eb9-448b-417b-b7b3-9f330542072b">
+      <statement statement-id="ia-7_stmt" uuid="8036c5d4-0735-4d3c-b75b-9a1e12ca4425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f49ea9da-eda7-48e0-9efa-58caf64c9e50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4755,19 +4755,19 @@ https://issues.redhat.com/browse/CMP-334</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c5759d7-2c9c-40b6-89e6-9039f676a87e" control-id="ia-8">
+    <implemented-requirement uuid="40dc1e99-1157-46e8-93e9-b91aaacf5722" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="64eff607-62b9-4020-a6cc-55f7363ba49e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3dd78d63-e634-49b4-b288-0cc058d71c60">
+      <statement statement-id="ia-8_stmt" uuid="5f420b03-beea-4c0d-84b5-4039a12d1577">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bed8babc-a810-411b-bd12-deb0cca5d951">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4ba793d-d7d3-4775-94eb-39e48f0cf40b" control-id="ia-8.1">
+    <implemented-requirement uuid="e36cd541-c9e8-456c-9a9c-4e897c58bcd2" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="192a2483-4303-484b-a119-778ef88f27e2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="494b8fee-2302-4604-9ae6-e0adfc2fa944">
+      <statement statement-id="ia-8.1_stmt" uuid="6430ab3c-8226-489a-8a51-ceb2ca7c2b16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64d3d4db-549b-448a-8308-d9e57759b155">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronically verified Personal Identity Verification (PIV) credentials
 from other federal agencies is outside the scope of OpenShift configuration
@@ -4781,10 +4781,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18d44be3-02dc-4f21-a241-bee9200d6ba5" control-id="ia-8.2">
+    <implemented-requirement uuid="1571fa34-2c0c-4837-8eb0-728567db9222" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="f447cfdd-c61b-4ba2-a096-6e8651b75837">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7dc848ca-bd57-49f0-aa24-cc7a10d59661">
+      <statement statement-id="ia-8.2_stmt" uuid="ecb2f8e0-c4f5-44e9-ba59-b7122437ab7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd8b698-d621-41cf-bb38-a1e0e4f77cf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of OpenShift configuration
@@ -4798,10 +4798,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b6e5d17-7733-43ee-9a76-ef0bddf473c4" control-id="ia-8.3">
+    <implemented-requirement uuid="086a9f3b-16b7-469c-958f-5a46a1b81120" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="0ef72752-3d9f-4989-a361-d203429b0df7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fb62d344-b174-41ab-bec5-3e0a6e533b06">
+      <statement statement-id="ia-8.3_stmt" uuid="59f3a1d3-380c-4767-8cbb-61c59d4f0b35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f50b47b6-83f0-41a1-b836-bb5aa76bbd31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -4818,10 +4818,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e5b0622-1915-48a5-b911-04e940594754" control-id="ia-8.4">
+    <implemented-requirement uuid="68413d07-5f0c-48dc-8329-bbd634cd2aa6" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="02e23e0c-401b-4ebc-ba4a-bc075639672a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bbe3b319-c17c-4f95-bb58-69be277d526f">
+      <statement statement-id="ia-8.4_stmt" uuid="3691e247-fa06-4e02-a52b-87472287de3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="451ba487-859d-46d2-be66-364a4f621a92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Usage of FICAM-issued profiles is outside the scope of
 OpenShift configuration and is the responsibility of a
@@ -4835,50 +4835,50 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7feed27-f926-4368-be3d-1d5d02b8b867" control-id="ir-1">
+    <implemented-requirement uuid="43039241-d333-4db7-9609-9b77b28a3f0f" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="a9e78303-d3c6-47a1-9eae-ac396d8d1f4b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dbd8cfe2-23fc-4b45-8930-05147c78c5fe">
+      <statement statement-id="ir-1_stmt.a" uuid="88eda018-bd0b-418c-9cb2-47118ed36ced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="36e593ea-5613-4124-95d4-390e27f9b4de">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3fa9831e-e519-4be9-8c5b-8a59c522d5c4">
+      <statement statement-id="ir-1_stmt.a.1" uuid="f3fa3086-4945-4831-bbe4-9e049146b989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="69574407-ddfa-4b52-bdd3-2ac9750dc545">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc857b37-ef21-4c07-86a1-195b373cba33">
+      <statement statement-id="ir-1_stmt.a.2" uuid="d6827642-8b99-43e5-bc4a-cea9fbd10cbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="90c02cbd-2076-42b0-89db-f693a425ec11">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d24e63fb-55d9-4a89-98d5-bfd09780a3ab">
+      <statement statement-id="ir-1_stmt.b" uuid="383de702-72c9-4a0f-846f-47cd60669782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="bd49a169-8b35-4bec-a24d-5582c44128d4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="76064a44-2191-4fb2-8409-4a338e8c6b31">
+      <statement statement-id="ir-1_stmt.b.1" uuid="bd1976e1-fa73-4ef6-80b1-4eb2e9e356b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="78f1310d-aa22-40ed-9df3-a9cde6d6e885">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a96d76b1-6e92-4710-aad7-d48893e71aba">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d6cd467e-3cf8-412b-ab91-6b316fa4a606">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4886,26 +4886,26 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddb415e6-6cd6-4239-a078-6aaa6486c44a" control-id="ir-2">
+    <implemented-requirement uuid="81b56ecb-1a80-4e29-afd9-836933f1776d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="8044957a-06e2-43a3-bc46-1b31f33b8544">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="07c0097f-a5db-495a-807d-2ebb0ba5328a">
+      <statement statement-id="ir-2_stmt.a" uuid="9984f5c1-9b0f-44f3-bb44-4013df8aae5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="b4cf2c1e-feed-44c6-b983-6eb5cee48668">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d76b38fd-2025-4bf1-a006-cfe01acdfd0d">
+      <statement statement-id="ir-2_stmt.b" uuid="86b318cf-5287-4082-8c9c-2264b4717d66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="32024790-6d1c-42ee-9b27-a0c3477d3ff7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d2ecee0c-97a4-46a5-836b-5ae773bd2359">
+      <statement statement-id="ir-2_stmt.c" uuid="9742cc48-f755-42e6-8abe-e19985c32dd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4913,10 +4913,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35273d2c-9bad-4c09-8246-cf6df1233f4b" control-id="ir-2.1">
+    <implemented-requirement uuid="2367133f-621b-4cab-8776-9deebf34d453" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="74bd1248-13f9-4430-8082-83118cc2d74b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8cd9438f-2a33-4c7d-973c-1efa3a8711d0">
+      <statement statement-id="ir-2.1_stmt" uuid="6c36f2d1-0d77-4577-a814-b65b41f02528">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4924,10 +4924,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5ae9db4-3238-42aa-9bd7-da671a82181a" control-id="ir-2.2">
+    <implemented-requirement uuid="4822fc7b-bc2d-4e52-8ffc-0ea2e8a6ca3d" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="e91861aa-5728-432a-908e-34b5da7a17a1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4e61cac3-7830-4906-9fab-e2971be03ed0">
+      <statement statement-id="ir-2.2_stmt" uuid="7e6a6c24-671b-4ba7-8cf8-ef5989c45dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4935,10 +4935,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae3f729a-5f12-40d6-8c5b-76f704b9bc84" control-id="ir-3">
+    <implemented-requirement uuid="fb508091-0909-4671-b454-7a461004d6d1" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="f1540411-cb56-4437-8cd1-8e123d212116">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ec427f39-f4cf-4d7f-9ea8-afb098a9e0b7">
+      <statement statement-id="ir-3_stmt" uuid="37fdd0d5-0d8b-448c-8f9d-2bb6c5cfe139">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4946,10 +4946,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d92a8bb-0ffc-4035-af07-13d7b81e0988" control-id="ir-3.2">
+    <implemented-requirement uuid="ad715b1a-2e93-486c-8561-073e5a82ab87" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="b21e1a82-dc38-4725-81ce-062e0ce999a1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="db9ff363-0cdb-40ae-8ed0-52648da76c3a">
+      <statement statement-id="ir-3.2_stmt" uuid="efdd36dd-4bb7-45ba-af25-6d6cecb488ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4957,26 +4957,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09fc4177-89fe-4c55-8130-219739a80052" control-id="ir-4">
+    <implemented-requirement uuid="c394eb2a-4cec-443c-a6f7-77349352fc20" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="2cda88db-76b2-47f7-9981-087ba2da39ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="279c5ff2-a356-4cee-b304-0b9389feab52">
+      <statement statement-id="ir-4_stmt.a" uuid="b6252153-ddba-4952-bd97-39f0d104771c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="6535f103-911a-4089-b713-4a612a44ec91">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7bcb31f5-a648-4623-abe5-a17a459e0095">
+      <statement statement-id="ir-4_stmt.b" uuid="e2104fee-fb83-43a6-a09a-85ce5502df00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="77e8d8ea-4243-4786-a3df-de96e90659a3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9f3e1bf0-e8e7-403e-aacf-828a44a4e4b1">
+      <statement statement-id="ir-4_stmt.c" uuid="457b25c6-28f9-464f-b964-cdc84235bf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4984,10 +4984,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0348a59-4426-4e20-a608-cc74db668105" control-id="ir-4.1">
+    <implemented-requirement uuid="cce7723a-f25a-45c6-bf29-6a38860ebeab" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="a303dbdf-b73b-4d9a-b851-fa5a4da02718">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4feb3cea-9d36-45c8-8d53-39f2f07feefd">
+      <statement statement-id="ir-4.1_stmt" uuid="12b13f92-8631-4e3b-bd23-1f1d938505cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4995,10 +4995,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb728ce4-4713-4a83-b8ab-4c2cca21cafb" control-id="ir-4.2">
+    <implemented-requirement uuid="50477ac1-d98a-43b8-af54-234026314dc3" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="7af97cef-e191-4859-9143-97d7cdcc4600">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4159be90-d0d1-44fd-bf0a-e9fb65ddc1ee">
+      <statement statement-id="ir-4.2_stmt" uuid="a3f16410-c76a-45fe-b7f0-3c3d6716f017">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5006,10 +5006,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa36773d-9fb7-4c92-91f0-b2c9dbc90183" control-id="ir-4.3">
+    <implemented-requirement uuid="1cee8ead-f034-455c-96e9-7ec73b925095" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="1426a85f-16b0-473c-98f4-9fbc6d550399">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="37f36751-6fcc-4e16-a6f9-ab99bfe57471">
+      <statement statement-id="ir-4.3_stmt" uuid="8877323d-5ad8-467e-b692-01b021da861f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5017,10 +5017,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5368309f-ef7f-48f2-bf23-e1bc88ad2b48" control-id="ir-4.4">
+    <implemented-requirement uuid="630fd8cd-d738-4a2a-aa33-78ce66629326" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="8f198509-1f40-4165-9734-58c1e9a25c65">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ad05088f-c98c-4b28-b1f3-ff2a738d276d">
+      <statement statement-id="ir-4.4_stmt" uuid="de031b26-7778-4df6-a74f-0acb14e50ed7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5028,10 +5028,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb0bab8f-0ebb-4c1c-b714-85e8e3b59464" control-id="ir-4.6">
+    <implemented-requirement uuid="f3490aa6-6340-4d5d-a3fc-bbdff1aa90cd" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="bad5c212-65fb-4156-9e25-6ea845015ee6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a10c157e-0d7b-4a47-97f1-50c0a359b3d3">
+      <statement statement-id="ir-4.6_stmt" uuid="9f49d788-c4d3-433b-9873-f2bb11c70b6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5039,10 +5039,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f13c0048-163e-41ce-9c26-8b0ea813157f" control-id="ir-4.8">
+    <implemented-requirement uuid="25578eba-cfed-447c-a5ac-523b65484931" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="558537e2-9e5a-410f-8da3-e1080e965bae">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="49541211-6da7-4f15-8d3a-6151e066a212">
+      <statement statement-id="ir-4.8_stmt" uuid="e56173de-466f-486f-91cd-59114e1cff27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5050,10 +5050,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ca97ad9-5cf7-4775-9689-f5e9a7685ed6" control-id="ir-5">
+    <implemented-requirement uuid="f8e53718-6179-495d-b4bf-22d1d2d49121" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="a821d299-97c8-4821-b5db-54a4aa61c5ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7ed3d404-2811-4dfe-8816-8cc6fe961683">
+      <statement statement-id="ir-5_stmt" uuid="c6ed00f0-aa54-42cf-9c24-3206ba3d77a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="367e314c-be0a-4933-8e01-8ac474a58997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to OpenShift configuration.
@@ -5061,10 +5061,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd161b96-39f3-43d3-9c18-e44b13c3a186" control-id="ir-5.1">
+    <implemented-requirement uuid="e4e6c774-fa7d-4308-8303-cf1c0654a266" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="ecb7dcb1-0fd9-4a3d-8d0d-ec49a203fa3d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a531daf5-b0bd-41a8-bde7-dddc6ea852b6">
+      <statement statement-id="ir-5.1_stmt" uuid="48da1fa4-4216-43f3-979e-5a1d78a7aa55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5072,18 +5072,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcf5b02c-9175-4c7e-aeff-f3f0a30e593a" control-id="ir-6">
+    <implemented-requirement uuid="85d0cae6-52cd-4630-9774-5f89fe81b838" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="b8cd0ef9-36c0-433f-83c6-142ff404ad72">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="553fe844-c990-45e6-a4ef-cc8b7704aa39">
+      <statement statement-id="ir-6_stmt.a" uuid="c3241b05-d5e4-4a28-9f92-42b18719d3ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="dc78efb8-e6c7-4e6f-9952-b1038d209c45">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d8b57a1a-0356-4dc1-91c8-104353a1aa5f">
+      <statement statement-id="ir-6_stmt.b" uuid="5c775a24-b49c-4266-a483-e37d1d37f3db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5091,10 +5091,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f068ed52-519e-4e74-abe3-1c60129f0de4" control-id="ir-6.1">
+    <implemented-requirement uuid="7f80008b-3d1f-45ea-89f3-752cbcae9e61" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="63148694-8482-4e07-b42c-4c4fc675591c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="591d0635-99bf-46b3-aabe-21c9ee9dc7e7">
+      <statement statement-id="ir-6.1_stmt" uuid="0bfb37aa-87c1-4fb5-bc5a-c515b6fb23e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5102,10 +5102,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d05d0eee-5fdb-4501-afeb-ed6858561773" control-id="ir-7">
+    <implemented-requirement uuid="11e39f52-40e6-426b-a23e-f889000bc40b" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="60b92ab9-0454-40a2-9f1d-256eb51a0881">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c93cafd5-06ef-4292-9b7a-cf8889ef6aca">
+      <statement statement-id="ir-7_stmt" uuid="6bfe8a45-3127-4281-a47a-adf2f5554f47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5113,10 +5113,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0166910-8fd0-4f8a-abdb-35a0e776c06b" control-id="ir-7.1">
+    <implemented-requirement uuid="624d9025-07d0-4fd8-a465-8df8b03abb75" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="38ecc091-25b0-4d85-8c28-3e04b1a0e0bb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="41626a2d-1e47-47d0-8cf6-c8f60802a1b7">
+      <statement statement-id="ir-7.1_stmt" uuid="d6cff08b-07c1-4b1e-8be3-357a62efd30b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5124,18 +5124,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="042e17bc-509f-4a04-9810-7c53277a7d5b" control-id="ir-7.2">
+    <implemented-requirement uuid="2752dfd4-738e-4eaa-a8d0-29a1dffa058a" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="cf7769cb-0d43-48b2-bdb4-4ab7fa38ef4b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="091c569d-1a95-4b85-a018-fd650e9ef45c">
+      <statement statement-id="ir-7.2_stmt.a" uuid="a4f32ff7-f55a-48a6-90f9-632f70aaf8f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="9d41d7b4-9286-4b91-a110-22988842cd1e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f4cd39ce-806a-4529-aa4a-f22887562174">
+      <statement statement-id="ir-7.2_stmt.b" uuid="6b0721c9-da4a-46f8-8a0a-a4f9a587196b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5143,114 +5143,114 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d2cd0cb-f16b-4c65-b0df-39af0dc794e3" control-id="ir-8">
+    <implemented-requirement uuid="bb4e7052-02ce-441b-9c4a-89c532ecfb5f" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="8dd02cdb-1677-4d29-8e08-0b074d31077b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="52ef92cd-de28-4b13-bc73-71fd08c5d715">
+      <statement statement-id="ir-8_stmt.a" uuid="227584e5-c6af-41d4-ab76-bc1381e3359b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="90eaaf23-7dca-4bf7-8db3-4e01ce4a7bbd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="949d2be1-287c-4f9e-8cd2-44aa8beaea2b">
+      <statement statement-id="ir-8_stmt.a.1" uuid="1c5de3cc-c433-4ace-91b7-6cd949843847">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="d081cafb-7c48-4b72-8354-e9ec10a7a03b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1a512dcc-d171-4349-8a31-e5c08c2251ac">
+      <statement statement-id="ir-8_stmt.a.2" uuid="f0317202-3633-4cd1-872c-2f027b8756ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="d3f0ad41-ec93-4fce-ad47-4fdaba64f5be">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9e3a09fc-5daf-4c9f-9097-18fcfc5674df">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b58411a1-bfd0-440e-9a31-8d9fd31edb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="f1f6c8db-a1a0-4221-993d-e8fbc34148b3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7783bb8b-9a17-478f-baa9-96fd9d7775cf">
+      <statement statement-id="ir-8_stmt.a.4" uuid="569d6e87-911a-4a6e-be38-a2813bb5e02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="23229c03-96ee-4daa-88d4-a7d42ba9e51e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ce800e04-6e1e-4f8a-9a4e-756977e5d840">
+      <statement statement-id="ir-8_stmt.a.5" uuid="efaea696-1fea-4abf-95b4-39344e4724e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="36d1ef18-b263-4868-9a3e-90ad317a6881">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4731de5f-6104-46a3-8084-da50fc406795">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c1b60d11-37c5-455f-b47d-c5c278638a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="61cc568c-78c9-4a0b-9072-2a223a110bde">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="91b6fbe6-a807-4fd2-94b5-7343b477e114">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d58998e9-3310-4ec8-b6b7-73f1c1ffbd36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="c56d52fa-15f2-43b1-ab56-8f75456b482d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d89a146e-90a8-45e8-b82a-f9af79799787">
+      <statement statement-id="ir-8_stmt.a.8" uuid="b66a3b8d-6cda-4aee-a38f-a0d4cd1c6bc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="fb101fdf-dbcc-4612-b61a-5d1cbffed66b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dace51bd-2c7d-4d6c-b3f2-03759cb79208">
+      <statement statement-id="ir-8_stmt.b" uuid="5c02f03a-0779-439b-86d5-7106516fda13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="dd86c23c-1fe1-4f7e-bebc-ee7511a5d72e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0614ed5b-e26b-4617-bc85-cf887cde3ca4">
+      <statement statement-id="ir-8_stmt.c" uuid="d239bbba-139c-4c7d-a720-3a66d534c6b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="ac02b00d-3613-41d0-8443-5f95b6b72b21">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="02741238-b43e-41ba-8316-166325c3be3c">
+      <statement statement-id="ir-8_stmt.d" uuid="edabf95f-64af-430d-ab6d-5f04c028889e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="5bd7e9bc-e313-4ce0-b26d-599c8c9d5e2b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="573cddfd-4139-4651-8c25-b06c24c6289d">
+      <statement statement-id="ir-8_stmt.e" uuid="5cccbc53-1a22-418d-b3d4-026759960888">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="c1966ddf-bd7c-46db-a832-5bc289b83f15">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2821583f-2731-4e2f-b712-22c280fdc44f">
+      <statement statement-id="ir-8_stmt.f" uuid="361269f5-7504-4190-b4d1-a73bff1622ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5258,50 +5258,50 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b28ea5d-2d74-4b4a-9c84-ec0adde0b104" control-id="ir-9">
+    <implemented-requirement uuid="b2e348a3-31bc-433d-a2f8-b5c241ef86ce" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="d3a403b4-f652-4e81-bec6-07c6ae1180ba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3f902683-142e-4cf5-a05a-94ef1f22f9f5">
+      <statement statement-id="ir-9_stmt.a" uuid="6da22d0f-ddb7-44c5-b7f1-53d7984979c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="bb16c8f7-cdb2-4da9-a05c-5fbd3ef89517">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="62c279d9-3d47-4a29-bce9-edcedba5a6da">
+      <statement statement-id="ir-9_stmt.b" uuid="f96ad164-4bab-4324-a1e0-8437001f03a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="5ca34ff9-8d47-4e59-ba25-bf4c242f5b11">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="442e1ef7-64ce-42c3-972c-931e4f27737a">
+      <statement statement-id="ir-9_stmt.c" uuid="ba4b075d-cc24-43f0-9a07-8ced5d7c0916">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="746a1c37-8159-45c5-a6e8-3ffbf0ad56a5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="607002be-4eb4-45c0-9f25-1e8b8839918c">
+      <statement statement-id="ir-9_stmt.d" uuid="c9c9321b-a290-4831-869d-5cdb693c0f86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="4709c005-e40e-4591-bd5a-f767b01110b0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5c3dc463-22fb-4620-a678-bec9ec29d162">
+      <statement statement-id="ir-9_stmt.e" uuid="aab8ed8e-18a9-40e7-8eb9-c09674ede8ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="54aa5faa-c8d2-4105-80a8-e51d4115f29c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3cbc2e81-2dcd-4a5e-9f87-4200737783e4">
+      <statement statement-id="ir-9_stmt.f" uuid="41ca2980-f5f5-4f5d-8aa2-8995a707f80e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5309,10 +5309,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cb53fa1-a3bb-4aa1-bdc2-36ccd39eebc0" control-id="ir-9.1">
+    <implemented-requirement uuid="ab55c7b3-b446-485f-908a-ee269a195e13" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="b606caf4-8f2a-4236-844f-25c603dd6e82">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9bc99f14-60be-491d-98e5-c9f38c02229a">
+      <statement statement-id="ir-9.1_stmt" uuid="500fefa0-05dc-4bbe-9745-a7e84326bd99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5320,10 +5320,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a7f2226-1221-4a02-9ab3-a4821a43a1a8" control-id="ir-9.2">
+    <implemented-requirement uuid="4f887b13-7b13-4e2f-a5b0-acd743b1d1d3" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="603016fc-3796-4c79-a6a6-5c43a0537a98">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1ad9572c-5f4e-4bff-b346-2f9a6777961f">
+      <statement statement-id="ir-9.2_stmt" uuid="eb82f482-7a0e-4707-b926-83e064fa27ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5331,10 +5331,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e045adf-d051-4810-883e-634686888273" control-id="ir-9.3">
+    <implemented-requirement uuid="22cf8a39-b2d5-40be-a422-0ae21886871a" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="1980f4ca-ff6f-4c77-8dae-b3f576c41834">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fdabfba5-7ab4-4db6-8301-96a9c6d3f7e8">
+      <statement statement-id="ir-9.3_stmt" uuid="3fd83d97-1751-44d7-998c-879ebf776087">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5342,10 +5342,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80fb10e4-78bb-43c3-9d15-1f628ae28ce4" control-id="ir-9.4">
+    <implemented-requirement uuid="1098c877-c428-4909-ab14-b74a151fccf2" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="7b4139cd-b3d0-47e1-8de8-062de2abd042">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5ee1fc85-961c-4e69-be95-383525688e50">
+      <statement statement-id="ir-9.4_stmt" uuid="e0ea69aa-daab-4b9a-9cf6-b5e89c485168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -5353,18 +5353,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c7f5810-5181-4c52-a646-a91b76868256" control-id="ma-1">
+    <implemented-requirement uuid="b10fe6d1-8b4a-4355-a102-d7114483e66a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="f185588f-72eb-43e2-87a5-e99cc1f9e51e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="946ebd94-52d8-4b2e-b1bf-f9ee160836ce">
+      <statement statement-id="ma-1_stmt.a" uuid="f9871dec-e863-4601-a0a3-6cf618410383">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="3b6ba187-8edb-4f89-9cc4-2fda25feda39">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a848ebe-0b4c-4b86-a2b3-d8d92d2dff50">
+      <statement statement-id="ma-1_stmt.b" uuid="70066806-55a5-46af-81bb-ef96b7601008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5372,50 +5372,50 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0be15ce9-aedc-4f1a-a962-82031cc3a095" control-id="ma-2">
+    <implemented-requirement uuid="2ed3fb53-97c8-4f9c-bcf3-320460f9f3aa" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="f8c30daa-2cb4-4245-8fe4-bf5c45248f03">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5f2136b0-7ac3-468b-a54c-f1f57251cd92">
+      <statement statement-id="ma-2_stmt.a" uuid="d3d3bf14-2476-4700-8e56-50f6c4c33e47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="400bdcd6-93ac-4fa6-bb9c-634e65c1dad9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="adfd2c39-33cd-40fb-ae06-5f87ac604a8b">
+      <statement statement-id="ma-2_stmt.b" uuid="e1493534-bb33-4385-b0a8-011771101e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="42203a9d-ef4d-4b0d-8d7c-5719848a052a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ddec4293-beb5-47e6-8456-bc4091f2a77a">
+      <statement statement-id="ma-2_stmt.c" uuid="c45aba08-33ca-41b6-8c61-3173a666e4f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="0d1beb0e-e7de-4a1b-8a7c-f37f29ab13a3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3d3dea41-2fae-48d2-ad82-10e4182baab4">
+      <statement statement-id="ma-2_stmt.d" uuid="5188a418-51bc-4418-ad92-cd6bc24d9d50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="157acce1-ccab-42e2-9149-c5e583cf378a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="294409a2-9902-427b-bf68-e1b3c00c3609">
+      <statement statement-id="ma-2_stmt.e" uuid="e664b60f-5935-4125-a2ac-3d4f42040367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="c42f9d07-d2b4-45b2-b79c-601761c63f32">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d478b110-4212-44af-96fd-a2ce7a2a72bd">
+      <statement statement-id="ma-2_stmt.f" uuid="237d6190-6c08-44c2-a328-2ed9e6c838c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5423,10 +5423,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e24fef0-79e0-4174-ab57-c13946f54337" control-id="ma-2.2">
+    <implemented-requirement uuid="32ff53c2-e820-4f97-a568-c9d06222273f" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="f8ee6a85-810d-49d5-8ce5-337286819bb9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fa83a9d9-5310-46ad-9b17-bc338eca43f8">
+      <statement statement-id="ma-2.2_stmt.a" uuid="40691090-1a06-4ca9-baa8-eb1a08ac07fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="840ac7ae-8951-4ac5-90ae-23b9db3ae518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5434,8 +5434,8 @@ https://issues.redhat.com/browse/CMP-341
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="60bb0127-10ec-4886-9eb0-02c0399f7592">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5c10b4e3-363b-4946-9422-d6cf66b75ce8">
+      <statement statement-id="ma-2.2_stmt.b" uuid="74cb7095-d4cd-4af9-802a-df57ac04233c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="840ac7ae-8951-4ac5-90ae-23b9db3ae518">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5444,10 +5444,10 @@ https://issues.redhat.com/browse/CMP-341
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c57f423f-2344-4f8e-b4cb-5a26c67290aa" control-id="ma-3">
+    <implemented-requirement uuid="fdfebb36-1e7b-420a-a053-b946e0071adb" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="f11c6b39-6c7b-4e2a-ad16-3e28e7ae50f7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="663baa8b-4234-43b3-8030-a911890def56">
+      <statement statement-id="ma-3_stmt" uuid="b4529b13-c674-4f08-9427-dbd97694278e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5455,10 +5455,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9093091e-ebdf-4f05-a8e5-b74143e82f63" control-id="ma-3.1">
+    <implemented-requirement uuid="0e77dc6d-69af-45e9-a308-375db32617ac" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="2234cc94-34e5-4cda-991e-85774668c0d3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="31db1e72-9be6-41d7-8bc0-397a85264aa1">
+      <statement statement-id="ma-3.1_stmt" uuid="e691a20f-9488-4437-8b9c-50e6b0666184">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5466,10 +5466,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1f29c0d-fd46-4a8e-b06a-1c27085cbe89" control-id="ma-3.2">
+    <implemented-requirement uuid="6a636ca8-7aa1-42f7-b901-174ecfbc3de4" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="70de7406-2efa-476a-8032-6879f30cc613">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a85cfe33-08a6-4129-95a4-eeb292e1bb51">
+      <statement statement-id="ma-3.2_stmt" uuid="42b75ed1-c31a-4c6a-9e60-2bf2e42d5f58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a13a2bff-16cf-4b17-aae8-777d336bb39a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -5478,10 +5478,10 @@ system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="504ddf15-532e-4e72-97e9-39d335837eed" control-id="ma-3.3">
+    <implemented-requirement uuid="870bfe36-974a-4c0e-9e27-e9a3ea93294e" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="f0cec231-872d-4661-bad3-5a3d5f423ec5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="34e17756-6b86-4993-a8d8-820951d3ef90">
+      <statement statement-id="ma-3.3_stmt.a" uuid="bf170846-fe82-434a-b6bc-bca8b57a4021">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a388243e-007b-4ea2-be24-332d8780977f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -5490,8 +5490,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="238ee836-ce35-4b0b-9e9e-f4736ed7c540">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0a28f97d-ca1c-4b46-94d8-1211af6643ae">
+      <statement statement-id="ma-3.3_stmt.b" uuid="7c27499d-28f9-4871-8065-d32c1c74aa7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="771c277e-946c-4a50-b2ef-93dccb7e35c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -5499,8 +5499,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="1cc68047-6f4f-414f-9186-6e0715aabcf0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="05a24997-cb88-43f7-8b91-19a743f9d0be">
+      <statement statement-id="ma-3.3_stmt.c" uuid="37b48713-246a-4b65-a9dc-fde415f29e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd7ef875-1eac-4e79-ada8-7644963c1d05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -5508,8 +5508,8 @@ facility is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="6c1079f3-3c0c-407b-aaa8-74b7d1c13931">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="40d2e2f3-0141-4804-a3ba-521b61a88fe5">
+      <statement statement-id="ma-3.3_stmt.d" uuid="10ebb45a-1949-467d-b9e8-b2fbacf9a9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8143f81e-90f4-4697-96e1-801032cd2b0c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -5520,18 +5520,18 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78b587fb-2ae1-4857-8062-367618ec6b2e" control-id="ma-4">
+    <implemented-requirement uuid="204c3081-9db4-477a-b1b7-acc6123933ee" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="45abe0db-4132-4076-acc8-c7793bb938af">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3635cf1a-07e6-49b3-8062-7b44eb624e19">
+      <statement statement-id="ma-4_stmt.a" uuid="50345522-239b-4d9a-a70d-7b5e6e2b3cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f83d066-75c3-4751-9058-9a0072ba2a51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="c0fe4927-5899-414f-9c87-04b4745907ea">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b8022d4c-b072-4746-8526-313bb3a6108d">
+      <statement statement-id="ma-4_stmt.b" uuid="9ef16448-cbe4-4c91-80da-e1cb54be20d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e80348b7-25d4-4d89-b28b-0882198f6646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -5539,8 +5539,8 @@ orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="f1f69b02-4124-423b-b161-99c8aa0b6275">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9f26996b-8116-4546-821b-5a014bfeabb2">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5548,16 +5548,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="21e90210-faef-4aaa-b217-31e2ed4d056c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="25673b44-00bf-42ec-a856-a28dc447f0de">
+      <statement statement-id="ma-4_stmt.d" uuid="29005666-5e5d-464f-8b34-73b8095d773b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74202b5e-92f8-4be5-a08c-b07c9b0f8149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="21fca263-d9b2-49a5-b546-f700a96a3660">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ff50a97b-16b6-4e9d-9063-f888b825e099">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5566,10 +5566,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c9603bc-3db8-4ed0-a838-e495d39b9aeb" control-id="ma-4.2">
+    <implemented-requirement uuid="5ce2c17d-db54-436e-bcb3-fcdbed7a3f45" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="8278016a-6b6b-43d8-8124-e386a0a1e8e8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b6682ee7-634b-4319-8c7a-e112c069fae8">
+      <statement statement-id="ma-4.2_stmt" uuid="8eabb2c1-31b0-4785-8a44-5054c8050fbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5577,18 +5577,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1394e8a4-24cc-4d8b-8539-63655b3d79cc" control-id="ma-4.3">
+    <implemented-requirement uuid="bc385ecd-e430-45b2-90cd-adfc2b2ebbe3" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="8010c2f3-8a3d-48d7-8de1-f77c6f410d92">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7f9ba450-0da9-43a5-b0d4-e3afa57959b2">
+      <statement statement-id="ma-4.3_stmt.a" uuid="05b0d878-30d2-4c3d-8aad-acf8a2d987ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="9d4b621c-2443-4ddd-99ec-0c609b02d70a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="82a27a5f-1ca6-40d2-9771-86dca9dd9920">
+      <statement statement-id="ma-4.3_stmt.b" uuid="36add7bf-8160-4df6-af3e-6997a1074938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2726f156-7a73-4fdf-a9d6-46d670ad0a17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5597,10 +5597,10 @@ https://issues.redhat.com/browse/CMP-371
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84653d29-f43c-4444-b605-0a5986493d4f" control-id="ma-4.6">
+    <implemented-requirement uuid="79fe8c81-dabe-4866-98ae-c330540ca036" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="a12c4c7f-774a-4254-b1c1-49400ba0d746">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="83b3c3a6-5c02-4c24-9801-d5ec1b381b50">
+      <statement statement-id="ma-4.6_stmt" uuid="4f07b841-19b9-4f3a-8202-e5df6fb84798">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26d1954d-0b65-4aaa-9294-05774d80dd67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5609,10 +5609,10 @@ https://issues.redhat.com/browse/CMP-346
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47ab90e9-cd16-4931-b700-4411c13ec6ac" control-id="ma-5">
+    <implemented-requirement uuid="c6462421-f340-4b02-9572-80913c2f5646" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="db0ded4b-c6b0-4ddc-8fc5-484c2de8480d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="17d87193-4b2c-409b-b623-c35e94c87430">
+      <statement statement-id="ma-5_stmt.a" uuid="4dc39efd-5d7f-4b4d-866e-04a28ffdb2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="124aa32b-c8d1-48cd-a8e4-ddaeb3480877">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -5620,8 +5620,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="3b1559d3-72a2-46bb-bbed-7d57b52c5f68">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="05905142-dde0-4b82-8b38-65e8d12cb8e9">
+      <statement statement-id="ma-5_stmt.b" uuid="b242b08c-223f-44d2-98b8-691eec589cf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72e60fde-d698-45ba-8c34-7bb3e0c6c8ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -5629,8 +5629,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="4105cb78-16ba-4d99-9153-ffefb4d707c7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2ae3d6f4-3744-4135-b069-fb32b92a7903">
+      <statement statement-id="ma-5_stmt.c" uuid="0f320f71-ba98-423a-adc4-5a126367dccc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e90741-c6f7-4d1f-a9b0-167c1eeb394c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5641,10 +5641,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58254a18-573e-4d74-84c0-c57ee2150d5e" control-id="ma-5.1">
+    <implemented-requirement uuid="a966e130-70ce-4e23-a70f-6310f3ee8639" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="d9fd3625-8bcf-4e5c-b436-fde5376e82be">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9fed7468-167d-46f4-8094-7db136c6691c">
+      <statement statement-id="ma-5.1_stmt.a" uuid="d563fffb-51f2-46e6-958f-c39290a08cef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28f67c55-45d9-4c06-9922-4473114ed208">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -5652,8 +5652,8 @@ citizens is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="335e1922-2ecd-4828-bf1f-0dab354e6c56">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="63497808-1002-49b4-8cad-7432397fa2d0">
+      <statement statement-id="ma-5.1_stmt.b" uuid="fdfd32c5-c193-4bef-8d31-615380d02da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="362916b9-da8f-4aac-932c-10a264871562">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5663,10 +5663,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e6e2d86-f0c9-4858-b3f2-25882c3b0186" control-id="ma-6">
+    <implemented-requirement uuid="ef948e47-fbc9-4af5-af58-e14406af116f" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="933e4145-520c-41a4-a716-57b52d44e12f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5236d84e-811c-4512-8d3d-34a63a7d732b">
+      <statement statement-id="ma-6_stmt" uuid="9434df4e-b1ff-437a-9cbf-578648ebd922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5674,18 +5674,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bb7c5a6-9460-42e2-8ddf-360d6e5d8653" control-id="mp-1">
+    <implemented-requirement uuid="1c2b137c-e0e6-4383-8c59-bb398437a58a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="ddec827a-9fab-465c-8656-30e93fc7e395">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7867ac45-84d9-4687-ada4-195885b35d6b">
+      <statement statement-id="mp-1_stmt.a" uuid="a90905bd-7ee4-459d-9fde-427e6ae14845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="4a812b4d-42b4-4a6f-a40f-8d1bb74211b0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a43c49dd-d98f-4969-ae19-b81f0dd88e11">
+      <statement statement-id="mp-1_stmt.b" uuid="f16f66b5-c2ba-45c1-8f16-8e3252f197ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5693,28 +5693,28 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65033784-c28e-4a5a-9580-97bca4b37676" control-id="mp-2">
+    <implemented-requirement uuid="108dc458-f5dd-4887-a989-5927a9611045" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="77caec3b-3d51-4907-8be5-9b217cbc2bfe">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="09beb2ba-8902-47cc-bd5c-a53bac2d41a6">
+      <statement statement-id="mp-2_stmt" uuid="4d8f11fd-331c-4950-b137-f08af8a0083d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce2016d1-0aef-46c7-a013-1424fb4cbbbb" control-id="mp-3">
+    <implemented-requirement uuid="d0b6544e-44d1-4edd-985e-a6b6d54a5e81" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="ef5b40e2-4621-4853-8e97-de2561d8676a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="76bee2c8-f7c8-401c-b203-656605695e53">
+      <statement statement-id="mp-3_stmt.a" uuid="b3630488-66ee-4d51-909f-058e6d757cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="7b62f349-85ca-41ce-8580-4db718aaaf59">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ac4208d6-0a94-4007-b494-23d0160de07e">
+      <statement statement-id="mp-3_stmt.b" uuid="04252dcc-ea70-48c2-a81c-48226104f7f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5722,18 +5722,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6083c4a1-cb5d-4710-ac54-60a404edb884" control-id="mp-4">
+    <implemented-requirement uuid="5cee2b9c-bd47-4d33-b57c-22d9f82041e5" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="a92b74e9-4572-4ba4-9b06-957a130b571e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ad9c2bc1-8727-4e5c-a3fd-883c5d5c3e57">
+      <statement statement-id="mp-4_stmt.a" uuid="edd4c6d2-e1c1-4c98-a7ad-1cdee99c6e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="e1b28d21-a76b-4601-8d2a-a618633dccd3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="30cf414e-9c45-4a4f-9b85-30e8814a884e">
+      <statement statement-id="mp-4_stmt.b" uuid="45b21575-6f5e-4763-a423-d07380760015">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5741,34 +5741,34 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e7ee626-d0e8-464f-9600-0efe74245eda" control-id="mp-5">
+    <implemented-requirement uuid="68193acc-d0b9-4a4c-a3b5-b5bda72630e6" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="c23cc39d-62c0-492a-ac6c-75e9f5b8283a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1b1e46af-6dea-4f05-bf6a-c38a82301da2">
+      <statement statement-id="mp-5_stmt.a" uuid="8c404d88-0d1e-4d18-b9d2-517af9ccdb23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="67eef096-680f-42ae-bcd3-814d1ddaff67">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="841822a1-155f-4825-a06b-309fddce3266">
+      <statement statement-id="mp-5_stmt.b" uuid="77d67d4d-5f52-4bf2-9b32-49c94ecb5530">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="949eebce-4f6b-4bff-a193-0fd91562d361">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="47666d0d-71fd-4e13-9176-91c96d5289ca">
+      <statement statement-id="mp-5_stmt.c" uuid="7cc6e721-c756-4423-bae8-109e9a62cc41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="28529b3a-e68e-49d1-8f1f-60c90e52b1e0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8d3dca8a-9698-43de-b3e9-7256672ef3ff">
+      <statement statement-id="mp-5_stmt.d" uuid="a0959b9d-89cf-4ea9-a20d-5d9c5f00303b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5776,28 +5776,28 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbe2d8c9-531f-4514-a5a7-6f0ac88b11cd" control-id="mp-5.4">
+    <implemented-requirement uuid="037a54ff-d1cb-4118-a65c-7704aae71480" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="6c439a24-c656-43aa-993d-f9cec31dd60e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ce81d27e-6dd2-474b-9c1c-50899c554d8d">
+      <statement statement-id="mp-5.4_stmt" uuid="e8b83342-3687-453b-be2c-a9364b11df2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b328fd99-6dcc-4906-8076-a9ce2f461abc" control-id="mp-6">
+    <implemented-requirement uuid="0427c8d9-1658-43bf-b365-c2d8b57f973c" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="8d4aafa3-5d20-4a46-ba10-f4e32a0287ce">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d86d1b50-1725-4535-946b-8ebf8a97e7b5">
+      <statement statement-id="mp-6_stmt.a" uuid="f49bef15-aa6e-4f61-b787-ba9c4c2b1372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="81e29115-5178-4d55-abfe-9957b0901937">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="55db0fbc-47f9-44e4-9452-88be7f04af54">
+      <statement statement-id="mp-6_stmt.b" uuid="31236cf3-7eb1-4545-8a44-72cec9a91f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5805,40 +5805,40 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c451cc6-fca1-4842-bc23-4d139e3b2158" control-id="mp-6.1">
+    <implemented-requirement uuid="d311ce3a-f151-4400-809d-689500bd0d34" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="3b4b154f-3277-4bad-8d27-ceb9e5aacfa2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ec47be88-16ff-4dd4-8fd5-c96ddb9af1c3">
+      <statement statement-id="mp-6.1_stmt" uuid="22d632c8-9923-4510-ab89-36dd89c29573">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="952a7771-5a05-4301-8be9-e6b3793d6945" control-id="mp-6.2">
+    <implemented-requirement uuid="f186bd35-b47c-4277-821b-d9595a39f9f8" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="154c1fc2-f11d-4154-a02b-251bbd5444f5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b01a2e00-79c5-471b-ac3c-802dc7675c6e">
+      <statement statement-id="mp-6.2_stmt" uuid="0145b297-a828-4259-b7ee-8235e00c827c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b38934e9-36a5-4a0d-a50d-34e0e44367fd" control-id="mp-6.3">
+    <implemented-requirement uuid="62c0eab8-a7d6-425d-8448-edc6acd5750d" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="c773c5bd-fe62-4431-b7ad-41347ebbd3f0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f09f566f-581f-462d-a320-f3f7c84b9b56">
+      <statement statement-id="mp-6.3_stmt" uuid="5e93e734-1148-42bc-ab0d-1d6e9901dfed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0312c3da-0790-43f2-a195-24739f51dd03" control-id="mp-7">
+    <implemented-requirement uuid="ec9f0f5b-634e-4648-a0bb-f90d4525af78" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="cc9ebc80-e98e-4cdc-9331-f2f34c1cc304">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7950adef-2910-43a0-8014-9b613a0318b9">
+      <statement statement-id="mp-7_stmt" uuid="864e4639-60ca-43bc-a00a-8ce2fb547d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab02986d-bfed-4206-8c15-412836e72d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -5846,20 +5846,20 @@ Openshift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ad07d70-25fd-4f32-a197-e8f83edadede" control-id="mp-7.1">
+    <implemented-requirement uuid="13df7266-0297-43fa-8cf1-abb43b354911" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="a6ade98b-c456-4946-a5d4-79895d5f148e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b5bc355b-0e87-45ef-a2e7-40d3adc94453">
+      <statement statement-id="mp-7.1_stmt" uuid="350395f8-7774-4c2b-8069-93b3a13a0b6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf3f86d5-62bc-490a-b093-a3004f6c9171" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="9801dfeb-ad13-4c38-9e3e-2c6118220cc7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b8fc014a-84fc-49fc-9639-e22d3bb3de76">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5868,8 +5868,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="7c43887c-a07f-42db-92e3-7dffefafef5a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d1889d77-84ba-4a8c-afc0-6bae9f15d3ec">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5879,10 +5879,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d4ceff9-5754-40c5-9fb6-82fd33e787d7" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="814c262f-acfa-4499-a614-79ce80d15582">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="46ce2f20-b68c-408f-8d2d-21b8fd14928d">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -5892,8 +5892,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="27a9657a-cdf3-4740-8ec4-d1b0b70259c6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d658a51f-ac6c-4dbc-8423-0db7032434bb">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -5901,8 +5901,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="5df22f47-e68a-473b-8679-226508eacc82">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ad6f4d61-09a5-4d9f-84f1-1f7ea8288726">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5911,8 +5911,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="5d40a55c-8d1d-437b-a54e-7efc4d5a23f3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="35b576d1-38e2-40c3-9e74-cedc554893ab">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5921,10 +5921,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5034ff8-7e2b-46d0-b9a3-38eff47f3530" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="fcc0017b-2eff-4512-8fb1-c5f015728bd2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d59161e2-d2fe-41f5-b216-2dad65d2b891">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5933,8 +5933,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="f95486be-45af-4421-87bc-5aea6299d0c0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cdc73bf7-bfe1-4e74-bbd9-959f6881656b">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5942,8 +5942,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="914a3929-5a93-489c-b374-03097be492c7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9ee79d1a-881a-4b4a-9fdd-f98c217f6b31">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5952,8 +5952,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="0b4a0d18-b115-4a9b-b22e-a2efcd9733b5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0549aa60-215e-4278-b5d0-5ac0ef4d16a9">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5962,8 +5962,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="ab336bd6-9f4e-47b3-b368-8531b8783b05">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="45dbeb03-7102-4753-a0ab-0f4178deef85">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5971,8 +5971,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="f7eb93c9-736c-490f-83aa-654167286e84">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="753b66dc-3ddd-484d-a869-56fc0b8da022">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5981,8 +5981,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="6fb200c5-bbfa-4828-84ac-e084e89f5d3a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ae1c79b9-f8dd-4829-b11b-848e8f0e8cdc">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5992,10 +5992,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e937ab7-48db-4f98-9aed-95ea8aa79fc1" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="e6b562cf-f421-44de-b8af-b075dad09598">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="43024636-a8ec-4004-b799-50a42a95c868">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -6006,10 +6006,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c399850a-f8ab-4aa2-a615-fff454fadbc0" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="e6f9d71f-50fb-48f3-8340-f9991a2e4574">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="04d4cf49-2acc-409c-9aa3-51899351f635">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -6020,10 +6020,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="380a5386-4d39-4b7d-a6fc-99d1b7df5866" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="8159b235-46e0-442d-ad1a-26f6561cde63">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7d57e08f-1d56-43b6-ae80-346c9aba050c">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -6033,10 +6033,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0610afe-6514-4125-9cbd-857f4c328f64" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="ec5e8299-c925-48fb-b384-d1e92aa1981a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8187bbc9-f585-4e71-8479-5d8f2a24ca7a">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -6045,8 +6045,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="0e92187d-25ea-4c82-8c7e-a3cd97d27a2e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3a5a47f3-8586-449b-8e6e-039ea76b7599">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -6056,8 +6056,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="7ca075c3-d2fb-4d2b-911c-0dbc6b4b5847">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2ca6b00e-2980-4880-9060-e8bac11a9eb8">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -6067,10 +6067,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f32fc1f6-6e1c-44af-9333-7fe3c792163e" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="8c208158-76cf-4adb-95d6-2c27300d945e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dcc8eb82-ed04-49da-b2bf-ed193306bd55">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -6079,293 +6079,250 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44f6d537-96f1-426e-8254-3c2e47f35efe" control-id="pe-6.4">
+    <implemented-requirement uuid="6d5c7593-49fa-4c9c-8d3d-bc7f35f5990a" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="f016b2b8-69e6-49d7-8d7e-4821c546dc73">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="846c76b5-736f-4a2e-81d7-dda8e365b39d">
+      <statement statement-id="pe-6.4_stmt" uuid="061d54b0-744f-485e-883e-4951aaf1093e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b28634f9-5734-4e72-a731-f205706d9f93" control-id="pe-8">
+    <implemented-requirement uuid="f095e424-f8ec-49c7-9bcc-f96ddcbb3d15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="faadf3a6-11bd-4100-bb61-209589af5544">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ab5f6e02-2910-4d58-84b0-4658fb688f7e">
+      <statement statement-id="pe-8_stmt.a" uuid="3ad283fa-6c9a-4617-9d2c-02d449dcbcf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="eb141e75-f5a7-452e-8f05-a1b6626e9a5a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="66785b8d-9116-45e4-8e10-26ec0c14645e">
+      <statement statement-id="pe-8_stmt.b" uuid="b0ba16aa-b9c1-4dfe-b376-cda0ce550a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db35664b-bb4c-4cde-8a31-f1d083ef19d3" control-id="pe-8.1">
+    <implemented-requirement uuid="f6ecb57c-7c19-44b0-bac4-a5fbab4df86f" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="533adcb6-8f3a-4cb9-90e8-313998c3622e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="daa7cfae-5efd-4583-b366-0ed482f6c831">
+      <statement statement-id="pe-8.1_stmt" uuid="454f3b43-de96-46c4-a3d0-f58dcb45f304">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd216510-92d1-4d3a-a84d-35357bd68680" control-id="pe-9">
+    <implemented-requirement uuid="0635d150-3a98-4e98-a667-6431990f587a" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="98936d13-c3f5-4a19-b878-a74ab201702b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4891d00c-070a-46d0-a230-a610d30fe3f2">
+      <statement statement-id="pe-9_stmt" uuid="c19229f8-a84f-470a-84ed-de7df10f336f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="224b03f1-1190-4e58-af41-7edf9d2475b6" control-id="pe-10">
+    <implemented-requirement uuid="a57e4d67-c598-4182-bd57-56c2b2317c43" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="61fad15b-c532-4c09-8543-e5352c8b755a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="36b149b2-56c4-402e-b246-0ef23f1246f6">
+      <statement statement-id="pe-10_stmt.a" uuid="d343c585-7b02-4533-871a-c32b446362d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="bf9d50f4-d471-45ac-a3f3-aa196dc8c267">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="94389c1e-ba14-4b54-a313-c0748c9f5cde">
+      <statement statement-id="pe-10_stmt.b" uuid="9edbcd42-3377-482d-9c61-3724cd426484">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="13ff5cf5-f5e1-4eae-af6d-8695390d11a6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1ba11b1f-7cd8-4efd-911f-f8f530eb8866">
+      <statement statement-id="pe-10_stmt.c" uuid="80b74763-f418-4932-b9d3-26a22ae47b8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="980544b2-c811-4e26-a7df-f859136fa66b" control-id="pe-11">
+    <implemented-requirement uuid="c691a5ed-fb84-4f08-9ccf-013cfdb3d933" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="a812b9c0-61e2-4d3e-a31a-e05884250cc8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a827ce9-e88b-4d2e-859a-5b227c4c1cf6">
+      <statement statement-id="pe-11_stmt" uuid="2c09299d-b3f1-4751-ac40-2dc19f06db40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="704e900b-ff52-409d-94ef-70a6290bda9c" control-id="pe-11.1">
+    <implemented-requirement uuid="bbceddc1-6c7f-4b79-a887-e5d81ab47923" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="f2df102a-122e-4885-9d12-83ff75a49278">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b1777360-8169-48ef-b498-fe99a56c4dc7">
+      <statement statement-id="pe-11.1_stmt" uuid="72ba5646-de53-49f3-b437-b73a78bb73b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b465fbf-5c1d-4f13-8b44-4f36f42b363f" control-id="pe-12">
+    <implemented-requirement uuid="814d78db-2372-41e9-a7c2-86eb5e84b3bb" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="4be22969-f8b0-420d-aaa1-5c5deace28d8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cc22925a-0aae-44d8-8231-fe0da435769a">
+      <statement statement-id="pe-12_stmt" uuid="f57faeee-5800-434a-aa8a-947a9ae886f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71b22736-35af-4a80-ab2e-8bbe58bd1373" control-id="pe-13">
+    <implemented-requirement uuid="4fb04d5d-82ac-46c9-a0b6-bf1bf7855bd7" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="4a5929eb-accf-4f56-86b5-fd8759715b3d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2a3997d8-b71a-4848-9bb2-096cea33771e">
+      <statement statement-id="pe-13_stmt" uuid="abdc8068-bb34-4683-b938-e70eb7d36f5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cef22b0a-8bc4-4ee3-9297-e7d93fc2c334" control-id="pe-13.1">
+    <implemented-requirement uuid="75252532-001a-40fd-be79-9834d2c23616" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="d6c7c079-603f-483f-8ebe-462a709e593f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="496ff7fa-524b-48a8-aea1-6f4c6fbbb8fe">
+      <statement statement-id="pe-13.1_stmt" uuid="8deeb6b2-d617-46df-aea8-c5284679b59b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b536b8a9-a50d-4ac5-9093-b240e78de3b4" control-id="pe-13.2">
+    <implemented-requirement uuid="0cd48fa2-10c4-465d-837c-c7baefec9389" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="b6c3e392-1d17-48ef-beb3-dd7413326cb5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4886c7d0-cf66-4b85-aac8-a9f3294f2248">
+      <statement statement-id="pe-13.2_stmt" uuid="4fba5a01-28f4-4cd7-ac08-c79049d5e88b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d45f093-5e8c-49ff-a109-e3b1f73e1430" control-id="pe-13.3">
+    <implemented-requirement uuid="f16ae8a9-7174-4efa-ba35-2c47d2b91a24" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="649da47f-baef-4d7c-99c1-2112151eaa08">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="29500a81-1e61-437b-993e-36099ff176d6">
+      <statement statement-id="pe-13.3_stmt" uuid="f92fa53e-d3d6-4c4d-b955-24ab2fa05540">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c9af0b4-65e0-4895-bf0a-04acad0abcb2" control-id="pe-14">
+    <implemented-requirement uuid="a8b0df72-c643-45b3-b800-1b06d1eb1d99" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="db157f23-187d-409e-b001-b1d8a924a041">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="23033688-5f82-46a3-87e6-f69090e20762">
+      <statement statement-id="pe-14_stmt.a" uuid="15495bed-f082-405e-b69e-c743c8c3c20a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="5d1a41f6-a7f9-4679-bb34-88210001e704">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="81bf1710-3ff3-4a20-b80d-2287eb92715c">
+      <statement statement-id="pe-14_stmt.b" uuid="a0d0eda2-1aa8-4afb-a24b-7c95d233bb3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3fbd381-aea1-40b6-bf29-f08a5f5092ae" control-id="pe-14.2">
+    <implemented-requirement uuid="f98f1c09-8ebb-4c9c-ae89-c4eeeac91bf3" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="1699e6d9-2477-4515-b5a0-c2a76bab0ab4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9a02551f-f322-4d9b-b092-a377cdae3381">
+      <statement statement-id="pe-14.2_stmt" uuid="2512deb0-8e8e-427e-b878-20df59f6bc92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c8f3df6-f761-4dfa-9679-e99df62d0152" control-id="pe-15">
+    <implemented-requirement uuid="901a3457-97b6-4093-bbe0-31ce3a1cdcf6" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="defaa2d1-a455-4165-80f7-d5378510b391">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="af8530be-c090-408e-bf81-36a57f9a21c7">
+      <statement statement-id="pe-15_stmt" uuid="61425ee7-5b2f-4888-8373-62f378945ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dfd5eba-46b3-483c-970b-f31fde1633c2" control-id="pe-15.1">
+    <implemented-requirement uuid="6a8204c1-82d7-42ed-8c0b-36ac861ad114" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="2ea556e4-943f-4ca7-acb9-d2189171cab1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="20a7e1bb-6274-44e6-861f-c1217341f1a2">
+      <statement statement-id="pe-15.1_stmt" uuid="fd4ea2a1-0064-47e3-ae90-39a271a19a12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03d58b30-c915-4a01-bf2e-f260b10b922c" control-id="pe-16">
+    <implemented-requirement uuid="17f3da9e-c287-44a5-8169-28cf3375c1d3" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="d2a5c456-44aa-493d-8e97-704f05014e9a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="94b3647b-6853-48c6-ae0f-00e8391c66f6">
+      <statement statement-id="pe-16_stmt" uuid="feaebed6-68b5-4c4b-8b88-883a8038ae9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d180604-c70d-4b03-a1fa-b5784fd4c375" control-id="pe-17">
+    <implemented-requirement uuid="a8903585-dab4-48bf-885a-8d4239c0a146" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="a9ed1e42-6a9e-45e8-a207-89b0583264fd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e950d213-5dd7-4c5c-a4d6-e89211be4641">
+      <statement statement-id="pe-17_stmt.a" uuid="4e5ec6fc-d0eb-4ade-a6a2-3155cf00d493">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="6c242b28-3ffd-4ab7-b58a-c6e902694bc0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1e74f03f-b6b7-4f72-848c-5e5f486a4e4e">
+      <statement statement-id="pe-17_stmt.b" uuid="f9b94f04-f1a9-47d0-b956-3d8a01fbfe9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="523c5af1-1912-4448-b425-d500f66da62d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5dbac125-fd18-43a2-b182-c1ae17cf4bdd">
+      <statement statement-id="pe-17_stmt.c" uuid="71d51466-6a5c-4e73-be85-8281000132ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93eb965f-31a7-4cde-ae5d-eb7882420e04" control-id="pe-18">
+    <implemented-requirement uuid="64febddb-5b7e-47fe-b36a-aa226f622003" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="6669ce4e-14ff-4618-a901-f55d27d32062">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="aaa23130-9c6f-4555-8dcf-a29760e26d67">
+      <statement statement-id="pe-18_stmt" uuid="17386ec3-a0eb-4780-8cde-c6e06a2be629">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef4c0f1c-6552-4ed4-b491-6ab2588ac99e" control-id="pl-1">
+    <implemented-requirement uuid="89868230-0876-48af-8880-46230d2f29c0" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="c9cd69b7-7d46-4a89-ae3f-26f1a09ac21d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0bd0ed77-a740-43ac-ae0b-6062d2dda4b7">
+      <statement statement-id="pl-1_stmt.a" uuid="8661b679-96b7-4c77-b230-bd4a38abe4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="3abb3ad5-4a27-4501-9bff-daa685ab2de4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e46890b0-b449-408e-874a-701c32b9c17b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="4fd0b069-5239-4c3d-abb4-0b6cb1e0700a" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="33149f15-7bca-464a-9448-365ee66408f9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="999c2eda-6520-4edc-bbec-be0a8d22ecb4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="e202edcd-a5a4-48d3-ac9b-de138eccb7a4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f380639f-2d02-42de-91c4-3cd7c6e239f9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="ca732183-f327-4974-a2a9-8a7d9a4cb130">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="77bf3ce5-b279-452a-b49c-b43304db8332">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="c5bb9d77-9cb0-48b8-a537-821902c25759">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f7a034c7-dd66-4209-af77-50c2893f0a1d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="85bac92b-907e-4e75-bdda-5a643f355cd0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6130a635-91bf-4c6c-9e92-397ca5183772">
+      <statement statement-id="pl-1_stmt.b" uuid="8ece81dd-536a-424b-a2fb-61952dd53bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6373,10 +6330,53 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35594105-e21c-4a25-b1b7-3c632215a442" control-id="pl-2.3">
+    <implemented-requirement uuid="9afad57f-6172-4f87-b55b-8cd68079e3c8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="ff1d3fe3-499f-4854-adc9-30f7bc0101e4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bc82fd7c-9a39-4b79-a611-43c4161d0991">
+      <statement statement-id="pl-2_stmt.a" uuid="4b7ed71e-ba46-4d43-b6b7-ea99bc5dcd94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="9a4add41-bc05-416c-a9e4-229cb6f61367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="fb20fcf3-5cd7-458f-8fd4-edf1306f9d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="06fb5ceb-ddd2-4c39-8ccb-356fb02780d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="782bc7bb-1af6-4c75-ad8e-769f8830e159">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="cfb0e9c7-e02e-48b9-9545-d7f1079f3841" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="e0441873-fe4c-4ba7-b968-b8f5bff5c152">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6384,34 +6384,34 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e94d4a6-1178-4bf1-b71c-dce36c48e9ee" control-id="pl-4">
+    <implemented-requirement uuid="98e11268-47c9-4eb2-bd17-5bcac114ab5c" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="890d33f3-ec09-4267-b578-01773cfd25c3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6b2b9749-8984-4aba-a4c8-e8a16f2b2e65">
+      <statement statement-id="pl-4_stmt.a" uuid="499d42ac-5c67-46fb-9e18-149401fb3abf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="c0983c7e-4eaf-4eb3-9a91-10d526edfdbd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9fe92035-ee39-4b60-b7cc-fe70dc051045">
+      <statement statement-id="pl-4_stmt.b" uuid="f9388bac-7d81-4eb5-8343-4962c303ffa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="605a98f4-00f5-48a7-bfda-1d78e4553c56">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dedf7278-1e63-432a-95f1-2261dac7a9e7">
+      <statement statement-id="pl-4_stmt.c" uuid="8f371b57-4152-475c-90df-2b05ffc39c5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="fb21171a-25d2-465b-b8cb-49584001b5de">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="57c14dd0-eb26-4c1d-b44a-06d8266bfdb8">
+      <statement statement-id="pl-4_stmt.d" uuid="96b2d54b-376d-4317-94b5-152505a1a8d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6419,10 +6419,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93478c65-96f6-401f-b560-8d16b7dfe48b" control-id="pl-4.1">
+    <implemented-requirement uuid="0631ed74-f5ea-4d53-8e4f-2a04944e15e6" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="efa360d6-f2d6-49e1-9764-b8ba63e8dd86">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4417f93a-7d08-40f8-8b76-be42c832b70f">
+      <statement statement-id="pl-4.1_stmt" uuid="3720957a-be86-4c93-ae1b-88066debe321">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6430,26 +6430,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="864d8f28-9647-4f4e-8e7d-bef13f6a4359" control-id="pl-8">
+    <implemented-requirement uuid="8c9309f3-7b5d-4459-92fc-36d4590cfd4c" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="9f45bcd8-8647-4def-847f-04c6bf462b00">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c22ca59c-9748-48a6-9131-368bb27c7d70">
+      <statement statement-id="pl-8_stmt.a" uuid="0f57aec2-e9c4-4376-948f-18a94d9b9083">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="cbdd87bf-03f8-4f57-88dd-92e64b484fe7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7e09febd-9a44-45e8-8144-52a97e2d759d">
+      <statement statement-id="pl-8_stmt.b" uuid="ed59aefa-4b9b-4a10-85a7-0b44cf3e104c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="035927e6-7d1a-42ae-8b1e-89784634807c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="011d6b6c-7796-4e95-9d39-6eadc4f7bc75">
+      <statement statement-id="pl-8_stmt.c" uuid="35f39cbf-20b3-45fe-b2bb-22d0cc4477b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6457,10 +6457,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2ea2f86-33cf-489b-96a3-60821f6e83a4" control-id="ps-1">
+    <implemented-requirement uuid="6418d139-6314-4ff0-af50-b28e66b16261" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="647d6aea-59f1-4c0d-b7d4-c1ce6eef3cbb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="47befd90-33aa-4d91-9f90-d8583e112262">
+      <statement statement-id="ps-1_stmt.a" uuid="b24ac5ec-0704-4378-998a-e73711c1f6e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6468,8 +6468,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="cf936418-4b77-4f91-9e90-bad6c49f79bf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="70f7cb3c-0045-4c34-836f-07bd02cf866e">
+      <statement statement-id="ps-1_stmt.a.1" uuid="f3c6288f-f0e2-4ff3-9e85-02a37d7ace14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6477,8 +6477,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="8e3e5be7-3ab1-4937-a99f-b173d6d1d2b7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0dc20cbd-0b27-41ed-a377-15e8718678cf">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9b53e6dc-8b9b-4147-9b13-709f2495c207">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6486,8 +6486,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="92ec9ecd-90a0-48ff-b897-e3c6c2f16511">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0acb3495-3162-4578-ae6c-b244ef80cba6">
+      <statement statement-id="ps-1_stmt.b" uuid="4f650c83-ce49-4c48-92a4-2c894efc17df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="337e7f04-ade2-4095-b026-96842ddb9414">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -6495,8 +6495,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="2138dbc2-9416-45e0-bd79-51f696c943d6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4c65153f-d68b-4d80-bbb0-b365b4e853f5">
+      <statement statement-id="ps-1_stmt.b.1" uuid="81dcc255-fee1-488d-8ca0-dd88f7c2ded1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6504,8 +6504,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="bd7dabb5-ba99-4ec5-9ee0-c22c7914e273">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d43259da-5a95-4501-950e-52b8d2856b55">
+      <statement statement-id="ps-1_stmt.b.2" uuid="7785900e-402f-4ccf-9bc0-597a2e7eb688">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6514,18 +6514,18 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a64d9a1b-e9cd-4ab4-aa0b-c693af2f58e8" control-id="ps-2">
+    <implemented-requirement uuid="37d305bd-2e58-4cc3-8fd7-311c59020818" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="4c7daff4-63e1-495e-b1f4-c3b08c8ffbd5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="46274527-414e-4056-baf3-0fc0d5276e65">
+      <statement statement-id="ps-2_stmt.a" uuid="e24c75d6-3b6c-4d16-83d9-036d896f93ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae453aca-5f7f-4c57-8ad3-40b0a9929f33">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="c729a31b-12f4-4d34-94d7-32a46d035666">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f3b1c3a5-3073-46b9-9bd8-692896a43e43">
+      <statement statement-id="ps-2_stmt.b" uuid="85ed1245-db1e-438d-96de-61ac6fc21ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955de2dc-b541-4f89-87be-be3aa93b2b96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of OpenShift
@@ -6533,8 +6533,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="f7241292-41aa-4b98-8e07-2cae40770aa7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a65fae17-1648-419b-bdc8-1fdea0dbdfb2">
+      <statement statement-id="ps-2_stmt.c" uuid="82eb9502-0431-4a91-ace1-25f947087689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1cdb5679-ba64-4c52-aa04-49a4040f8b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -6543,10 +6543,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="789f0545-e69c-4274-8a93-2875c526a2be" control-id="ps-3">
+    <implemented-requirement uuid="50b3ccf4-7437-4b9d-a4e9-2bd2111d0712" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="5811ea6d-2839-473f-a14f-85977b248581">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="acf3b99e-10b8-4d44-b4d5-b71d2e94cf90">
+      <statement statement-id="ps-3_stmt.a" uuid="ae898ca2-4245-47a2-b67e-9cb04cd16b60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d1537c-8e3a-4d4c-be9f-106f6072d75d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of OpenShift
@@ -6554,8 +6554,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="e454891c-9b95-4549-8e04-ac60ed007e1c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7162c3c2-35b7-49b6-8baa-4e3c00338ca0">
+      <statement statement-id="ps-3_stmt.b" uuid="9e412acd-66d6-42fc-a874-60196f12e434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5544b6cb-8c54-4e7e-8726-4b2ce8114fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -6566,10 +6566,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7441f41-2385-43c4-9aec-bf5ec2096d8f" control-id="ps-3.3">
+    <implemented-requirement uuid="56352245-c717-4c44-9855-540a11d30de5" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="dffe7761-d59b-4856-9536-570e8b295d77">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="00528e5c-a511-4f2a-9a25-8930a24c620f">
+      <statement statement-id="ps-3.3_stmt.a" uuid="c1108de0-83ed-4d8a-8a7c-53749058ea9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d09c04bd-7810-41e4-bcb0-225d8ada0f30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6579,8 +6579,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="5c180c5a-0f25-484e-aad6-631685de1c8d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6b199677-6c47-454d-849f-76531e23b89f">
+      <statement statement-id="ps-3.3_stmt.b" uuid="16039ff5-0c13-49ca-8051-f02fcf6ae567">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c7e61d0-4736-4a25-88b8-6262505d4d16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6591,10 +6591,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a7dbb46-b417-4970-9c7d-c6f5ec380ab8" control-id="ps-4">
+    <implemented-requirement uuid="a058b4a0-06f7-4cca-a104-955e4193ff8e" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="cfef8983-7fd9-4bdd-bc94-252c359547c1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4bc301ad-7f88-4d3c-a292-4aba4867caae">
+      <statement statement-id="ps-4_stmt.a" uuid="3c96cf7b-382b-4d78-803c-13d0c4c75b46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e47fb61-98cd-40de-a48c-3038ea513aad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -6603,8 +6603,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="4b1a74e1-eb09-4d5a-8eb9-df5913b17eab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ac6f8503-948a-48e0-9c3c-c0f776867ff0">
+      <statement statement-id="ps-4_stmt.b" uuid="35295a74-1026-436a-ae0e-6ec855cf798f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12f961d4-848d-40f7-8f40-40e10e88d0df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -6613,8 +6613,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="96e4385e-7126-4e27-9bbd-af060c0fa119">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fe05b596-b64d-48aa-a1b1-325ee5e54175">
+      <statement statement-id="ps-4_stmt.c" uuid="af8c79a4-798e-4bf9-a02e-140e04e48d10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec36ccaf-c3ab-4747-a425-c6bedc278aeb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -6623,8 +6623,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="3158b249-673e-44ae-8238-098b3fbd3414">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="54623d9a-df66-4509-a292-c7b0dbf038ef">
+      <statement statement-id="ps-4_stmt.d" uuid="8ea327e5-5a11-4a98-8827-eca5a7049fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d80627a1-8f9e-43a4-a7a2-a75249dc410f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -6633,8 +6633,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="a6aa1e68-8c29-42f4-9e32-25390452dea4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a33d7451-bbb1-4662-b488-d278ffa81283">
+      <statement statement-id="ps-4_stmt.e" uuid="f0301041-d18b-4c26-85b7-9b08eb82f8dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69d0287a-bda0-4d09-a48e-89d9bc9d50f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -6643,8 +6643,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="785b2203-24b2-4ef9-9170-63c7af337a62">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="98b6155d-d0b6-403b-a9f9-10067451a9b6">
+      <statement statement-id="ps-4_stmt.f" uuid="011f2825-4703-46b3-96d7-51cb5008f740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9264a668-6ecd-4ad9-ad90-bf8e50a666bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -6654,10 +6654,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ea3a86a-aaa3-4873-8f53-899f741953bb" control-id="ps-4.2">
+    <implemented-requirement uuid="7cea1b03-978c-48cd-9971-1ed703928d6d" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="a989aae4-0108-49b8-a6b4-c362dd4d2d9f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9f80fac9-2c0e-4eba-a307-c8333e5d1597">
+      <statement statement-id="ps-4.2_stmt" uuid="e9ebe04d-48ea-4e48-9fc9-8007070bc36f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a2ee485-a4e5-4548-a3dc-b252d1125086">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -6667,10 +6667,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c191a00-4b7c-4f15-810e-671be1de7010" control-id="ps-5">
+    <implemented-requirement uuid="f021987d-0773-4783-8fe5-638a1887ad41" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="fdbf6af1-0f16-40ee-b9e5-4e00b3e0fec0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b6031d37-b955-4f8a-ac81-00e9d1729364">
+      <statement statement-id="ps-5_stmt.a" uuid="71f7e07a-0962-4f69-8159-2e9e25384f86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="046ba626-c644-49c6-b052-fe0a5a90ddb7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -6680,8 +6680,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="791c296c-282a-4985-bc11-c39b6190f71b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="df2a9b89-fc58-4d02-9f24-ca435a05101e">
+      <statement statement-id="ps-5_stmt.b" uuid="9b950b32-4306-4b6f-b8fd-daecabbae7bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35dc728a-280b-490f-81d4-af07110b288c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -6690,8 +6690,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="17a6da62-3a31-4b08-a9e0-6e552c392c67">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ca9f7ddb-5fed-40c7-8069-40d04beeddc5">
+      <statement statement-id="ps-5_stmt.c" uuid="3fc5d320-e25e-4155-8a39-2f19efb6f270">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dae94fe-dbc1-4081-8464-f551f752798b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6699,8 +6699,8 @@ or transfer are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="df8bf4d2-be9f-4d65-b330-56b5700b9b16">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ea494db5-4358-4525-b20b-e0ba84bae298">
+      <statement statement-id="ps-5_stmt.d" uuid="411f7849-0de6-4bfb-b74f-2172c0af25b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e1cf303-9747-4c4b-8012-ed16c6dab514">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6709,10 +6709,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2edc1f78-49e3-4bec-ad60-a35f877c4714" control-id="ps-6">
+    <implemented-requirement uuid="1a89d281-0763-4c66-a8df-f4c676911d94" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="4990dfc5-1243-476f-900d-6c5b4ad62506">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1c129321-17a5-4092-8240-39e0602fe1da">
+      <statement statement-id="ps-6_stmt.a" uuid="0bbdf0b6-33f4-459b-bf47-0aef0c11860d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7a359d9-81cb-434b-a2be-7979b7e4a973">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -6720,8 +6720,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="bd7f4655-3ded-49e7-8880-43f2584b1a7f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="97de9dbb-42e4-422c-97ac-6dc978c70286">
+      <statement statement-id="ps-6_stmt.b" uuid="6ed74614-2509-4ef1-8412-0d72b7724797">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a45644f6-3dd6-4597-8ef5-3645ccdb53db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -6729,8 +6729,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="ab017369-9663-466c-bc87-369a309deda3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0daa0a67-3190-4086-887a-ea9a01600b70">
+      <statement statement-id="ps-6_stmt.c" uuid="ba99c181-39cf-4f21-8687-44efca1db67c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6738,8 +6738,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="5e9069e1-1264-45b2-8d77-a78af405da40">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7e26c252-d956-4fe7-a9ca-d2d399fc3d1e">
+      <statement statement-id="ps-6_stmt.c.1" uuid="8b6861d8-67c6-4ee8-85fb-940265a98402">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6747,8 +6747,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="c5bc85ce-3d17-4b61-9385-c8a11c123cdd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9b16eb7f-c041-43d7-a09c-4ba45ac5e863">
+      <statement statement-id="ps-6_stmt.c.2" uuid="9b14e8e1-6706-4803-9305-4e39b807b3a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6757,10 +6757,10 @@ access agreements are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f050c0c-a114-497a-8fe9-d774f09f79c6" control-id="ps-7">
+    <implemented-requirement uuid="9823674e-6560-4272-9878-ac4ccf6265ff" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="02580f10-2cd5-43ba-bced-6648ef1e9695">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8135c7f5-148a-4269-a762-4cddac6063de">
+      <statement statement-id="ps-7_stmt.a" uuid="fe812d2b-7c23-4aac-a3ea-551fdeb52599">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5a4573f-c61a-433c-9c26-244b43757c7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -6768,8 +6768,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="672db20e-1780-44e5-a672-d3cb9682d95f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2abfb2fc-4108-42de-a26f-ca73b9b401bb">
+      <statement statement-id="ps-7_stmt.b" uuid="760ce5b7-396d-4b48-9d82-4a58a0dadac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3a927d-e9dc-4fae-9fbb-26b02455e8a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -6777,16 +6777,16 @@ the organization are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="95361129-293c-49d0-a0f9-d12538e3b647">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cb9f08ef-568b-46a4-a2fc-181b91ea0e0a">
+      <statement statement-id="ps-7_stmt.c" uuid="8f063b21-41fd-48f0-bdfd-e9be890bdc0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ee8df1-b100-4388-a721-41e512901fdd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="e7289060-9210-4c75-97e9-558772686bba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="84d09c2a-230b-4faf-957d-eb13b571e723">
+      <statement statement-id="ps-7_stmt.d" uuid="83a11cc0-7793-4d8a-9e90-76993dc991fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d3a188b-9d80-4557-8ca4-b66bc1df60e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -6797,8 +6797,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="23c45c24-a8e9-4dd1-bdd6-643f52217dec">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0f969d30-bc60-46ee-96f3-a5167c7bde27">
+      <statement statement-id="ps-7_stmt.e" uuid="09ffad36-86ce-4a99-98d9-3b1ae3af8ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12999939-abc7-4215-909a-394cf63184e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of OpenShift configuration.
@@ -6806,10 +6806,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="715ba74f-1b4c-4d80-be35-e24c02a7fa9d" control-id="ps-8">
+    <implemented-requirement uuid="aa9d1f60-1c2e-44d5-9f55-7d7de80fd800" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="54a13a32-1917-4151-8328-54391559578c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cd1b9b70-4194-44f3-bced-89d07a5ddf2f">
+      <statement statement-id="ps-8_stmt.a" uuid="f8d7d00a-923b-46d1-a7e7-331808aa594a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fcb49196-9d3c-418c-9242-85e984011583">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -6817,8 +6817,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="1b70008b-7910-4201-b47a-5753c3ed8a08">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d140f48c-cb96-4cf8-9ea9-37dc06d3c74a">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -6828,10 +6828,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc849e9d-474f-4b98-a76f-af6a8285d408" control-id="ra-1">
+    <implemented-requirement uuid="3bfbc934-621c-4c62-a8f3-c59fa780cc7c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="2ebf7ea6-b553-44ca-9760-3139a200f09b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="79dbfcab-1e8b-4dae-b8db-6c37fca4fad1">
+      <statement statement-id="ra-1_stmt.a" uuid="c39e40d4-607f-4cd4-83fa-cecbcd6c3166">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6839,8 +6839,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="bff1dfcd-d071-4bc2-8832-35a8490d007c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="da3242a9-b989-4cc1-a7b2-3f048ee33bbe">
+      <statement statement-id="ra-1_stmt.a.1" uuid="91c6f409-6df9-4a9b-ab2f-42edea1fcffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6848,8 +6848,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="bb3ad541-a27e-4193-b90a-7824096ea52d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7aea7263-c88c-480f-b795-5a51946e3da3">
+      <statement statement-id="ra-1_stmt.a.2" uuid="bf7f3604-2e9b-4d59-9a2c-d0d031beadf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6857,8 +6857,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="24714651-5239-4b90-ae93-962f60197ce8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6776c382-f894-4d57-b41d-9ff2cb7732bb">
+      <statement statement-id="ra-1_stmt.b" uuid="f7c298b7-b302-4c3d-a246-7184dcfddc45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6866,8 +6866,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="8e2679f5-4f67-4627-852c-16731abb9a39">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="806403eb-002f-4cbc-8af0-90f4030e2b8b">
+      <statement statement-id="ra-1_stmt.b.1" uuid="72741310-7fe8-4032-bf53-b655ea2af645">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6875,8 +6875,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="5811d290-2180-4f93-8a66-c0ed77b9603f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="913b7488-b95a-4708-8502-973620169439">
+      <statement statement-id="ra-1_stmt.b.2" uuid="5792d319-a3b9-4692-8e69-f2b76bd23587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6885,10 +6885,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e4c171d-488f-4036-8b1c-322104f492ee" control-id="ra-2">
+    <implemented-requirement uuid="31deea7c-6add-4a41-8588-b35cd74200e2" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="001dd6d3-87e6-459d-844e-56363dd74060">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="74575042-2916-4c4e-a8c1-8d386b428ac3">
+      <statement statement-id="ra-2_stmt.a" uuid="e425d113-cb52-4770-a787-dbfb9283baf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b646a97c-a692-4944-81b9-d72d1a1dbfa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -6897,8 +6897,8 @@ guidance, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="9cb55c04-5ad8-424f-b005-cb2958bbaae9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6fc50309-2bf0-47e8-9cc3-a6ac6b0f8b8c">
+      <statement statement-id="ra-2_stmt.b" uuid="180f1b32-6728-4307-bb8d-e5f3e11616b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e4bd24f-ef83-4d22-ba7f-9e298da40889">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -6907,8 +6907,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="3a964867-87a6-4810-8548-7c096656f2c5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c529c505-b48c-4332-9f9f-f5cc53ca62e3">
+      <statement statement-id="ra-2_stmt.c" uuid="6d002ff0-ef05-4c3f-8bc1-22eae07f0f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67fdd016-131f-4800-b183-bf0316142769">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -6918,10 +6918,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bedd6a1-2cc6-4b8e-862f-bd198a359c04" control-id="ra-3">
+    <implemented-requirement uuid="4eef68a0-d37e-4d8b-af8c-932640baa277" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="adb3052c-dafa-4622-9dd6-39c5bb151060">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="347f8bb1-9d80-4074-936f-5476d27f6834">
+      <statement statement-id="ra-3_stmt.a" uuid="de140349-fc88-4c48-99d7-6d6e5f160517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc7839ff-252e-4d8d-b76c-ba50c8fab112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -6931,8 +6931,8 @@ transmits, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="9ecde33b-495b-45ba-a06e-b4662b80a2d1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="92d5125e-1d94-44fc-a225-aa824e347cd1">
+      <statement statement-id="ra-3_stmt.b" uuid="648e4432-a1ed-4d2d-a44c-72cb255d638f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2898b82-0d1a-43d5-8b7d-6eed5da1f17b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -6940,8 +6940,8 @@ documents, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="0d85ac96-75b9-45a1-a28b-7061c2008d99">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="41590ae6-2755-47a7-9017-340f93f7c426">
+      <statement statement-id="ra-3_stmt.c" uuid="ce4d2f6f-9c07-490a-8ade-90d59226f649">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2b4dcf0-4978-45a4-b3f6-1a5fa0895772">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -6949,8 +6949,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="40500332-1301-4db1-a69d-4a6d76d5177a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b0b2099e-02b5-4e69-bd46-e932b60cd86f">
+      <statement statement-id="ra-3_stmt.d" uuid="f3b2eb0d-d1ca-4e6d-8d42-d52cc870a44c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ca46929-3bb7-41eb-9c71-ef2dcda81be9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -6958,8 +6958,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="6396f315-2cad-458f-b707-b0ae8fcc92ed">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="12dd2672-7067-48de-8551-ba81468653dc">
+      <statement statement-id="ra-3_stmt.e" uuid="afb420a3-1588-43c0-8d92-1d6a19c26a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ebb371-bbba-4b7a-91f2-0ac7bb23304d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -6971,18 +6971,18 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03ce5bb1-94ad-4d30-9c26-eeb490f8c9db" control-id="ra-5">
+    <implemented-requirement uuid="d4d65759-0b51-4008-b230-13f0cad39da3" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="eeaabce9-2ade-4ff2-af11-bfeee2572770">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9b889fad-be39-475f-ad23-15c0daa1da60">
+      <statement statement-id="ra-5_stmt.a" uuid="f17a8ec1-9d5d-4580-bbc2-b4353fee950c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="5c58df75-61db-41d5-9f2e-9c39d5ee36fa">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="78def2c0-1ee8-41c8-88d7-eb0a4aac7850">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6990,16 +6990,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="a9c5afa7-b76c-4ae4-b783-1a78d82644c4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9783b959-d2c7-433e-b1d9-197f0e893372">
+      <statement statement-id="ra-5_stmt.c" uuid="836b92c2-8835-4d79-926d-81f585abb42d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="f4e8d4af-f8b7-4ab4-a05c-d045ac45d9d0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d8b95659-68e9-45b4-a9f0-1687ac056ddb">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7007,8 +7007,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="1b978fff-ae9c-49eb-86ff-37cfb00b61f8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9d398d0d-d959-4ef5-8830-13e77f25ea3d">
+      <statement statement-id="ra-5_stmt.e" uuid="37953ae8-a61c-4f2d-ba69-7c11b415b703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bd9f1ee-7804-4aa2-b15e-03a253025368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -7020,10 +7020,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fef0b4a0-b3ca-4c4a-a65c-7636cd84e798" control-id="ra-5.1">
+    <implemented-requirement uuid="99bfb322-3894-4141-babf-b99bfe1d7692" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="cd797a7e-9124-4449-8e88-0f9619e88f2d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e22e4921-8ce6-4711-8b09-4d9781751605">
+      <statement statement-id="ra-5.1_stmt" uuid="c78f080b-6d2c-4038-830f-eb3c7e1ae855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e39b5519-8ce6-44bf-b85b-37b0f2295593">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7032,10 +7032,10 @@ https://issues.redhat.com/browse/CMP-353
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c9fd99a-d9e6-4a14-a042-f9cea650d5bf" control-id="ra-5.2">
+    <implemented-requirement uuid="252c6ba8-177e-4271-9d60-77e94367b757" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="139e3688-09a0-48ca-9489-41a5b19b121a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cd0fd757-af41-4906-bfd2-a3100b3800d4">
+      <statement statement-id="ra-5.2_stmt" uuid="efd7ce58-8caa-44d2-a557-2e1a8bb106a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7043,10 +7043,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a7c1355-afd9-4b5b-af0d-97ef96ebf452" control-id="ra-5.3">
+    <implemented-requirement uuid="e8f78c47-1c52-4c94-9072-eb04448803bc" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="51512bab-dcad-41cb-8b5b-f90ff43f84f2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fb7252da-cffc-4763-aa3b-7b038a5d109a">
+      <statement statement-id="ra-5.3_stmt" uuid="81d05f8b-1150-4907-a6fb-fadfb30f5f2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7054,10 +7054,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a3af9fa-0dab-4e9c-b22c-9bbd948d444b" control-id="ra-5.4">
+    <implemented-requirement uuid="d194d2af-b539-434b-86c4-c330c1e61adb" control-id="ra-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.4_stmt" uuid="29435e43-df4e-47f8-a71c-b8093990a1ec">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="86d7b08e-a8e3-4c48-8b5b-e80cf071bf5b">
+      <statement statement-id="ra-5.4_stmt" uuid="62a12a26-4c85-4031-8ec1-ca06cefc7b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2eca7b45-5942-4994-b711-b525128ca9a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7066,10 +7066,10 @@ https://issues.redhat.com/browse/CMP-354
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca958a74-1705-45fd-b995-75eb02e61428" control-id="ra-5.5">
+    <implemented-requirement uuid="d3e5fad0-3c63-4c9f-8e76-12ad125bf340" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="c00f44f2-f928-470f-818b-311489f157a7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="09cff604-06e9-4a08-9fc3-4ede87a41f9c">
+      <statement statement-id="ra-5.5_stmt" uuid="bb4660d7-4f44-4c2b-9f1c-c9bfb7183ca9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c5bf90d-ac0b-4600-95e9-897075990aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For the purpose of conducting a vulnerability scan of OpenShift, the OpenShift API and nodes
 should be scanned using the OpenShift Compliance Operator. OpenShift supports
@@ -7080,10 +7080,10 @@ Cluster Administators are able to access and run the operator for compliance and
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4902af21-137b-42ac-bd91-ee566c22804a" control-id="ra-5.6">
+    <implemented-requirement uuid="3a66b623-7a77-4166-9bc8-fe36369d6a66" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="3571c31d-046a-4a64-9407-4966fdec1f14">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="77d66228-3d2b-492e-9111-f3fad95fc450">
+      <statement statement-id="ra-5.6_stmt" uuid="42e81289-d5c0-4fb6-a470-ca1b979a6f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65f278f2-f1de-4fc4-a2a8-625d8839df42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7092,10 +7092,10 @@ https://issues.redhat.com/browse/CMP-356
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3d735b1-1584-4eaf-8b4c-d8e04f1dcce7" control-id="ra-5.8">
+    <implemented-requirement uuid="95a86ba9-c73d-4ea6-bf2b-3925b389493f" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="ad487b28-0000-452f-99b1-c7d00abf03cd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f08e5d2c-f57e-4b9b-8e1f-aa00e7c3f12f">
+      <statement statement-id="ra-5.8_stmt" uuid="f664f019-6de1-4755-9f04-9e25964a1102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67e7e64d-1b94-4fc9-9749-2ca36805a52e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -7105,10 +7105,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b39102ca-7152-4645-af71-5ea5cf51f2c1" control-id="ra-5.10">
+    <implemented-requirement uuid="698ee8f0-70df-4834-afd4-d262276f9162" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="91df9ea8-7e84-4050-bab6-952ace023e8e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1706cac9-9dd5-45ec-ae87-769d94530065">
+      <statement statement-id="ra-5.10_stmt" uuid="d035a3f8-570a-470e-a243-e23b046990ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="695d8f9d-0723-4adf-9611-126f375852c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to correlate the output from vulnerability
 scanning tools to determine the presence of
@@ -7118,10 +7118,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b808c363-96b5-4d2d-9a1a-e33ba30ed68a" control-id="sa-1">
+    <implemented-requirement uuid="46175d8c-c262-4815-a381-7c1f4872a44a" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="331c402c-f730-4c8c-9b33-b6b19bd13208">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c174a08f-861d-487a-a250-31ad4d9c3df1">
+      <statement statement-id="sa-1_stmt.a" uuid="0c2fb97c-2841-4c9c-9c64-3a30cfa2c885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7130,8 +7130,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="67c06d73-1060-42e7-a3da-ee59f33056ab">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="30302c7e-d8eb-4214-b3d0-4bbbe535ca0e">
+      <statement statement-id="sa-1_stmt.a.1" uuid="a7bad430-0d6e-4e8e-9df8-113430accf6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7140,8 +7140,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="589d8c7d-facf-42ff-9126-c5589536d9ca">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7e3f5bac-345a-47ab-8ff0-51513cad6f05">
+      <statement statement-id="sa-1_stmt.a.2" uuid="e946d4ac-cf58-49aa-b1ce-1f1f4efa6a1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7150,8 +7150,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="c731cd3e-281c-4a52-9fb2-51742ff773d9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9fcedf8a-f2a7-41de-a6c7-3ec5ae448883">
+      <statement statement-id="sa-1_stmt.b" uuid="93ca6950-0e3f-44a1-805e-a64737d09b08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7159,8 +7159,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="48aa34c3-2921-42a8-b5da-bd84e5b57e86">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="00c70add-14d1-4f23-8053-d7ea74762682">
+      <statement statement-id="sa-1_stmt.b.1" uuid="bd4f2cb4-847f-4f4c-931c-948b2e7476aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7168,8 +7168,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="903c8e09-3304-48f7-8809-9ddeb03fafe2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c41c669f-03f9-4507-ae2b-1ed77b56df94">
+      <statement statement-id="sa-1_stmt.b.2" uuid="826cee26-2ebb-44a5-8a0a-26e4fe4d1a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7178,10 +7178,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bb17ded-ddca-4690-94f3-5af2a3e04784" control-id="sa-2">
+    <implemented-requirement uuid="880a9424-3bc8-47b0-8d90-7a7cc8f08023" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="2540d71a-0331-4374-827e-627e2315ffb5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c62fa110-393e-406d-bf99-0ff1d2186a9d">
+      <statement statement-id="sa-2_stmt.a" uuid="fc47bc65-d051-44cf-b98a-5d9a0356f474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dcf71d-eac7-4ce3-af35-7b3e574997c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -7190,8 +7190,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="dce270f4-877f-467d-adcd-55e45cb8fa47">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6fb81f89-a0bc-4d82-9721-cf8211612936">
+      <statement statement-id="sa-2_stmt.b" uuid="3685259c-66b4-470c-9da0-6fad099d6e5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c829fb17-abe4-457a-8451-75ad86d36f38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -7201,8 +7201,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="d3e9b03d-283e-4203-9950-f24f4f0f965e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="900eba98-d975-4a37-8d85-c0bb2d46d4fa">
+      <statement statement-id="sa-2_stmt.c" uuid="2b7c4ef2-c540-4683-a633-795c99f687b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f21e997-d0b1-4d3f-abab-e7b6b5743832">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -7211,10 +7211,10 @@ documentation are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3425c5d8-e8d4-4605-8e92-8bc0ae67d8a1" control-id="sa-3">
+    <implemented-requirement uuid="4b3cd903-81fc-4a32-9832-6b967acb18c8" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="4a0d1b2a-b5a9-43dd-a62e-7220e14047f5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4d8e5cad-3c51-4663-8343-9fe52201054a">
+      <statement statement-id="sa-3_stmt.a" uuid="9a15d6de-18c2-47f2-9622-c7d39deb8f8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a4ae5ef-fcf4-41e7-a41b-d8d300d1c57b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -7223,8 +7223,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="2f69b7b1-b64d-407b-a0c4-e8bdc857a35f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0ecd144d-166f-43a3-a4be-2496d1a77171">
+      <statement statement-id="sa-3_stmt.b" uuid="1a183eb7-9f87-49da-8f1b-ba580be9bdd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd84749-931b-4fca-8d62-9f7ea3cdd3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -7232,8 +7232,8 @@ life cycle are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="4251835f-68a5-4994-803e-692177b05cb1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="56589601-9e45-4ba6-8ab9-44dcd909d018">
+      <statement statement-id="sa-3_stmt.c" uuid="030a665c-8a6f-4f0e-9f26-3521e733f7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ed7cb61-e7fb-4e18-b55d-f4f171158807">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -7241,8 +7241,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="70aa7d46-96c2-430a-a690-827833ce20bf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="16a21e73-67ca-41c8-8a6e-56b805895cf4">
+      <statement statement-id="sa-3_stmt.d" uuid="5be291c8-e453-4828-9224-37814c38ccd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7461713-8ea2-4840-ad52-c9e877e7f51e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -7251,10 +7251,10 @@ activities are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="363f6dd9-df85-4fd7-866a-13dbb5e733ef" control-id="sa-4">
+    <implemented-requirement uuid="4c425b9b-a871-4e71-9d35-ab1990789375" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="00f96b54-4be8-4551-afe7-a14d36bc1463">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="84fabf14-7339-4f3b-a15b-7a4b2bfe83ab">
+      <statement statement-id="sa-4_stmt.a" uuid="f9dc2050-658f-4d3c-ab5a-11221a03656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdcf642f-0ad8-4f50-94b5-cc8b29f9d090">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -7262,8 +7262,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="38a5e6b9-e23c-4eb6-8ce1-b92b5cc41398">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="97b6606b-b4bb-4773-8a32-8e5e0ca41df3">
+      <statement statement-id="sa-4_stmt.b" uuid="1444637a-9f7b-41f2-bfcb-9e5f8b359517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0fba4bd-1c76-40ec-9a33-1ed138551a80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -7271,8 +7271,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="4d5e15f6-c2ea-4a6b-8697-eaab066ff52e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6b4758ef-c903-4a75-ab7a-c95622c84acb">
+      <statement statement-id="sa-4_stmt.c" uuid="5046dcd6-30b8-49a6-8774-93e0ffef45c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf529bd-91c3-474e-b0c6-777fcc5cffbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -7280,8 +7280,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="78129f0a-0ce4-446e-8162-6c35480ddf10">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b78b9ae4-e456-4512-b409-b830fc836dd5">
+      <statement statement-id="sa-4_stmt.d" uuid="a704a7c4-133e-4b37-8c2d-ee72fe0d0247">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="733da578-3bab-42b0-96bf-5ed6c85d832b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -7289,8 +7289,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="4dd4ecbd-461f-47a4-be77-cad762b974c3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ea0ca893-ca9a-47e3-adbb-2d49acfdb2e1">
+      <statement statement-id="sa-4_stmt.e" uuid="5a1d9736-3556-40c8-9120-303349cfc92b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a079f5b3-49e3-460d-8778-5098f04705ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -7298,8 +7298,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="be7f365e-83db-4f14-b064-23bce4e24324">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b2f09839-916d-4221-bd1d-5839dcc846b5">
+      <statement statement-id="sa-4_stmt.f" uuid="41f8de4b-2c62-4d99-ab89-1f0303738385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ce208fb-60c3-47f5-855e-9fc2e5bd0db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -7308,8 +7308,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="c287b072-9be7-482b-a5ed-32e6045a2dad">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7c59399d-e8d4-40e5-8534-25bef61dc79e">
+      <statement statement-id="sa-4_stmt.g" uuid="6c8fb61b-8dc6-4391-a608-d0941b0d093f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66030e0c-d706-4d48-a588-f0f4cbc62d79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of OpenShift
@@ -7318,10 +7318,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d506d9d-18fb-4939-88a2-cd5ebcdf6fdf" control-id="sa-4.1">
+    <implemented-requirement uuid="5304b0c8-226c-4b93-8016-3c5d124f854b" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="b15324c1-3282-4ac7-8420-4b83fb2c32a5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="eec71067-b697-4a1c-ac1d-d83399a27de3">
+      <statement statement-id="sa-4.1_stmt" uuid="64169bbc-e536-4a43-a859-591743b4b950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d3defd9-e7ba-4864-8474-4487cbcaf84e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -7331,10 +7331,10 @@ https://issues.redhat.com/browse/CMP-360
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2731c1e7-b1f7-4974-8a38-23352fffb838" control-id="sa-4.2">
+    <implemented-requirement uuid="44c7e4b7-6adc-4f5b-9dc5-e761001d8982" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="c1e9a1f6-1a9a-4e01-b45d-0e9066043455">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e1339a1d-5724-46b9-a2ce-8d858375ea00">
+      <statement statement-id="sa-4.2_stmt" uuid="59c5a200-46b7-48ab-bc21-d6932d43a016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6535c33-0142-4714-8f10-09335fc6dc79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -7344,10 +7344,10 @@ https://issues.redhat.com/browse/CMP-361
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fca4931-5ff0-4133-9aaa-76190907ac93" control-id="sa-4.8">
+    <implemented-requirement uuid="11659e90-59b5-4173-b43b-1812ae1883b6" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="19cd24b6-f083-4580-a7df-6f81a0eb1d40">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ce04a875-641b-40da-ae4d-452cdfdffaf0">
+      <statement statement-id="sa-4.8_stmt" uuid="4b9d4eea-be9d-4f5f-9a67-ce7e25a48f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597f1282-83d4-49ec-8766-9be0dbbd2f16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -7357,10 +7357,10 @@ https://issues.redhat.com/browse/CMP-365
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27c59693-83c7-4ebe-a791-a03889d3bc42" control-id="sa-4.9">
+    <implemented-requirement uuid="9ff8b64a-8a54-4e48-ad70-1fdaea27c11e" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="9a738804-e3c8-4726-9225-986cd228479b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="03c39c57-b610-473a-b9fe-e969ed80751b">
+      <statement statement-id="sa-4.9_stmt" uuid="267db06e-5550-47ff-9734-f9d2e6f704f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d42c837f-2526-4ac8-8d24-1add8af53ab1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -7370,10 +7370,10 @@ https://issues.redhat.com/browse/CMP-366
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebfb2b3e-6ac0-4e04-8656-aef222d72e61" control-id="sa-4.10">
+    <implemented-requirement uuid="8ee28a5f-de3c-47d8-a3d3-863e2110d3d2" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="16024b39-833f-4eed-bdea-7b5df86b9434">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e0cfb572-a56f-4329-baa6-45e9efae151f">
+      <statement statement-id="sa-4.10_stmt" uuid="6712c5ae-4df1-4d08-99cf-b2387507074b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7381,10 +7381,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="569b63cc-fb5d-42a2-935f-eba42ec4eff4" control-id="sa-5">
+    <implemented-requirement uuid="f45b1f55-9edb-45f4-85ed-b1bbeac70efb" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="3ee81dbc-8b55-4a25-ac69-248656e72132">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7cdecacb-cf95-48dc-ae0a-91fca4368e97">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -7393,8 +7393,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="c8ce7027-e60b-4780-b3ea-4dff19f2df6a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6f1256ca-6da8-422f-8936-a99107f496e1">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -7403,8 +7403,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="943d647d-4e0b-498b-b596-6ace273d1776">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4bb5e39a-96a3-4046-8068-b0db84f8adc7">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -7413,8 +7413,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="1223488a-f884-49c7-a4f1-1b2814ac9703">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b8244f69-a1de-44cf-a455-ed3e466e2c20">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -7423,8 +7423,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="0dee861b-4552-44ef-bebc-40d80fefa90f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="59726e74-6bf7-45f8-840a-670ed652e6bb">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -7433,8 +7433,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="09adc13e-f787-49c8-ae94-b8bfd3ec0fc9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="05d03653-5f83-4acb-bad3-ddc560f21c56">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -7443,8 +7443,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="049d813a-6dba-497f-9f5c-159550fea7ba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6409c62d-acd8-4ee7-a782-86cb39054f48">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -7453,32 +7453,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="1ec16713-b5b7-469c-bd54-f7ba3d3876c7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="94c528fb-d9f1-4fa9-82f2-ea1eeda866f2">
+      <statement statement-id="sa-5_stmt.b.3" uuid="fb21bfac-d62d-4932-a2ab-7c929fbeb2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="3bdfc315-563c-42e7-9899-3cbbe0d6d4f2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a3a414fa-6fbe-4666-9095-b8267b79bc2f">
+      <statement statement-id="sa-5_stmt.c" uuid="fee19988-cd1f-4ba4-b170-f6bb31cdc115">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="5c1707c4-5de2-424c-b5c9-0cae91fc0f19">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="86fe0c22-e1b5-437e-ac03-a2707232a3d0">
+      <statement statement-id="sa-5_stmt.d" uuid="c8689aa5-cc05-4fb0-bcf0-0e767c9df94f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="73c2a95b-ed73-4cc2-8046-dbd0194e9806">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8ff18ac5-55d9-4112-b565-e598e98fe505">
+      <statement statement-id="sa-5_stmt.e" uuid="a19603a4-be8a-47b7-b182-7357f7f0bcd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7486,10 +7486,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64e9af6f-8b6c-412d-ac4f-83756cfd3d0e" control-id="sa-8">
+    <implemented-requirement uuid="3d9caa00-cb96-42c9-a63a-8d818f7d9c2e" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="47050635-5fb0-48a0-b2f5-b44409ea0eb5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f9394b2d-4c04-4e30-a74e-e06caec95ec2">
+      <statement statement-id="sa-8_stmt" uuid="1fb6ae20-07e8-42bb-a7dd-0ed7c6828623">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7497,26 +7497,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95795fb5-a788-4951-8872-2c07a1256016" control-id="sa-9">
+    <implemented-requirement uuid="4f3d3760-6a96-4488-9064-b66323171ff5" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="8fb596f5-d0ac-404b-90ed-0f183aa39746">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d5521a5a-5bad-4f32-b070-44f8cded0580">
+      <statement statement-id="sa-9_stmt.a" uuid="790594b4-8dc9-4e6d-a7be-8a4f821d60dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="71870d66-6e0e-49b9-9e3b-9ac1271c12cd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7b5f602d-0912-49ff-a7e4-584720178c7c">
+      <statement statement-id="sa-9_stmt.b" uuid="2fdee7a6-17ac-4f3c-8234-e51975aa8bfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="0de5090e-1620-4062-acaa-5bae36e07ada">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dd92dcb3-8d19-4e57-bf57-598b594cebb2">
+      <statement statement-id="sa-9_stmt.c" uuid="f91bbfe1-2590-4996-bbf3-5a931f802ecf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7524,18 +7524,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8e759df-3a92-4159-be81-d2bfd5fdedab" control-id="sa-9.1">
+    <implemented-requirement uuid="1e0c024d-da7f-4c3c-b6fa-9f35abb7d991" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="8c42faf1-1c17-4116-9e3f-ed0487265c09">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8ba7cf3e-c41f-49aa-b3d2-0e0fc09106a2">
+      <statement statement-id="sa-9.1_stmt.a" uuid="77d286f1-3862-4fdc-b034-1cbec7788df0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="6e94e7c1-c2aa-46ee-b5f4-5a6363d6fad0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc8277fa-eca8-48ee-939f-4a197eb7e0a5">
+      <statement statement-id="sa-9.1_stmt.b" uuid="5b440203-0c98-4a61-94bc-1739bd25a350">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7543,10 +7543,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97e9d9d3-7bd8-48a8-8a59-c52ca574d5c6" control-id="sa-9.2">
+    <implemented-requirement uuid="16385c4e-e3fa-4c22-8028-e9141a389fe8" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="64766820-2403-4910-9162-eaa51617d82f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="34493312-f0b8-4012-b269-564c1572961d">
+      <statement statement-id="sa-9.2_stmt" uuid="16f50ee2-60ed-402e-a770-f49fb83f6d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7554,10 +7554,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3735f3a-4aca-4581-b6d0-d771f3725456" control-id="sa-9.4">
+    <implemented-requirement uuid="73a17370-4c1b-477d-a0a2-43c24dee33fb" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="2da10b06-d751-40c8-afd0-035da5035d7b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d12fee68-91aa-4e9f-9888-2fefe7473467">
+      <statement statement-id="sa-9.4_stmt" uuid="4b181d05-f0f3-42e9-9466-6aac04d5e824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -7565,10 +7565,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff56e4ec-3116-4bae-8ad2-4268ed00b755" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="c2e9fcd4-19ae-479c-8453-9a60a3bbe6bf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a6cf354-4f9f-4ad2-851b-9ec69d9e29b4">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -7578,10 +7578,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4e575a4-1737-4579-a18b-c9a1fe0e62db" control-id="sa-10">
+    <implemented-requirement uuid="23e70356-2035-4233-a7f4-8370b3d60157" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="41245e28-70c9-42ef-998e-bef5e989c09a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="18818a97-9c83-428e-8aec-7ce46c6c5672">
+      <statement statement-id="sa-10_stmt.a" uuid="95684487-9444-4195-8dbb-962f685d5bd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ac6e51-7ce3-4f56-bc71-b6ee264973d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -7590,8 +7590,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="79a9f009-f185-4edf-83a3-7233123da552">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5329dcbd-b31c-4add-86a1-51147ab18edd">
+      <statement statement-id="sa-10_stmt.b" uuid="3f0d837b-9027-4ba8-ac9e-9b4f1b9544a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa90dca2-ea44-4706-8cb9-2280b5d5f2d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -7600,8 +7600,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="12695bf3-2162-412c-9c3a-6086b3b3b5b4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="738271a0-9af0-4516-ac55-4f638747da6f">
+      <statement statement-id="sa-10_stmt.c" uuid="40f2740d-7c38-4a52-aff6-f09b9240678b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe37bd74-209c-4b2f-acfe-3da20c65069b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -7610,8 +7610,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="86a0194b-e40b-4cf8-8ec7-eb352e68a1ed">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b83208da-a11c-4df4-837b-1dea8a9f26dd">
+      <statement statement-id="sa-10_stmt.d" uuid="a1e3cfe6-bafd-4bcf-add0-e2df6c385eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51149b43-7746-4674-81e0-9343b6556130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -7620,8 +7620,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="2ca509bd-0260-4948-9bb9-3c7afe41bc9e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f0867631-e0c0-4c65-aaad-442ff86ba5d2">
+      <statement statement-id="sa-10_stmt.e" uuid="1d119dee-e436-41b2-ab4d-2dbd8a87a222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b6d4be-f2c6-43b7-9f49-133379f30817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -7631,10 +7631,10 @@ https://issues.redhat.com/browse/CMP-369
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff96ad81-8fa0-45f0-8e22-312c47b0359c" control-id="sa-10.1">
+    <implemented-requirement uuid="4c64a19c-d9a6-4f5f-8362-95028e8a5a27" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="f6cdb23e-d43e-407b-a8e0-3cddb0efbb8b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="765bcc8f-ffe1-4d14-9bcb-fa00bd801818">
+      <statement statement-id="sa-10.1_stmt" uuid="3893e7a9-f701-4695-bb10-3c715ec900de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5a26a-f4da-4af3-97c9-1b9cd4601ff9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -7644,10 +7644,10 @@ https://issues.redhat.com/browse/CMP-373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae2379b8-6feb-4546-a9f2-b770a00c03fa" control-id="sa-11">
+    <implemented-requirement uuid="a86926a5-e735-4a73-83bc-60bc088ce819" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="76e0f9a4-b78f-4235-939c-7ade18e1207f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d574804b-145e-42f1-a170-163d72ea486c">
+      <statement statement-id="sa-11_stmt.a" uuid="46fc688a-6a7a-491d-8c9d-f3ca597d33eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f34b6662-ab38-41e3-ac72-b08cb8675a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -7656,8 +7656,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="b2583b6c-53f8-4fcd-b00e-25c31e76bdcb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="08ab0119-8a71-437c-947a-12eefe342ac1">
+      <statement statement-id="sa-11_stmt.b" uuid="3c6b0a07-19e1-4b56-8978-84f78e5d41b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c00fc148-bd08-4f25-aee0-9ad9d3760062">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -7666,8 +7666,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="eba0f90b-8487-4961-9b43-f6e0939ff0cf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="71a3280d-4bad-46ac-8f1f-3ddfa206a076">
+      <statement statement-id="sa-11_stmt.c" uuid="95db2f92-ab21-4cdb-bf9b-41002f9858be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c0e9f2-6558-4dd6-b14e-9a254d3cd9c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -7676,8 +7676,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="c58adc95-471f-460a-ac36-3222576822bc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fe59e72a-dfd5-4b9a-8a90-9685050b168e">
+      <statement statement-id="sa-11_stmt.d" uuid="efebb503-1b64-4ce9-832c-3be4e01cc4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b2f4dcf-5965-417a-8706-e9e23c034690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -7686,8 +7686,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="3b07c345-0ec8-487f-94e1-0cdc96b8fd64">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6b970282-29e2-4985-aad4-c7ab2a3d6d9b">
+      <statement statement-id="sa-11_stmt.e" uuid="fcf54721-40fd-49b0-af2d-7c710acfa862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="528f9b93-35a6-4d13-8a0f-acb56b90303c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7697,10 +7697,10 @@ https://issues.redhat.com/browse/CMP-374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c347949d-dbfc-4db6-a14f-89d7344cecf7" control-id="sa-11.1">
+    <implemented-requirement uuid="390d4359-e23c-4ea7-a03e-33ab0f771c89" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="236935c6-7c37-48a4-8c0d-9deb8a58cf4c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d881ed02-45a7-4063-9f67-2eeb6b28b7af">
+      <statement statement-id="sa-11.1_stmt" uuid="78fa5d63-08f1-40f8-aa7f-302d689735df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3953a8df-4a05-4b03-811c-eecbc5b1115f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7710,10 +7710,10 @@ https://issues.redhat.com/browse/CMP-375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21f717ed-1689-4c99-834c-4eab449d4eeb" control-id="sa-11.2">
+    <implemented-requirement uuid="f6a79121-574a-4870-8fd6-f0b7f8e8264b" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="7b41ddc6-2041-417f-a200-62a20d5fc19d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3f3d4782-d0d3-4f09-b680-9a1a23a0c499">
+      <statement statement-id="sa-11.2_stmt" uuid="bc1c0016-a06c-4757-af0f-2bebb94fb87b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a25713a-4531-486b-bb1d-534a8fd9065e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7723,10 +7723,10 @@ https://issues.redhat.com/browse/CMP-376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d96c6e3-b63d-4a79-be56-9ffc12afe633" control-id="sa-11.8">
+    <implemented-requirement uuid="b2c4d52c-2d22-410b-91fd-6adcafe27600" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="54f597b5-df86-49e2-b7c1-ceab69cbd780">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c7f73b93-80b7-43c2-a0fe-9f9866137211">
+      <statement statement-id="sa-11.8_stmt" uuid="6bb50194-184f-4669-9484-5e251888ba63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5626f4d-3991-4663-8a15-b4c106696880">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7736,10 +7736,10 @@ https://issues.redhat.com/browse/CMP-381
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8e7b8da-02e2-4b29-8ed7-c33fc85eee7f" control-id="sa-12">
+    <implemented-requirement uuid="f99a1cbb-dede-4f71-85e7-ec6dea75bbd0" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="1efa199e-ba04-43f1-90cb-f7dfe727fe64">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="63d981d5-e5a0-4b03-a6a3-d680c3758fde">
+      <statement statement-id="sa-12_stmt" uuid="c563269f-4c41-4a77-8ebc-ec51acb22f6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bc51b63-9523-4031-8845-df80783e280f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-12 is planned. Progress
 can be tracked at:
@@ -7749,10 +7749,10 @@ https://issues.redhat.com/browse/CMP-382
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9616473-da95-45a6-b0b6-12affe960b8c" control-id="sa-15">
+    <implemented-requirement uuid="0f371a25-e91f-4885-9f0f-943e04eead02" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="a99d63f3-0ed3-4055-9e18-9725be6bfa46">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c1a763c4-ad0e-4d26-81fe-5f95856c5216">
+      <statement statement-id="sa-15_stmt.a" uuid="b66fd6cb-383b-4281-8109-92b4966ce76f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f74d490-81a7-4297-b413-71ae4a1015f2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a) is planned. Progress
 can be tracked at:
@@ -7761,8 +7761,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.1" uuid="b1d325bc-5c10-4d1a-af2b-03237a24d6ad">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="73f5a899-866c-4460-a4f3-d83c6927ed2a">
+      <statement statement-id="sa-15_stmt.a.1" uuid="bd3166ec-9fe3-45cf-aa6f-14651b1e28d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb23a2a8-de80-47aa-9881-041ee04a669a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(1) is planned. Progress
 can be tracked at:
@@ -7771,8 +7771,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.2" uuid="6b13dbad-3649-48af-bfb5-8100fdc00b14">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ddd5bf25-f9b9-4a4f-81a7-016c9831666a">
+      <statement statement-id="sa-15_stmt.a.2" uuid="1f93b263-b721-4673-acdd-ed89b320f6f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ee92eff-1182-4982-bf5a-ffe29b3679e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(2) is planned. Progress
 can be tracked at:
@@ -7781,8 +7781,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.3" uuid="4906ef44-571c-4af5-92c7-454bdd89ac9b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e2fa5120-370b-493e-bbe2-5f4cf901f359">
+      <statement statement-id="sa-15_stmt.a.3" uuid="ac6d04eb-d23f-4686-841d-0ac6d4f58e00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d6c1033-2542-4eb8-b24d-79dd2ab5bb31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(3) is planned. Progress
 can be tracked at:
@@ -7791,8 +7791,8 @@ https://issues.redhat.com/browse/CMP-383
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.4" uuid="ae52731c-6682-4a94-8d39-726ae39d3906">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7f18289e-ec7c-4296-a6c6-edce1be078db">
+      <statement statement-id="sa-15_stmt.a.4" uuid="0a6afb90-82b2-423e-aa27-f03cf47f5e9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7063db13-5c35-4b99-87b8-ef5e3ad15fa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(4) is planned. Progress
 can be tracked at:
@@ -7801,8 +7801,8 @@ https://issues.redhat.com/browse/CMP-382
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="b9fa0e55-3687-4d84-901c-f9aeefd09f5d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="97cf237d-263a-46ea-b7fe-cb1f6274e6a3">
+      <statement statement-id="sa-15_stmt.b" uuid="f3c3d6b5-025b-41d2-82fc-91318fa4d074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fff64b6c-e115-40bc-b9c1-32ef0891faa9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(b) is planned. Progress
 can be tracked at:
@@ -7812,20 +7812,20 @@ https://issues.redhat.com/browse/CMP-382
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="109ff55e-d04c-485f-97ba-6246bdb01302" control-id="sa-16">
+    <implemented-requirement uuid="9bb3c0cb-a2a8-46a7-9ca4-b2a4e6f1ef91" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="0c466097-6de3-4687-a7a8-d0e1bcbb5ebe">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e942d437-3774-4d36-9943-2c0b6bca2194">
+      <statement statement-id="sa-16_stmt" uuid="1b44cb72-6d8a-4a8d-8437-288906e1ddc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90480eb2-7f20-4b67-b557-b325700907b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-16 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a96a54a-1d8b-4efc-9bc1-3ae343565a86" control-id="sa-17">
+    <implemented-requirement uuid="bc6ced25-c598-4c02-a447-25960226df22" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="2d200287-3ab2-4ea8-8514-ec9813adc52f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a49c4da4-f1dd-413f-986c-22dd20b4e3e4">
+      <statement statement-id="sa-17_stmt.a" uuid="3d8ff4e8-11a7-4163-95af-7fc49f9848c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="699e84a8-2766-46eb-ad5a-484eb4c9c3a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(a) is planned. Progress
 can be tracked at:
@@ -7834,8 +7834,8 @@ https://issues.redhat.com/browse/CMP-389
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="77eefb14-5214-4664-9c9a-36cc62ad6229">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2ba748ce-e504-4f51-8bdb-e2c0ea06db80">
+      <statement statement-id="sa-17_stmt.b" uuid="11528158-c617-414b-80e5-81b5bf49a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af3ab2ae-ebd4-4242-ae94-c54c59a8e8a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(b) is planned. Progress
 can be tracked at:
@@ -7844,8 +7844,8 @@ https://issues.redhat.com/browse/CMP-389
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.c" uuid="fa3a9386-3d17-41db-8386-8d25dd670e3c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d9b58ce3-2431-4702-af52-a27f980b0280">
+      <statement statement-id="sa-17_stmt.c" uuid="23942290-6e90-4392-9c34-0a2649fa4335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3378fc76-522a-41f2-a73a-0d670a84dfd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(c) is planned. Progress
 can be tracked at:
@@ -7855,18 +7855,18 @@ https://issues.redhat.com/browse/CMP-389
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="849c19f2-bac0-48f8-91a4-45a2fb7475d1" control-id="sc-1">
+    <implemented-requirement uuid="6f1144bd-a44c-4b04-997c-b59d54a710d2" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="e319237d-235a-479b-966e-001b00211b80">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f06df955-500f-42af-90ce-1c1f7350617a">
+      <statement statement-id="sc-1_stmt.a" uuid="1fa652f8-6db2-4210-a8eb-f51d9dc94c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="4ecbc59d-c63b-4a99-b215-d35937a30e30">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ff1847b7-9e53-4ce9-a3cd-47cafc21c228">
+      <statement statement-id="sc-1_stmt.b" uuid="ab7e745f-41f6-47a2-a535-600910be8e7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7874,10 +7874,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="642d710a-13fd-416b-9814-60cfd7d07386" control-id="sc-2">
+    <implemented-requirement uuid="591ef3b8-6fee-4e3f-a241-82278e96a4e7" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="ac2bf4f4-3dc0-4b4f-ae93-be51803e26c1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fa44f7d1-a896-41ac-90c9-b4aa02fa69ea">
+      <statement statement-id="sc-2_stmt" uuid="143cf0ca-c117-4586-a1cd-91947e3f1a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa072737-5175-4d0d-a2ab-e535883b1181">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -7892,10 +7892,10 @@ https://issues.redhat.com/browse/CMP-429
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="382d72d7-e126-42e9-9bed-cfad5d66568b" control-id="sc-3">
+    <implemented-requirement uuid="4585b1a9-f2b6-47c5-9ea1-fe85860e03b5" control-id="sc-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-3_stmt" uuid="6e61053b-c61c-4760-bcfa-6585308fe6e8">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d999949c-7659-4865-90ce-73ceb8e6d64e">
+      <statement statement-id="sc-3_stmt" uuid="47370f6d-b791-4508-9f02-15d432b516ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49b6197f-11f4-40fb-b3fb-0086caf4bae7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for deployment utilizing namespaces,
 host roles and other features as well as policies and procedures
@@ -7910,10 +7910,10 @@ https://issues.redhat.com/browse/CMP-467
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73766c6a-3633-4e7c-a406-bda4ea897fba" control-id="sc-4">
+    <implemented-requirement uuid="96f7fae4-b1c4-4625-92ac-3353f07bb6ca" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="407bf402-7946-44fc-aef7-1803d1d2c700">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="665123ef-d4b3-4ac1-b9d3-cd4c6df0f9f8">
+      <statement statement-id="sc-4_stmt" uuid="deb25b8f-b7c0-4ffc-87c3-ddb3e0e9e98b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="617b39ae-8abc-4fb0-9c00-c50746b0d781">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -7927,10 +7927,10 @@ https://issues.redhat.com/browse/CMP-428
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d95d1fb3-7950-4abe-8bd0-ce6071a92fd7" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="b1cebb78-55e6-4806-8fa3-674929616431">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="75b629ea-af39-4f81-933c-c3b3a45d5f11">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7940,10 +7940,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68cd6047-f8d8-4eea-a52c-4e7b450853fd" control-id="sc-6">
+    <implemented-requirement uuid="2ecd1aa4-1ec5-424c-8299-2f1847c78d2d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="c98bbfa2-bb5e-42a7-911e-743676957932">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="60544683-1e5a-43f8-bf14-76a189533823">
+      <statement statement-id="sc-6_stmt" uuid="1c65ffd6-790a-45be-9f96-dae549f63731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb086507-2e55-4213-b420-2f757534f30d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -7958,10 +7958,10 @@ https://issues.redhat.com/browse/CMP-476
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69a2ac53-fd53-46e6-a989-cb89cdd009e6" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="cb25ca80-ba6d-49b5-a72e-f08ed53d74cf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dfeb459b-334c-4cc8-bad9-fbc26a45d0af">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7970,8 +7970,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="a286d524-cac8-41e2-917b-44e72c1c1942">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="384a69ad-7911-4d03-ae74-5308a4265845">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7980,8 +7980,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="97ff05a9-3aa0-42fa-b332-67720233c61d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="af58affc-ecde-4b8a-9b69-75223d958935">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7991,10 +7991,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c89b0df-f84d-405c-a054-7a48e126f2ed" control-id="sc-7.3">
+    <implemented-requirement uuid="186b2385-1f1a-4a9f-87cb-fa9ba58408bc" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="b24b5651-f2c1-4b5c-8ed1-7044fabc6516">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="37ba5785-5b16-444f-9d0a-fec087cbfe22">
+      <statement statement-id="sc-7.3_stmt" uuid="34c09b45-a0e3-4736-b446-a55a9b2a919e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c23c58f-8d5c-4070-a9c0-8ae34f8b5eb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -8004,10 +8004,10 @@ enforcement.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82e0afdd-5ed0-4dbf-bf7a-082d34485678" control-id="sc-7.4">
+    <implemented-requirement uuid="40c87c66-53dc-4c7a-b967-a4c56d768cad" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="4628edf3-c2bc-4bb6-971e-d2082bdc1e6f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5b361541-ec5f-4f82-815b-91315dbc8c67">
+      <statement statement-id="sc-7.4_stmt.a" uuid="b9b8c5f1-be1c-463b-89a6-f55da7e89336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42b18df6-6a61-45a2-bbbb-8278df55804c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication service
 is addressed at the network infrastructure layer and is an organizational
@@ -8015,8 +8015,8 @@ control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="6147f7a5-7351-483b-84ac-a3496d0c4947">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cdba5609-ebc7-4508-a1e7-a836f02f6aaa">
+      <statement statement-id="sc-7.4_stmt.b" uuid="535c8a55-e076-4c4f-832a-0689111c527d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f000ffd-6bcf-444e-86bc-0d6240403c42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside the
@@ -8025,8 +8025,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="ab6ef51d-fccb-4198-88bf-f4c4eadbb7c6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="97193e4c-b1aa-4396-b35b-960e7bc8ae5b">
+      <statement statement-id="sc-7.4_stmt.c" uuid="09f0b017-481e-45d6-be8e-58fd0c6249ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1129c924-e34d-4f9c-9c92-f732ba16c7ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being transmitted
 across each interface is an organizational control outside the
@@ -8035,8 +8035,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="65bb4e9b-d406-4cc4-a44f-1529afb4e7ff">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f308cd44-24c4-409d-93ab-b62cc0a87ee9">
+      <statement statement-id="sc-7.4_stmt.d" uuid="99605571-65d1-4b0e-b820-6f6d4cb27321">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecf8a969-d110-4dd2-b016-c66831f9c91d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational control outside the
@@ -8045,8 +8045,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="98130643-38cc-4a35-bc8e-ddc9cfe835fb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="853cbfbc-f774-4afa-b0b2-3e55e4a35dd7">
+      <statement statement-id="sc-7.4_stmt.e" uuid="8f644a62-bf77-4048-aee7-d660628f64dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3de3cfe2-e7c1-4cb1-b7db-5a472f4b0f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally defined frequency
 and removing exceptions that are no longer supported by an explicit mission/business need
@@ -8056,10 +8056,10 @@ handled at the network infrastructure layer.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8796109-1c0c-411d-9d65-6f66b3dc2758" control-id="sc-7.5">
+    <implemented-requirement uuid="299dcdaf-d2bd-44b1-9f34-7a83c829a2b4" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="c54f4dc8-e595-4ed2-8b38-c82b63057d75">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a87cfea0-e5cc-4b59-b8d4-d4db26738bec">
+      <statement statement-id="sc-7.5_stmt" uuid="796764c4-2388-42ab-99f8-bdf5a00fb0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b15b06f-d5dc-4fb0-af24-596c93208d35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -8073,10 +8073,10 @@ https://issues.redhat.com/browse/CMP-424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c42b7d2a-555a-4177-8ebc-d6818f543d10" control-id="sc-7.7">
+    <implemented-requirement uuid="bcea67a7-eae0-48d6-aa01-b4e2a3a68210" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="20dc2526-8e3c-4c32-98c6-8285a0201c7a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="afbe0cc7-ebf4-48be-bd2a-bfe6955d4d7d">
+      <statement statement-id="sc-7.7_stmt" uuid="cab35424-140c-42cb-9ab7-deae4b0da66d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1152f196-9746-4432-a593-6ee4a6ff7334">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure OpenShift nodes do not act as proxy or relay servers between
@@ -8085,10 +8085,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92a898c6-91c6-4cb3-a806-3c8a10e6fe0f" control-id="sc-7.8">
+    <implemented-requirement uuid="7decfaf2-b8e3-498b-ae55-671b24506ec9" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="b96eda31-bdcf-42b3-8494-3f7d78a9ff1d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ff4fc3c9-6034-475c-9d4e-38f34810b29f">
+      <statement statement-id="sc-7.8_stmt" uuid="833f91c1-8eb3-4422-8059-f8d05cfe7237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adba8470-6219-47a4-aeb4-ba166c6b610a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8098,10 +8098,10 @@ https://issues.redhat.com/browse/CMP-477
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f550b96c-c2bf-4558-873c-9cf9b53eea27" control-id="sc-7.10">
+    <implemented-requirement uuid="679c2de8-d087-4463-8622-1b5cdd1ff547" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="bcf95d88-6726-486c-bf40-706d83706a99">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a084ded6-229c-4806-8f40-698303311df3">
+      <statement statement-id="sc-7.10_stmt" uuid="d73cea55-f22c-4ba1-a9a5-02dd9fafbe04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82aa1ba8-6968-43b2-8c19-cbe7df2a6ffc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8111,10 +8111,10 @@ https://issues.redhat.com/browse/CMP-482
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b2a29b9-db18-4933-a1e2-9cbc53e8f7df" control-id="sc-7.12">
+    <implemented-requirement uuid="7bcc9d61-0924-4650-a79c-d2bcf6e0bfde" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="6a543d5b-73ec-4d80-b845-722b1c538910">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ea698ac4-105a-43e2-8716-fdd80fc11aff">
+      <statement statement-id="sc-7.12_stmt" uuid="04b972b1-e2d5-4deb-868d-b1a1bb971393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c721f916-ebf5-44d2-930a-0f52d3887fec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -8128,10 +8128,10 @@ https://issues.redhat.com/browse/CMP-483
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fa78dbf-f749-495a-8c7e-fa432b3daa4f" control-id="sc-7.13">
+    <implemented-requirement uuid="f1197a21-c333-4172-a38d-61974c0d7104" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="94772982-96d5-443a-ba18-9b339cb222a2">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8981b7a2-a40c-4b46-91ac-cc3be228f6b7">
+      <statement statement-id="sc-7.13_stmt" uuid="24191c4d-9451-4c9e-abbb-6b1e57bf12eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ee1f34-09bd-4973-b7ed-91901cf226cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that OpenShift is
 isolated from other internal information system components by
@@ -8148,10 +8148,10 @@ https://issues.redhat.com/browse/CMP-484
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a4ff2a3-7444-4356-bcb2-7b28dca4e4d3" control-id="sc-7.18">
+    <implemented-requirement uuid="7e0070ef-c09f-48d1-9579-efebc49bb27b" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="703d91e8-ab99-4090-8b4b-5ef28a75ca84">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f505ad66-e13f-4d43-9b8a-6eafd7cc4e91">
+      <statement statement-id="sc-7.18_stmt" uuid="6bc5981d-371a-4efe-91bb-23f0994ae97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f446eca6-5b4d-47c8-815d-301752b4d6ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8161,10 +8161,10 @@ https://issues.redhat.com/browse/CMP-488
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="030664b5-3b51-47ab-81f3-fc9d30bfd741" control-id="sc-7.20">
+    <implemented-requirement uuid="9b22263a-6581-43bd-9229-7c6c2e20bc77" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="fb9e8956-ebeb-4a56-bb46-6c23c33b9e6d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f0455abf-93c3-4054-b773-af43bd779af9">
+      <statement statement-id="sc-7.20_stmt" uuid="d56944e9-176b-469f-9616-3f55ab9f86ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f635877-5d6e-4ea7-a1bb-a73604c5fa9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met when SELinux is enabled and configured properly
 with namespaces being used as well.
@@ -8172,10 +8172,10 @@ with namespaces being used as well.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf51d6c5-7e46-4d14-a6d5-63d20b88e56f" control-id="sc-7.21">
+    <implemented-requirement uuid="64438902-f29d-4aa4-8a62-4853674b24e2" control-id="sc-7.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.21_stmt" uuid="bd093c20-a7d6-4876-868c-d22813fbfb29">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="12ab3fa7-e590-4ee6-9ddc-0d45efadaef3">
+      <statement statement-id="sc-7.21_stmt" uuid="5983e354-e073-4af8-8f42-ae69e1bd7b14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="143bf9a5-3bbb-47ff-a892-bce11a26ef04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8185,10 +8185,10 @@ https://issues.redhat.com/browse/CMP-489
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9bd2602-f3e2-4d22-bfb0-e8eade5f253f" control-id="sc-8">
+    <implemented-requirement uuid="5204cabf-dbf5-4d92-9cd1-804354d80d7a" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="d676d344-e1f1-47e8-ae02-700897fd99b9">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9eb1bd3e-75ca-435e-a5b0-71b16be95d06">
+      <statement statement-id="sc-8_stmt" uuid="10ab3b1d-fa32-4dfb-b7f0-c5c4f924b33c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fee56b6-5600-43e3-9132-b328cd2e17aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -8196,10 +8196,10 @@ information.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8efa542-12a5-451a-93ec-dd8417a78c0d" control-id="sc-8.1">
+    <implemented-requirement uuid="d79b39ec-b75a-4d9d-b839-2f28d69d9e98" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="4c2d85cf-32ae-4f17-aff2-e00791809b23">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7d15194d-a7e3-4eb4-a4ec-6e33125df76c">
+      <statement statement-id="sc-8.1_stmt" uuid="84d59cbe-40c4-4f22-8df4-1246640eef00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acd8d90a-0f39-4844-acf7-6a4ed7f9b815">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -8210,10 +8210,10 @@ network communications that carry customer data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28695138-dfa2-4f38-9eaa-aec5f69a1545" control-id="sc-10">
+    <implemented-requirement uuid="df5e51eb-966c-402f-98c6-1bc7cb654de8" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="8587b61f-a254-422f-9104-9758eec85778">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="99df1f7f-7611-4a43-b0b3-03472aee816c">
+      <statement statement-id="sc-10_stmt" uuid="49fd79b3-99f8-474f-82f2-797e2fcb4835">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fcef049-edaf-49f1-ae92-34545047b7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -8228,10 +8228,10 @@ https://issues.redhat.com/browse/CMP-422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e511b8d-9778-4c26-914b-4b70b7f386e9" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="4eee5216-a95a-4918-b8fc-2d7dac79a498">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="709d0afc-d8af-4c60-97c5-1c4880cd3fb2">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8241,10 +8241,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8f6335e-8a42-46c5-862f-be4cec30d6f6" control-id="sc-12.1">
+    <implemented-requirement uuid="63ab894b-cf8f-4a84-9833-1d270552f36b" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="2efda00a-6809-4a36-a7de-b6fc842b1638">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a5f4a3f5-4a00-4502-8bac-c15f929c07cd">
+      <statement statement-id="sc-12.1_stmt" uuid="212fc07b-7b23-44fb-9faa-e66e524fbe4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a4db13e-65b6-4b6a-9f33-5d4e6c86902d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8254,10 +8254,10 @@ https://issues.redhat.com/browse/CMP-497
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e103b841-e4cc-454b-a131-ec89672d756f" control-id="sc-12.2">
+    <implemented-requirement uuid="f654668f-472a-4fbf-a522-57b6eecda6b0" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="b0b80eb2-29f4-497d-84d2-f8a935cfd818">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="40c3ab8c-f28b-4118-978a-f809acd7fb2f">
+      <statement statement-id="sc-12.2_stmt" uuid="67ed0c07-b5b2-435c-bf22-d186feeafb91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7cd35cb-8dd1-4c8c-be3a-46ce4c45892f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8267,10 +8267,10 @@ https://issues.redhat.com/browse/CMP-498
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb123798-d796-468f-b686-0f3793785884" control-id="sc-12.3">
+    <implemented-requirement uuid="573937d5-283f-457f-8b61-cf35b660c70a" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="e1141aff-b963-42d4-a586-edd5ecdc5dfe">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="74456244-3964-4c26-91d9-d3b31a2099a8">
+      <statement statement-id="sc-12.3_stmt" uuid="a440cef9-784e-4366-a8cb-6d94f9df94bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90872c45-14ad-48c2-8509-c00f5833d23f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8280,10 +8280,10 @@ https://issues.redhat.com/browse/CMP-499
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2ce9a27-fcf9-47a5-adf5-e0d66b0041e9" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="608800ed-df81-42f0-9e14-2a5b0ba771bc">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7345e779-94cb-432f-beb7-d6567b1eba7f">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8293,10 +8293,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05a0abd2-9d7f-467f-8f4d-950a3881df85" control-id="sc-15">
+    <implemented-requirement uuid="33b5b086-7214-4783-a0c5-ba185fda8e71" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="985bf52a-a1f7-4763-b2ae-9f6d475b57ba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="766d40ef-c80c-4dbd-bb3d-d831a8b417d1">
+      <statement statement-id="sc-15_stmt.a" uuid="22e07405-dd19-4fe8-a698-f29ef5735dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8305,8 +8305,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="0a9ca02c-02f4-42d2-b970-bf6c755f3639">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4db441c9-0027-4fbf-a584-dc74afcfdb1e">
+      <statement statement-id="sc-15_stmt.b" uuid="ca736a8c-d2fb-4c10-8a69-03137dea9b7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8316,10 +8316,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b98efc13-825f-4d36-b875-8f5606537a6e" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="76d701f4-470a-464f-92ee-9b71a22739b4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6a7758ca-d519-43f5-bd00-39b6c48a62ba">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8329,10 +8329,10 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b32a757-9ce7-467f-8908-25f66718999a" control-id="sc-18">
+    <implemented-requirement uuid="59ba49a5-f687-4224-aece-d0a9bb94e1b5" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="815cfbe5-99a8-4693-be3a-a91023dd9ffb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="05d88706-c12a-4252-9533-c2d2de714b4a">
+      <statement statement-id="sc-18_stmt.a" uuid="d1b9d625-add0-4a4b-85d4-9bd95d0ec719">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="114c57ea-d393-4155-aeae-c3fc55e99699">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining acceptable and unacceptable mobile code and mobile code technologies
 are organizational policies/procedures outside the configuration of OpenShift.
@@ -8343,8 +8343,8 @@ web console that is accessible through a web browser.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="9502aefc-80da-4b22-a4ec-2448ac970bc7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="ba67914d-5a12-4768-83fe-64c1538bf76b">
+      <statement statement-id="sc-18_stmt.b" uuid="7ec821bc-9bdb-47cd-b102-c239b04cf6e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8eeef5cf-f7eb-448a-926b-3bbc65e5784b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing usage restrictions and implementation guidance for acceptable
 mobile code and mobile code technologies are organizational policies/procedures
@@ -8356,8 +8356,8 @@ that is used to power the graphical web console that is accessible through a web
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="c23d3e02-a69f-4f97-bb94-4971c4871ebe">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e58f6541-b35f-444e-8fe1-f79ece0997ae">
+      <statement statement-id="sc-18_stmt.c" uuid="21b3f744-2fa4-4360-b635-fb0433a7c833">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef9f9588-dbed-4a4a-be56-40eb10bbf0fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -8370,18 +8370,18 @@ web console that is accessible through a web browser.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa64f4d7-9992-4109-9067-999f3de71e38" control-id="sc-19">
+    <implemented-requirement uuid="bc408d6f-99ea-4a9f-b808-c973d7933495" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="68c7529d-1b5e-4ba1-b166-23bd6adeda01">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2fe394a2-b35c-423f-aca1-43e44d50885e">
+      <statement statement-id="sc-19_stmt.a" uuid="267f7ba8-5551-46c4-a4cd-b91d6b92c2ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="6a6e0408-f194-4a60-8681-bac2ba5a2026">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3fa99c55-7b46-4de1-94f3-85e24ffaa632">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -8390,10 +8390,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd8966b4-9ce5-46c1-9d3c-ff222caa2cac" control-id="sc-20">
+    <implemented-requirement uuid="e8aba7c2-acb4-4654-b1d5-e600a651d4c3" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="675bf236-b9b1-4162-aa84-3a19845b3111">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b01c3d98-b546-448c-8015-bc26da271821">
+      <statement statement-id="sc-20_stmt.a" uuid="a438c5ea-e94c-44e1-9c84-4d29a630732b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60a17e-515b-4a94-821a-de75ff70ced1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -8408,8 +8408,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="18cc180f-a703-452b-9b2f-77858cc3556b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d502c9ef-b033-40be-a9d2-cee281c827ae">
+      <statement statement-id="sc-20_stmt.b" uuid="3b9bf6aa-8da0-4050-bb86-c3357e8d9f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76baf97e-0a1f-4b12-bb26-a59e03124332">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -8425,10 +8425,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb84fd49-f537-4ab2-b3a2-27a95afc2781" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="26a531e0-4948-41d6-aa5f-45bc25172a26">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7671cd14-cd46-4a33-aa83-2da09754f3ec">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8438,10 +8438,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3030a252-0a11-4ada-8dec-95260f1af8ef" control-id="sc-22">
+    <implemented-requirement uuid="5fee0dd7-b1f6-4891-98bd-848c114c8822" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="6c1a6e28-8553-487c-8754-d48958afa729">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="49b2e308-0ca9-43e4-8d84-b1afe78ff831">
+      <statement statement-id="sc-22_stmt" uuid="81094d0d-abb6-44fe-b96d-302346ffb9a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec8d8758-4010-4e53-bf8f-07d498fe1433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for ensuring
 services are fault-tolerant and implement internal/external role
@@ -8455,10 +8455,10 @@ https://issues.redhat.com/browse/CMP-409
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25dd8cd0-1d89-4cff-814a-9addaf0ab5a3" control-id="sc-23">
+    <implemented-requirement uuid="55f35173-b26b-446c-84e9-4d9c3403963f" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="c451e0ba-fd60-4cdb-a413-dc5a61ac12f4">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="6df9731d-8b69-40f6-953d-6aea27f6ae09">
+      <statement statement-id="sc-23_stmt" uuid="c6fbdad1-b354-4172-bf6e-6d9004084a83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d91fa822-db8a-44f5-8ade-232b776bd79a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -8478,10 +8478,10 @@ https://issues.redhat.com/browse/CMP-408
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d52b847-7949-4e7d-80f0-d00023ca0a54" control-id="sc-23.1">
+    <implemented-requirement uuid="b985a08c-0c77-45bf-aee6-6f338f66844c" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="0c2e7408-8042-474b-994b-0570c8dc5918">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="312022ab-ba6c-40d7-a249-5d819b367632">
+      <statement statement-id="sc-23.1_stmt" uuid="cd72eb89-b726-49e1-9c75-43eaa350ceed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="680c783f-957d-497c-ad0a-b7b30e965b29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8491,10 +8491,10 @@ https://issues.redhat.com/browse/CMP-503
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe84d437-dd3d-4c21-a0d8-56fa46fddc30" control-id="sc-24">
+    <implemented-requirement uuid="760dc535-35d5-4aaa-a424-d6f48867e4c5" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="b0e43559-b690-45d7-9395-8edb9324b983">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="33524310-c379-425a-973e-da304ee50a8d">
+      <statement statement-id="sc-24_stmt" uuid="420dd762-6c23-49b2-b672-06fb5d6978fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c361032-37ec-4037-9c35-181d6eab1e82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8504,10 +8504,10 @@ https://issues.redhat.com/browse/CMP-506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55efc294-6ef6-4e3d-9627-8dd61644c806" control-id="sc-28">
+    <implemented-requirement uuid="2f992720-6db0-4356-8634-6339b0d6cda8" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="52cc7fe0-20b7-4e2a-8db5-c21afb552888">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="443d22ff-ab19-4882-ab92-6778b4295f5a">
+      <statement statement-id="sc-28_stmt" uuid="8ef6d238-c643-47a9-852d-368fa7d3e931">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32649326-f922-49d4-bd77-0b13901bf763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8517,10 +8517,10 @@ https://issues.redhat.com/browse/CMP-407
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93928072-bcf2-4fb5-8421-72df63bf064d" control-id="sc-28.1">
+    <implemented-requirement uuid="2fdd7a56-3726-4eb1-bfcf-5e176b9a3034" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="1f82b26e-5a96-4e2e-9d63-07dd9dc7950f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="4e3e9bf7-3774-41b8-9882-f0a4babbb261">
+      <statement statement-id="sc-28.1_stmt" uuid="71a057ff-989d-433f-9ba8-138a0d68cd4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e0ee74f-bb55-464d-aee1-4aac52eb7bb3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -8541,60 +8541,60 @@ https://issues.redhat.com/browse/CMP-509
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36cc2ff6-6ca5-4c08-a06c-bbaeebfdaa10" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="7b29df73-a294-4885-b9bf-9a04c3c85ee0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="76b1695a-d489-4117-b889-ed363fe2cf88">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e880d09-8658-4c53-8205-941a7724d944" control-id="si-1">
+    <implemented-requirement uuid="0e8f74e1-33d5-490e-8ac7-915f29de22fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="d81e099b-ca5b-4b1a-bde6-cca4e288a003">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bcb03a57-85e6-430a-8ea4-c6470e50e945">
+      <statement statement-id="si-1_stmt.a" uuid="89bb11fc-5456-4431-b5f0-9f781b3a5730">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="603b5ac4-e7a2-4c9a-857a-644b91bc1c20">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5869fc80-4d3a-4e7d-b979-507442eb6484">
+      <statement statement-id="si-1_stmt.a.1" uuid="11d47f68-9baa-4b99-8e12-9ea77692cd34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="53c1e100-4dd9-4183-8bcc-0c9499db36ba">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2f15d8ed-d735-4970-86f7-08840aaa8dc8">
+      <statement statement-id="si-1_stmt.a.2" uuid="41bb516d-57c2-400a-aa40-9bdbda591302">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="35b17192-e5a5-4652-b092-0f45a1c5e7dd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="06fcd863-b3e3-4323-bf85-2c221cd2e4ce">
+      <statement statement-id="si-1_stmt.b" uuid="448424c2-d63d-47a9-820c-f87eb4d1d61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="85c3d10c-6d89-452d-9119-262632ca7f58">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="37dbf1b9-bc7e-4399-813e-3b36c9e142ac">
+      <statement statement-id="si-1_stmt.b.1" uuid="15a10a6e-2916-42cc-a2b7-02aa6cb1c31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="c28c12e7-1d45-4a19-ab7e-bc2ab1013217">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="95bded0a-9a0e-499f-b3c0-88c4fd1be8bf">
+      <statement statement-id="si-1_stmt.b.2" uuid="1cedc5bd-d780-421e-af4f-0cb3453299cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -8602,10 +8602,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed80df10-4bbe-40b8-9130-070aed44abf9" control-id="si-2">
+    <implemented-requirement uuid="acd2c7f7-78db-433e-b76e-fb6644fa7a8c" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="cdbe7bcc-a261-48a6-97c0-1d07556f3740">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="75d38469-339c-4f2f-8214-fc4860327754">
+      <statement statement-id="si-2_stmt.a" uuid="150a4ab4-9760-4f58-8c29-f44da3d0a040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3fc37ef-182c-4e56-bfb4-7aa0866c8659">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -8615,8 +8615,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="3688321e-d33a-4ba7-ba8a-805b4649bb25">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="54c80028-40d8-4d02-8a91-306101f82ebf">
+      <statement statement-id="si-2_stmt.b" uuid="75906d70-3ce6-45e4-b658-5eb304210d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ced799b7-8fcf-4128-ada3-51e5a2540b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -8626,16 +8626,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="a3e42510-7eb0-45bc-b84b-fb60a6f18c7f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f7eea85b-3b00-4862-9e33-557cacaf5508">
+      <statement statement-id="si-2_stmt.c" uuid="2aca2ec6-b658-4a2a-9869-7a9cd31e5aed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="bd678075-b4ad-452d-befa-0b7a1bfdef13">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc41f312-51be-49ee-949a-bff4b5483763">
+      <statement statement-id="si-2_stmt.d" uuid="eb56e9a2-e774-4c5f-b5fe-252e51a2ffe2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -8643,10 +8643,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4588c8fb-6b7c-4b5d-89bc-190732b23332" control-id="si-2.1">
+    <implemented-requirement uuid="215e150b-3030-414c-abb0-d250f8d5e88c" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="0408a3da-8bb0-44f2-92da-0a46d239db72">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2fd8213f-bc15-46df-bbce-f4ca48b2e269">
+      <statement statement-id="si-2.1_stmt" uuid="5a8ec765-bc42-4136-b844-0322400dc658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="236427d0-9b5c-4fa0-9296-8eaf8c701c8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-2(1) is planned. Engineering progress can be
 tracked via:
@@ -8656,10 +8656,10 @@ https://issues.redhat.com/browse/CMP-526
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f0ba78-39f4-4157-8870-87849a9dbeff" control-id="si-2.2">
+    <implemented-requirement uuid="25e6bb3e-56cc-4987-892a-3e681e6f3441" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="521db3e8-0cbf-492b-bf46-b4156c56f90f">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="04c20628-f4a9-4d06-9e02-14c31bfbe8ad">
+      <statement statement-id="si-2.2_stmt" uuid="166767a9-51b0-49a0-a1bf-86af3fa2e962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d5517-24f7-404a-ba5b-c641b36f0d73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -8677,10 +8677,10 @@ https://issues.redhat.com/browse/CMP-405
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62b03be1-7d5f-4add-8ab2-cfa2632701d9" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="ce386045-7be4-4255-915a-f833ea276bbf">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="927f1e4b-5307-4650-8ac5-b5155aed3061">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -8691,8 +8691,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="7240aa85-711d-454d-a4cd-6a5996be682d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a3cb349b-da7b-44b9-87f1-c30f03b13ddb">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -8704,10 +8704,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d720fa65-5335-4913-9569-67301e322af9" control-id="si-3">
+    <implemented-requirement uuid="d03e35c4-20d8-4401-8054-29203a44f102" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="7f4460b2-a64f-432d-8e52-d6442e345214">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e578c372-0b77-4f9d-8869-60a9223169d0">
+      <statement statement-id="si-3_stmt.a" uuid="cb35531b-7b7e-4234-a016-f42f9495dedf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8feb56f5-7538-4f7d-9600-abf7be214a63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -8719,8 +8719,8 @@ the use of third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="aa28d7b8-1e1d-4a1f-9b25-8f7effec6e6d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3af46bea-438b-4043-9887-2a5ac60ab04b">
+      <statement statement-id="si-3_stmt.b" uuid="1f80555f-bc6f-4222-a1b9-328f6e963a2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40235cf0-b670-42af-9cce-e65e5d66994b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -8729,16 +8729,16 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="303e76b6-c3ae-4238-8fd8-a3ea2f099458">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc65ff94-c891-4502-8595-e4c78646fe46">
+      <statement statement-id="si-3_stmt.c" uuid="93198438-e9d0-4c8c-85f9-69a2fe14725e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62b6ff60-503b-43b8-b8ce-d55f1b66f3a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="3475af5a-81b1-4410-9032-010dd4c7dfb0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d1a06f14-bf03-4d42-8175-6a4a0136585d">
+      <statement statement-id="si-3_stmt.c.1" uuid="c8b61a4d-ef1e-4312-99fd-46a971c468ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2fe1168-6387-408f-a6ff-ffad317babd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -8748,8 +8748,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="34a4d3ff-60d5-491f-b0b5-7f620f3cdf60">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2832f3a1-d59b-41cd-ad4d-198f86977fb6">
+      <statement statement-id="si-3_stmt.c.2" uuid="dbbf2830-fcb7-43e0-a25f-462b52458e6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="843974a3-151a-4498-b7ce-bc4b79db5ba8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -8757,8 +8757,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="29c09100-4c92-4cc3-b5e7-844683c30e5c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a680bd20-88a9-46f5-8a5d-332170ea55f4">
+      <statement statement-id="si-3_stmt.d" uuid="756f51fa-f7b8-4e68-8136-c111a2527e73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38eadf00-e46c-4362-bef2-72cbd283d26b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -8767,10 +8767,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c710683f-2c8b-4441-9a3e-413fa8dfde79" control-id="si-3.1">
+    <implemented-requirement uuid="1cb9ce8c-a065-4e29-8ce4-cf2326fb5635" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="3aeb32e5-8bef-4341-9f82-d639ce4853f6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2a5e9d80-0308-4bd0-8230-9c2e8f9ccd65">
+      <statement statement-id="si-3.1_stmt" uuid="eb659309-6941-4e3f-b759-e9650d65d7f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3e4d451-1297-4cb9-948a-5c981fa69b20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -8781,10 +8781,10 @@ protection mechanism is centered in one location.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="923b1d50-9d30-42e2-9c95-91699fee800b" control-id="si-3.2">
+    <implemented-requirement uuid="18ccdba5-ad8c-4be5-bc88-3d1aa521f7fc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="f23d2de1-9200-4eb4-9b95-812e6dd90083">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9de81dda-868a-48eb-b036-87862447ed26">
+      <statement statement-id="si-3.2_stmt" uuid="f025634a-0829-43ea-a63b-43512c51068b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9640d91-db08-4e76-86bd-d5f90fb4fe43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -8795,10 +8795,10 @@ mechanisms definitions are configured to be updated automatically.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f84eaa7f-053f-4fa8-bf8a-c60d666db09b" control-id="si-3.7">
+    <implemented-requirement uuid="cf3810d4-c2f2-4aae-9d19-8a62dc9eff70" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="f6ec225c-9ba7-4b38-aad2-0afd49e51302">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7a14f3f7-9255-44fc-9c81-0b090bf43f4d">
+      <statement statement-id="si-3.7_stmt" uuid="c8f35cf2-5a10-456f-ae5d-d11ebbb2e481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cee870d-007c-4f0a-a265-2c7467b1ffd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -8811,26 +8811,26 @@ do not yet exist.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c62e6ac1-b770-47fb-88e3-a47a4a239848" control-id="si-4">
+    <implemented-requirement uuid="25c959c5-8a92-4f38-a617-7cae7084371a" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="6df2e846-ab63-4410-912a-0ddb0967a5bd">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="d44ec1c0-70f7-4238-81e8-be23915fec59">
+      <statement statement-id="si-4_stmt.a" uuid="f7f8ef33-a9ed-4edb-bb56-258b61657b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="efe1622d-2d0f-4db8-876c-515073bec590">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="230a2a78-1b25-44a3-b8a0-2729b8670320">
+      <statement statement-id="si-4_stmt.a.1" uuid="5da408eb-abe2-4c82-b6c7-92a1a4a90cb0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="e15cfc63-d89b-456d-8254-c8089e19cd10">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="a45196fa-00ef-4542-81a5-7346a6c9a3d7">
+      <statement statement-id="si-4_stmt.a.2" uuid="1397afde-4529-4488-9431-5793335b0f1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37ed665d-3ebe-4bfd-9e6f-2ef07d234d14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of OpenShift configuration.
@@ -8838,8 +8838,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="886c780c-13c3-4277-ace2-070036f708c1">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0e7645d1-2f73-41ea-8359-f2dccbbd5cb4">
+      <statement statement-id="si-4_stmt.b" uuid="927dcfd6-d65d-44cb-ae8a-0262022e472e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8643ab34-5004-4e6f-8d27-7b6cf51c3d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -8847,16 +8847,16 @@ of OpenShift configuration. Functionality to meet this control can be provided b
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="cd767a92-2497-483f-a0ac-9db7b948347b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0c1da1b6-d950-4dc1-8ec7-f238cca0dace">
+      <statement statement-id="si-4_stmt.c" uuid="3b2f5ae7-8a1c-4e5a-976e-98a5c25e7920">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12e67e7e-f874-4a36-b1ff-cdcf0b59eb76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of OpenShift configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="ae6479d1-a704-488c-9865-8b4e4d1ab99a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bdbe9f56-7da5-459f-98e2-acdb01a4037c">
+      <statement statement-id="si-4_stmt.c.1" uuid="c7b17e51-9eb3-4bde-946a-5caae90737ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955c6e53-d7bb-4843-bf72-663b90900ff1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of OpenShift configuration.
@@ -8864,8 +8864,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="132debc9-3378-4828-814d-39d74571b647">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b1272ca2-f007-467e-947f-ca13928ba343">
+      <statement statement-id="si-4_stmt.c.2" uuid="993e77dd-845f-42e4-998b-bba17a7296b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dac05c6e-105b-45b6-98b5-fb90db5d1d65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of OpenShift configuration.
@@ -8873,8 +8873,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="efebb55a-1648-433d-9c11-1198189c9d7e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fa6905d7-8953-4778-b511-a07ce9bfd043">
+      <statement statement-id="si-4_stmt.d" uuid="394a954f-2bd5-4ae9-8746-3fbf6c212a1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcd1844-0d69-4003-85e3-9e4ca79094f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of OpenShift configuration.
@@ -8882,24 +8882,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="14c59728-8d34-4ed1-b9b8-81bb31d720e6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="25754f2c-8f87-4aae-9ca5-df6dcac38b15">
+      <statement statement-id="si-4_stmt.e" uuid="d65da8b5-977c-4240-80b8-a8313ff5d93d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="cfc20d07-b6e4-47d2-8a61-60c4dbf25b61">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="2e2d9db6-19e8-4412-9312-75273f135772">
+      <statement statement-id="si-4_stmt.f" uuid="294b5994-af2e-48bf-b955-944a37af62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="50ece330-cc92-4d84-a8d1-f5d7d0d7c6da">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="cec4b10a-30e7-453f-a208-1a43a306b3ff">
+      <statement statement-id="si-4_stmt.g" uuid="e2f86efe-2dce-4ca9-b769-a2abe286e1ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -8907,10 +8907,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f25a43d-47c9-4c27-8e91-d9803b2a9571" control-id="si-4.1">
+    <implemented-requirement uuid="66008e4c-18e0-494c-a330-a7bd09ee451c" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="d7c73d5d-f697-468a-b763-8a45311361a6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="41a0b18d-40be-46f0-8ad5-49d8f0adedce">
+      <statement statement-id="si-4.1_stmt" uuid="08000796-1afe-454a-9a67-eeca19611a96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ac18faa-f282-461c-b17f-e9c723ac1768">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the OpenShift environment, and documenting how this
@@ -8922,10 +8922,10 @@ systems.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36fb424f-c4f5-44f3-83c5-d3fa713056ae" control-id="si-4.2">
+    <implemented-requirement uuid="a466564a-c24e-44f5-a371-0d118c5aad09" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="1065f026-37c3-4213-8e0a-ba63e0e4c763">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="61ccc766-c144-452e-9478-a8abc4ccaabc">
+      <statement statement-id="si-4.2_stmt" uuid="bfec4448-35cc-4e5b-95c3-e12ba645a0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="158a60d2-2cb0-4c25-87b6-2a893330343c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -8939,10 +8939,10 @@ analysis of events.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="073b0960-c080-4ad4-9710-7e947196d461" control-id="si-4.4">
+    <implemented-requirement uuid="7b2489d5-2f6f-4d1f-b59f-dca4ae41798a" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="d074cda5-e6e8-488b-8d8b-3c32e792be28">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="8ebbfc82-1f40-4c2a-9061-88c1d8af27de">
+      <statement statement-id="si-4.4_stmt" uuid="ad0d0571-b244-4c86-9d3d-b043dda2a718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e96419b-1e8a-4449-84f4-3d330c160a20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -8954,10 +8954,10 @@ not, how network traffic is continuously monitored.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc7f107c-55b9-450e-8f07-d12b50ea344b" control-id="si-4.5">
+    <implemented-requirement uuid="9ed28fbd-039e-4879-824c-5fb5fa40ada4" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="409714fd-c015-4745-ae21-cbf287cf235e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="de271405-b872-4c6e-8ae1-c0c2a694d4ba">
+      <statement statement-id="si-4.5_stmt" uuid="7d9d1d38-f847-436f-80f1-5f2040122816">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae281442-f332-407e-959e-52cb7a2dd9df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -8969,10 +8969,10 @@ the notification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4c7832b-77b7-45e2-8607-368e571701b3" control-id="si-4.11">
+    <implemented-requirement uuid="459f6945-85fa-427d-ab8a-33bb92ea39e9" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="be3eb455-e785-4437-8573-75a8e24b7c22">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9bd729c3-8090-4519-9956-487aa1840675">
+      <statement statement-id="si-4.11_stmt" uuid="24b7252d-7fd5-4ee4-9f72-feacc50f239a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -8980,20 +8980,20 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fe3b850-3356-44d7-98de-2247dfee6483" control-id="si-4.14">
+    <implemented-requirement uuid="77b509be-7cf7-42e8-8ff7-b10b248717d5" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="52a15c47-3cd9-478c-8d52-4bdc4490151c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="34fe3151-dc38-481c-87fa-9d98b90c4be9">
+      <statement statement-id="si-4.14_stmt" uuid="27cd3a44-7a05-485e-a403-03f55d64a5d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="532e540d-6cc1-47a9-b4d8-2ff09efdef2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An OpenShift infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a25f612-13b4-4fb9-bd5f-a53c55935b27" control-id="si-4.16">
+    <implemented-requirement uuid="07d7972f-8d1d-4f42-ad1a-42cede0f3a4c" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="50ebca7d-ba24-4cbb-9db1-b38300fb6bed">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="98df444b-cc6e-4850-98ef-a2079d80dc44">
+      <statement statement-id="si-4.16_stmt" uuid="816c1b9b-678c-4cd0-9101-99a2ad18fea9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9202c5d-7097-4f4d-95f1-5de0b334241b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -9008,10 +9008,10 @@ https://issues.redhat.com/browse/CMP-536
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b8c0cf4-4fd2-41b7-b5ce-c69bdbaea495" control-id="si-4.18">
+    <implemented-requirement uuid="d2cbb742-daaa-4125-9ee3-dbd658af64cf" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="c8d94684-7db0-4be2-9d14-847262c3390b">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0a0416f3-454e-4207-95c8-95c8419e710c">
+      <statement statement-id="si-4.18_stmt" uuid="cf285747-2532-438c-9878-d8429e3dc8ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e1eb355-99c5-490f-b12e-117555710770">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(18) is planned. Engineering progress can be
 tracked via:
@@ -9021,10 +9021,10 @@ https://issues.redhat.com/browse/CMP-537
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab3b34fa-de11-499b-9a27-002864866c5a" control-id="si-4.19">
+    <implemented-requirement uuid="41a535d0-af56-451b-998d-445154a12ca3" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="2f9c9994-feef-4604-8aa0-97000e128e51">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f8e1e510-3e99-46f1-973c-5be236c11071">
+      <statement statement-id="si-4.19_stmt" uuid="2006bd02-9d69-43ee-8c87-41d6860430dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -9032,10 +9032,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31795323-4bff-418e-9d41-0ca13993dad9" control-id="si-4.20">
+    <implemented-requirement uuid="f16c7058-e89e-432e-8074-212ed7efe6d4" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="e6eca721-c061-42f2-9def-ec11adb4fb2a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="464e5de2-532c-4032-8784-e074786e91ca">
+      <statement statement-id="si-4.20_stmt" uuid="9871f713-8749-4cdc-88de-3485f7f23fde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da2241b7-a23b-4049-98f2-1c78a7285774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9045,10 +9045,10 @@ https://issues.redhat.com/browse/CMP-538
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a97831ed-2d22-4a5a-89f7-e10e1c673671" control-id="si-4.22">
+    <implemented-requirement uuid="a7fd1508-2b77-4f5c-b286-dc3d3f76ee1b" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="fbdfee83-ede9-4fe9-a181-5f47d70977d3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="432388fd-ff9a-4550-b3f3-c8ee8977687b">
+      <statement statement-id="si-4.22_stmt" uuid="07a995c2-3bc5-4012-9c79-8cd666cf90d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2fd10c0d-6887-46e1-8445-2236ca57468b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9058,10 +9058,10 @@ https://issues.redhat.com/browse/CMP-539
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76e64257-6736-4fa6-bb2b-21a28a856025" control-id="si-4.23">
+    <implemented-requirement uuid="98028f8c-5930-4998-bd26-08155dabbfa5" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="64231dd9-1112-4317-8573-626f45e90aeb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="b9dd1a2f-69c0-4504-8685-ed0091051da4">
+      <statement statement-id="si-4.23_stmt" uuid="adcd815e-3474-4e31-83ee-9a98d83170b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="542dc884-02ac-4274-8e10-10149db2dcfa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -9075,10 +9075,10 @@ https://issues.redhat.com/browse/CMP-540
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34a2eca2-827c-4439-bd3f-18e23d824ffb" control-id="si-4.24">
+    <implemented-requirement uuid="772e7b5f-a085-4dbd-83c6-5b8ac9eab8e6" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="cf232c7d-48a2-47e3-8874-52a889ed71f0">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="559c9aa0-b804-4ae4-a420-4849a191a9d2">
+      <statement statement-id="si-4.24_stmt" uuid="c3b3fd35-3364-472b-bf7c-783221a95a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f28d76d9-f570-4cd7-962b-5587092f4b5d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9088,10 +9088,10 @@ https://issues.redhat.com/browse/CMP-541
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9d137ed-a288-48df-bf43-6226b1d15733" control-id="si-5">
+    <implemented-requirement uuid="8ec27eb7-4619-44ff-822a-10bd87aac4bc" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="62c7916d-0ab0-42a3-b877-2f2b1fae40ca">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="9f8cba7c-53b4-4248-80e2-7562ff6ee1c1">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -9100,8 +9100,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="384405b3-2f97-419f-a89c-04b151da250c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="e9ef07ae-9d05-436b-9603-eadbc86b8730">
+      <statement statement-id="si-5_stmt.b" uuid="2e01a8dc-26a1-49f5-bbd9-392a1a482ed6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e219191d-4e17-405b-b8ea-02e60bccd5ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -9114,8 +9114,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="9c1c6c99-2849-4531-8d44-6664a8e61f96">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="7f8f1bcb-0c1b-4a63-9609-f65d47ef9dc8">
+      <statement statement-id="si-5_stmt.c" uuid="b95cab0b-0eb3-47e7-9811-d137e81fcaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d1ce87e-ebc5-4d36-a0cc-af9f4a4e7285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -9124,8 +9124,8 @@ procedures/policies outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="812e23ef-5724-4c02-b88d-9c7a9658681d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c9225458-837c-4101-ade2-1f26d86b7364">
+      <statement statement-id="si-5_stmt.d" uuid="b2a66012-d185-46c1-b29d-7bacf1416509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e91ce37-4368-4594-a977-44aba9a99ac6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -9134,10 +9134,10 @@ procedures/policies outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e8cacf1-d0f0-44b4-a01d-989d6d506c10" control-id="si-5.1">
+    <implemented-requirement uuid="971931cc-4e53-47a6-8903-108202f8af60" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="729737d2-2071-40aa-b096-28aa524dfaca">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bcbf5ba5-0eaa-4044-933a-9687afc2b478">
+      <statement statement-id="si-5.1_stmt" uuid="db3f3f20-5509-45ac-8e29-3e7042d49379">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -9145,10 +9145,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17c077ab-d6fc-4175-a2be-fb771e45a9c9" control-id="si-6">
+    <implemented-requirement uuid="db734672-4491-4bc0-83df-6e1c367064c4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="afe47c28-7d89-4859-917e-ccd84bf46490">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="986040eb-617b-49c1-872d-fcc0b6cba98e">
+      <statement statement-id="si-6_stmt.a" uuid="705d5b25-1cc4-4a17-a467-dcba7f7eb858">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1be72547-09fa-4e5d-97b8-90d5d6f5c3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -9163,8 +9163,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="d72328ad-8750-4ccf-9bde-7d176bd5c187">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="f25c05a0-f937-4840-93ad-26cfad18a136">
+      <statement statement-id="si-6_stmt.b" uuid="c8938a79-90df-4705-8f84-0851a5571634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df99302-8afa-42b5-ad64-d171a878c25c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -9180,8 +9180,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="98445552-1963-4e10-bada-7631c85e0884">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="dda54ea9-0ee6-43a6-904e-446ff0fa4f71">
+      <statement statement-id="si-6_stmt.c" uuid="644fd87b-44c6-4637-a737-837a44d925ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0edc2e83-d6aa-4a31-9980-0091fa7f777d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -9195,8 +9195,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="28cb67cd-3b5f-415b-9069-70a4a25ec54e">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fff26cf1-c719-4d26-a4b1-745258176830">
+      <statement statement-id="si-6_stmt.d" uuid="ea6a903d-35f5-4cb6-9fb6-1b881404cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="474dceb6-7148-4aa4-92c1-2489caded95b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -9213,10 +9213,10 @@ https://issues.redhat.com/browse/CMP-542
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3008d457-4410-4f55-8020-3e17ece52f4b" control-id="si-7">
+    <implemented-requirement uuid="75b37a46-3c5d-4af3-b138-3dd476964635" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="c8a5e293-7818-4d7b-a15f-26efb816c839">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="488a7f88-6159-4da5-a11b-30bff73bf81d">
+      <statement statement-id="si-7_stmt" uuid="8f7edc4b-595d-481e-95ef-290b4ef632cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c1d92f-ecb2-4ea3-a509-a65151878115">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -9231,10 +9231,10 @@ https://issues.redhat.com/browse/CMP-394
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c35008c-9f09-40e9-a8ba-89d68973a419" control-id="si-7.1">
+    <implemented-requirement uuid="ca455f35-8815-4603-b38f-dbd91fcb6a79" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="c7e9b03f-adc0-49ef-846c-17cd964bf1e6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="5ec228a6-6c1e-4735-8a6e-a0b67fa2fdf4">
+      <statement statement-id="si-7.1_stmt" uuid="b9e27bf9-5e74-407b-bc19-f1ee19c96e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a3da903-2950-443c-ba74-bffeec06af44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -9251,10 +9251,10 @@ https://issues.redhat.com/browse/CMP-395
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9570eb4-7447-4db5-bb3b-ad5b708d7d61" control-id="si-7.2">
+    <implemented-requirement uuid="acb16927-d2fc-4225-a852-db8327ab867a" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="1d5361fa-44b6-409b-9015-e161dd021cc3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="410cf899-a9cc-4ec8-a93d-e596eb3afee6">
+      <statement statement-id="si-7.2_stmt" uuid="d5bc44ab-8cc9-492c-82a6-822e33ec89be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe84e8d0-f2df-4ab8-ae9d-e9941839979e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(2) is planned. Engineering progress can be
 tracked via:
@@ -9264,10 +9264,10 @@ https://issues.redhat.com/browse/CMP-545
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af513468-f891-4b2e-aa51-6e642acb18bb" control-id="si-7.5">
+    <implemented-requirement uuid="f0149f2e-d5c6-4d98-b81f-c8113b528173" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="81edce1f-fddb-4c43-9992-e8bd218f64c6">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="80d49ea6-57a9-4ade-bf62-95ff2b7758a2">
+      <statement statement-id="si-7.5_stmt" uuid="77115b5d-35ea-4f75-b0fc-b65825e7950b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1f9e992-9496-4294-b9cd-0cdc1fdb827f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(5) is planned. Engineering progress can be
 tracked via:
@@ -9277,10 +9277,10 @@ https://issues.redhat.com/browse/CMP-547
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf49d95e-d41b-4553-b26a-de9139aa6792" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="1399f87a-3485-4ab2-a6d9-87ddc09a90a5">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="3fd23106-660c-483b-aeec-0c56b0925e25">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -9292,18 +9292,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eac2d5b0-ee7b-4503-a7e2-57c9961e88fc" control-id="si-7.14">
+    <implemented-requirement uuid="4bdde144-9f59-4019-b792-7456e4ff2d73" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="e0d1c813-4a89-4315-b7ac-7ce114617088">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="078c2902-8119-4d34-a130-1a58797243fc">
+      <statement statement-id="si-7.14_stmt.a" uuid="c905c226-3790-49b7-8fd0-f7a31c0e75f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="af0d7c19-35bb-4bdc-9d2e-b5430bafed62">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="1d1fca2e-c7bd-4a50-910f-9c9df1f1b567">
+      <statement statement-id="si-7.14_stmt.b" uuid="0b2f469f-68d0-49de-8826-af14a48340b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -9311,18 +9311,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a263a486-2cf6-44da-a0d7-6418feade8d2" control-id="si-8">
+    <implemented-requirement uuid="6f5a333b-f2ff-476c-b54c-74553e72f6a7" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="389528cb-8e01-4837-8bed-5cdd298f83ad">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="c9afdae6-6bdf-465e-b8b9-0c8198bddb53">
+      <statement statement-id="si-8_stmt.a" uuid="ac0f7d09-61f4-4a9c-a2b9-525120f97297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="581e5ee4-7994-416b-98fc-eeeacf93943a">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="47441d63-f742-4398-a675-9ce4ae18b267">
+      <statement statement-id="si-8_stmt.b" uuid="f31b8176-bb94-4199-9f49-82454ea49c29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -9330,10 +9330,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db3cce57-1081-4180-a346-4ff48fb5240e" control-id="si-8.1">
+    <implemented-requirement uuid="a1b96e2a-325f-4eb4-b83a-96ba0aac1dc5" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="e20f7a4c-28cd-42b7-92cd-aac16664ffa3">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0ff15d5f-75df-4cc8-84bb-6196bc3198a5">
+      <statement statement-id="si-8.1_stmt" uuid="6e868698-9ad3-48a4-a4d0-fb0e39d54cfb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -9341,10 +9341,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1812662-3c3a-42e1-9f56-8587ad821dbd" control-id="si-8.2">
+    <implemented-requirement uuid="cb776500-b818-4fe9-b109-bc38c53e9c2b" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="326110c5-f19e-49b7-9b56-c9e14faf9fb7">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="78c54264-ad88-47d4-8a41-2f513e1ed4fe">
+      <statement statement-id="si-8.2_stmt" uuid="219a5678-ef0b-4908-a040-fc3001dadb7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -9352,10 +9352,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab42798a-0b19-40ef-b973-dcaa9481eb32" control-id="si-10">
+    <implemented-requirement uuid="5637a065-2c41-4b1c-8392-b5ffc146062e" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="23f0cc40-ddc5-4982-a317-26196f887126">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="95f7b235-f9c5-45c4-a9df-284f6e003edc">
+      <statement statement-id="si-10_stmt" uuid="ed487876-7061-4778-96a1-04a08a800007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="230d9846-c77c-44ce-970a-06f688716e92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -9372,10 +9372,10 @@ https://issues.redhat.com/browse/CMP-393
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6997e630-fccc-4ba8-9d96-9e9f140aed4e" control-id="si-11">
+    <implemented-requirement uuid="9d4f8c58-966a-48c6-ac16-f1be1ae2dd35" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="b4fcb858-ffc4-4337-9ef6-99508594939c">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="0cbf2f86-cca7-45d5-82c4-4c32ff7c2655">
+      <statement statement-id="si-11_stmt.a" uuid="a55473ef-7114-43c7-98ad-4015560fa82c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f9fb551-baaa-44eb-94b9-d95e13448ee6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In OpenShift, the logs depend greatly on the component. Some
 components would just write messages to stdout that the cluster
@@ -9393,8 +9393,8 @@ security information, account information, etc.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="18fb6d40-2c5e-46ad-b98b-7eec5fc11b9d">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="bf04ab8e-1d41-4b1e-b648-2e5d5a41bfb8">
+      <statement statement-id="si-11_stmt.b" uuid="0e20cfd6-f6a6-484f-9b51-643953bd0ce2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06c151a0-f34d-4bf1-a89b-fd089b157b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the API server logs are protected by UNIX permissions and
 only cluster administrators are allowed access to logs.
@@ -9402,10 +9402,10 @@ only cluster administrators are allowed access to logs.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecf028a6-27ff-4272-a82f-28e83aaaaad9" control-id="si-12">
+    <implemented-requirement uuid="b1a1d601-8791-4d0c-8bbb-027ee58dcb42" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="ae599109-6ad1-4d5e-ae06-a0b2f7fe0bdb">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="46fb5fcc-0213-440c-b73c-3540b715aeea">
+      <statement statement-id="si-12_stmt" uuid="d5b07424-e2c1-4d00-9ec9-19ae396fdf63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b53f03e2-1235-4a29-ba26-5b7ebc6674a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -9419,10 +9419,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="892fca0b-be76-409a-ac2d-815000c03d21" control-id="si-16">
+    <implemented-requirement uuid="07b05c21-ca99-4770-897b-7afb45267bc6" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="1d0fd092-8808-4f02-993c-100fcafd8d75">
-        <by-component component-uuid="bcf22859-b1e5-41d1-8fee-081044584e96" uuid="fc778c02-88f5-4e8b-8b56-7dec2fce3cd4">
+      <statement statement-id="si-16_stmt" uuid="82384d89-06fa-413f-b7bf-575a6a296515">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a0cbc1f-3514-414b-90d4-49d2a3e0eebe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-container-platform-4-fedramp-Low.xml
+++ b/xml/openshift-container-platform-4-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="8d648194-86a9-4643-8787-4e78c0cf43c9">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="f409247e-b753-4917-a14b-3d9bbe657d17">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.76+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.29+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="c680ed4a-5e6e-4efc-bcc2-0c18cdc3a19a">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="171ee010-d057-4850-a539-decb5a4b40f5" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="c6123d54-e917-457e-836c-bd47c2115367" control-id="ac-1">
+    <implemented-requirement uuid="e0198023-c291-420f-9859-85e195c4faa9" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="ae24d9dc-5126-4a46-bc09-6f4c30a0f120">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9d735c56-8ca7-487d-be83-b7d91f8ad02d">
+      <statement statement-id="ac-1_stmt.a" uuid="2971b853-d916-4401-8ca5-c8fa0924d237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd3fa9f6-4df1-44c0-b3fa-59a4ce506b87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="4ef0135e-7ccc-4ffe-b7bb-56a41bb67a00">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b2e0063e-b79a-4661-bea5-cc94a343c754">
+      <statement statement-id="ac-1_stmt.b" uuid="ed757c19-aed5-476e-842a-a09178430b8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b47f666e-0fe4-4bf8-808a-5666b837c0d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afb65d2f-5f2a-4af0-b97a-4afbbb318537" control-id="ac-2">
+    <implemented-requirement uuid="2c5581cf-ef35-49a4-9a0a-9debda8e77d1" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="b1159e0e-4ea6-4a9b-9627-a275007a878b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="351b6946-5f14-4367-9931-e8a7978a45e1">
+      <statement statement-id="ac-2_stmt.a" uuid="fdc1d0c5-014f-4605-ab9e-babf06ad410a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ad7a627-339a-44a7-a584-ee8b8d28daf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="1fd9b51e-24d7-490e-91bd-ec7a2a5c6c86">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bb7b17fc-89c5-4825-85b2-fea56a47456b">
+      <statement statement-id="ac-2_stmt.b" uuid="3bab5523-04da-4a6f-a9a9-df415bf5d095">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61f14919-d2bc-431e-82da-3134faaa614b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="91b6865d-e7a5-4745-82d0-0f8b8eaae8a6">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="edcd99c8-349a-4ede-9946-95f43b942c63">
+      <statement statement-id="ac-2_stmt.c" uuid="893b989d-5db1-4129-8350-081bed59bba2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4956345-f525-4925-bf7b-4908b5097170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="8e664513-43bc-4164-8cd8-a1e0f1be52c5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5aaebd8d-25c6-4678-8286-dae599e87e42">
+      <statement statement-id="ac-2_stmt.d" uuid="4c9b242e-3572-40d2-9a44-0b1219ea99e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3850f91d-0960-42bf-9630-d79d395190f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="a9db04a1-2d88-416d-96ee-b76aa53ae26e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6c074d93-aac7-4ae9-9770-4d19f18fcdcc">
+      <statement statement-id="ac-2_stmt.e" uuid="969844e3-6d0f-49f6-98c1-391254329da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07456e22-883f-406c-84f4-b2f5e919cf08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="66106f7f-79d3-4a3c-b077-82b7a6862e72">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ff931603-ee55-4351-a3ca-198f56712db7">
+      <statement statement-id="ac-2_stmt.f" uuid="832a1208-b86c-45e9-9f3f-b9bd4af97c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e347cefd-92b9-4f50-8968-cff93aaa856d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="d1ded4ef-eaf2-4fec-909b-46ea111053b4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c3fb1286-3728-4cc0-b97e-0e74ce5a1490">
+      <statement statement-id="ac-2_stmt.g" uuid="e80a0cfa-b390-46b1-b9cb-8ea18cbc29fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31bfd818-2e8b-4eed-83b3-cd0eea10bfe8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="7fc9f837-e5b8-459d-a7d8-87679c2be770">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6b10fefa-89aa-406a-9fa8-e683ceeb31ad">
+      <statement statement-id="ac-2_stmt.h" uuid="309b0bbd-c4aa-49a7-8bf4-1e6be2c3cfda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e691baac-1b31-4922-9a1b-6c3f31555beb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="a84fd414-1b58-464f-89bd-ef7762be79fd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="72de11a3-9ae5-495f-8f45-8a24d8f63517">
+      <statement statement-id="ac-2_stmt.i" uuid="f7ea5464-e9d0-4cfa-9fe0-56c99573928c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4190dc05-462b-44fd-a76e-9a018866b323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="4a7acd82-3a86-4c90-b21d-c0694aaa12e1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="802b919d-1a71-46ee-bfcd-e9af725e4e35">
+      <statement statement-id="ac-2_stmt.j" uuid="8bb6d26d-039f-4fe5-96e2-7fdce209c1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8ee0649-d86f-421d-a490-1e5d81031674">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="fca23e55-1a38-4f05-8b47-f9efedd0af54">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cc86c5fc-9d27-4710-bff7-6c290c2bcada">
+      <statement statement-id="ac-2_stmt.k" uuid="23489861-614e-405e-b5c2-17662d7768c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e35086b3-4628-4ffd-9fb4-439a4ba21532">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39a63c2e-c966-434d-8f30-9cb14a7316ad" control-id="ac-3">
+    <implemented-requirement uuid="8ed60360-91df-45c9-bae5-82a7bc31a7b3" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="57bd47ff-4a54-449f-8e50-803f5c60fe10">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cef08a96-d9d2-4a71-a2bc-6e52fd95ecff">
+      <statement statement-id="ac-3_stmt" uuid="f0bb86a5-90e9-402d-b977-53a357f35912">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3144d8bb-1a8d-444d-809e-f38d4290dad3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met through the use of Role-based Access Control
 for an OpenShift user. Namespaces should also be configured to
@@ -592,10 +592,10 @@ sandbox users and resources to only the required projects.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0af29856-ab57-4d21-9228-4ec6de1cc513" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="e179489f-b8cf-4672-a99d-4b577f944050">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bc02998f-7bf1-4d33-8032-ab8d477a8ebc">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -606,8 +606,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="a52e8be6-907a-4923-b4e7-4ce552b85578">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="796477b8-683c-4a11-b344-525efedcc421">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -619,10 +619,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e4e5f19-fdd4-4678-9b10-23e43db5eeed" control-id="ac-8">
+    <implemented-requirement uuid="1871ab2d-f550-4a44-abf0-755904c32987" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="534e2f9d-d60a-42bd-b64e-0c466dc70ff7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="008507c1-00b1-4e86-9967-cb3cbd1e58e4">
+      <statement statement-id="ac-8_stmt.a" uuid="81fee283-7ebc-4201-8c6f-6c842d1258ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbaba125-1dff-4fe4-a089-3bbbfa1485ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -642,8 +642,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="ebbf49a3-d12b-459c-999b-df980f33a02e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="de63b699-2f0d-4c46-8177-78f1f5be1a70">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -658,8 +658,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="27b9c22c-b491-46a1-8db4-6f2eff240b0b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="61493057-c6e7-4c99-b79f-cfc253cbbfb4">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -677,8 +677,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="4ecc7239-d0b0-43cc-87c4-0bea09d73aa0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="279146c9-c9c1-4b90-9322-f45859af1da1">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -691,8 +691,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="11bdfa8a-affd-489f-8faf-9e76655f6453">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a3ef1273-3006-47a7-9921-db6e5bd8369b">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -706,8 +706,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="46986c94-4c37-463d-9cf9-3c72ffb2f005">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="191eb724-6ecb-4e95-a9ed-5617d423dbf0">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -723,10 +723,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8965583-7a31-4901-9999-e4258ecb8591" control-id="ac-14">
+    <implemented-requirement uuid="2292ced5-1bda-494f-aa51-ef64228072a5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="9bbaac58-f089-4e54-8243-8162103c6856">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b92fc283-c7ec-4f44-b40c-388369816886">
+      <statement statement-id="ac-14_stmt" uuid="627160b9-85a7-4e24-9beb-643788ea9fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10130008-0803-4042-898f-872c8464d34f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -736,18 +736,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c251886-bc3c-4f8c-b212-580db13c9be5" control-id="ac-17">
+    <implemented-requirement uuid="5a29a780-d78e-4632-ab61-dc00a1cb0cff" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="60b15479-bc01-4a52-9013-f2b116ce7b7b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0ed3b739-ff4c-4c5a-a21b-e095dbdcf7a0">
+      <statement statement-id="ac-17_stmt.a" uuid="f3fdfb30-0212-4348-a5ad-ab13c5acb066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="33b41b58-025e-46b7-b583-94d9bc0c3c7b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0c945571-5f09-40ef-b9ef-a768cc090754">
+      <statement statement-id="ac-17_stmt.b" uuid="b2e75aa9-b2f3-4990-a770-899b2be99b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -755,18 +755,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58c7e061-22e9-4795-8c21-7fd5f4fd82b7" control-id="ac-18">
+    <implemented-requirement uuid="a137be9b-db9a-4432-b346-697717b883de" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="dda6bbce-64a6-43e7-9f70-7e4a9f1da0db">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="56305c52-365b-4468-8906-9166d968a7f5">
+      <statement statement-id="ac-18_stmt.a" uuid="ce5ee22d-7d86-436c-bed8-98ba87480aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67017357-816e-48d8-ad67-84ca7d5d9d24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="8fab5281-b0a2-4681-af37-6dda3373a3b2">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ba0c0e3e-da29-4875-ad64-de0ec9bb331a">
+      <statement statement-id="ac-18_stmt.b" uuid="506e53cb-dc82-4df4-8615-623609005745">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e370990-461a-4d3a-a840-d0ca212cde3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of OpenShift configuration.
@@ -774,18 +774,18 @@ system are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42719f46-d98e-4fde-9af9-5bcda40c77ff" control-id="ac-19">
+    <implemented-requirement uuid="86ed2bac-7994-444e-aa3b-062de041b71e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="598bef92-5f05-4f70-afc6-e610e92674b7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2190c580-580f-424d-b1a1-ce0bce2c5ae9">
+      <statement statement-id="ac-19_stmt.a" uuid="179cd8c9-3d7d-4984-b992-f75b748a5622">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1426997b-7d52-4dba-b9d5-84fee93f7d8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="58a78481-905c-4e99-89b7-180408527dbf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="518a6066-55c0-426a-8546-568e378bd3af">
+      <statement statement-id="ac-19_stmt.b" uuid="58260cd8-1853-4758-8827-2d7b8fe2e9d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="296305da-52b8-4adb-bc00-f2d04345bc9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of OpenShift
 configuration.
@@ -793,10 +793,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abf114cf-aea0-4787-bf48-a1fb8cac7aed" control-id="ac-20">
+    <implemented-requirement uuid="0794e2f3-0316-4600-987b-57769e6091d3" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="d659053f-ec5c-44a5-a88d-7b66d6ad0203">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e1e87ab6-4d6f-472b-b506-c0fbac363bf2">
+      <statement statement-id="ac-20_stmt.a" uuid="c3ceb797-40c9-4c32-88da-bc2c3d02557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e2635d7-0d90-45f7-ab07-a72f837f9950">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -804,8 +804,8 @@ systems is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="19b70aec-bd88-4bf7-b4e8-3442d4f3f878">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2d9c4eaf-1869-4ff0-bc27-031b4592e6dc">
+      <statement statement-id="ac-20_stmt.b" uuid="0de55e9f-7322-4e3e-8934-b0ba825f62a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5372dc5-f754-4f92-85af-1a52d9aa9a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -815,10 +815,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8d7d356-ea7c-4f4a-8dfd-4ff93dfd9e48" control-id="ac-22">
+    <implemented-requirement uuid="f6ef3a84-58d8-4513-aad4-89f3f6a90990" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="09a8c835-48c4-4810-a96e-08a14f570955">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6fb3b5f9-04ee-43ef-baff-d5a0243c4be7">
+      <statement statement-id="ac-22_stmt.a" uuid="c7e11f37-7e67-4880-bc3a-b57dba50840b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="376f4ff8-c17d-40df-9517-a104d6234154">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -826,8 +826,8 @@ system is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="bbe8069b-b09b-4b37-b75b-e5eff0fdcc83">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ac1ef7f6-f47c-4838-af88-a57a469cf1a9">
+      <statement statement-id="ac-22_stmt.b" uuid="3fefacff-d1d5-45e2-91a1-3bcec05feab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec07b4f-b422-4324-8342-a8a0a2d4082e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -835,8 +835,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="a982eea1-44ea-4daa-866d-dec88f786a99">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5de501b0-1fa7-4779-90d4-63130e606060">
+      <statement statement-id="ac-22_stmt.c" uuid="74b40455-dd6b-4af8-a62f-6be80b7b921f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2009a919-1675-4f79-9e2b-92ef86ab360d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -845,8 +845,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="5834a11b-376b-47f6-add9-ca1b73cd9dd4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0946ea97-e406-49e8-90e0-c002be58d08f">
+      <statement statement-id="ac-22_stmt.d" uuid="78333f22-f26a-43d3-84ef-4fd62a7fc128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="179f843f-79fd-4d99-91e7-a6276487bab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -856,18 +856,18 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e528d2e7-306e-4ba5-b0cc-2f14914a0852" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="5f4a7b06-dd8d-414b-b471-1f2800c1e5a1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3120ad93-076f-4cb3-bc98-c12c902c0ce1">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="75fb9a9f-ab04-4a65-9219-a01abd2ab34c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2a71f299-a78e-4305-8a2b-36d2d2232f40">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -875,26 +875,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="153a609f-7734-49b9-980b-be43d6ead974" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="146b6e89-9c3f-4a0c-a761-3dd8b7811231">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ccafa1f4-f80c-410c-ae12-4eec95034a7e">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="82cf83e4-645c-4893-a244-391e1f087621">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="dc949cf6-b545-47bd-9edc-1ed57ec4a91f">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="6bdbfbcf-687d-4d08-9ecf-b7451dfac411">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3eaebf77-7fbb-40c9-96e1-66af67f246bc">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -902,26 +902,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d1b6adb-413e-4511-b642-3ec52051f0e3" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="85a2884c-a182-4059-9971-ffb9658556d5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="aa76b166-1d86-454d-905b-45817d08f7e4">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="ba4e0e35-5bb0-4827-9b12-fde5da31f677">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="58c7e432-566a-4eef-b9b7-77a118c2c8a5">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="b51c2e21-c949-4532-b2a0-d16744158a49">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bc8d6878-05a3-4155-b7fa-b850a04b9d15">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -929,18 +929,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e7da7ca-0518-4b21-91e4-bb8e32fd76fe" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="bbdceecc-f2d0-4c63-bbf7-6a5f17eb8827">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cb8a5c12-7526-4eb7-9ec0-189c5e1b6ba1">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="7a795a3b-d23f-4ed7-adbd-fe3e81ea6498">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="77b36a82-2731-4876-95ca-f9ce69d4e43a">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -948,18 +948,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb8763f3-fd99-47ac-9bfb-c1179b8a236a" control-id="au-1">
+    <implemented-requirement uuid="ef0a9955-e6e6-400a-b0c2-4c90a3572de1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="e41e9d3e-c1c6-40b7-8dd9-810480c5ac12">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="644ac083-40a8-41b2-b480-3d43d059cc58">
+      <statement statement-id="au-1_stmt.a" uuid="a62838df-3f8d-4562-bab9-7c3fb3901ef9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f02538f5-6b4b-47ad-be64-68cde7e322b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="71b2939f-77dd-40c4-9144-b4fa9aece1a1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e7bc4168-ea8a-4a23-90d3-21e89b97be4b">
+      <statement statement-id="au-1_stmt.b" uuid="1a981643-a22c-4097-907f-183a4a6c69ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="896963fb-9a31-41f0-b128-3d133586df01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of OpenShift
@@ -968,10 +968,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e153a9a-42d4-4495-8641-ca607568146b" control-id="au-2">
+    <implemented-requirement uuid="7be12d88-184e-400b-9fa3-52fd68eacaca" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="a1cd495a-6d92-4b91-8aa7-c446b60221dc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3ca1ab91-818e-4c7a-9b1d-0d36569b3bb9">
+      <statement statement-id="au-2_stmt.a" uuid="4d421c20-31f0-4ce1-ac50-b99c88342ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -979,8 +979,8 @@ https://issues.redhat.com/browse/CMP-155
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="d6f979f3-47e4-44e9-b6c5-ce45c93c4046">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8d651cca-9ef4-4885-9ead-bbd0e68eb51a">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -988,8 +988,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="2ee8d144-b0b2-45e1-bb89-2becb2a4b3a1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="20390e87-9ef8-485f-a900-9112fbf99629">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -998,8 +998,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="2d39ec6c-2ddb-4e58-888d-d76d6076cc7c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="620e4988-b8c3-44aa-84f3-641bc608b998">
+      <statement statement-id="au-2_stmt.d" uuid="5888b387-1140-4214-85f2-a70baffb4734">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1008,10 +1008,10 @@ https://issues.redhat.com/browse/CMP-155
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a28241de-39cf-4943-8168-42d2b3356e84" control-id="au-3">
+    <implemented-requirement uuid="a8aa07c1-977c-4acf-ab95-7b1304cd50db" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3_stmt" uuid="9f730f26-1d80-47f5-9651-d480e1935f63">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4aa7a356-db4a-416d-9a7c-74c8f38e3b73">
+      <statement statement-id="au-3_stmt" uuid="c9bdcd27-57a5-4c8d-9187-b9b44e8aedd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86a2f7e-3776-48bf-b89d-a341ef18bb87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1020,10 +1020,10 @@ https://issues.redhat.com/browse/CMP-156
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b3ca7fc-879f-420a-ac02-eb8c444c9227" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="273b1064-c98a-4927-904e-492e28e358e1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c04dc35b-d806-4fc3-84fa-53dd6a0781f7">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1032,10 +1032,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09674748-c3c2-431c-84c8-70b72af76020" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="1dd16e13-557c-40ee-9c2e-065d4a73ba3f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8e81039d-e882-4f40-9bff-2b69ce84941a">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1043,8 +1043,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="33873f5e-5aa9-47ca-a57f-983452e7777d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="455b754f-9265-4a10-a303-795855d92e88">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1053,10 +1053,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0adf76ab-4439-45a6-840b-9bc2a8494461" control-id="au-6">
+    <implemented-requirement uuid="b8f5d492-d89a-47a8-8100-8d3467acfd32" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="77fd3741-139f-434a-8124-ba7497c5c1e0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b80e80f6-1e9f-4ccc-923d-ba3b8c0801e7">
+      <statement statement-id="au-6_stmt.a" uuid="08063edb-8d74-4477-818b-b829fbd5dbd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a88cb0f4-5871-49b9-9199-2ed0b21e10cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1065,8 +1065,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="1765f36c-8a21-4e8c-a097-d03f02639876">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="909eed92-2354-4e37-8d58-205540a4399f">
+      <statement statement-id="au-6_stmt.b" uuid="1a73feb9-9aa3-4bbc-b713-e4094e86ea4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eca14996-d7f3-4ce1-bdf3-addb2bb13ac1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1075,10 +1075,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a2d0561-af3d-4def-9a2b-1c45b386dfc1" control-id="au-8">
+    <implemented-requirement uuid="9c2388b8-6ef5-45cf-93d2-cd87d4f39794" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="ec869428-8bce-400c-a466-e58102af84c4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0a85dd54-28f7-43b7-9eb9-24c911d7f78d">
+      <statement statement-id="au-8_stmt.a" uuid="7edb6f5a-e08e-4faf-a375-bad11b80aa7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3e4e1da-469f-42f2-a0e1-2c8ffaeae1ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API uses the internal system clocks to generate
 time stamps for audit records. At the code level, the OpenShift API
@@ -1097,8 +1097,8 @@ which really is a time.Time value which comes from the standard golang library:
 https://golang.org/pkg/time/</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="7fbf1b3f-ab0f-457b-b698-065b6d5c5db2">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="66da2eaa-4cee-450f-a12b-34ff6d97b7ac">
+      <statement statement-id="au-8_stmt.b" uuid="8199e4bb-c82f-4ace-9317-6db96229ad0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca64871d-2677-4674-8c06-a118a56ef997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -1114,10 +1114,10 @@ for more example of audit records.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3d83ab0-f49c-4d05-a512-b12fd3c3b182" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="a6ef5958-ec20-44f3-bd8e-5856e758a35b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c549a530-ae22-4eda-941d-de7adf79b4d4">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1126,10 +1126,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61347356-2a5b-4bff-a602-f55919557a06" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="0266b51b-841e-4e00-9ba3-44fae11821f9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7f5fcd0e-5442-4868-8e28-2744060f62af">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1138,10 +1138,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7441ee25-82ec-4662-a001-1b5cd84528a3" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="27380d9b-572a-445e-b1f3-9bf49f90b261">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="60e22296-9e0e-4486-ada0-729c3e191e1e">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1149,8 +1149,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="80006b79-d6b4-4bbb-b94b-ef64cace9585">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="33642535-3a67-494a-a1a6-02e11e2d1ea8">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1158,8 +1158,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="f5e7e489-8512-401a-bdc8-55c94b70938a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="95151bbd-967f-4abd-8118-941df6a74263">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1168,10 +1168,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9caa4d9-89b8-45a4-a85a-246afca0cc49" control-id="ca-1">
+    <implemented-requirement uuid="fb9e823f-f30a-49cf-8e64-8b12563d512b" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="2b31e451-7897-4ead-b910-494fd4f2251b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="926c650d-45ef-4bfa-85da-5ad3c8234f62">
+      <statement statement-id="ca-1_stmt.a" uuid="e4ced95c-04ba-48ca-9570-5ec802f01701">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1179,8 +1179,8 @@ the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="15eaadeb-5680-4289-aa1b-1de02cba8fd4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a3a1dbef-8926-4673-9898-94d87bd12a89">
+      <statement statement-id="ca-1_stmt.b" uuid="a65bb5b4-db69-495d-8756-9d322f94c158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1189,34 +1189,34 @@ the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30a0268e-817e-4fdf-95dc-afb39cd57633" control-id="ca-2">
+    <implemented-requirement uuid="8d8afad9-0508-45b9-ba76-18768cd27aa7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="627a0816-a305-4bd9-bda5-1b5104315bfd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="51874b5c-0eec-40ff-acc7-61f16cd18b33">
+      <statement statement-id="ca-2_stmt.a" uuid="5edc8cc8-7dd1-473d-ab0f-070f2f4287b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="970efcdc-a329-49c6-bacf-fb41dbe8603a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2768dc63-5c0b-4673-8045-8cb13a82795b">
+      <statement statement-id="ca-2_stmt.b" uuid="0dd59305-6612-44cd-9bb8-3983326a6dd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="b3c653b2-843a-4cc4-bd80-fde9a0934c32">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a99608c1-a2c7-4ec3-9980-617260345b74">
+      <statement statement-id="ca-2_stmt.c" uuid="fa943605-14cf-456a-ad67-8eac021ab68c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="e8bc09cb-9248-4da6-a696-111acd44a957">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f8ab6022-37fa-4ede-8791-d8182083e682">
+      <statement statement-id="ca-2_stmt.d" uuid="8540655a-6e76-436d-8513-3723a102553d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
@@ -1224,10 +1224,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dd6773d-aae7-4cc9-a5ec-7ddf09961167" control-id="ca-2.1">
+    <implemented-requirement uuid="08d49c7b-953f-4cd0-9813-50874951537b" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="f163820a-1c7a-43ae-85d6-072e6d550875">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="688bd431-0502-4508-8466-30b794daab41">
+      <statement statement-id="ca-2.1_stmt" uuid="38aa23f1-4422-402a-924a-ec395b6a768a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3b9dd57-eac9-45a8-99ab-907dfa329afe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of OpenShift configuration guidance.
@@ -1235,10 +1235,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd9ffe88-d400-4371-a0f1-848f46f70687" control-id="ca-3">
+    <implemented-requirement uuid="d852491f-4160-48e1-afb7-2e2ec47b7d99" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="7215a259-eeff-4c54-9b0c-69c97191c7ef">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1ffe7618-ac77-4f03-bcc5-58aa96e8428a">
+      <statement statement-id="ca-3_stmt.a" uuid="2c3ee9df-91cd-437a-82c9-864e15531e98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -1246,8 +1246,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="749252ee-8e3c-48d0-ab29-5b4596ab1be0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4904e900-d8f5-4b95-9ca2-3b07b172b598">
+      <statement statement-id="ca-3_stmt.b" uuid="4eb00eec-a9ed-4ee3-a6c7-484b670b8529">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -1255,8 +1255,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="7ef33f8b-41fe-4145-b978-3e7bde46e451">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="181b8353-4bba-4592-8454-a177d452eb73">
+      <statement statement-id="ca-3_stmt.c" uuid="b11f5bcb-6d01-4308-8993-e1f6c74da678">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -1265,10 +1265,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="382d0917-3037-4ad5-a5f9-58900c5ff8e5" control-id="ca-5">
+    <implemented-requirement uuid="4d507723-069b-4eec-b5c5-97cd3e94d334" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="40c4f5fa-49c7-42ec-987b-6a76b9e9ca46">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8b0ab1eb-f075-4b7d-808e-d16321ce18e2">
+      <statement statement-id="ca-5_stmt.a" uuid="89655419-75ed-4ec2-bdc4-07f88fe99933">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7da1eaef-58ea-4508-bf86-2095cb61dfae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of OpenShift
@@ -1285,8 +1285,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="c9bb5bb3-5536-4085-bfcd-83a4404de0c9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e2b497d0-e410-4acc-b19e-1c8f7dacc039">
+      <statement statement-id="ca-5_stmt.b" uuid="8e8f321c-48f5-4ff6-8654-76986b9774e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd5cdde-ec46-4ca6-b2c7-ba5f7fd31de2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -1300,26 +1300,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f63c35d-372b-4df8-be09-15d792dd37b2" control-id="ca-6">
+    <implemented-requirement uuid="f62731c0-3032-42e8-8694-31c841118669" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="801cbb40-bf2e-4991-ad36-86b200760571">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="500efbdc-ed64-4cf2-bdcf-f724dab55110">
+      <statement statement-id="ca-6_stmt.a" uuid="fe0d6c95-f1a6-4353-968c-b520c4853cb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="f0f7e44e-1bea-4fea-97b5-57f8186b0084">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="52a3eace-87f3-4d75-a9fe-f70f84c5f3ab">
+      <statement statement-id="ca-6_stmt.b" uuid="4029322f-8f15-4f57-a0c7-70c8654c0505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="b9a1c181-a0a5-4230-82f5-0490dfd38b34">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9c977d75-9bed-4735-9290-e2f69c3761de">
+      <statement statement-id="ca-6_stmt.c" uuid="f0742c71-cd50-4fb4-90bc-bc7b6839f689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -1327,10 +1327,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6db2603b-ac2a-4a74-b778-16644e835d10" control-id="ca-7">
+    <implemented-requirement uuid="55addee1-b8b3-4109-80b1-b8227770eb8b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="b120240b-6ba3-49f3-bcd7-45879a0ac03f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="efb2fc93-8601-419f-bd49-558d5a39710d">
+      <statement statement-id="ca-7_stmt.a" uuid="d6a330d2-df2e-4d92-9cd0-1956cc3c7781">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7b1e437-6967-48fe-bbfa-c7cd030c0de0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -1339,8 +1339,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="7994c92b-29e6-4254-b358-7338a631aa80">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9ce81947-d794-4509-b20d-d287b21b999d">
+      <statement statement-id="ca-7_stmt.b" uuid="c4ca4be2-e8e3-4f6b-a10d-d7cac01ab064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="033b0fa8-776d-4796-bffe-cd824557b80b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -1349,8 +1349,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="8ecf3d36-e502-4dda-9c10-aedbf5a39a2c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="60b37b70-8b00-4bf3-9822-264bbdb58869">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1358,8 +1358,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="768fed15-b58b-45b4-a622-83b0262bbdcd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7ba78eac-74b4-476c-97f7-ab7c7c1a7978">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1367,8 +1367,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="6c74f68a-37e2-472e-bdbd-5fc31a8b76be">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f462c213-bd28-4c4c-a76d-39cf31a51091">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1376,8 +1376,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="3b6aa097-c1f6-4527-8ef9-fac62c9174f7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ce226176-f2b7-4989-b371-37da020cab8e">
+      <statement statement-id="ca-7_stmt.f" uuid="b09f9aba-1b28-487c-997b-fd2a7ce6c033">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="291a33c4-ec9c-4387-bba7-db910c86c7a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of OpenShift
@@ -1385,8 +1385,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="6bcf04cc-1b95-40cf-9637-11b0f26fee44">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e91274e4-ca20-4b06-94ee-0c1c47209d83">
+      <statement statement-id="ca-7_stmt.g" uuid="a32b68f0-5ca4-43dc-aee3-8bf1d9e27165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c50876-9275-40f2-bc33-4ee44dcf13f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -1395,10 +1395,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b1dffd9-9eba-45b7-8d35-a804cb83d4ec" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="567d13d2-bc16-4643-8271-6abb23ca296d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="afd8c501-1c7a-45a0-87a0-99159cff8ed7">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1406,8 +1406,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="530b2c3b-8d28-4007-b6b0-7d9b83e11c00">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0e9aef01-6a46-4851-90d1-8cc31ee0aa4e">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1416,18 +1416,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1278b38-78dd-4566-8a8a-bffa3292080d" control-id="cm-1">
+    <implemented-requirement uuid="53b3abac-4a28-4161-959b-fa09347080a4" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="efe2b280-1705-4a61-bd1c-a16660b22886">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="50ee4220-aac7-4532-a41c-4b5ef625cb7a">
+      <statement statement-id="cm-1_stmt.a" uuid="0e08d61c-98ad-4d8d-9cef-ca802b007cc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77ee3a9b-63d6-4f8d-bf3e-f10feb7ec653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="061196b9-dd05-4938-b7b8-249832042ea1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7d44f2eb-0e5c-4777-96e2-010e9c792d76">
+      <statement statement-id="cm-1_stmt.b" uuid="13dfc8dd-1b1f-4f8f-a824-fda32a269ecc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6eccf7c-0437-4523-a842-44769fdd2ae4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of OpenShift configuration.
@@ -1435,10 +1435,10 @@ management policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c47ff9b8-52a4-4115-9145-c6bc8cb38124" control-id="cm-2">
+    <implemented-requirement uuid="7ec7cc47-526c-4739-94f5-5362151297e2" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="5f113441-7f02-43e6-b9d7-f3ad5e104adb">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7d2395e1-ea2d-4950-bd8c-971622bb55a3">
+      <statement statement-id="cm-2_stmt" uuid="6aaa5474-1312-44d0-a614-bbcbc95a220f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e95a42-d853-44e4-8693-3cc9f20747c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management in the OpenShift Container
 platform is to implement the principles and patterns of GitOps
@@ -1467,10 +1467,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="844413d7-ade6-4bbc-a612-e5c609235f34" control-id="cm-4">
+    <implemented-requirement uuid="bf7559c7-c3f7-4b66-a683-9209b935cc2b" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="99263318-e2ce-4430-8942-733391a24aef">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7cf7b67e-c27f-4d60-ae15-17d3d40fad91">
+      <statement statement-id="cm-4_stmt" uuid="07305a6a-1193-4962-8b48-f144f31e60c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbc8a0c6-4b3d-4773-98b0-3a137e065b28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -1479,10 +1479,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c728f651-5d37-4b3c-b22f-a94ac3049c27" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="92b55d6f-3c3d-4736-a242-a438cecb517a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a8b59b53-9692-417e-b85b-e9f96c604b67">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1491,8 +1491,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="2a81a962-b92c-4186-a7a1-f1b04325dbc5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="48e338f4-1ace-4024-ac74-ee8acc515ade">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1501,8 +1501,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="1be9d0f7-39a0-46c3-9fe2-8dce08bc99d5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7f9d181e-01af-4a12-afb5-a6b5ea1f68f9">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1511,8 +1511,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="ed65aa3e-0db9-4f7e-bcd6-520e0d5c1696">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ddf162ff-1a52-4c39-a99c-8d03c58cad85">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1522,10 +1522,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c005e154-1129-444b-81d7-b775a01361bb" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="409e0698-7b46-4fe3-a6e4-21419f181a6b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="91d51330-08f0-4f7d-961a-68a310c61e06">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1534,8 +1534,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="522ad482-aa9f-47e4-a252-e92dc00d378d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0bc931f6-e494-42e8-9daf-f92cba977d1b">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1545,10 +1545,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8305a518-d440-4dae-b24c-e3fe5b130863" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="ea7d1df8-74dd-44f5-860b-8e9cb95652ab">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="92e8e1fd-a046-4ab2-8205-fb1ac9be86aa">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1557,8 +1557,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="05f9ec8f-11a9-41ea-a4d1-04f42372acd3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9a8c9936-b7c8-4f78-9758-ea013bc12b62">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1568,10 +1568,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6e45452-ee08-46a7-8ff9-ff7bb336daa1" control-id="cm-10">
+    <implemented-requirement uuid="7f6e0d1f-9540-4672-9ea2-87bc92bc1ba7" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="a4f7e401-27bc-493c-b11b-cfdf89c52564">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2c9f55ca-b8fd-48db-a17b-8d551c25ae5d">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -1583,8 +1583,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="6b309959-1cd6-4b4c-8eed-d6c1713f2442">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ed6d4b3c-8e3c-432e-88d0-83365543fa17">
+      <statement statement-id="cm-10_stmt.b" uuid="d39f780a-b0cd-4641-993b-431a62e3c29a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be79d021-c2a3-4c06-b5c0-f455be84026b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -1605,8 +1605,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="478cc587-eb99-4c9d-a47b-c6db87cc2e3b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="325d4130-2cba-426f-94ba-d88eadf6e294">
+      <statement statement-id="cm-10_stmt.c" uuid="26789b14-6c9d-47c6-88e9-ddc4e67722bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b094128-1abc-4616-8b9e-00eee0d19af3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -1617,10 +1617,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20526874-f933-4ce2-90ab-af794fd1e27a" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="edf62e68-5d9f-4c8a-9d66-4977ab7f66c9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5e6522e1-5ea4-4d79-bb67-cd12705e25ca">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1629,8 +1629,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="c0757f93-5569-4434-8500-6621d7c17721">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="19e3f55f-d57d-43d6-ad8e-83997b06a943">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1639,8 +1639,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="bb8f4828-c6bb-469c-9ac6-8eac292e2263">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="53774d6e-6856-4faa-81e0-ca21b6915ba3">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1650,18 +1650,18 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04b43431-9aed-4569-bd6f-88cd210e686c" control-id="cp-1">
+    <implemented-requirement uuid="771b728d-1714-4fd3-b5f5-a09573598f06" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="dfcedaad-d806-454f-8d6e-47d4ef3374e8">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="88ae4208-17a2-4406-9cf5-3800b07b957f">
+      <statement statement-id="cp-1_stmt.a" uuid="66819085-e959-469f-bd11-b640883f4a9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5292e97-ef74-4234-a89c-9a4db072d285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="65b3359c-a7f9-4bfd-8a04-498906b9ca7f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="42f78f63-27c7-4957-bda3-e082970137a5">
+      <statement statement-id="cp-1_stmt.b" uuid="a502aa27-f4c0-48cc-aee2-a763691a788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b9fab65-b3f1-4cb1-a823-f55077e3378e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
@@ -1669,10 +1669,10 @@ policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac9bca80-02a9-41ea-b8ad-fc9da4d4895a" control-id="cp-2">
+    <implemented-requirement uuid="b9394721-3b8d-40cc-b02e-69fad58f7c0f" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="1735f3be-fc97-40a1-85e0-c4dfe89885b2">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cac2b3fc-ad3b-4b04-8447-52544d0b95e6">
+      <statement statement-id="cp-2_stmt.a" uuid="8a136600-d66e-4ae9-bfd3-b15b9507039c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2aa923a-7992-49a6-84d8-d04470b30ac7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
@@ -1684,24 +1684,24 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="d4eade14-7efa-4a95-b7f7-4da184799fbd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a359d336-a37a-4807-863e-3e07e40f2f20">
+      <statement statement-id="cp-2_stmt.b" uuid="20c9cde0-812d-4c04-b472-bc27cfe4350b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="331d8009-959d-4fb9-8fe3-3b2a69179d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="557081d3-c030-4aa8-94cd-d1ba42b71db4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e738a832-58d5-4f5a-997d-9886c489ec7c">
+      <statement statement-id="cp-2_stmt.c" uuid="54d178ce-a421-4486-9ce2-3d35d8e2a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe6802b4-1a91-4382-baab-2f3d7a1630f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="f1e2845f-2522-48cb-af22-26ac9467297b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c3a800d4-a6b7-41bf-bcb2-8c7fb267f0b6">
+      <statement statement-id="cp-2_stmt.d" uuid="9dfe91e6-60a2-4fc6-a292-26a3ca28cb37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6ef3bce-d733-47fa-a032-756fd0e81257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -1709,24 +1709,24 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="ff988e1a-9f83-4959-9130-085e1af85c33">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ed1fda97-1e7a-4ed2-b5cd-ab5cbc3c2092">
+      <statement statement-id="cp-2_stmt.e" uuid="12e03d0f-7239-43ff-8511-42826295c45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8ffbee2-6b43-413d-9e41-723756839798">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="97081be8-aa46-49e5-880a-b15a5dd1fe0a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fd2a547b-9acb-4327-b990-299bc30a7405">
+      <statement statement-id="cp-2_stmt.f" uuid="3953f722-8d58-4b44-8f87-62d3a9186cc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="263af822-5945-4071-b329-b0064d3a15f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="0213cfc3-c036-406f-b9b2-05224f9592a3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="46051490-4e9f-41e2-ab95-c63b196e500c">
+      <statement statement-id="cp-2_stmt.g" uuid="80043547-0078-4f6a-8e9c-cd6eeea6ccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa9f95a9-c72d-4dbf-8f27-c6f8493a27ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of OpenShift configuration.
@@ -1734,10 +1734,10 @@ modification is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8143490-e33f-4a59-b01a-54487fd088ce" control-id="cp-3">
+    <implemented-requirement uuid="f8334ecb-8969-46c6-9bd2-85a7c4939117" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="a9725bef-8e7b-439a-8748-565c00ca68df">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="61c1fb17-4542-44fc-abf5-7f5427f7ca79">
+      <statement statement-id="cp-3_stmt.a" uuid="eacc635b-d7be-45c0-b1e1-a8c0caab0f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c46d9b50-b074-4b05-ad17-52cbefe2a778">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -1746,8 +1746,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="5a9a7cf3-fbaa-4295-98bf-c06f4bb22eaf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="03fab68e-1a09-4a93-b63f-62dda3e9961e">
+      <statement statement-id="cp-3_stmt.b" uuid="55d0cf39-d41d-47f2-acf1-9611c9cd28d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e2deff2-ef78-4842-a130-31d1f96ef3c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -1755,8 +1755,8 @@ system changes is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="12aaa448-7acf-4637-88b7-0e4bea605d2b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7146eb8b-8179-467b-9083-31a82bb0517b">
+      <statement statement-id="cp-3_stmt.c" uuid="84c463aa-dba8-43d3-9028-eb8251c5d259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5aadb256-2286-47f9-b444-493b37edbc52">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -1765,10 +1765,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="637560c0-dd2b-49b7-8b52-1b849ee130c0" control-id="cp-4">
+    <implemented-requirement uuid="37f1ec1d-eca4-4821-832e-60470f2ed2d9" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="df371cc1-3d6c-4b97-8a36-7b43ac0cf36b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9299a0db-1060-4b02-9de4-7cbbfa969cc4">
+      <statement statement-id="cp-4_stmt.a" uuid="a0121166-a8d6-4542-9a77-458b36f5fff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2d078574-7f68-43e8-860c-e009ad734355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -1778,16 +1778,16 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="33059ff7-007d-49a6-ab06-cb7fa6befd11">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1c829baa-ea7d-4f82-9f0e-7fb877db0071">
+      <statement statement-id="cp-4_stmt.b" uuid="cf743a34-3cfd-4fa9-a58c-07c4d34a9250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c86cbed-d193-4e6b-b255-6d100e78a57e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="e820a4ef-12f1-4373-902f-0acc09ef5843">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="811ff058-f8f9-439d-a4f0-11c2b81f0083">
+      <statement statement-id="cp-4_stmt.c" uuid="1f36412a-d485-4a3b-978e-d823b0c049be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8788b75-6ab4-44bc-b7fc-63dec92b1fbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of OpenShift configuration.
@@ -1795,10 +1795,10 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3b1e84d-eac9-4329-ba65-356b109157a4" control-id="cp-9">
+    <implemented-requirement uuid="b8ed0b80-8f2f-482a-9ecb-036cfc41ec26" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="a7026095-cf67-4ba6-a296-e18eea820af9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="db071ef4-3ee4-42f7-aa8a-f341f2e5bfa3">
+      <statement statement-id="cp-9_stmt.a" uuid="baffa994-23ab-4ef5-a98e-935efbb3a03e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91111cd6-ceec-4076-b4db-2f7432fbe684">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1819,8 +1819,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/backing-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="b1abead0-967e-4930-96b8-e5197c702cee">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c6778843-b513-4775-8974-0daa3d9ba713">
+      <statement statement-id="cp-9_stmt.b" uuid="5c32e132-5d18-45c1-9044-08de5dba08c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4e1dc78-ba58-44a8-b06e-7e3bdd228353">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1841,8 +1841,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="e4338f35-7574-4b37-b91b-aef6280e03ce">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="467972f4-6d54-4ec3-b014-a30729c18dc3">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1853,8 +1853,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="1a2b0bd2-20c7-46a3-8194-45273406c3ee">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="94c336c0-52cf-43da-a329-1b072c46b96a">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1871,10 +1871,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce39d9a4-2d3e-4177-8113-b4083e57b574" control-id="cp-10">
+    <implemented-requirement uuid="60c05e35-8cbb-431e-be0e-7298fb2e3885" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="9a1e25b2-7e40-4f11-890d-aeee364b4f64">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="32e472ef-51e9-4773-92a4-f4af56a856de">
+      <statement statement-id="cp-10_stmt" uuid="4cfec696-2533-43e2-8cd4-d83034a25b0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc615e64-aa2a-40d5-9bf5-f9fec7b0860a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their OpenShift environment. A successful control response will detail
@@ -1889,27 +1889,27 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63861150-d3a4-4bbe-9090-f8162dd032c0" control-id="ia-1">
+    <implemented-requirement uuid="7a63474b-62ca-479d-964b-d58bce457f95" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="108e9250-8fb7-474a-b4ba-b15e1e3a31b7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="72a188c8-04ec-4d58-94a5-bd533022e0c6">
+      <statement statement-id="ia-1_stmt.a" uuid="a36fe514-78f8-4e92-a6f5-ffbdbac40098">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a33d8b8-0bdb-4d23-8859-0363adaacce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="7a15ca00-214a-41de-a310-21d0569d2330">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5e71c60b-b782-4ae3-b31f-45a2c84ef759">
+      <statement statement-id="ia-1_stmt.b" uuid="1ad8b1ab-65d9-4977-9a6a-3dd415e440ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe0d32dc-7657-41d6-8617-03d01c8d0590">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b51293b1-02ec-40d4-bb5f-0d61bc38d0d3" control-id="ia-2">
+    <implemented-requirement uuid="d5bf1824-63d0-459f-8124-139f199c926a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="8ea17e2a-6da1-4784-a698-22a59e2b071c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="54c57672-22e9-4f4d-a376-ed911007462c">
+      <statement statement-id="ia-2_stmt" uuid="69702027-98b2-432d-9be3-8816afa66b86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e572a34-7d36-430a-acde-f6d4ece3a6b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Unique identification and authentication of organizational users
 is deferred to the organizational identity provider (such as
@@ -1928,10 +1928,10 @@ container image, is provided by correlating system audit logs.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d606611e-0e53-4802-8977-76410e0eadf8" control-id="ia-2.1">
+    <implemented-requirement uuid="31ff8a91-b777-49fb-b8a8-89cb0b4aae44" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="528b00c0-b7b0-4bc4-b556-19f833d404be">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ef259fc9-738b-4782-9d29-8ad1976d510e">
+      <statement statement-id="ia-2.1_stmt" uuid="eca3dba3-92b6-4796-8f9f-3b9c961260eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11288f65-ae11-479b-8f16-163d14246986">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementation of multifactor authentication for network
 access to privileged accounts is deferred to the
@@ -1950,10 +1950,10 @@ needs and requirements.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b82492b-aea7-44c7-95c4-786c6b6ff8cd" control-id="ia-2.12">
+    <implemented-requirement uuid="cd277188-f18d-4c2f-81d1-52b4f05d4850" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="3e0317ed-926b-45e3-b288-ac822b9987eb">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="394a1adc-dbab-4b45-a09a-144033c2ec0d">
+      <statement statement-id="ia-2.12_stmt" uuid="c8df24aa-90fc-40ce-8b44-eb61bf261d49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8a27df5-d2b4-454c-9d33-ff6bf5108270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronic verification of Personal
 Identity Verification (PIV) credentials is the responsibility
@@ -1968,18 +1968,18 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="387878c9-5fc4-41c1-b4c5-d65827163dc3" control-id="ia-4">
+    <implemented-requirement uuid="f8c650c8-2244-4408-8c43-b7d628cddbf9" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="20e4ce29-792f-476b-a3d7-6467de718186">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="77a0c7a7-c634-4fee-8965-2d1d0743797d">
+      <statement statement-id="ia-4_stmt.a" uuid="af77be7e-e7ac-43f6-838e-93a7def235f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ae35092-d4b9-46fc-8151-a7c985b0cf73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
 requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="bc3024ce-d0bc-41d5-845e-214fdca47175">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a56aecdb-9808-455a-ad6b-4c186fe60a6b">
+      <statement statement-id="ia-4_stmt.b" uuid="d4c31b6a-6158-43f2-8271-7bbe4f914cfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae5e68fd-d86a-4fa0-8600-a3560f6361b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift
@@ -1992,8 +1992,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="32587428-4164-4cbf-b39f-cf9d0abe441e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6e3c001f-eaf1-4d90-b501-d4d5b7b9312b">
+      <statement statement-id="ia-4_stmt.c" uuid="4cadb32e-e9a0-46fe-9a9e-2b5198cf8dc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23c9fe46-b3b5-49ac-9dbd-091b95caffa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2005,8 +2005,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="9521e90e-4d20-4a74-916b-265d7115bf21">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="635946dd-36f6-4fa6-908e-5c447a5a5637">
+      <statement statement-id="ia-4_stmt.d" uuid="c1c3dfe5-dc9c-4795-b8f3-d4781b33a61d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b50a8422-1e67-4289-beba-bfac3b80e45a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of OpenShift configuration.
@@ -2018,8 +2018,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="140b5c03-4a3c-4a3e-95d4-e5b627b49b6e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2026ad08-d728-43d0-a1a9-6e69709af43d">
+      <statement statement-id="ia-4_stmt.e" uuid="1ef28ca6-a1b3-4310-99d3-4d5b9d555331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78d3d56d-9076-495a-9b79-451d78c74481">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of OpenShift
@@ -2033,10 +2033,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64eb5411-b5b5-428b-89e7-ef293ea879ff" control-id="ia-5">
+    <implemented-requirement uuid="f45786b2-8ed7-4ee6-9977-1cbfd8439463" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="5688695c-8965-425e-b784-b4dd39fcc727">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="052c09eb-80fb-4bd2-bbe3-7ab8d441a01e">
+      <statement statement-id="ia-5_stmt.a" uuid="b77b381f-73ee-45d2-b1ee-6dbd2a271b05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="035e502e-7530-462b-af9e-ef68b2c1e6f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -2044,8 +2044,8 @@ is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="8321cbca-0f6d-40fe-b378-96c1bfa461f6">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2b8d95aa-d1a4-4c78-9bba-d7a4ad7473ef">
+      <statement statement-id="ia-5_stmt.b" uuid="9edf37b0-e399-4984-80d6-d022fb4db90f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bf9a1ed-032c-440f-9e8f-68b7c4658645">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2057,8 +2057,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="64b4696e-9135-4099-876e-b994c0b4c79d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="49040d6c-a7bf-40d5-aa5a-6b89ec9eb54b">
+      <statement statement-id="ia-5_stmt.c" uuid="a5fbcaf4-4a96-4c7a-86e8-1cc7eb2bdfb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f524611f-505a-4fff-9a00-9f2e38d9fecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2070,8 +2070,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="0f9ffe6a-727b-4023-b61e-2e9e648e212f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="488d0a1f-9a35-42cd-b492-e0c34cd63776">
+      <statement statement-id="ia-5_stmt.d" uuid="fdc6a0b9-914a-4099-9357-a8cd1607a7a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f6ba12d-0e6c-4f30-b8ed-d623e84a01c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -2084,15 +2084,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="47e8e162-c61e-44c5-9837-2fd86e42af3e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8b01858b-94a1-4ca2-a8c0-fd69aa921131">
+      <statement statement-id="ia-5_stmt.e" uuid="a8b479e6-63c8-478a-8ff7-d4d29749603e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c4e68b-fded-4a39-87a1-bb4af4c888a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="e52cb84a-6151-48ea-97fa-8748611f70f8">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1ce0bf66-586d-4bec-8b50-35eeb29de706">
+      <statement statement-id="ia-5_stmt.f" uuid="21d07f6b-a8a0-45f8-a9fb-77e8c140557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b95f8b1-9bc1-4f9d-a602-132c9801e281">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2104,8 +2104,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="11645cd4-678f-4e86-ad72-72dee931d3aa">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="55286c72-c5e9-4b53-bb34-3d25402b8fd5">
+      <statement statement-id="ia-5_stmt.g" uuid="f196ad36-8645-4831-be4f-7284660a97e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5be5103-5818-4050-861f-4c8878a5535e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2117,8 +2117,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="f154b24e-e05d-4359-bb11-d3a2e6917854">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="80e9394b-694a-4b39-b029-50b56642d6dc">
+      <statement statement-id="ia-5_stmt.h" uuid="ae312eb9-a9b1-484e-837e-55213c542bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3253f21a-52de-4279-81f7-050827a480a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2130,15 +2130,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="912a7657-d0cc-435a-9439-f83bd7fd194a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1ab75154-9d20-4b40-b82c-c735ec31a733">
+      <statement statement-id="ia-5_stmt.i" uuid="1103eb61-2511-4e4e-9dc8-ae2e27ee4fcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="858b0f18-ca29-4ecb-9da4-ebe49a3ddf8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="55d510a9-d8cf-4f13-8b4d-47f6aadce9e7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="abb95983-1dc0-4b44-9aa8-76c57c5df0b4">
+      <statement statement-id="ia-5_stmt.j" uuid="0d9d2135-b850-4062-9382-e6e1435da287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="171d97d3-9690-4d1b-849a-ae505ebd52d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -2151,10 +2151,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f1df47c-0aae-47c7-84d1-87d5066bca9a" control-id="ia-5.1">
+    <implemented-requirement uuid="c840dd2d-2134-4106-b0e1-cdbdf942e3ee" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="450fa69d-2792-44b1-9139-6d6df472e059">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7fba10d7-4275-463d-b482-b20cf5bf9f8b">
+      <statement statement-id="ia-5.1_stmt.a" uuid="5494089a-1a35-4115-88e3-cf817fa662c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0080de48-f09f-4e25-84a7-d8fdc5704bb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -2168,8 +2168,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="bc28ef77-59d7-49b8-aba2-d484232fb433">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4e72e7f7-b3eb-4587-b045-bad18d8daa16">
+      <statement statement-id="ia-5.1_stmt.b" uuid="af6af93e-ea08-4c92-ae76-993187816f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="affed9b7-8fe7-49f0-92ea-6d594ebc48ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of OpenShift configuration.
@@ -2181,8 +2181,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="4c1d009d-0a5a-461a-abc1-3f6f32061cd2">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="69c3fbb0-38c2-40f6-99a0-b7146ed2939c">
+      <statement statement-id="ia-5.1_stmt.c" uuid="3ecfcdf9-1a50-42d6-b687-328fb6f3d17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e124b321-8080-4d56-a14d-45aef97161fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of OpenShift configuration.
@@ -2194,8 +2194,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="ad1eb085-1043-4c60-9088-ad3c5a53307f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="dabeffa5-8532-4d53-9a83-d6e30256ce0a">
+      <statement statement-id="ia-5.1_stmt.d" uuid="59ef1f9e-aba7-4b83-b9f3-9e580162fffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67102d51-3421-49c3-8272-98e08992dca4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of OpenShift configuration.
@@ -2207,8 +2207,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="a61cb51a-fc4d-4071-9276-772baf2f35b7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a346f2f6-ea5b-4c59-b4c4-1bc3c9f245cf">
+      <statement statement-id="ia-5.1_stmt.e" uuid="a1ebe259-90ce-47a3-89b7-3a836ba771ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eaf0053-9ecf-401c-8c93-a735e11b7306">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of OpenShift configuration.
@@ -2220,8 +2220,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="0dbda0ac-a12e-4878-b0fd-0a067ab1604a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f7ffcb71-e246-4d4a-888d-0fb7b086a79d">
+      <statement statement-id="ia-5.1_stmt.f" uuid="256c38d6-45fa-443e-907d-ff06e549ccf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f4d75ab-40f3-4890-97bc-bd148fe15e9c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of OpenShift configuration.
@@ -2234,10 +2234,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51243f00-c2a6-4b65-821c-bea2bfa1d6bb" control-id="ia-5.11">
+    <implemented-requirement uuid="aba44873-a665-4cf3-972c-4bb448283d71" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="dc75bbe7-20cf-400c-b2e2-8d406f53d2eb">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2b3e8647-e48a-4643-bc9e-84821c411756">
+      <statement statement-id="ia-5.11_stmt" uuid="dc253871-14d6-47f5-8139-0a58bffbc0c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98b4157c-f7dc-44e4-b6fa-2621e57af0de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -2245,20 +2245,20 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2bb58e4-5520-4c29-8848-e6d050bfb594" control-id="ia-6">
+    <implemented-requirement uuid="d82ede4e-b4c6-4df6-8637-06ea271f4988" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="18cecf75-3ee5-4112-9c11-1df4404fd249">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5dec4fa2-36f8-4abb-bdbe-47982cccd842">
+      <statement statement-id="ia-6_stmt" uuid="954333a6-db59-4363-84ff-4a093276cc26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1de62daa-6d58-4197-b444-1f300cfa16bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, OpenShift Container Platform session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98b3c844-3f0b-410d-a3b7-29a32d1d5653" control-id="ia-7">
+    <implemented-requirement uuid="15f30ea6-ea07-4a5e-8f4b-911b2b9913aa" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="55a52bc3-c269-48e5-8a28-da7914c85e1c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="86453b46-6412-48d9-9eae-e26ac00aa39b">
+      <statement statement-id="ia-7_stmt" uuid="8036c5d4-0735-4d3c-b75b-9a1e12ca4425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f49ea9da-eda7-48e0-9efa-58caf64c9e50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2266,19 +2266,19 @@ https://issues.redhat.com/browse/CMP-334</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bbb62d5-ee65-4a74-84fd-93adf8d39536" control-id="ia-8">
+    <implemented-requirement uuid="40dc1e99-1157-46e8-93e9-b91aaacf5722" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="7098d338-2697-4980-a715-e7008f1a5328">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2bde769d-afef-4399-bbd9-4e968c922934">
+      <statement statement-id="ia-8_stmt" uuid="5f420b03-beea-4c0d-84b5-4039a12d1577">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bed8babc-a810-411b-bd12-deb0cca5d951">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84270730-be4d-48be-a529-1eec0aa867de" control-id="ia-8.1">
+    <implemented-requirement uuid="e36cd541-c9e8-456c-9a9c-4e897c58bcd2" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="26df92d0-adfe-4407-8369-e934b724ab78">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="11a97f20-299e-4442-b2e1-d79ad969f49e">
+      <statement statement-id="ia-8.1_stmt" uuid="6430ab3c-8226-489a-8a51-ceb2ca7c2b16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64d3d4db-549b-448a-8308-d9e57759b155">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronically verified Personal Identity Verification (PIV) credentials
 from other federal agencies is outside the scope of OpenShift configuration
@@ -2292,10 +2292,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee05af74-fb79-45f8-9a77-3c233cf070dc" control-id="ia-8.2">
+    <implemented-requirement uuid="1571fa34-2c0c-4837-8eb0-728567db9222" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="2d177f2c-4e53-4f87-acfc-81ceabe52ef8">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f0ee79cd-282c-44a0-8c66-b823887008b7">
+      <statement statement-id="ia-8.2_stmt" uuid="ecb2f8e0-c4f5-44e9-ba59-b7122437ab7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd8b698-d621-41cf-bb38-a1e0e4f77cf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of OpenShift configuration
@@ -2309,10 +2309,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4715ee2f-88e3-4949-8139-7e2a7d35d10a" control-id="ia-8.3">
+    <implemented-requirement uuid="086a9f3b-16b7-469c-958f-5a46a1b81120" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="1a2a5398-4152-41d7-91a0-3cb5535631be">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cb7ea9a6-bf3f-4a5d-b6be-20834f79a9ae">
+      <statement statement-id="ia-8.3_stmt" uuid="59f3a1d3-380c-4767-8cbb-61c59d4f0b35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f50b47b6-83f0-41a1-b836-bb5aa76bbd31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -2329,10 +2329,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3ce5730-a46e-4d9f-96e6-2941bf9329a3" control-id="ia-8.4">
+    <implemented-requirement uuid="68413d07-5f0c-48dc-8329-bbd634cd2aa6" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="25661a0e-a539-487d-868a-1330b90dda0a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7ed011f1-33e9-4418-ad1f-81c062543bf0">
+      <statement statement-id="ia-8.4_stmt" uuid="3691e247-fa06-4e02-a52b-87472287de3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="451ba487-859d-46d2-be66-364a4f621a92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Usage of FICAM-issued profiles is outside the scope of
 OpenShift configuration and is the responsibility of a
@@ -2346,50 +2346,50 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ef5c21-a969-4433-b6e4-f6d137f47f67" control-id="ir-1">
+    <implemented-requirement uuid="43039241-d333-4db7-9609-9b77b28a3f0f" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="28f54041-93f3-4dd9-9f41-d5fa552430fc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="13b2bbd2-d6eb-4c36-b09b-863518f1cdd1">
+      <statement statement-id="ir-1_stmt.a" uuid="88eda018-bd0b-418c-9cb2-47118ed36ced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="c81fde30-9168-48cb-abe1-ec07cfec7a81">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4db37ace-fb3f-43b9-8c34-13e68640bb9e">
+      <statement statement-id="ir-1_stmt.a.1" uuid="f3fa3086-4945-4831-bbe4-9e049146b989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="ef83b420-5209-431b-8977-3ede5d33be0b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fd3ad9a0-5233-4bbb-b395-18d043cb7c39">
+      <statement statement-id="ir-1_stmt.a.2" uuid="d6827642-8b99-43e5-bc4a-cea9fbd10cbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="4b9f7172-060a-465a-a57e-297b98032a3b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="74968a60-b032-4929-9d26-280cf40243a0">
+      <statement statement-id="ir-1_stmt.b" uuid="383de702-72c9-4a0f-846f-47cd60669782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="8185f6f3-3d13-4476-b8c0-9607c901b1bf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e6d1ef70-5d55-4ba5-a45a-136897a8e42a">
+      <statement statement-id="ir-1_stmt.b.1" uuid="bd1976e1-fa73-4ef6-80b1-4eb2e9e356b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="7fe8f957-5559-4512-a5e6-5bcc993bc81c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f9958a51-29bc-4493-b2f4-05d8ff7af530">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d6cd467e-3cf8-412b-ab91-6b316fa4a606">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2397,26 +2397,26 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92bcafd0-3eb2-4f58-847f-b64bd0857b70" control-id="ir-2">
+    <implemented-requirement uuid="81b56ecb-1a80-4e29-afd9-836933f1776d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="2147c6d9-6c9f-474f-b167-d288ec972265">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="112aeeb7-e298-44df-85d5-75e8863d7a89">
+      <statement statement-id="ir-2_stmt.a" uuid="9984f5c1-9b0f-44f3-bb44-4013df8aae5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="55def462-1391-4942-951c-cf4e2b081607">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6bf449c0-01d7-4bc3-90b3-ff090d9fd61d">
+      <statement statement-id="ir-2_stmt.b" uuid="86b318cf-5287-4082-8c9c-2264b4717d66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="9cdbe96b-9f96-4bb2-97d4-411034337a68">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9b74ca02-a690-4208-8871-762d970bda37">
+      <statement statement-id="ir-2_stmt.c" uuid="9742cc48-f755-42e6-8abe-e19985c32dd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2424,26 +2424,26 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a183b418-4403-4000-b999-c5f12cd570f5" control-id="ir-4">
+    <implemented-requirement uuid="c394eb2a-4cec-443c-a6f7-77349352fc20" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="6621bbb1-29a3-42d9-b211-657100bc3a50">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5a516c36-e9f4-4047-bf0a-fb2600b6e94d">
+      <statement statement-id="ir-4_stmt.a" uuid="b6252153-ddba-4952-bd97-39f0d104771c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="de9ec3cf-e3b5-41c9-916a-9383ff20d6fd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0bc1fb88-1dbf-43b0-8f80-a67a2a02bdcf">
+      <statement statement-id="ir-4_stmt.b" uuid="e2104fee-fb83-43a6-a09a-85ce5502df00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="7b21390e-2ef0-4276-87ce-5f082f322a43">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0ffcd513-4158-4e24-a92d-bca38715467c">
+      <statement statement-id="ir-4_stmt.c" uuid="457b25c6-28f9-464f-b964-cdc84235bf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2451,10 +2451,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aaed1585-00b1-4664-9bcd-72890a2d3918" control-id="ir-5">
+    <implemented-requirement uuid="f8e53718-6179-495d-b4bf-22d1d2d49121" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="226884b2-e721-4983-89bc-2ddd1d1452aa">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6668f420-8c0f-4ed8-8e14-90ee3b003b70">
+      <statement statement-id="ir-5_stmt" uuid="c6ed00f0-aa54-42cf-9c24-3206ba3d77a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="367e314c-be0a-4933-8e01-8ac474a58997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to OpenShift configuration.
@@ -2462,18 +2462,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70a445ad-be07-477d-9281-a93df1767e9b" control-id="ir-6">
+    <implemented-requirement uuid="85d0cae6-52cd-4630-9774-5f89fe81b838" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="6b7cc603-0816-45e5-98dd-ebd50c11d5f1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a9cff0d4-6088-4fad-ba08-d1e8548b4b95">
+      <statement statement-id="ir-6_stmt.a" uuid="c3241b05-d5e4-4a28-9f92-42b18719d3ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="d3e31003-cea1-47b5-990d-ead7ecbd43fa">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fc6a7901-4e6e-4d13-a8f3-788d74bce329">
+      <statement statement-id="ir-6_stmt.b" uuid="5c775a24-b49c-4266-a483-e37d1d37f3db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2481,10 +2481,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08a4bb49-2e92-43a3-ba8c-fd45f54aedf1" control-id="ir-7">
+    <implemented-requirement uuid="11e39f52-40e6-426b-a23e-f889000bc40b" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="761a0992-c4f2-4009-9dd5-0f7423864827">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="32b15f20-2466-4bc8-83cd-36679e9eadd7">
+      <statement statement-id="ir-7_stmt" uuid="6bfe8a45-3127-4281-a47a-adf2f5554f47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2492,114 +2492,114 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c840d36f-9d58-4797-85ea-f86eac45aaac" control-id="ir-8">
+    <implemented-requirement uuid="bb4e7052-02ce-441b-9c4a-89c532ecfb5f" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="7012babe-914e-45b5-838e-850e93c5cf7f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bb5d1870-a068-4534-be2e-72107fe03579">
+      <statement statement-id="ir-8_stmt.a" uuid="227584e5-c6af-41d4-ab76-bc1381e3359b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="2f1c0fef-faa7-4c65-ba50-597ac5ab7136">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7e78eda3-aada-4d11-bcc6-30642b6839a1">
+      <statement statement-id="ir-8_stmt.a.1" uuid="1c5de3cc-c433-4ace-91b7-6cd949843847">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="b0e8281a-99ac-426d-a5b6-b4400ac4c52a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="61c0b853-6caf-4605-8efa-28358bf5b0de">
+      <statement statement-id="ir-8_stmt.a.2" uuid="f0317202-3633-4cd1-872c-2f027b8756ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="9a23c7da-1b0a-4691-8655-b3d03ea8254c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="05595cd0-b56c-49fd-af16-b3bfc8af99dd">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b58411a1-bfd0-440e-9a31-8d9fd31edb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="f58d8ca6-836b-4a78-a5a0-95e012868011">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="46e0beb2-a400-49a5-b0ca-089ba24bf47f">
+      <statement statement-id="ir-8_stmt.a.4" uuid="569d6e87-911a-4a6e-be38-a2813bb5e02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="45622b5a-51f5-4dbf-9305-387f3db9344d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="62f23ffd-7f36-4a4a-bdae-d41f1f969228">
+      <statement statement-id="ir-8_stmt.a.5" uuid="efaea696-1fea-4abf-95b4-39344e4724e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="ddcae7db-8bf1-4fdb-8ccf-b33b41fcb6fd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="30fc43f3-ccd6-45c9-92ac-38a7ab3b4462">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c1b60d11-37c5-455f-b47d-c5c278638a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="ac40881e-66c2-4f51-8ddc-50f8a814f683">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0a8f5bed-4bc4-429a-8fab-b77e111ba4f1">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d58998e9-3310-4ec8-b6b7-73f1c1ffbd36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="457a09a6-4987-4371-b13f-30563ca04828">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="391eea4c-24d0-42bb-9327-07a69f727bdc">
+      <statement statement-id="ir-8_stmt.a.8" uuid="b66a3b8d-6cda-4aee-a38f-a0d4cd1c6bc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="b250038c-4f9f-40ee-94b5-e0ee459f7e12">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ec6d20b5-d8e2-4b19-9682-b11557b68186">
+      <statement statement-id="ir-8_stmt.b" uuid="5c02f03a-0779-439b-86d5-7106516fda13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="29719683-edeb-441f-b62e-bba3e03a0f7d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="12ac7209-d297-4cf4-b598-a1ceb2c15aa6">
+      <statement statement-id="ir-8_stmt.c" uuid="d239bbba-139c-4c7d-a720-3a66d534c6b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="710db71d-f08b-4ac4-8401-3dc4c22b28ca">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4dc2fe6b-6070-4dc5-b891-7ebbc3a7787e">
+      <statement statement-id="ir-8_stmt.d" uuid="edabf95f-64af-430d-ab6d-5f04c028889e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="6925990a-b27f-4ae0-9a4c-d0230f2a7579">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="897ca923-fc15-47b0-9668-e8003b15ca88">
+      <statement statement-id="ir-8_stmt.e" uuid="5cccbc53-1a22-418d-b3d4-026759960888">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="ba26aaae-3e11-41f4-8f0d-dda0a3a53e3b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2a81e162-9625-4bc0-8ce6-11414b22c6e8">
+      <statement statement-id="ir-8_stmt.f" uuid="361269f5-7504-4190-b4d1-a73bff1622ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2607,18 +2607,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a8f02f8-885b-4741-b59a-8cd87c2e793b" control-id="ma-1">
+    <implemented-requirement uuid="b10fe6d1-8b4a-4355-a102-d7114483e66a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="5e307286-8e33-4292-933c-f3f9287b4a87">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3eb09010-bf66-4cef-9c72-5fafd6834c99">
+      <statement statement-id="ma-1_stmt.a" uuid="f9871dec-e863-4601-a0a3-6cf618410383">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="a9634087-7653-47e8-a550-47d7b1fbef5c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ff87514e-4ca6-49fc-bdd0-da48c8fd828c">
+      <statement statement-id="ma-1_stmt.b" uuid="70066806-55a5-46af-81bb-ef96b7601008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2626,50 +2626,50 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e6b0354-733e-442a-abc5-557c3d6f38d0" control-id="ma-2">
+    <implemented-requirement uuid="2ed3fb53-97c8-4f9c-bcf3-320460f9f3aa" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="959aa3e0-b384-4016-9e60-68dfd2df981f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8f8949db-4fb1-44bf-afc7-7442e9a13860">
+      <statement statement-id="ma-2_stmt.a" uuid="d3d3bf14-2476-4700-8e56-50f6c4c33e47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="c05e50c4-c22b-476f-a475-fbdae3b7596e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="09b1b32d-235c-4437-a565-2099eec83237">
+      <statement statement-id="ma-2_stmt.b" uuid="e1493534-bb33-4385-b0a8-011771101e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="8f65fb4e-6f5c-4b91-b94f-c3dbbb733db0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="15b010f6-156e-4f6f-b2f1-0535466a9892">
+      <statement statement-id="ma-2_stmt.c" uuid="c45aba08-33ca-41b6-8c61-3173a666e4f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="4df13e9f-10e2-4960-b487-32c89bd5db87">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="d02516c2-f9dc-4576-b667-3ecf514949eb">
+      <statement statement-id="ma-2_stmt.d" uuid="5188a418-51bc-4418-ad92-cd6bc24d9d50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="df813e12-4f6f-49e7-b71a-cebf88372f3a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="36ee2216-7cec-4662-b02f-246998ee5651">
+      <statement statement-id="ma-2_stmt.e" uuid="e664b60f-5935-4125-a2ac-3d4f42040367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="087d1719-75ed-43df-9437-ff382b821d30">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="96a2bae1-0581-4d92-aa11-12f49307b3e7">
+      <statement statement-id="ma-2_stmt.f" uuid="237d6190-6c08-44c2-a328-2ed9e6c838c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -2677,18 +2677,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50c0d0fb-0c9a-438b-a095-01632f0acce2" control-id="ma-4">
+    <implemented-requirement uuid="204c3081-9db4-477a-b1b7-acc6123933ee" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="036ae816-ee37-4890-8e26-27a5617480ab">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7a967d8b-641e-483d-a937-53fa5a2d26bb">
+      <statement statement-id="ma-4_stmt.a" uuid="50345522-239b-4d9a-a70d-7b5e6e2b3cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f83d066-75c3-4751-9058-9a0072ba2a51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="3626a059-4d2b-4aef-9073-7411f2970f73">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ba536330-4aaf-4e9d-b0b7-d90e83fe61d4">
+      <statement statement-id="ma-4_stmt.b" uuid="9ef16448-cbe4-4c91-80da-e1cb54be20d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e80348b7-25d4-4d89-b28b-0882198f6646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -2696,8 +2696,8 @@ orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="1772de67-d166-4e04-a8b6-1803b66e8b26">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1e432979-aa05-407b-82c9-53327a2294eb">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2705,16 +2705,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="aab8acf7-631f-4b45-8c17-c4bcdfe68c0c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="72419ded-f4b0-4180-8494-075457462298">
+      <statement statement-id="ma-4_stmt.d" uuid="29005666-5e5d-464f-8b34-73b8095d773b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74202b5e-92f8-4be5-a08c-b07c9b0f8149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="330d3de6-6997-4997-895c-614a466db82a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="28134a09-1836-408e-80e9-91c29546bde8">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2723,10 +2723,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9e7431e-5498-4c76-aae6-b1a10918ede9" control-id="ma-5">
+    <implemented-requirement uuid="c6462421-f340-4b02-9572-80913c2f5646" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="66812902-0b32-4cc5-85f9-c1dc51aa70ae">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c3a197d2-3fe9-4c3a-9f39-ea75ed45c109">
+      <statement statement-id="ma-5_stmt.a" uuid="4dc39efd-5d7f-4b4d-866e-04a28ffdb2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="124aa32b-c8d1-48cd-a8e4-ddaeb3480877">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -2734,8 +2734,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="cc1003d9-12b4-441a-81fa-1b04b4c31904">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="99db3498-1b70-480f-ae7d-ffb145ff0587">
+      <statement statement-id="ma-5_stmt.b" uuid="b242b08c-223f-44d2-98b8-691eec589cf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72e60fde-d698-45ba-8c34-7bb3e0c6c8ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -2743,8 +2743,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="70a51e39-64db-4830-acbe-74e4ea72c72f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8075c1ea-9595-4933-a8d6-5a31d9404f87">
+      <statement statement-id="ma-5_stmt.c" uuid="0f320f71-ba98-423a-adc4-5a126367dccc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e90741-c6f7-4d1f-a9b0-167c1eeb394c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -2755,18 +2755,18 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ebce71e-5ae4-4e21-98b6-df9d78662704" control-id="mp-1">
+    <implemented-requirement uuid="1c2b137c-e0e6-4383-8c59-bb398437a58a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="6467c189-17cf-4f00-a4bb-15f611bb3d8a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2a12346f-5264-4775-b70e-4ad09a3bdfc2">
+      <statement statement-id="mp-1_stmt.a" uuid="a90905bd-7ee4-459d-9fde-427e6ae14845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="0a15f569-ebf9-4c8f-bc49-61d40ae23522">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="720a5061-b715-4701-9f82-846331c4adbd">
+      <statement statement-id="mp-1_stmt.b" uuid="f16f66b5-c2ba-45c1-8f16-8e3252f197ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -2774,28 +2774,28 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5640b9c-5db2-463e-a155-41d1ad52b650" control-id="mp-2">
+    <implemented-requirement uuid="108dc458-f5dd-4887-a989-5927a9611045" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="6103e4a7-75fb-4a65-bd3a-1c8b90e11414">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9372ad36-b9c3-49ec-99e6-b80200340b55">
+      <statement statement-id="mp-2_stmt" uuid="4d8f11fd-331c-4950-b137-f08af8a0083d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b366ede0-de5f-469a-8b63-adc03bb79f40" control-id="mp-6">
+    <implemented-requirement uuid="0427c8d9-1658-43bf-b365-c2d8b57f973c" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="d73ea0f3-90d8-4c22-ae85-18520ba0ea5d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="16164c67-09c5-406d-82ca-392e8690b159">
+      <statement statement-id="mp-6_stmt.a" uuid="f49bef15-aa6e-4f61-b787-ba9c4c2b1372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="d1c3a689-644f-43f8-9872-c15f4a3d0265">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="13202cfb-c5dc-4863-b0ba-b00d1f7bcdbb">
+      <statement statement-id="mp-6_stmt.b" uuid="31236cf3-7eb1-4545-8a44-72cec9a91f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -2803,10 +2803,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2970645-0fae-4199-bf4d-d04b2cafa549" control-id="mp-7">
+    <implemented-requirement uuid="ec9f0f5b-634e-4648-a0bb-f90d4525af78" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="29c06d9c-a682-4e19-a70f-6768eab6d8c8">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2ac9668b-e123-4c88-b44d-21c71ea474ea">
+      <statement statement-id="mp-7_stmt" uuid="864e4639-60ca-43bc-a00a-8ce2fb547d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab02986d-bfed-4206-8c15-412836e72d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -2814,10 +2814,10 @@ Openshift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c234ece-ab2e-4353-acbb-362418328f37" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="42334480-34ac-4c56-841f-e831c5f67011">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="083632de-e646-46e3-99ac-1b6e6a08dc23">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -2826,8 +2826,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="3e9d7bb6-342e-47c8-b586-cb375d3bc059">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c53f9da1-f1cc-4aec-904c-800f017d83c9">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -2837,10 +2837,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="359bb948-dd05-405e-b930-d28c2078b149" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="bee60e05-13cf-49b5-9e98-1db87a28263b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="68f7ba55-57f0-4568-93d0-653b546a12fa">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -2850,8 +2850,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="12a103fa-525a-4bda-a54c-ee103f2cd14f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fef050fc-57bf-4b3a-82ba-a2a9ad515bc0">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -2859,8 +2859,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="6d47ecfc-1b3b-4382-af9c-9da6df0c2e89">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="51d1d16b-2ca9-49e4-a431-f93ed681d255">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -2869,8 +2869,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="69feb108-db7d-4646-b1b5-855efd6ed1fc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="29475825-cc0c-4d11-85ea-2e0847e783d3">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -2879,10 +2879,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37c71cd3-0610-4956-b54e-50bf710da6dd" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="f115c20d-fca7-4b3c-8c1c-c436e424f2f3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="06f909ac-b43a-4e5e-a06e-759c9c280576">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -2891,8 +2891,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="5244c7a7-1f65-499c-aa7d-ea84fec6d7e4">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e4395285-40e5-4508-873e-b12ab9129d08">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -2900,8 +2900,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="6902212d-173f-4df3-935e-76000e1d0168">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a3a84d2a-75a4-48a2-91af-36806d1c651c">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -2910,8 +2910,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="13b03d07-e519-4fca-b575-1956fa59314c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="746ff933-e635-469a-80b4-b4b619d78db2">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -2920,8 +2920,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="3e07409c-37b7-4e76-a884-e129f311b765">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f7cfd41d-f641-4cb3-8467-75762a29b7ce">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -2929,8 +2929,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="614ea703-e2bc-4dde-9354-52d29f925018">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="65047641-c01b-4846-8c8c-eefc6c31e999">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -2939,8 +2939,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="29f99681-a988-4fb7-8e76-7f3399f5ea49">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ff195981-f30d-4d9e-a8ff-4a6925f815ce">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -2950,10 +2950,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de132fb6-e65e-475b-b016-23edd5d0b50a" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="d8e24b07-bde6-4376-be4c-beea0be9c786">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4e361873-ef6d-4f0b-bded-987539df772a">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -2962,8 +2962,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="1e75413a-1d54-4d9c-8b2d-c4c7dd6cc9d7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a7591dd3-5288-4eae-9f41-0009ed56b43b">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -2973,8 +2973,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="fbcdb85e-0708-4713-97e0-f774596b8bcf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e0ca4b5c-d0ac-44bc-8104-cfe6c7a1c30b">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -2984,92 +2984,92 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbdbce0f-4635-4f7d-a4df-f4f26a3b6c59" control-id="pe-8">
+    <implemented-requirement uuid="f095e424-f8ec-49c7-9bcc-f96ddcbb3d15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="907be27d-4f3c-4c20-999e-8d741350a88b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4fdf555f-85c8-4359-a795-d2661ee1746d">
+      <statement statement-id="pe-8_stmt.a" uuid="3ad283fa-6c9a-4617-9d2c-02d449dcbcf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="820d4bfd-34d0-42d6-8da0-d8adce7517eb">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5ba641d0-dae9-47ee-8eb0-ca1ff41a80d4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of OpenShift configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="16a6abbc-dfea-4d3a-8100-71bc9d65ee24" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="8098ca6e-3ecd-4d33-ab3a-9b4cb597e553">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="14b10e37-757d-4ed1-bfee-927d0608ee40">
+      <statement statement-id="pe-8_stmt.b" uuid="b0ba16aa-b9c1-4dfe-b376-cda0ce550a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bab15c6-eedc-4bde-a041-8c0fe8d043d7" control-id="pe-13">
+    <implemented-requirement uuid="814d78db-2372-41e9-a7c2-86eb5e84b3bb" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="c55d987b-02b0-4572-930d-c8b0cc2bcae1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4a3b5b83-f145-4481-9c44-1b83c0ab910a">
+      <statement statement-id="pe-12_stmt" uuid="f57faeee-5800-434a-aa8a-947a9ae886f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6371c5fe-bd80-499f-80b0-1f7efa452cd4" control-id="pe-14">
+    <implemented-requirement uuid="4fb04d5d-82ac-46c9-a0b6-bf1bf7855bd7" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="dba1a26d-811a-401d-88e3-7bc5327cdd71">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0d040390-f54b-4aeb-aa18-a63d6b6a0ac4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of OpenShift configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="5192259e-6d0a-4d97-a747-bbac58d37894">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="292b9493-8938-402e-84eb-5f72ea03b962">
+      <statement statement-id="pe-13_stmt" uuid="abdc8068-bb34-4683-b938-e70eb7d36f5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90ff4eb3-29d8-40df-b440-875e2b3be24b" control-id="pe-15">
+    <implemented-requirement uuid="a8b0df72-c643-45b3-b800-1b06d1eb1d99" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="cf7c62e1-134e-4436-9d12-a5bd93c2aa37">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="83f26b35-0872-4721-b767-f54edaa916b8">
+      <statement statement-id="pe-14_stmt.a" uuid="15495bed-f082-405e-b69e-c743c8c3c20a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of OpenShift configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="a0d0eda2-1aa8-4afb-a24b-7c95d233bb3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcc01b63-4056-4362-82a8-c407b8cf7d4d" control-id="pe-16">
+    <implemented-requirement uuid="901a3457-97b6-4093-bbe0-31ce3a1cdcf6" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="74faa9fb-a32d-45c3-bc97-dc323dae4d70">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f35d425d-d4b6-40db-8cad-54da9e03f3dc">
+      <statement statement-id="pe-15_stmt" uuid="61425ee7-5b2f-4888-8373-62f378945ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ecc0098-367d-44c3-8f88-cb38254dff69" control-id="pl-1">
+    <implemented-requirement uuid="17f3da9e-c287-44a5-8169-28cf3375c1d3" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="0747f503-450c-4090-82cb-8a239f71c505">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fd4bd467-1f02-47c9-a1fa-deab3dd2af97">
+      <statement statement-id="pe-16_stmt" uuid="feaebed6-68b5-4c4b-8b88-883a8038ae9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of OpenShift configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="89868230-0876-48af-8880-46230d2f29c0" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt.a" uuid="8661b679-96b7-4c77-b230-bd4a38abe4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="e9a80377-1a60-4eaf-ad85-5c850d96632b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b1b23295-3726-4e6e-904b-e226eab0022c">
+      <statement statement-id="pl-1_stmt.b" uuid="8ece81dd-536a-424b-a2fb-61952dd53bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3077,42 +3077,42 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="769f6903-0498-430d-81d3-708950618f62" control-id="pl-2">
+    <implemented-requirement uuid="9afad57f-6172-4f87-b55b-8cd68079e3c8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="6fa34c56-0219-46aa-8827-d04f909fef61">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="44c14668-e33f-4a74-b04d-b63fb9e57acf">
+      <statement statement-id="pl-2_stmt.a" uuid="4b7ed71e-ba46-4d43-b6b7-ea99bc5dcd94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="87fd072b-402b-496b-b1e8-4ae91c7e84ea">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c12f7790-5690-4843-b4e8-bd95fe970eb6">
+      <statement statement-id="pl-2_stmt.b" uuid="9a4add41-bc05-416c-a9e4-229cb6f61367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="a37eb665-8d37-4680-8f02-659b0b7e9a8d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a54f9afc-d6d2-4e09-be11-4a4bbb2878f0">
+      <statement statement-id="pl-2_stmt.c" uuid="fb20fcf3-5cd7-458f-8fd4-edf1306f9d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="cab1c2b6-55fd-4964-a247-69f2aba04012">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fafe6de3-3dd6-4554-8f7c-da8aa7f037d2">
+      <statement statement-id="pl-2_stmt.d" uuid="06fb5ceb-ddd2-4c39-8ccb-356fb02780d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="8ada920f-856a-4b95-b800-26ff089d3227">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2e984416-7200-4d31-9cdb-16baa0a03826">
+      <statement statement-id="pl-2_stmt.e" uuid="782bc7bb-1af6-4c75-ad8e-769f8830e159">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3120,34 +3120,34 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b39597e9-8c6f-45bb-801c-216bfd89ef90" control-id="pl-4">
+    <implemented-requirement uuid="98e11268-47c9-4eb2-bd17-5bcac114ab5c" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="27fdb3cd-e523-4701-ae25-153a9dd641bd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cd757c3a-d8d6-41f9-8d84-ea20c1ce90d7">
+      <statement statement-id="pl-4_stmt.a" uuid="499d42ac-5c67-46fb-9e18-149401fb3abf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="8e6da435-f60f-453b-9f53-c8fcbee28e04">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a74dab40-827a-4c5b-b5de-5da7bfe10c24">
+      <statement statement-id="pl-4_stmt.b" uuid="f9388bac-7d81-4eb5-8343-4962c303ffa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="a004fc4b-b7f5-47d4-9d79-959627c5425c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a26461e9-bba0-4b9a-8244-de89c0c3b232">
+      <statement statement-id="pl-4_stmt.c" uuid="8f371b57-4152-475c-90df-2b05ffc39c5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="b63bbfd8-cf2a-4571-abf1-37f7886c9127">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b530b7af-a470-4d12-a2a1-3f1ace84e71b">
+      <statement statement-id="pl-4_stmt.d" uuid="96b2d54b-376d-4317-94b5-152505a1a8d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3155,10 +3155,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b238c31-66c7-4a4f-a618-3d69bf169b9a" control-id="ps-1">
+    <implemented-requirement uuid="6418d139-6314-4ff0-af50-b28e66b16261" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="f08003ca-876e-4bf3-a698-7a3fc2a6ea83">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="669e66de-4b87-427c-b8c7-c98dfbb533e7">
+      <statement statement-id="ps-1_stmt.a" uuid="b24ac5ec-0704-4378-998a-e73711c1f6e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3166,8 +3166,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="4def860b-6590-4093-9217-f3036ccc0ff7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2f7cc393-ce4b-4fd1-b2eb-229e39011939">
+      <statement statement-id="ps-1_stmt.a.1" uuid="f3c6288f-f0e2-4ff3-9e85-02a37d7ace14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3175,8 +3175,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="5f941346-f643-44b1-8b53-800000f73ddc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ab6c25df-ec49-493d-9e90-d184490e6564">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9b53e6dc-8b9b-4147-9b13-709f2495c207">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3184,8 +3184,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="a3916f5d-46f8-4786-81d7-80fbb7387417">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="69bc23c4-3215-45d7-a6d6-d94d714b4d3b">
+      <statement statement-id="ps-1_stmt.b" uuid="4f650c83-ce49-4c48-92a4-2c894efc17df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="337e7f04-ade2-4095-b026-96842ddb9414">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -3193,8 +3193,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="54df569d-7d94-435a-b7c2-f376350f4a57">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5578f753-fa09-4912-98bc-a6fcaa7e647f">
+      <statement statement-id="ps-1_stmt.b.1" uuid="81dcc255-fee1-488d-8ca0-dd88f7c2ded1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3202,8 +3202,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="bd268233-bc83-40e2-a788-136770f8a8fc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="dcb6ab81-035c-4391-b778-1590e09acfbd">
+      <statement statement-id="ps-1_stmt.b.2" uuid="7785900e-402f-4ccf-9bc0-597a2e7eb688">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3212,18 +3212,18 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="817c652b-e3e2-42bf-819c-e126d681fc66" control-id="ps-2">
+    <implemented-requirement uuid="37d305bd-2e58-4cc3-8fd7-311c59020818" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="5385224e-9c9c-424f-9666-1feef4b3697c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="44a95ffc-7dc4-4764-9f2e-bb3247f68643">
+      <statement statement-id="ps-2_stmt.a" uuid="e24c75d6-3b6c-4d16-83d9-036d896f93ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae453aca-5f7f-4c57-8ad3-40b0a9929f33">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="110f28bf-f9de-47e7-848f-44094e136123">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3eb79f7c-55db-4745-9084-7d6a31718c69">
+      <statement statement-id="ps-2_stmt.b" uuid="85ed1245-db1e-438d-96de-61ac6fc21ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955de2dc-b541-4f89-87be-be3aa93b2b96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of OpenShift
@@ -3231,8 +3231,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="61d8e636-4702-4cd5-b7a8-93d5dd7a3e1c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f24c0ffb-5e2a-45c3-ada4-24b2841bc9b2">
+      <statement statement-id="ps-2_stmt.c" uuid="82eb9502-0431-4a91-ace1-25f947087689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1cdb5679-ba64-4c52-aa04-49a4040f8b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -3241,10 +3241,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ecd38ab-5b61-4f5b-8db7-a03ca2e957ab" control-id="ps-3">
+    <implemented-requirement uuid="50b3ccf4-7437-4b9d-a4e9-2bd2111d0712" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="af404911-babf-470a-8c01-947fb4ffd3c1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9da7002e-bc80-4dbf-8b25-0b9b8a05eca7">
+      <statement statement-id="ps-3_stmt.a" uuid="ae898ca2-4245-47a2-b67e-9cb04cd16b60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d1537c-8e3a-4d4c-be9f-106f6072d75d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of OpenShift
@@ -3252,8 +3252,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="8110ae95-5967-468e-82ba-21d0fb0588a9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="926a09b4-e1cf-41fc-987c-1da64d125acb">
+      <statement statement-id="ps-3_stmt.b" uuid="9e412acd-66d6-42fc-a874-60196f12e434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5544b6cb-8c54-4e7e-8726-4b2ce8114fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -3264,10 +3264,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c8a5bb4-3f45-4fe9-be8e-e55c89068956" control-id="ps-4">
+    <implemented-requirement uuid="a058b4a0-06f7-4cca-a104-955e4193ff8e" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="56ae6a10-1564-4942-9a3e-7f52a416f6c5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="92f34d24-07be-4a24-ab82-c2b3bdd537b4">
+      <statement statement-id="ps-4_stmt.a" uuid="3c96cf7b-382b-4d78-803c-13d0c4c75b46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e47fb61-98cd-40de-a48c-3038ea513aad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -3276,8 +3276,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="a4fa26bc-0021-4fff-94c5-23f1aac218f1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c20a4659-c099-4b03-82d1-8b58b65b82fe">
+      <statement statement-id="ps-4_stmt.b" uuid="35295a74-1026-436a-ae0e-6ec855cf798f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12f961d4-848d-40f7-8f40-40e10e88d0df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -3286,8 +3286,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="ba1ae282-218e-4ad7-9211-b39682dd002e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="d857913f-9e18-4625-bce4-67fdafa19b0d">
+      <statement statement-id="ps-4_stmt.c" uuid="af8c79a4-798e-4bf9-a02e-140e04e48d10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec36ccaf-c3ab-4747-a425-c6bedc278aeb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -3296,8 +3296,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="637bfede-adf3-4810-bfe1-9620ad23566e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="17fdb95d-38b6-4c65-810f-5d2039e0e695">
+      <statement statement-id="ps-4_stmt.d" uuid="8ea327e5-5a11-4a98-8827-eca5a7049fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d80627a1-8f9e-43a4-a7a2-a75249dc410f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -3306,8 +3306,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="b1065bbf-a844-477e-b452-09942b08fe0d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="6d3090a8-f2c8-47a0-a19c-39e150090c79">
+      <statement statement-id="ps-4_stmt.e" uuid="f0301041-d18b-4c26-85b7-9b08eb82f8dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69d0287a-bda0-4d09-a48e-89d9bc9d50f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -3316,8 +3316,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="22c429ea-b3bc-48c1-b64e-d039a0f11608">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="163902c5-d4d2-45f1-921b-fd3fcd147734">
+      <statement statement-id="ps-4_stmt.f" uuid="011f2825-4703-46b3-96d7-51cb5008f740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9264a668-6ecd-4ad9-ad90-bf8e50a666bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -3327,10 +3327,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01e5f1c9-636d-41aa-b64c-23b51551026c" control-id="ps-5">
+    <implemented-requirement uuid="f021987d-0773-4783-8fe5-638a1887ad41" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="e220ac5e-a9da-4af3-b3e9-630daa7bbac1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="d3f23c42-1650-4b6e-bde4-5aeb2c8e7b0f">
+      <statement statement-id="ps-5_stmt.a" uuid="71f7e07a-0962-4f69-8159-2e9e25384f86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="046ba626-c644-49c6-b052-fe0a5a90ddb7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -3340,8 +3340,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="8866e375-f564-45d0-8de6-38fc6dd22161">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9fe5d829-6636-4041-bffe-6797fc2e9dc1">
+      <statement statement-id="ps-5_stmt.b" uuid="9b950b32-4306-4b6f-b8fd-daecabbae7bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35dc728a-280b-490f-81d4-af07110b288c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -3350,8 +3350,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="87404188-4404-49be-b9cb-44893f00a388">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bb54141a-8df9-4f69-ae14-cd9b3181b5a7">
+      <statement statement-id="ps-5_stmt.c" uuid="3fc5d320-e25e-4155-8a39-2f19efb6f270">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dae94fe-dbc1-4081-8464-f551f752798b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -3359,8 +3359,8 @@ or transfer are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="1679e1f3-11ee-452b-af27-cc2996c86e43">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bc5ce150-a23e-46b2-ba5a-c120da2fabd2">
+      <statement statement-id="ps-5_stmt.d" uuid="411f7849-0de6-4bfb-b74f-2172c0af25b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e1cf303-9747-4c4b-8012-ed16c6dab514">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -3369,10 +3369,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82de9704-14f7-4c7b-8634-238169e3aa7d" control-id="ps-6">
+    <implemented-requirement uuid="1a89d281-0763-4c66-a8df-f4c676911d94" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="f478a4d2-0028-4320-8d2d-cc6e7524d729">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="09519edf-ad28-4cc3-b5d3-24d56d0e2074">
+      <statement statement-id="ps-6_stmt.a" uuid="0bbdf0b6-33f4-459b-bf47-0aef0c11860d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7a359d9-81cb-434b-a2be-7979b7e4a973">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -3380,8 +3380,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="f5cc9e79-5041-4a1c-bccc-bf12b91a4c4e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="66778509-4bc0-489a-8842-07f6e476e3f2">
+      <statement statement-id="ps-6_stmt.b" uuid="6ed74614-2509-4ef1-8412-0d72b7724797">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a45644f6-3dd6-4597-8ef5-3645ccdb53db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -3389,8 +3389,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="308ce3c8-03f2-4a48-99bf-a7dff7f5361b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8e6ca231-ef86-476b-94f8-2dec951f0a1e">
+      <statement statement-id="ps-6_stmt.c" uuid="ba99c181-39cf-4f21-8687-44efca1db67c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3398,8 +3398,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="cbd66bae-6f51-4aea-b1b0-634f717a79f0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ae991b52-fece-40ff-84ea-d4b0d1a74ea9">
+      <statement statement-id="ps-6_stmt.c.1" uuid="8b6861d8-67c6-4ee8-85fb-940265a98402">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3407,8 +3407,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="b31eeec1-e0f8-4c42-8059-ec7c5401155f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3a29c9ed-4a3e-40cd-a9f4-0d4a595f6b5b">
+      <statement statement-id="ps-6_stmt.c.2" uuid="9b14e8e1-6706-4803-9305-4e39b807b3a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3417,10 +3417,10 @@ access agreements are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fab7c7f2-4253-4e3b-b751-acde9b4a9399" control-id="ps-7">
+    <implemented-requirement uuid="9823674e-6560-4272-9878-ac4ccf6265ff" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="5348e763-bbe5-4427-8a74-16fc825eddfa">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8791972b-5a71-4949-b2eb-487eb5ee2bbc">
+      <statement statement-id="ps-7_stmt.a" uuid="fe812d2b-7c23-4aac-a3ea-551fdeb52599">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5a4573f-c61a-433c-9c26-244b43757c7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -3428,8 +3428,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="f876414f-35d4-4fe8-8c30-92a89bb4944a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fad198b8-6b7e-4569-97c6-630842132f2b">
+      <statement statement-id="ps-7_stmt.b" uuid="760ce5b7-396d-4b48-9d82-4a58a0dadac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3a927d-e9dc-4fae-9fbb-26b02455e8a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -3437,16 +3437,16 @@ the organization are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="ef80b992-baf1-4834-87d9-8550a6a65c4a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="db056dff-3884-45bb-8860-347665df31f3">
+      <statement statement-id="ps-7_stmt.c" uuid="8f063b21-41fd-48f0-bdfd-e9be890bdc0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ee8df1-b100-4388-a721-41e512901fdd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="391ae172-95ca-4d10-9ebc-0f12f9033287">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3dba46d5-d402-4a58-af84-5ab2c78d1dff">
+      <statement statement-id="ps-7_stmt.d" uuid="83a11cc0-7793-4d8a-9e90-76993dc991fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d3a188b-9d80-4557-8ca4-b66bc1df60e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -3457,8 +3457,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="d892ca29-586e-4022-a54e-2f746eef4ddf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9116626e-2cce-453c-ad5c-997497e902ab">
+      <statement statement-id="ps-7_stmt.e" uuid="09ffad36-86ce-4a99-98d9-3b1ae3af8ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12999939-abc7-4215-909a-394cf63184e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of OpenShift configuration.
@@ -3466,10 +3466,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5caea1e-32a8-4a10-b0c0-4cefc42c9c06" control-id="ps-8">
+    <implemented-requirement uuid="aa9d1f60-1c2e-44d5-9f55-7d7de80fd800" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="8cbc5940-cc6b-4b67-b917-20a7d1d2dabc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="34aaa93d-c6a5-4fbf-916f-d4ec410faebb">
+      <statement statement-id="ps-8_stmt.a" uuid="f8d7d00a-923b-46d1-a7e7-331808aa594a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fcb49196-9d3c-418c-9242-85e984011583">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -3477,8 +3477,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="4c14d422-5b94-4f55-a19a-3c98037ec864">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="396bbf7c-6460-4004-bf56-8f6d1c67f2a3">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -3488,10 +3488,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f85b516a-3d25-456e-a5a5-fc3f84944782" control-id="ra-1">
+    <implemented-requirement uuid="3bfbc934-621c-4c62-a8f3-c59fa780cc7c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="235d2ecb-d6e0-41bd-9ee4-05a36f60531c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8a63cdf8-dca2-426f-af21-5c56be9f0804">
+      <statement statement-id="ra-1_stmt.a" uuid="c39e40d4-607f-4cd4-83fa-cecbcd6c3166">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3499,8 +3499,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="188c6901-6d4a-49e7-9799-3c5b09910f7c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5ed014e9-2f49-40b4-b71c-809cae4f9639">
+      <statement statement-id="ra-1_stmt.a.1" uuid="91c6f409-6df9-4a9b-ab2f-42edea1fcffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3508,8 +3508,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="5ea86da1-108a-4d95-882a-70c1e1d393e1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b6610ff7-2044-499f-93a0-2d7d4309c182">
+      <statement statement-id="ra-1_stmt.a.2" uuid="bf7f3604-2e9b-4d59-9a2c-d0d031beadf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3517,8 +3517,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="06c7b1e2-f079-4fe0-b9c3-c99d807e3a6d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="50399c13-f61e-4cff-82ce-12bb7337e154">
+      <statement statement-id="ra-1_stmt.b" uuid="f7c298b7-b302-4c3d-a246-7184dcfddc45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3526,8 +3526,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="499ec80c-9e3e-4c61-8825-e4f985268544">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="632462dc-b503-4a46-bc6b-24d6cb82ff60">
+      <statement statement-id="ra-1_stmt.b.1" uuid="72741310-7fe8-4032-bf53-b655ea2af645">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3535,8 +3535,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="11ab63de-c58e-4023-8e8b-a3dad838bcda">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4c41e2c8-7622-4743-9c33-25469ff90a0f">
+      <statement statement-id="ra-1_stmt.b.2" uuid="5792d319-a3b9-4692-8e69-f2b76bd23587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3545,10 +3545,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4bc0bb3-05ea-42ab-b3f4-61c4244e2676" control-id="ra-2">
+    <implemented-requirement uuid="31deea7c-6add-4a41-8588-b35cd74200e2" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="06eeb4c9-07da-4580-82dd-7783e5576485">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ad8b96cc-22fd-49e9-8647-ed97f708a958">
+      <statement statement-id="ra-2_stmt.a" uuid="e425d113-cb52-4770-a787-dbfb9283baf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b646a97c-a692-4944-81b9-d72d1a1dbfa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -3557,8 +3557,8 @@ guidance, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="9a823307-91d2-428d-9baf-9c9565a99987">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7ba3c1d9-1d25-4482-9ecb-3dd0d215e58d">
+      <statement statement-id="ra-2_stmt.b" uuid="180f1b32-6728-4307-bb8d-e5f3e11616b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e4bd24f-ef83-4d22-ba7f-9e298da40889">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -3567,8 +3567,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="97ff0348-46e3-4bb4-974f-7cc12f6a1973">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="62e94e45-e0bd-4f6e-a2e4-4d87e231ace4">
+      <statement statement-id="ra-2_stmt.c" uuid="6d002ff0-ef05-4c3f-8bc1-22eae07f0f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67fdd016-131f-4800-b183-bf0316142769">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -3578,10 +3578,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ca574d4-0b3e-4af8-bfa1-920b195a917b" control-id="ra-3">
+    <implemented-requirement uuid="4eef68a0-d37e-4d8b-af8c-932640baa277" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="9c40a176-253d-4fc1-80cf-2baa7709237b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="30280c1f-58e7-40be-8214-228b8728160d">
+      <statement statement-id="ra-3_stmt.a" uuid="de140349-fc88-4c48-99d7-6d6e5f160517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc7839ff-252e-4d8d-b76c-ba50c8fab112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -3591,8 +3591,8 @@ transmits, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="be63fbc8-cf97-428b-8f5b-edf6f4f0ee07">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9f8ca3d9-0641-425c-a310-b02b64c7a2c6">
+      <statement statement-id="ra-3_stmt.b" uuid="648e4432-a1ed-4d2d-a44c-72cb255d638f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2898b82-0d1a-43d5-8b7d-6eed5da1f17b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -3600,8 +3600,8 @@ documents, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="8df0c543-64df-4257-873e-b5195cf30a62">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="69f6b151-5b1e-4411-8806-ce6200ee2e48">
+      <statement statement-id="ra-3_stmt.c" uuid="ce4d2f6f-9c07-490a-8ade-90d59226f649">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2b4dcf0-4978-45a4-b3f6-1a5fa0895772">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -3609,8 +3609,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="ac07c997-825d-4fc2-b5d4-a8053f39c1c9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1895fb4a-0ea6-4083-a684-9a5cdd5fdccb">
+      <statement statement-id="ra-3_stmt.d" uuid="f3b2eb0d-d1ca-4e6d-8d42-d52cc870a44c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ca46929-3bb7-41eb-9c71-ef2dcda81be9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -3618,8 +3618,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="65bb7808-eceb-4aa8-9f74-1c337894ea16">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="98a6f533-1114-45ee-9c60-d7748b8afba8">
+      <statement statement-id="ra-3_stmt.e" uuid="afb420a3-1588-43c0-8d92-1d6a19c26a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ebb371-bbba-4b7a-91f2-0ac7bb23304d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -3631,18 +3631,18 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc095c46-1923-4868-a392-d18d086f3c7f" control-id="ra-5">
+    <implemented-requirement uuid="d4d65759-0b51-4008-b230-13f0cad39da3" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="415d8d11-9473-4771-ac2f-42604544e060">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9fc630fb-5033-4653-955f-c93ae54b206c">
+      <statement statement-id="ra-5_stmt.a" uuid="f17a8ec1-9d5d-4580-bbc2-b4353fee950c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="9e3a842b-47cf-4f84-a3d8-2d4cef297425">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="67a20554-b6c9-4685-a076-a13e857c9c99">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3650,16 +3650,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="2c60724c-47f9-4df0-bef5-a44a5a77c05d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="66f01d5c-fc50-4e60-99ad-e124d44e6c7e">
+      <statement statement-id="ra-5_stmt.c" uuid="836b92c2-8835-4d79-926d-81f585abb42d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="b9c20971-188c-47b3-82dc-f1ad6c63bff3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8062b991-072e-4813-b573-56901cbfd47c">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3667,8 +3667,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="a9faeafa-3e94-4d4b-86c2-7afaa3739921">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c03c948d-fb23-45e9-8009-34a26031835e">
+      <statement statement-id="ra-5_stmt.e" uuid="37953ae8-a61c-4f2d-ba69-7c11b415b703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bd9f1ee-7804-4aa2-b15e-03a253025368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -3680,10 +3680,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5eaa7994-bf2a-47dd-8349-7abc10815f33" control-id="sa-1">
+    <implemented-requirement uuid="46175d8c-c262-4815-a381-7c1f4872a44a" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="8c670692-485f-4dbb-ad8d-0347340a649d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c8f47dea-5217-4220-8c3f-7bfa91815b38">
+      <statement statement-id="sa-1_stmt.a" uuid="0c2fb97c-2841-4c9c-9c64-3a30cfa2c885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3692,8 +3692,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="894fcdbc-e700-4537-a8c5-1ec65944df66">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="043cbb8f-8b59-4ad3-9b71-04a68d1b7e0a">
+      <statement statement-id="sa-1_stmt.a.1" uuid="a7bad430-0d6e-4e8e-9df8-113430accf6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3702,8 +3702,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="e6bb4b1e-c219-41b0-8daf-5a4d6d607187">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="943c0c00-2387-443c-b243-d84023d336e4">
+      <statement statement-id="sa-1_stmt.a.2" uuid="e946d4ac-cf58-49aa-b1ce-1f1f4efa6a1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3712,8 +3712,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="8f96180c-f188-4cb1-945d-7faf09661ae5">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fef35776-c9eb-465f-aad0-697c861ce797">
+      <statement statement-id="sa-1_stmt.b" uuid="93ca6950-0e3f-44a1-805e-a64737d09b08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3721,8 +3721,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="aca97b4e-723e-4706-9e87-3de700a1d63f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e053c0ec-2659-4322-8358-907cdcc98b26">
+      <statement statement-id="sa-1_stmt.b.1" uuid="bd4f2cb4-847f-4f4c-931c-948b2e7476aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3730,8 +3730,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="26105a4b-b67f-4d2d-83aa-02edbf2e08e6">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a76aa17d-2e43-46b9-8702-01f5c41a3559">
+      <statement statement-id="sa-1_stmt.b.2" uuid="826cee26-2ebb-44a5-8a0a-26e4fe4d1a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3740,10 +3740,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5f5302e-ff05-4be6-ac63-dfbe14b07abf" control-id="sa-2">
+    <implemented-requirement uuid="880a9424-3bc8-47b0-8d90-7a7cc8f08023" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="f8642b56-b357-4179-b2b3-3c689334721b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="32740996-bdb6-446e-be99-9a7d3daddea9">
+      <statement statement-id="sa-2_stmt.a" uuid="fc47bc65-d051-44cf-b98a-5d9a0356f474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dcf71d-eac7-4ce3-af35-7b3e574997c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -3752,8 +3752,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="febb5830-c3bf-4513-bbb8-e1afec1d69e7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="44fc772c-2cb9-4e88-8baf-c2421ea28451">
+      <statement statement-id="sa-2_stmt.b" uuid="3685259c-66b4-470c-9da0-6fad099d6e5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c829fb17-abe4-457a-8451-75ad86d36f38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -3763,8 +3763,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="0e93f586-d5f9-4a10-a7cd-45ee61f062c3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e6e299e7-be90-4411-942a-a8d1e81f79ca">
+      <statement statement-id="sa-2_stmt.c" uuid="2b7c4ef2-c540-4683-a633-795c99f687b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f21e997-d0b1-4d3f-abab-e7b6b5743832">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -3773,10 +3773,10 @@ documentation are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35dccd05-c0bb-4f01-be91-022a82c3848f" control-id="sa-3">
+    <implemented-requirement uuid="4b3cd903-81fc-4a32-9832-6b967acb18c8" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="061a1c63-91a4-4254-a4d3-b0f6686454eb">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fef3eab8-ed9f-43d4-ad89-345286368edc">
+      <statement statement-id="sa-3_stmt.a" uuid="9a15d6de-18c2-47f2-9622-c7d39deb8f8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a4ae5ef-fcf4-41e7-a41b-d8d300d1c57b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -3785,8 +3785,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="05712d9f-50cf-41c5-aa64-8c20a4f9f5d6">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e6644f72-5947-4558-a1b3-dbaaf4342ef4">
+      <statement statement-id="sa-3_stmt.b" uuid="1a183eb7-9f87-49da-8f1b-ba580be9bdd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd84749-931b-4fca-8d62-9f7ea3cdd3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -3794,8 +3794,8 @@ life cycle are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="7f1caab1-d69a-45fb-9e04-033080c7e2d3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fd61e10e-ab5c-4b18-85e1-b79449b6295b">
+      <statement statement-id="sa-3_stmt.c" uuid="030a665c-8a6f-4f0e-9f26-3521e733f7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ed7cb61-e7fb-4e18-b55d-f4f171158807">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -3803,8 +3803,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="625dac41-9447-4456-b198-f0f1ab161a36">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2bfafd0c-81f0-45f4-9dea-44341c2eda0a">
+      <statement statement-id="sa-3_stmt.d" uuid="5be291c8-e453-4828-9224-37814c38ccd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7461713-8ea2-4840-ad52-c9e877e7f51e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -3813,10 +3813,10 @@ activities are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61720043-c342-4b75-9028-99fe28b6378e" control-id="sa-4">
+    <implemented-requirement uuid="4c425b9b-a871-4e71-9d35-ab1990789375" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="19a04bb5-309b-4a67-9d6e-37a6d0d75f73">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="640e5e48-301a-4897-b60f-e8dcb00da1d2">
+      <statement statement-id="sa-4_stmt.a" uuid="f9dc2050-658f-4d3c-ab5a-11221a03656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdcf642f-0ad8-4f50-94b5-cc8b29f9d090">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -3824,8 +3824,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="43fc6016-dd83-4539-873b-5ea8c96293b7">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4ad8dc9e-4e4b-4bdb-9ffe-aef400d6aa00">
+      <statement statement-id="sa-4_stmt.b" uuid="1444637a-9f7b-41f2-bfcb-9e5f8b359517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0fba4bd-1c76-40ec-9a33-1ed138551a80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -3833,8 +3833,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="ac94c0dd-ec97-4b37-b76d-6a3b09e95e9d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="24dd4d56-c722-4f61-b1b8-65148babd390">
+      <statement statement-id="sa-4_stmt.c" uuid="5046dcd6-30b8-49a6-8774-93e0ffef45c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf529bd-91c3-474e-b0c6-777fcc5cffbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -3842,8 +3842,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="0117e138-9dc7-427a-9b73-2ce53a802058">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="530a54f1-628d-4f12-a436-ec40f4108885">
+      <statement statement-id="sa-4_stmt.d" uuid="a704a7c4-133e-4b37-8c2d-ee72fe0d0247">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="733da578-3bab-42b0-96bf-5ed6c85d832b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -3851,8 +3851,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="68c55ca4-d155-4f2b-877d-7fe7544ceb02">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="44ed2516-d440-4730-93c3-440610369219">
+      <statement statement-id="sa-4_stmt.e" uuid="5a1d9736-3556-40c8-9120-303349cfc92b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a079f5b3-49e3-460d-8778-5098f04705ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -3860,8 +3860,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="5d62f99e-e4aa-4764-945a-bb150a066cca">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0507a1d0-26ab-4e4b-bdf2-3bc8b7507eeb">
+      <statement statement-id="sa-4_stmt.f" uuid="41f8de4b-2c62-4d99-ab89-1f0303738385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ce208fb-60c3-47f5-855e-9fc2e5bd0db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -3870,8 +3870,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="d18fb224-5092-4b63-929e-6c59acf4cdce">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4db52a67-5781-4148-b6e1-cb866f5391e4">
+      <statement statement-id="sa-4_stmt.g" uuid="6c8fb61b-8dc6-4391-a608-d0941b0d093f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66030e0c-d706-4d48-a588-f0f4cbc62d79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of OpenShift
@@ -3880,10 +3880,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea03658a-0681-4d09-a381-7f348de00c3c" control-id="sa-5">
+    <implemented-requirement uuid="f45b1f55-9edb-45f4-85ed-b1bbeac70efb" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="37705f06-3709-4049-ba4c-6d44b3ac8ace">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ede66901-c1b8-4b4b-aa3a-5cc3488bd6ef">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -3892,8 +3892,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="911c2962-5cb1-44d5-b418-49f29c8c07ab">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5cd0e04f-61c8-4324-85f2-2f96bdf97e15">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -3902,8 +3902,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="df252111-e805-429b-9d6f-998825f304ca">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="275f6018-16cb-42a7-a613-1a86bcf89fe3">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -3912,8 +3912,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="84d9f8fd-db17-4817-9901-9f92cdcdd78e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1f9e3b04-080b-42eb-a18a-5fac0a4ac5eb">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -3922,8 +3922,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="a373a531-2fe9-4fac-b6b3-e01c6145943c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="d22dad0c-b748-44fb-9d33-7fc1767d92c1">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -3932,8 +3932,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="ae577557-1cea-45fb-a781-068ef47c3804">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="824ab182-6414-4b3e-ae6e-431fe9be4427">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -3942,8 +3942,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="6b38a411-5a8d-43b5-979c-1d9a3d3b376a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="58279fa6-1ac8-426f-a057-89aed9dafbde">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -3952,59 +3952,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="15212895-98cc-4a53-a83b-185b538709e6">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="70ac9086-3155-4181-92e5-342776be3af3">
+      <statement statement-id="sa-5_stmt.b.3" uuid="fb21bfac-d62d-4932-a2ab-7c929fbeb2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="a82dcb79-200b-405d-8419-f4ec5a9c9e90">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="39d75d25-e0fb-4790-9665-834587895803">
+      <statement statement-id="sa-5_stmt.c" uuid="fee19988-cd1f-4ba4-b170-f6bb31cdc115">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="851cf852-6040-45c7-8c2e-d56df8885f10">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a59d6d1b-ac96-475b-8153-17acd8d9b475">
+      <statement statement-id="sa-5_stmt.d" uuid="c8689aa5-cc05-4fb0-bcf0-0e767c9df94f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="70b9d6b1-d2da-4073-a44f-f27b780e0071">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="2437d6c8-e67b-4d85-9847-7b56ec502196">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to OpenShift configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8b805fda-7dff-4e11-807c-c20055634abd" control-id="sa-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="0f669228-79b3-4d9d-9786-69c49388bbbd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bad64714-2f70-4f0b-a4e2-6b004072064b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to OpenShift configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="42870734-672f-4984-8e3e-2160655e243d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="99223152-3cc2-46dc-8c34-90a8d636840e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to OpenShift configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="e35b71e3-b0c8-4aa1-9b2c-866ee33474a3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0a247e57-1afc-4cae-a9d5-aad925eab7be">
+      <statement statement-id="sa-5_stmt.e" uuid="a19603a4-be8a-47b7-b182-7357f7f0bcd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4012,18 +3985,45 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ee6693c-d851-4afa-b570-76b2f4af33c4" control-id="sc-1">
+    <implemented-requirement uuid="4f3d3760-6a96-4488-9064-b66323171ff5" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="f7a2e705-0a8f-469e-8ada-911b4299306d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="21110ee3-b7a2-4098-bfaa-71106e589f93">
+      <statement statement-id="sa-9_stmt.a" uuid="790594b4-8dc9-4e6d-a7be-8a4f821d60dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to OpenShift configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.b" uuid="2fdee7a6-17ac-4f3c-8234-e51975aa8bfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to OpenShift configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.c" uuid="f91bbfe1-2590-4996-bbf3-5a931f802ecf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to OpenShift configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="6f1144bd-a44c-4b04-997c-b59d54a710d2" control-id="sc-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="sc-1_stmt.a" uuid="1fa652f8-6db2-4210-a8eb-f51d9dc94c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="27a5742b-6748-4e16-89df-211fa915983c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="18642d0e-3893-4ec5-ad69-918b0dd7f6fc">
+      <statement statement-id="sc-1_stmt.b" uuid="ab7e745f-41f6-47a2-a535-600910be8e7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4031,10 +4031,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a71a4730-ac61-4ee0-9150-1e041326f330" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="bdfaeedd-a0ce-4af1-8615-d9e2b31de954">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="021e5703-be3c-4795-b1d5-ffded824eef2">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4044,10 +4044,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d0b6835-7178-4b19-93c3-79ce551784af" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="913f4f1b-aa7c-4040-b3ae-047cfd0ab497">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4621e6ed-30a8-4b7b-a28b-740038a0582f">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4056,8 +4056,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="050c608b-975e-4f8f-b582-cc8893ebdfa8">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="65743bc9-3177-431c-a101-4b4f68dc7e3d">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4066,8 +4066,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="81f69e65-8949-49e9-a1dd-3fc91e9c9bee">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="4be18554-73fd-4413-8994-a6dee50eeda9">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4077,10 +4077,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff498e4f-4da6-4024-8db3-1b7b5904d971" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="3dc4a987-f06e-4cdb-ba0f-6a9862ea1faf">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="067fe1cc-9c91-48ab-8dc0-8a1f7c410c08">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4090,10 +4090,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6978163a-aef5-4318-adac-0495412c6bd4" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="d856d7f5-663f-439e-8ab1-d4a24690175d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="787fee21-2dfa-44e7-8158-ad33ed7428a2">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4103,10 +4103,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="383328ff-bb0b-444a-a1e1-b5610674cf5f" control-id="sc-15">
+    <implemented-requirement uuid="33b5b086-7214-4783-a0c5-ba185fda8e71" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="6f72cf7c-28d5-4d41-b24e-bd69be8d9e5b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1fc7e54a-9386-45a4-9acb-fb2646aa6451">
+      <statement statement-id="sc-15_stmt.a" uuid="22e07405-dd19-4fe8-a698-f29ef5735dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4115,8 +4115,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="2b061dc5-ea29-4038-9927-0ede17448369">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9539249b-8ce9-464d-81a8-4d6c8d42345e">
+      <statement statement-id="sc-15_stmt.b" uuid="ca736a8c-d2fb-4c10-8a69-03137dea9b7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4126,10 +4126,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b2abff5-75fb-4155-823f-1008e4bce137" control-id="sc-20">
+    <implemented-requirement uuid="e8aba7c2-acb4-4654-b1d5-e600a651d4c3" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="0a8f0bc7-e61a-41d1-976a-b3fdb66a42ab">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ff081b97-90ff-4152-b53b-b23925b9176e">
+      <statement statement-id="sc-20_stmt.a" uuid="a438c5ea-e94c-44e1-9c84-4d29a630732b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60a17e-515b-4a94-821a-de75ff70ced1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -4144,8 +4144,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="341da2d3-451c-47af-8938-c5b7d0dd0efc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="f7bc5d18-6a5e-4b77-a0e6-13896f4f258e">
+      <statement statement-id="sc-20_stmt.b" uuid="3b9bf6aa-8da0-4050-bb86-c3357e8d9f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76baf97e-0a1f-4b12-bb26-a59e03124332">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -4161,10 +4161,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="948bdc21-804b-46cb-8d33-b3a293fd5059" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="2bf0bd41-9faf-4a29-ae07-64561353697b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1a25201b-f141-4aea-b37a-0addfcad65a3">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4174,10 +4174,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="402b376d-4db6-4b2b-912e-7fac3ff3527c" control-id="sc-22">
+    <implemented-requirement uuid="5fee0dd7-b1f6-4891-98bd-848c114c8822" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="917c1d8d-2bc2-4f4b-9a02-78c7a0718940">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="78fcf871-1fa4-4c40-8123-ebb83dd74348">
+      <statement statement-id="sc-22_stmt" uuid="81094d0d-abb6-44fe-b96d-302346ffb9a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec8d8758-4010-4e53-bf8f-07d498fe1433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for ensuring
 services are fault-tolerant and implement internal/external role
@@ -4191,60 +4191,60 @@ https://issues.redhat.com/browse/CMP-409
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d15ba0c8-679f-4433-a030-71184740cf6f" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="259189c5-5c33-464c-9c72-620b01018711">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="edfb95e3-9ca2-41ca-98bc-a085244e1365">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88341e63-ae1d-447c-87d0-62a37c61804a" control-id="si-1">
+    <implemented-requirement uuid="0e8f74e1-33d5-490e-8ac7-915f29de22fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="0170f47c-a6ee-4dd2-8a44-64ea9568222d">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b4747df2-50f8-4bf0-89c3-6710a6f4c4c1">
+      <statement statement-id="si-1_stmt.a" uuid="89bb11fc-5456-4431-b5f0-9f781b3a5730">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="a616da48-9aa9-4120-99aa-ab4a93609f56">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="aa3932a6-ca5c-4f52-9781-de2e065cee65">
+      <statement statement-id="si-1_stmt.a.1" uuid="11d47f68-9baa-4b99-8e12-9ea77692cd34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="62b78af0-6940-4351-8d78-dfb09f307c12">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="060cb21d-69aa-4d3c-8fd5-a7ac8c1c4ef7">
+      <statement statement-id="si-1_stmt.a.2" uuid="41bb516d-57c2-400a-aa40-9bdbda591302">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="8fd54bab-2cdb-4937-b8de-acc3f46d53b3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="982e9ef5-6a90-44b0-8e11-7cba345dbff7">
+      <statement statement-id="si-1_stmt.b" uuid="448424c2-d63d-47a9-820c-f87eb4d1d61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="a8df1fb1-9714-43f0-a864-3d1b35d6b26e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b1a08c78-dff7-4b61-924a-863e3e356864">
+      <statement statement-id="si-1_stmt.b.1" uuid="15a10a6e-2916-42cc-a2b7-02aa6cb1c31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="2bd9aeaa-95d7-4edc-a96c-4096c77e5c97">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="fe39523d-bd24-428e-87b9-1bf64c8eca9c">
+      <statement statement-id="si-1_stmt.b.2" uuid="1cedc5bd-d780-421e-af4f-0cb3453299cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4252,10 +4252,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3481b46-421d-44d4-8984-4ef9d5fd2c9b" control-id="si-2">
+    <implemented-requirement uuid="acd2c7f7-78db-433e-b76e-fb6644fa7a8c" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="f34cf9ac-5458-4eb6-80dd-3f69aa8d2597">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="9c1447ed-bcdd-43c1-b795-fa07d6a86174">
+      <statement statement-id="si-2_stmt.a" uuid="150a4ab4-9760-4f58-8c29-f44da3d0a040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3fc37ef-182c-4e56-bfb4-7aa0866c8659">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4265,8 +4265,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="7ea5eb63-639a-410a-85a9-8f99739ac02f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0d1837d4-ce27-46b3-94f7-546277415276">
+      <statement statement-id="si-2_stmt.b" uuid="75906d70-3ce6-45e4-b658-5eb304210d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ced799b7-8fcf-4128-ada3-51e5a2540b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -4276,16 +4276,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="aff8dd41-2bdb-42b1-93e4-7d2ea234c9bd">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cb07dae7-32ae-4a45-b415-a28846399255">
+      <statement statement-id="si-2_stmt.c" uuid="2aca2ec6-b658-4a2a-9869-7a9cd31e5aed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="e86e8201-3893-4ccb-acd6-7571e0d7befc">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="7ca4249a-2dcb-408c-adc6-86be4483fe49">
+      <statement statement-id="si-2_stmt.d" uuid="eb56e9a2-e774-4c5f-b5fe-252e51a2ffe2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4293,10 +4293,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72bf9121-0340-4f47-a872-1783a88d110c" control-id="si-3">
+    <implemented-requirement uuid="d03e35c4-20d8-4401-8054-29203a44f102" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="c17d7cc7-cf08-4840-98b3-521b62bf8111">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3448a126-1386-4166-9088-782771486189">
+      <statement statement-id="si-3_stmt.a" uuid="cb35531b-7b7e-4234-a016-f42f9495dedf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8feb56f5-7538-4f7d-9600-abf7be214a63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4308,8 +4308,8 @@ the use of third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="d4b6928d-695b-4f7e-9a9c-4009cbf21cd9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="bbf9614a-3ec1-4500-b3ab-2a2b2f9b78a7">
+      <statement statement-id="si-3_stmt.b" uuid="1f80555f-bc6f-4222-a1b9-328f6e963a2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40235cf0-b670-42af-9cce-e65e5d66994b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -4318,16 +4318,16 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="bd4cf568-9605-4470-80ae-9d25e92738b0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="cf8c872d-d292-43e9-afbe-3a4b8376a9fb">
+      <statement statement-id="si-3_stmt.c" uuid="93198438-e9d0-4c8c-85f9-69a2fe14725e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62b6ff60-503b-43b8-b8ce-d55f1b66f3a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="04b76076-30bf-44e0-acd6-a46344ff0ed2">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0d4efea5-4047-4d39-a955-7cf5ba168e47">
+      <statement statement-id="si-3_stmt.c.1" uuid="c8b61a4d-ef1e-4312-99fd-46a971c468ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2fe1168-6387-408f-a6ff-ffad317babd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -4337,8 +4337,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="c00bab3f-bb8e-4339-b643-d861ab16ed2f">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8985abb1-76c8-4720-9c01-e2c845a15876">
+      <statement statement-id="si-3_stmt.c.2" uuid="dbbf2830-fcb7-43e0-a25f-462b52458e6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="843974a3-151a-4498-b7ce-bc4b79db5ba8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -4346,8 +4346,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="632482eb-135b-4caa-9fa1-0083be6c4087">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a18bfb04-4ede-4ec9-91b6-d63b5f1dfe88">
+      <statement statement-id="si-3_stmt.d" uuid="756f51fa-f7b8-4e68-8136-c111a2527e73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38eadf00-e46c-4362-bef2-72cbd283d26b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -4356,26 +4356,26 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebf12e5d-e723-4088-b422-b7f05fe8082b" control-id="si-4">
+    <implemented-requirement uuid="25c959c5-8a92-4f38-a617-7cae7084371a" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="2a0e6833-3a3d-4346-ac82-f1469db2ec99">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ea29b6d1-2cbe-4a8f-aa95-dfce70b29bf0">
+      <statement statement-id="si-4_stmt.a" uuid="f7f8ef33-a9ed-4edb-bb56-258b61657b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="105b2758-0dc8-453a-a2d7-1bc441bc521b">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="0f6164a4-2a96-486a-8d2d-ccb08d5b4ded">
+      <statement statement-id="si-4_stmt.a.1" uuid="5da408eb-abe2-4c82-b6c7-92a1a4a90cb0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="fb71cc49-9fcc-423c-a359-9e93d743d019">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="8aea8e44-50a2-480f-b67f-2fb0c1d7e3e9">
+      <statement statement-id="si-4_stmt.a.2" uuid="1397afde-4529-4488-9431-5793335b0f1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37ed665d-3ebe-4bfd-9e6f-2ef07d234d14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of OpenShift configuration.
@@ -4383,8 +4383,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="0f9c9841-0862-4501-91ab-9810ed64bd44">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="e53c9e28-f9b5-4a9f-9016-6e112948bc7d">
+      <statement statement-id="si-4_stmt.b" uuid="927dcfd6-d65d-44cb-ae8a-0262022e472e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8643ab34-5004-4e6f-8d27-7b6cf51c3d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -4392,16 +4392,16 @@ of OpenShift configuration. Functionality to meet this control can be provided b
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="efeac73c-67d0-4253-81dd-769c86c313e1">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="b5bbb4fe-bba4-4dff-8dfc-123ec879778e">
+      <statement statement-id="si-4_stmt.c" uuid="3b2f5ae7-8a1c-4e5a-976e-98a5c25e7920">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12e67e7e-f874-4a36-b1ff-cdcf0b59eb76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of OpenShift configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="5d76cf3c-252b-4e05-8e4a-010e9f12970c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1793a44a-d508-4613-ab77-ff0cd505696b">
+      <statement statement-id="si-4_stmt.c.1" uuid="c7b17e51-9eb3-4bde-946a-5caae90737ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955c6e53-d7bb-4843-bf72-663b90900ff1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of OpenShift configuration.
@@ -4409,8 +4409,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="173e2c5e-73cc-4cd4-a27f-14c79fb95af3">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3588b785-94df-4f2b-a7c6-1c46eb0faf50">
+      <statement statement-id="si-4_stmt.c.2" uuid="993e77dd-845f-42e4-998b-bba17a7296b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dac05c6e-105b-45b6-98b5-fb90db5d1d65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of OpenShift configuration.
@@ -4418,8 +4418,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="6e63e22f-ae66-4469-80a3-0ae9aafd0d10">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="c0a1478f-5bf6-4783-b91f-23226f6cc03e">
+      <statement statement-id="si-4_stmt.d" uuid="394a954f-2bd5-4ae9-8746-3fbf6c212a1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcd1844-0d69-4003-85e3-9e4ca79094f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of OpenShift configuration.
@@ -4427,24 +4427,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="c55c102a-2642-4fca-b986-95d418e02c90">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="1c953256-7eee-4619-b375-f77221f69c4b">
+      <statement statement-id="si-4_stmt.e" uuid="d65da8b5-977c-4240-80b8-a8313ff5d93d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="2c153d39-6fec-44c7-89ac-52f099d2fcb9">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="ad552eb7-34b7-4409-9d97-585746e60bf1">
+      <statement statement-id="si-4_stmt.f" uuid="294b5994-af2e-48bf-b955-944a37af62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="d33788d8-fd54-49ff-8175-b2b6cf7181f0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="5ee5b869-478d-4aad-a550-7d8c084b760d">
+      <statement statement-id="si-4_stmt.g" uuid="e2f86efe-2dce-4ca9-b769-a2abe286e1ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4452,10 +4452,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c622ef35-62bd-4b68-b7bb-0b2e2539795d" control-id="si-5">
+    <implemented-requirement uuid="8ec27eb7-4619-44ff-822a-10bd87aac4bc" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="4401a3f2-8d9f-43a8-8452-8b6e12810281">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="a6185b2f-2814-49b5-836a-9dab53c99197">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -4464,8 +4464,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="d4725e4a-6aea-479f-8342-86baf0baebb0">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="02b97948-3adf-46c8-8c4f-6a6543533bc3">
+      <statement statement-id="si-5_stmt.b" uuid="2e01a8dc-26a1-49f5-bbd9-392a1a482ed6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e219191d-4e17-405b-b8ea-02e60bccd5ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -4478,8 +4478,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="b6c27b81-2f48-46b4-ac5d-0a860f87ae1c">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="22646ddb-972a-4fc5-9442-28e9d9113f59">
+      <statement statement-id="si-5_stmt.c" uuid="b95cab0b-0eb3-47e7-9811-d137e81fcaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d1ce87e-ebc5-4d36-a0cc-af9f4a4e7285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -4488,8 +4488,8 @@ procedures/policies outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="08f30f87-8be6-4cb0-b30c-9ccad5fc5f64">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="3f5136b9-7426-4b76-9421-bf447494e1c0">
+      <statement statement-id="si-5_stmt.d" uuid="b2a66012-d185-46c1-b29d-7bacf1416509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e91ce37-4368-4594-a977-44aba9a99ac6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -4498,10 +4498,10 @@ procedures/policies outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fdc6281-82c0-4deb-9b46-ce4bac5dd8fa" control-id="si-12">
+    <implemented-requirement uuid="b1a1d601-8791-4d0c-8bbb-027ee58dcb42" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="3773c621-1fea-4468-b4dc-98b0d3690e4e">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="32b52155-4597-4f70-96e5-6bf8c4fe1d5e">
+      <statement statement-id="si-12_stmt" uuid="d5b07424-e2c1-4d00-9ec9-19ae396fdf63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b53f03e2-1235-4a29-ba26-5b7ebc6674a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -4515,10 +4515,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48750a9e-a96a-4aac-abc5-1cc9c4e456ea" control-id="si-16">
+    <implemented-requirement uuid="07b05c21-ca99-4770-897b-7afb45267bc6" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="81e45fe7-2f14-4789-b943-8abb6fe0302a">
-        <by-component component-uuid="171ee010-d057-4850-a539-decb5a4b40f5" uuid="878b1752-8a6f-4f77-b0fa-552d671f0a17">
+      <statement statement-id="si-16_stmt" uuid="82384d89-06fa-413f-b7bf-575a6a296515">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a0cbc1f-3514-414b-90d4-49d2a3e0eebe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-container-platform-4-fedramp-Moderate.xml
+++ b/xml/openshift-container-platform-4-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b76b57ce-a1c4-4d20-ad35-f525e9f11fc9">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b3ba0b20-ff6f-452f-a7ce-27003893cb7c">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.81+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.37+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="d6f9474c-2043-46ea-a6d5-962d9469d60a">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="ac28a952-b554-40c6-85cd-93292b142f78" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="8b859f2a-c313-4cea-9c98-483b8f590f17" control-id="ac-1">
+    <implemented-requirement uuid="e0198023-c291-420f-9859-85e195c4faa9" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="bef0bc86-47b8-4054-992d-5a11289d8c45">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a7eacbf1-6fdf-464e-8ae3-3201d1e723a2">
+      <statement statement-id="ac-1_stmt.a" uuid="2971b853-d916-4401-8ca5-c8fa0924d237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd3fa9f6-4df1-44c0-b3fa-59a4ce506b87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="4e2419de-cac7-4320-82aa-b3a9e0db0f7f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f358b948-2efe-4870-a959-70c06323fd72">
+      <statement statement-id="ac-1_stmt.b" uuid="ed757c19-aed5-476e-842a-a09178430b8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b47f666e-0fe4-4bf8-808a-5666b837c0d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c90c3701-31c4-4768-8e7e-a890703a8ae0" control-id="ac-2">
+    <implemented-requirement uuid="2c5581cf-ef35-49a4-9a0a-9debda8e77d1" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="59861ba5-7d12-4daf-9381-2ed6b10e819f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b669bccc-c1fd-4860-9723-a29aa956ab3a">
+      <statement statement-id="ac-2_stmt.a" uuid="fdc1d0c5-014f-4605-ab9e-babf06ad410a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ad7a627-339a-44a7-a584-ee8b8d28daf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="cceb023c-770e-406f-91ea-35b00e8e8879">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="93f357e2-ea65-4f11-b450-91a58c2674c8">
+      <statement statement-id="ac-2_stmt.b" uuid="3bab5523-04da-4a6f-a9a9-df415bf5d095">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61f14919-d2bc-431e-82da-3134faaa614b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="6a6c4e5c-2da8-41c2-b111-124973a713a8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="79bee402-96da-420b-b561-57ed900438fe">
+      <statement statement-id="ac-2_stmt.c" uuid="893b989d-5db1-4129-8350-081bed59bba2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4956345-f525-4925-bf7b-4908b5097170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="8883c29c-5d00-4558-9aeb-c2af66c88806">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cfce0046-b9f3-4115-9d5c-518ce7188089">
+      <statement statement-id="ac-2_stmt.d" uuid="4c9b242e-3572-40d2-9a44-0b1219ea99e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3850f91d-0960-42bf-9630-d79d395190f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="db4726f6-4c74-4410-a3d2-f96c1c4be60d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="637ac7c9-ee3f-4366-9232-2df52978051c">
+      <statement statement-id="ac-2_stmt.e" uuid="969844e3-6d0f-49f6-98c1-391254329da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07456e22-883f-406c-84f4-b2f5e919cf08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="e513a97b-9ea6-4bd3-a315-30fc84a6491f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="28ab2bb4-74de-4c4e-89f7-749102839a94">
+      <statement statement-id="ac-2_stmt.f" uuid="832a1208-b86c-45e9-9f3f-b9bd4af97c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e347cefd-92b9-4f50-8968-cff93aaa856d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="ea1e9dbe-29c9-4e7d-bbf3-b1d2a6f25d48">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="738b770f-730b-4343-8cfe-8bb1e9978328">
+      <statement statement-id="ac-2_stmt.g" uuid="e80a0cfa-b390-46b1-b9cb-8ea18cbc29fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31bfd818-2e8b-4eed-83b3-cd0eea10bfe8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="2a77e84e-7bc3-44a0-b070-aedb613cf87e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7964da81-6b8e-4255-942e-ae62472e79c7">
+      <statement statement-id="ac-2_stmt.h" uuid="309b0bbd-c4aa-49a7-8bf4-1e6be2c3cfda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e691baac-1b31-4922-9a1b-6c3f31555beb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="d481e21c-7e9e-4aa5-ae1d-2a6a61b4c210">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6e2f4f2b-fdd5-4b2d-ab1d-b63713c0e69b">
+      <statement statement-id="ac-2_stmt.i" uuid="f7ea5464-e9d0-4cfa-9fe0-56c99573928c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4190dc05-462b-44fd-a76e-9a018866b323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="b356cc72-8a9b-4b86-b3e4-39a6fc498ef6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1fad2c6c-1991-4647-83e4-1d40ca6ef70b">
+      <statement statement-id="ac-2_stmt.j" uuid="8bb6d26d-039f-4fe5-96e2-7fdce209c1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8ee0649-d86f-421d-a490-1e5d81031674">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="4017604f-b91a-4933-83ed-5f0b4f9fb32a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="55cfdbd6-28c6-4d22-84af-69bc3445a6e3">
+      <statement statement-id="ac-2_stmt.k" uuid="23489861-614e-405e-b5c2-17662d7768c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e35086b3-4628-4ffd-9fb4-439a4ba21532">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53050a67-d301-4312-b0bb-4d57a816a930" control-id="ac-2.1">
+    <implemented-requirement uuid="71608a8a-d089-4954-b51b-2221f505ec2c" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="44dbd595-f197-40d1-9ac1-53a6594e7772">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="01726ab7-5c45-4c87-ad76-29102384a0d8">
+      <statement statement-id="ac-2.1_stmt" uuid="d810afaf-6285-4d35-b93b-dfaaee5a334a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c1564796-d940-43cf-a045-b462f51cee98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift components of the system support automated
 management through monitoring of accounts and system
@@ -601,10 +601,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cf0a156-24d2-4627-a688-9978d5bd3249" control-id="ac-2.2">
+    <implemented-requirement uuid="15663a5f-9548-43f5-90fa-9a9ee651356c" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="7d6b9eee-3ccf-496c-8e19-fce16471543d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9157628b-4ac1-4217-a387-0fb5c534e559">
+      <statement statement-id="ac-2.2_stmt" uuid="eb582557-e0f9-48af-9d91-00a0842824b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91d5bc1e-6bdc-4f6d-9322-c41a68573f5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the capability to create
 guest/anonymous accounts or temporary accounts. Any
@@ -616,10 +616,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d02bc3d-4958-4439-8ae7-032c1b510f11" control-id="ac-2.3">
+    <implemented-requirement uuid="e20a5a38-dec4-4fec-b76f-cf4e06a8ba5f" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="34e32c55-1c60-4391-982d-b31ee73d5896">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2b652002-801d-41ae-bb2d-ac6451dfb502">
+      <statement statement-id="ac-2.3_stmt" uuid="721acfa4-a4e8-4359-8975-ef95f0549b8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81b3fad1-f504-4d3a-9cf6-a871edafda17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the ability to automatically
 disable user accounts. Automatic disabling of these
@@ -631,10 +631,10 @@ To configure an IdP, see https://docs.openshift.com/container-platform/latest/au
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc0fee47-c0d7-4ff2-afdf-58cf9c06fdf4" control-id="ac-2.4">
+    <implemented-requirement uuid="ab1bfdb4-b28e-473f-8f0e-7fca979a658e" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="1c2b3866-f6d6-4009-b4c7-f2ce282bd7e2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="121c5279-e3bd-4a5e-b1d4-863de3f061fb">
+      <statement statement-id="ac-2.4_stmt" uuid="ff9934b1-570a-4ace-9514-3a96da164797">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6937e246-fb33-4df9-9dc6-e93b469a1250">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To meet FISMA requirements, OpenShift must be configured
 to use centralized authentication (e.g. LDAP, Red Hat IdM,
@@ -647,10 +647,10 @@ service.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f7e7f96-80ec-4afc-b900-b427656f5ba6" control-id="ac-2.5">
+    <implemented-requirement uuid="2e0d4e7a-3946-4faf-bf32-e7b97b978e7b" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="bcf0dcf6-3994-4ff3-ad4a-7dd7c3ec8dfa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c0ff986e-4aa3-4c52-b47c-b234fc48cfe0">
+      <statement statement-id="ac-2.5_stmt" uuid="b0d83af7-15be-479a-bf3d-c1ad429b569c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6cd6beeb-9176-4ef1-9609-6a0442dc4046">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2 (5) is planned. Engineering
 progress can be tracked via:
@@ -659,10 +659,10 @@ https://issues.redhat.com/browse/CMP-82</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34e054c3-6193-4dc0-b12b-9cbc5a774560" control-id="ac-2.7">
+    <implemented-requirement uuid="215d4c67-0389-4250-8a9d-94e5768dc97c" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="c1504598-6363-430a-9cbc-501b53cb3b87">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5a3d3e36-9900-4d95-8340-9201b6f4076e">
+      <statement statement-id="ac-2.7_stmt.a" uuid="cb087f11-2c7b-4215-9494-6f2d577fbafa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21350fe2-0e01-4b99-894d-c42aa132f9d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -686,35 +686,35 @@ More information for SCC can be viewed at:
 https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="1d5da5aa-0b62-4a2a-a174-31d75cdf298b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c0d62c27-f020-42fe-82a9-2176a0d51863">
+      <statement statement-id="ac-2.7_stmt.b" uuid="164abe78-f231-4e48-93d2-89c799431201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d55ad9bb-4055-47a7-bffa-a324310cc8a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="3a2a74a5-256f-44f6-a257-9df54130882a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="52d808fb-c0e5-44b8-9cbf-3b442085b405">
+      <statement statement-id="ac-2.7_stmt.c" uuid="49cd45ff-f358-431d-81f6-a3a6729aae6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c2073a3-6634-4c7a-be8d-8272d954bdba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83ee35fc-92c7-41e2-bf4e-75522f7ccfa9" control-id="ac-2.9">
+    <implemented-requirement uuid="2a6b5a09-c3a0-4009-9f0f-edeca0282466" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="11b053c8-3980-4a0a-a201-cb9bf187c1d4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4a673318-6470-4d51-a538-e58f9d5e3307">
+      <statement statement-id="ac-2.9_stmt" uuid="088f54b2-99bc-4179-b6fb-62a409ca203e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e243f06-367c-4ba3-8ef9-12959c75d0b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1069fb3f-3e3d-4b95-ac20-50fa844220d2" control-id="ac-2.10">
+    <implemented-requirement uuid="75e3c63a-6cb3-440b-8d80-e09bf7200e6a" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="87619bde-f961-43d2-8598-7470d6d3306a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="97027484-2035-4174-b376-1ba2c94f9608">
+      <statement statement-id="ac-2.10_stmt" uuid="f39028f7-2123-499f-b93c-893d702db421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49fc7330-de6e-4102-9900-72f2af447fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not have the concept of group accounts.
 
@@ -724,10 +724,10 @@ of operating the shared identity service and not OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b6bccee-3ebf-4bca-9177-0d5dd4846945" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="cd2702ef-5960-4790-b87e-2eac2dad0cc7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d730e12-30a4-402a-b078-3d6fffbbaa97">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -735,8 +735,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="838e22e6-c4d0-4656-9750-6ea55a580229">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bb382fef-ab52-4da1-8ee5-54905cdf0c00">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -745,10 +745,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2c75f83-4c26-4179-8568-c4ce288ad329" control-id="ac-3">
+    <implemented-requirement uuid="8ed60360-91df-45c9-bae5-82a7bc31a7b3" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="c0d2a25a-446d-44b5-88a7-4726c222c8fc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bf55e0ff-9b38-45c9-94b2-7d44fa754cc7">
+      <statement statement-id="ac-3_stmt" uuid="f0bb86a5-90e9-402d-b977-53a357f35912">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3144d8bb-1a8d-444d-809e-f38d4290dad3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is met through the use of Role-based Access Control
 for an OpenShift user. Namespaces should also be configured to
@@ -756,10 +756,10 @@ sandbox users and resources to only the required projects.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdf67397-626f-40b0-a533-d71b34f601f1" control-id="ac-4">
+    <implemented-requirement uuid="52d4a6ad-af88-4e7d-92f8-effe11d5f363" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="b214463e-6266-4c76-8219-a60c01a9fd84">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="328e00fc-e335-4a63-97bd-8207bb3094b9">
+      <statement statement-id="ac-4_stmt" uuid="d22b8559-ef87-40a0-96c1-9b10c8adb3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6345764-c22c-4e76-b06a-f8c1d20537d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -767,10 +767,10 @@ https://issues.redhat.com/browse/CMP-98</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e11a69ae-9abf-4b4a-8a89-ba81bdaf1437" control-id="ac-4.21">
+    <implemented-requirement uuid="013bf472-055f-4057-a9a7-67e12094efbf" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="31ae75cd-956f-4899-81c4-0e4bbee3c060">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="387b806f-ddb8-487d-b5f4-556cdd7938f6">
+      <statement statement-id="ac-4.21_stmt" uuid="726b5013-677d-483e-8063-362924525d43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58c793a2-66e5-488b-bdd8-eb09cd4d03c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -784,10 +784,10 @@ https://issues.redhat.com/browse/CMP-113</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22d61858-c890-4f4d-ad54-e9613e9188d3" control-id="ac-5">
+    <implemented-requirement uuid="f2764d74-68e7-4097-9afe-4af33f58ebce" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="3ac6b889-bda2-4965-8f40-2f344386849a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b58ac112-294c-46d0-8a7a-a6b32014c8f8">
+      <statement statement-id="ac-5_stmt.a" uuid="4f9794ad-e884-4617-8ae1-a5dbfd8173a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c7839c5-1a22-4bcc-8f60-a3bb9edc75a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of OpenShift configuration.
@@ -800,8 +800,8 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="4decab87-d75f-4867-aeff-0c7c4d0977e5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c30e4ac3-4c86-46c1-937c-48544081c08f">
+      <statement statement-id="ac-5_stmt.b" uuid="56c7bb04-452f-4526-8868-bddaf9d9072f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffa33246-5de2-4462-b5eb-0e156fa0bc87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of OpenShift
@@ -815,8 +815,8 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="137d6cce-bd94-4a3d-9f2e-b4cf36801dc4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bfe0cc88-9d32-4496-9fc0-193a5ea9f3c8">
+      <statement statement-id="ac-5_stmt.c" uuid="a7b31cd4-647b-46a2-97c8-dcd939af4ffc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0bbfdca-fada-4c60-844f-97352e49b8cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -831,10 +831,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95166df5-154a-4242-bc57-aeb54eec0504" control-id="ac-6">
+    <implemented-requirement uuid="88abbdda-8e98-4645-80b9-5595e5f7d2c3" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="db1c01f2-4dae-4724-87a8-e5d17bd5bfb0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f5016d41-2eee-4eab-bd77-dc3537d51575">
+      <statement statement-id="ac-6_stmt" uuid="2919dd72-8813-440e-95aa-eb4a48e9292a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f513ea4-777c-4021-88e1-d944a78e84d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -843,10 +843,10 @@ https://issues.redhat.com/browse/CMP-115
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dfdf9fd-fcb0-44f8-833f-1d3f7900446a" control-id="ac-6.1">
+    <implemented-requirement uuid="be17b2e2-832e-40b8-8b3f-ecfca434f4cb" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="3ef6e533-9d16-4ef2-8bdb-456b724f0c07">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0c0bc840-05b4-4aa6-9dde-f6c5b99420f7">
+      <statement statement-id="ac-6.1_stmt" uuid="3d1ce575-6e16-4e36-a4ba-c376990f21c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d844c0-1c7c-4fb3-a161-cf80cdee6df3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -855,10 +855,10 @@ https://issues.redhat.com/browse/CMP-219
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4357d28a-23c6-42ce-b742-d6c99714c260" control-id="ac-6.2">
+    <implemented-requirement uuid="2f88947c-672c-42df-9318-6837c2af234b" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="eb445573-aab9-4c71-a206-d0c154cb5ca3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c8d3ca78-2769-4a31-8458-5fcf76ad7e34">
+      <statement statement-id="ac-6.2_stmt" uuid="3c9f06ea-c341-4363-a3b9-10d98fb1db5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2aeeba05-5891-442d-8182-60a5a0389867">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 OpenShift configuration.
@@ -881,10 +881,10 @@ https://issues.redhat.com/browse/CMP-220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22250546-dd1d-42da-8e91-66f921a19848" control-id="ac-6.5">
+    <implemented-requirement uuid="e3e3efab-5461-4dd0-8720-65773f2e5379" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="e3e165a5-5186-41c8-b1c0-53cb11ae6d27">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="95bef89d-675c-436f-9df3-e7ee85777c0b">
+      <statement statement-id="ac-6.5_stmt" uuid="6582b7a1-0f0e-4d84-98f3-ebe259e0b29d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626ddc47-b7c5-417f-9610-19c21a97cfcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -893,10 +893,10 @@ https://issues.redhat.com/browse/CMP-118
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dac7760-3bca-478b-b8f2-df5404df54b0" control-id="ac-6.9">
+    <implemented-requirement uuid="a46cc993-69c0-40a9-b1c7-3b51a8170ecc" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="825acaab-38fc-42f7-92a2-ffa43e3d986e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e6718d43-dd2f-4bd5-98d1-0608eb890183">
+      <statement statement-id="ac-6.9_stmt" uuid="1b950782-4ef9-4f2f-aa12-d01c6885456e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7754724-50c8-4d11-b4a0-d4235cb8ef81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -910,10 +910,10 @@ https://issues.redhat.com/browse/CMP-122
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbad56b0-488e-4cf6-9a42-1cf98371d0e5" control-id="ac-6.10">
+    <implemented-requirement uuid="3e6efe21-9357-46fb-9506-c930ed1c9bd1" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="aa815c4c-d1fe-4b53-9867-a3417ea8a413">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="858f8610-0646-4dfc-87c6-583443b5a561">
+      <statement statement-id="ac-6.10_stmt" uuid="fcec7506-27c3-45a4-abc8-25e198fd2ca7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f817e29-325b-449e-9120-08bf8dc62dca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -928,10 +928,10 @@ https://issues.redhat.com/browse/CMP-123
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75cb5661-7bcc-49d8-b78f-5db79f4ce7d7" control-id="ac-7">
+    <implemented-requirement uuid="cb84ea2a-aa7f-4ca1-a112-98adda4ef300" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="4a921cec-c428-46cf-b73b-b04966185d0b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1e2ff254-2c69-40ab-879f-16a4d912f585">
+      <statement statement-id="ac-7_stmt.a" uuid="c6f44433-35ce-4551-8e69-ccd1c6fefbfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d49b1fd-a0dd-4916-bd70-cd9f161a830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for enforcing a limit on consecutive
 failed login attempts.
@@ -942,8 +942,8 @@ https://issues.redhat.com/browse/CMP-124
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="d1af1a78-9fd7-49c4-ba59-da42e301251e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9504bdd4-1227-4b60-b78f-6326b133c4e7">
+      <statement statement-id="ac-7_stmt.b" uuid="5b7d9846-3174-4dac-9b78-192e9dbb169c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83315ca3-684a-4b34-943a-05edbd9f2a26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for taking required
 actions defined by the customer, upon account lockout.
@@ -955,10 +955,10 @@ https://issues.redhat.com/browse/CMP-124
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22b7eac2-e1f3-45e3-b777-a3c8582651d3" control-id="ac-8">
+    <implemented-requirement uuid="1871ab2d-f550-4a44-abf0-755904c32987" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="dcdf8aae-8573-4368-80c1-255861dc950a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="21d8ce33-aacd-4099-b665-609868800b38">
+      <statement statement-id="ac-8_stmt.a" uuid="81fee283-7ebc-4201-8c6f-6c842d1258ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbaba125-1dff-4fe4-a089-3bbbfa1485ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -978,8 +978,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="da18f6c5-a2b1-4d1b-b52e-63434d826c7e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b3a4265f-26f1-4bab-94a3-63b7d7a4ac6e">
+      <statement statement-id="ac-8_stmt.b" uuid="196b39d7-5d87-483b-8ce5-32a33ca589a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="557a28c6-1c41-4bc4-90b6-53de6fe4fd8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -994,8 +994,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="b9ecbf13-1c5c-46c5-abfd-e038bdc552b4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7f3c94ca-ad31-4b85-961b-ed4303eb438a">
+      <statement statement-id="ac-8_stmt.c" uuid="c28e12bc-a3d3-4a70-b7ee-b7de8ecf75bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af0bc3ea-ca24-4552-8656-59fba841b604">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1013,8 +1013,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="97df57b1-8c2b-4fd0-9f81-74c3eaf40032">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="909d6d13-406f-4c3c-8887-7a472eccb616">
+      <statement statement-id="ac-8_stmt.c.1" uuid="1d329e71-fa09-40ba-9b20-8996bcdbc077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f11243ca-3eaa-4b60-b965-36ff3af33ac3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1027,8 +1027,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="6c08478c-b9de-46d0-800f-47518326ad14">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="541ea903-8d12-4674-aa57-ff5e12020904">
+      <statement statement-id="ac-8_stmt.c.2" uuid="98f8e7d7-eb26-49ac-a193-e2204f0cbf04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e55af32-263c-45f9-95eb-3d2aa3bb3d39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1042,8 +1042,8 @@ https://issues.redhat.com/browse/CMP-125
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="5a1ad719-3e7f-4545-b286-82bf90da4dfa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3baa5567-a748-4b5a-bd5c-a042dfc37ee5">
+      <statement statement-id="ac-8_stmt.c.3" uuid="c70495dd-83a3-4cdc-9159-d11e8552f9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f774fb73-6464-4e11-9977-19048563a4b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1059,10 +1059,10 @@ https://issues.redhat.com/browse/CMP-125
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="719699f0-9bb3-46d0-820c-28e315179400" control-id="ac-10">
+    <implemented-requirement uuid="317d48f2-c463-4fd9-a033-49c4ef0fa7d0" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="04395c18-5aad-45b4-b261-509185b80d3b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="88c236d9-6c53-4bac-9a44-3b75c138f6e3">
+      <statement statement-id="ac-10_stmt" uuid="3f970970-cbef-4fb6-a9b4-26b91e499a28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aed70d9-b8b8-4e83-89c0-337f33551afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1076,10 +1076,10 @@ https://issues.redhat.com/browse/CMP-131
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f657504a-6b2c-41dc-bf3d-a5050b0a77c3" control-id="ac-11">
+    <implemented-requirement uuid="e915b154-d306-4240-b477-551192bcedc5" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="b5ea4f09-0724-4615-b3b4-b7b280f57e53">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="405a100e-bf10-49ef-80cb-2d21f82b1c8e">
+      <statement statement-id="ac-11_stmt.a" uuid="ddde43f0-56b3-481b-96dc-95b0befdff3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1087,8 +1087,8 @@ https://issues.redhat.com/browse/CMP-222
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="73f7374b-766f-4c64-8be6-e29316664687">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="823ee6d0-690c-4658-8984-4a02f5c0e380">
+      <statement statement-id="ac-11_stmt.b" uuid="9cfa0153-ccc7-4fad-baac-e5e5beee1046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc13d468-eafb-4e76-a258-4653088b4c5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1097,10 +1097,10 @@ https://issues.redhat.com/browse/CMP-222
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccc52422-f85b-44d5-bde0-7ef39c5453ae" control-id="ac-11.1">
+    <implemented-requirement uuid="ab6903c4-8a5b-4507-ad07-184780da55aa" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="f7dfb1db-39a0-479d-99d9-08801e572738">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="663e0ddd-8a17-41a2-85b0-acbbb08c09d0">
+      <statement statement-id="ac-11.1_stmt" uuid="e16650c5-8d95-4e15-bc8e-5d3e7457ba56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09896195-8492-4293-a137-628ef9ab4ea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1109,10 +1109,10 @@ https://issues.redhat.com/browse/CMP-221
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4190c11b-bba5-474e-81fd-92be895f9a0e" control-id="ac-12">
+    <implemented-requirement uuid="80d9fe3f-ec91-44e1-8c30-69b9aaf4e472" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="ace3186b-e18a-4cd1-8795-665eae640725">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fe6b6940-4b11-4bc5-aca0-297557ff08bf">
+      <statement statement-id="ac-12_stmt" uuid="fc0fc943-da69-4c4e-946a-4d377389240b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="292db0d7-a6a2-4127-a9b1-4efb2359e579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1127,10 +1127,10 @@ https://issues.redhat.com/browse/CMP-132
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edde69a8-9bc0-46f1-8a00-7f256f581f57" control-id="ac-14">
+    <implemented-requirement uuid="2292ced5-1bda-494f-aa51-ef64228072a5" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="20beaad1-6343-438e-9742-832467e14cdd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cbc6dbb3-0bbc-4251-9f79-54e8716a1916">
+      <statement statement-id="ac-14_stmt" uuid="627160b9-85a7-4e24-9beb-643788ea9fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10130008-0803-4042-898f-872c8464d34f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Regardless of access mechanism, such as the OpenShift Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -1140,18 +1140,18 @@ non-configurable behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dc7c7de-acdd-425b-97c2-97424c40a07f" control-id="ac-17">
+    <implemented-requirement uuid="5a29a780-d78e-4632-ab61-dc00a1cb0cff" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="88d50a85-a54f-4fb7-8242-9faa7d0d9419">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="51996fc9-8683-4313-b530-ff752e7610d4">
+      <statement statement-id="ac-17_stmt.a" uuid="f3fdfb30-0212-4348-a5ad-ab13c5acb066">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="2a01a0df-2ce0-4206-9f8b-d3f7bc378b96">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ab248324-e202-4b11-9e6b-6ec2a994eca8">
+      <statement statement-id="ac-17_stmt.b" uuid="b2e75aa9-b2f3-4990-a770-899b2be99b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -1159,20 +1159,20 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73f14323-ef0a-451d-9c77-f3a27b460392" control-id="ac-17.1">
+    <implemented-requirement uuid="e8186e42-4077-4a1f-8d78-734534553a2d" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="9955b9b3-a072-43f8-8b99-83a88187096f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3fa706b4-a405-4b1c-ad19-543645663860">
+      <statement statement-id="ac-17.1_stmt" uuid="b27603fc-b7e2-49a2-99f6-2ae0836e0d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32c2c705-2546-4bef-9f35-b858913689b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="318e906d-2ae8-4a5a-b5c4-a4af9f82be9b" control-id="ac-17.2">
+    <implemented-requirement uuid="88b90b9a-fb15-4e92-9fc6-1fa52e43892c" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="ea66da46-2ea3-4ce8-9f37-d89279407df8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b74bff2d-c5d9-4262-9903-b96bcdd5d20e">
+      <statement statement-id="ac-17.2_stmt" uuid="f3d9d92e-2e38-4824-be78-32ed9cf94460">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36668d5a-b24d-47f1-9ae3-69c368fbb2c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Beginning with OpenShift 4.3, when OpenShift is deployed on Red Hat Enterprise
 Linux, and FIPS is enabled as a kernel setting, OpenShift will use OpenSSL
@@ -1204,10 +1204,10 @@ https://issues.redhat.com/browse/CMP-144
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f67ece71-b4de-44b2-b69b-401a3c62cfb1" control-id="ac-17.3">
+    <implemented-requirement uuid="39d48f16-1d4f-47cd-a477-ddb3574cdf02" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="cce048cc-7ffa-40e0-bb22-11860fe6419d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="af227fe1-366e-4b26-9dd2-33634516941b">
+      <statement statement-id="ac-17.3_stmt" uuid="7967ae9c-1cd4-42ae-bdcf-f84c036ae938">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09af0121-32d6-4b5b-8587-b4c4adeea806">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1234,10 +1234,10 @@ https://docs.openshift.com/container-platform/latest/networking/routes/route-con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94aeb1a4-121f-4f9a-b905-2086369f20e0" control-id="ac-17.4">
+    <implemented-requirement uuid="2b7ceece-2a8a-4c2b-8f5a-d14e43c96d30" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="a9759993-1044-465b-ac1f-c365282fbc63">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="93cda97c-d33e-4321-9d3d-856438d956c4">
+      <statement statement-id="ac-17.4_stmt.a" uuid="2fac32de-656d-4642-bf78-e1cf164fc928">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62f34e74-45a1-484f-8492-9f54561aaef5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to security-relevant
 information via remote access only for organizational defined needs is an
@@ -1245,8 +1245,8 @@ organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="e2d1c16e-be1d-436c-a233-029aa12c6676">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5f57abe4-1f6c-4ee0-81d2-e9b278a8e76b">
+      <statement statement-id="ac-17.4_stmt.b" uuid="2a3800a5-ea81-426a-9eed-8686d02c572c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69ea0dae-a55a-45a6-bed8-76192aeac67f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and access to
 security-relevant information via remote access in the security plan for the
@@ -1256,10 +1256,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a0fd112-0f89-48ab-8b59-0bad562263d5" control-id="ac-17.9">
+    <implemented-requirement uuid="6d39d74d-7cc9-4300-95e0-18776a3bb79a" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="f9e6fc84-7631-42ca-b648-6ce9bdfc170f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4140b47f-4639-4634-b55d-1801a8823747">
+      <statement statement-id="ac-17.9_stmt" uuid="0f860f1f-ebb3-4506-af67-3a93ecc11ef4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7de19c9-673d-4a6d-8e4d-796b592c1787">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift utilizes the firewall technology embedded into Red Hat
 Enterprise Linux. This technology, named firewalld, allows a system
@@ -1278,18 +1278,18 @@ for tenant applications immediately.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9a603a7-2d34-48f2-af60-433d6bc3d6a3" control-id="ac-18">
+    <implemented-requirement uuid="a137be9b-db9a-4432-b346-697717b883de" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="b9d896ad-589d-4f37-9650-0c4511a2d9fe">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fa402592-1d56-467a-88a4-c5908adc5d4a">
+      <statement statement-id="ac-18_stmt.a" uuid="ce5ee22d-7d86-436c-bed8-98ba87480aac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67017357-816e-48d8-ad67-84ca7d5d9d24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="ac258f91-f023-4746-a424-16ac80ae3f96">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="58a4e544-f3ce-4dde-bfdd-319bb9a87433">
+      <statement statement-id="ac-18_stmt.b" uuid="506e53cb-dc82-4df4-8615-623609005745">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e370990-461a-4d3a-a840-d0ca212cde3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of OpenShift configuration.
@@ -1297,10 +1297,10 @@ system are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48e5bbf3-63db-4913-b816-9b73c01bf7f1" control-id="ac-18.1">
+    <implemented-requirement uuid="56c8fc13-85fd-4f4b-b7a2-f8823dcbc13a" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="07394a88-5e71-44db-a8dd-dc1fde519894">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b765dddf-b5ee-4a86-91ed-bf093543d323">
+      <statement statement-id="ac-18.1_stmt" uuid="659e3e0a-5917-4d36-adce-d7fd342315a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1ceb27e-635d-442f-b219-3e1be8d30867">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 OpenShift configuration.
@@ -1308,18 +1308,18 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3d14ce4-dc58-471c-a57d-601788be6dc1" control-id="ac-19">
+    <implemented-requirement uuid="86ed2bac-7994-444e-aa3b-062de041b71e" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="8228e7ca-32d0-480c-8a97-a2414288d2fb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bc4871a4-3b61-47db-b383-090840eb6973">
+      <statement statement-id="ac-19_stmt.a" uuid="179cd8c9-3d7d-4984-b992-f75b748a5622">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1426997b-7d52-4dba-b9d5-84fee93f7d8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="fd98d0d0-e50f-4eab-96cd-ff8508003565">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7b32d7f0-6520-4d94-a817-017c7fbea24a">
+      <statement statement-id="ac-19_stmt.b" uuid="58260cd8-1853-4758-8827-2d7b8fe2e9d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="296305da-52b8-4adb-bc00-f2d04345bc9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of OpenShift
 configuration.
@@ -1327,10 +1327,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc8f1d8c-7bad-4e90-96d4-c2af9c7c2385" control-id="ac-19.5">
+    <implemented-requirement uuid="dd752582-728f-4f6c-9caf-fe4bd2fd4422" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="08d0c214-01eb-4a58-815e-8f627b4c3bb1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cd52b3ba-f701-41ed-bd03-796ed2a86937">
+      <statement statement-id="ac-19.5_stmt" uuid="4f1455e4-2691-4587-bc33-3cc15fbf181c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4549175-08d5-4dce-9837-a98c69cb0694">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of OpenShift configuration.
@@ -1338,10 +1338,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="770d5ab3-edad-4083-9cef-91aa58e14787" control-id="ac-20">
+    <implemented-requirement uuid="0794e2f3-0316-4600-987b-57769e6091d3" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="e2a962fc-3872-4572-acc5-c3669d75b4f3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6744ff14-d09a-4ab9-8520-49b57778f07d">
+      <statement statement-id="ac-20_stmt.a" uuid="c3ceb797-40c9-4c32-88da-bc2c3d02557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e2635d7-0d90-45f7-ab07-a72f837f9950">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1349,8 +1349,8 @@ systems is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="ba7122ee-882c-4cb9-9e13-9ad2a79512a0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="249226be-2c4f-4e0a-9030-a6e00673ca5e">
+      <statement statement-id="ac-20_stmt.b" uuid="0de55e9f-7322-4e3e-8934-b0ba825f62a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5372dc5-f754-4f92-85af-1a52d9aa9a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1360,18 +1360,18 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb2aaa66-4e03-4054-9230-3e3c8d58ba3e" control-id="ac-20.1">
+    <implemented-requirement uuid="a02d662d-2d0d-413f-a040-1a2400dc933c" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="2b5a69a5-c1f1-42e1-9891-2ddbcd266dd1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="83569e21-1671-4f7b-a757-7bb930187dfc">
+      <statement statement-id="ac-20.1_stmt.a" uuid="3b390916-7af6-4ede-9787-392e09e4cf1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86d7739f-3888-4a20-8cd9-c17683414ca5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="5bbafd1c-a2c7-4621-9b1b-efd9010152b3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9ca7dbf2-1e7d-4021-bcd8-abaf207a5c98">
+      <statement statement-id="ac-20.1_stmt.b" uuid="cffcb9b7-ad0a-43d7-94ad-3aebe0650ed0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d21ed88-81a8-4e27-9806-4dbce94289f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1380,10 +1380,10 @@ information system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb26325b-eb0e-48cf-a3be-cbfb4aeaabb8" control-id="ac-20.2">
+    <implemented-requirement uuid="738af087-76f9-4aa8-ab3f-a1bb09c19568" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="145fc01d-cc6a-4502-8d8d-785987685da7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="12c8e376-27aa-40b5-b14e-f4ab2b88906e">
+      <statement statement-id="ac-20.2_stmt" uuid="8d0ca122-e016-4d26-8c98-dc10bdc3af88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16969b66-25bf-4ef0-8fcb-f65b8f820f02">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1393,18 +1393,18 @@ systems is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b8aca80-8b59-4d7b-a04b-5b3822ea493b" control-id="ac-21">
+    <implemented-requirement uuid="61a0e15e-4c16-43aa-a234-4d335e4ce619" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="691885c4-7962-4934-bc08-008a46888cad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="67276001-53fe-4d12-9465-1212d5c657ad">
+      <statement statement-id="ac-21_stmt.a" uuid="7e54743e-5a48-414c-9276-b5c5d341b28d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bf8c9ef-3cdd-41ba-93a1-5cceb69f17d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="030c3325-8db7-451f-9207-868fba37be0e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2224e87b-5e32-452e-85ea-3ec6bb0a2c8d">
+      <statement statement-id="ac-21_stmt.b" uuid="ebdf4603-5832-43c0-a84e-a8da8858ddef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5635039-936c-456c-8f6d-5f3b83b3cadf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1413,10 +1413,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed55bad5-857f-4493-acec-5c6ed5d12984" control-id="ac-22">
+    <implemented-requirement uuid="f6ef3a84-58d8-4513-aad4-89f3f6a90990" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="9331e75e-8780-43ec-b670-fbfc86d259c6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7185f72d-4a7c-4db0-b2cf-d79c24263430">
+      <statement statement-id="ac-22_stmt.a" uuid="c7e11f37-7e67-4880-bc3a-b57dba50840b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="376f4ff8-c17d-40df-9517-a104d6234154">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1424,8 +1424,8 @@ system is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="93ebce84-b487-4ca6-b0c2-0435e5fe0629">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9f583eb6-153f-4fa8-8529-0f63b4819454">
+      <statement statement-id="ac-22_stmt.b" uuid="3fefacff-d1d5-45e2-91a1-3bcec05feab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec07b4f-b422-4324-8342-a8a0a2d4082e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1433,8 +1433,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="a232174c-78bc-4f6f-8b0f-606de5b742db">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1e480ce3-fecb-438a-9d2d-96a01399807c">
+      <statement statement-id="ac-22_stmt.c" uuid="74b40455-dd6b-4af8-a62f-6be80b7b921f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2009a919-1675-4f79-9e2b-92ef86ab360d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1443,8 +1443,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="0e179101-7f8b-46f7-873b-a394ead08b8d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1da5c2d4-28e6-42de-bd96-bd07de4c8137">
+      <statement statement-id="ac-22_stmt.d" uuid="78333f22-f26a-43d3-84ef-4fd62a7fc128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="179f843f-79fd-4d99-91e7-a6276487bab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1454,18 +1454,18 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f180a55d-82f2-4f07-bad8-0aac7e2fd1d6" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="b0bbd480-a1a4-4f7d-9a99-1aed0c856080">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b30614b3-0cab-402f-8858-b0a226c1bad8">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="5aca9f32-6e29-4159-97bd-ee2df5f5a3ab">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4a8bf18a-10a3-4095-93e3-bf0b835452d6">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1473,26 +1473,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d582b72-97b6-4b24-8776-6bf364f44d77" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="910743c8-b190-4e63-8dff-79ed243db0ac">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="da01bc2b-8857-4478-8a89-6744b0251cd3">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="223be604-d18d-4002-b377-e9fa1db68f75">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5aeefc41-9b90-43c4-92e0-ff0fd22ef69b">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="b5cd1c88-4c0a-45d1-ad22-5a9b0517ad42">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cb4048b3-c49f-401d-a3f9-93a1adcbd86f">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1500,10 +1500,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0004c705-1c1c-4086-bf08-6b31a29831e4" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="4aa83565-9891-4af9-b3b8-e83121ec577c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="08a101c6-3e01-4eec-95fb-81cc458d5482">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1511,26 +1511,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9dd7cded-3820-4dba-8afc-b25b92e502b2" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="4bfac877-4a36-4618-8bed-6aad0f3c0174">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c3a22a76-f8bf-4d37-b19a-21a3dfb3dd38">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="4140b41d-661a-4d39-aefe-7b37a4bd06f8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="da4d59bb-3473-4e29-8bc2-ea2778a65a0d">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="076b3626-ce78-43dd-988d-39f6fb455e2d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d2ac464b-842b-4d47-9b43-5f7c83692170">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1538,18 +1538,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="225f5e79-485c-493c-aaff-1f7fe05004bd" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="4c6e2829-b6d3-4fe3-a8a6-2b23e3f60f93">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7c65de74-cd21-4e34-99b8-952b10122d7a">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="c8d9315a-c776-4462-9628-9b0b8df6159a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="38f4a244-72e0-4faf-a39e-d7793053d0d1">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1557,18 +1557,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bcd827c-9990-4f08-9aa8-06030f4c436d" control-id="au-1">
+    <implemented-requirement uuid="ef0a9955-e6e6-400a-b0c2-4c90a3572de1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="69181a35-947e-471b-95a4-981e0ec8cdcf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="add8625b-2ec8-40cd-9975-8642366d7410">
+      <statement statement-id="au-1_stmt.a" uuid="a62838df-3f8d-4562-bab9-7c3fb3901ef9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f02538f5-6b4b-47ad-be64-68cde7e322b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="ca539f67-1f06-4828-8975-65ab86ec31ad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a5d11e2d-a35a-4a0c-92fb-b29ab012fb01">
+      <statement statement-id="au-1_stmt.b" uuid="1a981643-a22c-4097-907f-183a4a6c69ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="896963fb-9a31-41f0-b128-3d133586df01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of OpenShift
@@ -1577,10 +1577,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95ee6bfa-0d2b-41d6-b594-c99133144d1b" control-id="au-2">
+    <implemented-requirement uuid="7be12d88-184e-400b-9fa3-52fd68eacaca" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="5b3d13da-65f9-480b-a260-b5752ea2b991">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="01b45bed-63c8-44d7-a0ab-469a38345e41">
+      <statement statement-id="au-2_stmt.a" uuid="4d421c20-31f0-4ce1-ac50-b99c88342ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1588,8 +1588,8 @@ https://issues.redhat.com/browse/CMP-155
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="7bf5b59c-ff81-4be7-a3ca-830e03c5ce9c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="11a3f908-c126-469e-9c8b-93c5b1a34054">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1597,8 +1597,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="390c6fe5-d041-483d-a346-242602a41663">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="485a7836-1c13-4d5c-b1a1-190625f2d5a9">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1607,8 +1607,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="473d718c-0ae0-4943-8fd2-6dfe8c4ee544">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="146ff2bf-a846-4d5e-a476-26fa3435293c">
+      <statement statement-id="au-2_stmt.d" uuid="5888b387-1140-4214-85f2-a70baffb4734">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22194943-6a36-4115-93d0-d17399a4c4d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1617,10 +1617,10 @@ https://issues.redhat.com/browse/CMP-155
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e10ad51-400b-462d-a890-6f686a195d5e" control-id="au-2.3">
+    <implemented-requirement uuid="a8714d40-4409-4029-970f-b6db4119d80d" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="9555c096-9839-40f4-99e5-68fb3c7457ce">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4db4b912-680e-4824-b94c-9c82d2ab6586">
+      <statement statement-id="au-2.3_stmt" uuid="4c57f753-4a67-4f30-8406-64b13510536f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe2ca5ac-2ed2-4808-817a-dc1fb2d7cdc7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of OpenShift configuration.
@@ -1628,10 +1628,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7e01564-ea05-4264-bf7d-59fd1c689f4a" control-id="au-3">
+    <implemented-requirement uuid="a8aa07c1-977c-4acf-ab95-7b1304cd50db" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3_stmt" uuid="8334798e-edba-4d86-9b20-ae863503835b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="aa6a8eef-2bfd-47e0-94fd-0ea09fce115e">
+      <statement statement-id="au-3_stmt" uuid="c9bdcd27-57a5-4c8d-9187-b9b44e8aedd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86a2f7e-3776-48bf-b89d-a341ef18bb87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1640,10 +1640,10 @@ https://issues.redhat.com/browse/CMP-156
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee3a9b08-f9a6-4379-81b8-2723a29dd247" control-id="au-3.1">
+    <implemented-requirement uuid="c1e0e21f-dcd1-496e-8035-c390c79d8ee5" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="a8b67dd9-f550-4e27-b61c-b93d4aec6f02">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e00ebcb0-ee68-4ad7-8bee-6491a031bb3d">
+      <statement statement-id="au-3.1_stmt" uuid="75fb7866-11a8-41b8-bad1-b9155c8ffcc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dc50397-62c3-4794-9b21-da85086bc5ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1652,10 +1652,10 @@ https://issues.redhat.com/browse/CMP-157
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1aa3a657-647d-4731-b9e4-95823c699f1e" control-id="au-4">
+    <implemented-requirement uuid="29b45c5c-75d3-46af-be25-434858dee17e" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-4_stmt" uuid="c6244650-bc4d-4079-a277-316f04c5eda1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="10ad619e-b4b2-4cc1-87a0-77faa2e577ee">
+      <statement statement-id="au-4_stmt" uuid="18d3e825-6592-4360-aac3-79664eca082d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efa9da94-2510-4f80-b6c9-1acdb42d0e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1664,10 +1664,10 @@ https://issues.redhat.com/browse/CMP-159
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92ef8ba9-afc6-4810-82d8-e496ecd7ea55" control-id="au-5">
+    <implemented-requirement uuid="f97bbe7b-147d-412e-b97a-16f76d92e95b" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="ded65f85-7a28-4de5-8666-92e78040414a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ef7d50fb-bd6a-4907-bd85-87e04d305f7f">
+      <statement statement-id="au-5_stmt.a" uuid="33bda322-1557-4843-a1ac-2a625bffba6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1675,8 +1675,8 @@ https://issues.redhat.com/browse/CMP-161
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="ca1f8e74-50d2-4c00-859d-02d295bc10ee">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="315c2294-76e4-47c4-9a0c-1bdbcf336aca">
+      <statement statement-id="au-5_stmt.b" uuid="c41dba8f-3f59-4ea9-bf10-ab1ba45f6ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="685697d4-0052-41cf-a049-3274830e10f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1685,10 +1685,10 @@ https://issues.redhat.com/browse/CMP-161
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e8d10cc-8655-4dec-bd34-7a60728eabdd" control-id="au-6">
+    <implemented-requirement uuid="b8f5d492-d89a-47a8-8100-8d3467acfd32" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="f9e7b03b-23d6-4bfb-bef4-c03025346b0d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b77e3352-3ead-45f4-9c2b-7df9c3062a42">
+      <statement statement-id="au-6_stmt.a" uuid="08063edb-8d74-4477-818b-b829fbd5dbd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a88cb0f4-5871-49b9-9199-2ed0b21e10cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1697,8 +1697,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="6bbcf8ce-5dd8-4ba2-8a88-a35725a0dd3d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5e8191ac-a8d7-4ddd-a5fe-d83abcdd831b">
+      <statement statement-id="au-6_stmt.b" uuid="1a73feb9-9aa3-4bbc-b713-e4094e86ea4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eca14996-d7f3-4ce1-bdf3-addb2bb13ac1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1707,10 +1707,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="189b433a-5cf1-415f-bbd8-d6943d92849c" control-id="au-6.1">
+    <implemented-requirement uuid="8f3651de-9640-4a2c-85b7-11ac36329a38" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="2b40b901-7744-44f4-ad9c-cd1b092a16f3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="eb736e70-3284-49dc-8d55-a640b2e43281">
+      <statement statement-id="au-6.1_stmt" uuid="17f07aaa-cd19-4907-b660-672d4014657e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0829c1f9-bba9-4e1c-a268-31bdcebefe36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 https://issues.redhat.com/browse/CMP-167
@@ -1718,10 +1718,10 @@ https://issues.redhat.com/browse/CMP-167
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfef6db0-f96e-4fbb-b69c-9c2d2cf6d661" control-id="au-6.3">
+    <implemented-requirement uuid="bf22437c-7619-499e-9d5c-94a487cb035a" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="f1b435f8-e51e-4be2-92c3-c4cc9d5c09ae">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9db31ffc-d6dd-4128-b7fe-a1547ae7868e">
+      <statement statement-id="au-6.3_stmt" uuid="e0ef9471-ce63-420e-ad27-c678b3f9f0ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eaa9b62c-fbb9-4a23-ba48-c729771c4471">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1742,10 +1742,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging.htm
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fa254ac-c229-45e7-92bf-85fc68975691" control-id="au-7">
+    <implemented-requirement uuid="06a7191c-ddff-46e4-ab94-e82663e33249" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="8ea05ead-5481-4698-9479-d7551aa32bb3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2fcb8ba0-68bf-4f0f-9add-33c09213bf79">
+      <statement statement-id="au-7_stmt.a" uuid="6bcc436f-7317-4689-bff0-acbf2c50aaa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0cd3cf46-dc7e-41eb-858a-fdb5910d3822">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -1763,8 +1763,8 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="b70bbc81-5d6c-49ec-adf2-26971aec579b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a867db2-958a-467d-9be3-1e45b395f277">
+      <statement statement-id="au-7_stmt.b" uuid="c6f0bb72-36c3-4761-9a5b-c40627d0a446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9b3215f-331a-4fb7-9067-a704d26e888f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When OpenShift's Cluster Logging Operator sends OpenShift cluster logs to a remote log store,
 the operator does not alter the original content or time ordering of audit records.
@@ -1772,10 +1772,10 @@ the operator does not alter the original content or time ordering of audit recor
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa6db721-2278-4f05-924b-acb4696ef398" control-id="au-7.1">
+    <implemented-requirement uuid="058aed75-8622-4dfa-ae99-2c359885e02f" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="f2c162f2-316e-48d9-9859-0cee6b116588">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="00fb2df6-48c5-49c5-9710-a9f20422d6ea">
+      <statement statement-id="au-7.1_stmt" uuid="720c614a-f263-426b-bd33-2363ad574369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="258ecfda-b77b-46a4-af8e-0970feb52488">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift supports an audit reduction and report generation capability that
 supports on-demand audit review, analysis, and reporting
@@ -1794,10 +1794,10 @@ https://docs.openshift.com/container-platform/latest/logging/cluster-logging-dep
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cc85979-e09a-4b4c-a94a-4c8b60452789" control-id="au-8">
+    <implemented-requirement uuid="9c2388b8-6ef5-45cf-93d2-cd87d4f39794" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="01c96a2b-e983-43d8-993f-c209116af484">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a2217636-d07d-41bd-a02b-d7f957949f16">
+      <statement statement-id="au-8_stmt.a" uuid="7edb6f5a-e08e-4faf-a375-bad11b80aa7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3e4e1da-469f-42f2-a0e1-2c8ffaeae1ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API uses the internal system clocks to generate
 time stamps for audit records. At the code level, the OpenShift API
@@ -1816,8 +1816,8 @@ which really is a time.Time value which comes from the standard golang library:
 https://golang.org/pkg/time/</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="61085f14-3756-47d3-ae43-31bb13837ad5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d78a4496-505e-486c-9ad5-d1040f335f3a">
+      <statement statement-id="au-8_stmt.b" uuid="8199e4bb-c82f-4ace-9317-6db96229ad0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca64871d-2677-4674-8c06-a118a56ef997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the OpenShift API records time stamps for audit records
 that can be mapped to Coordinated Universal Time (UTC). For example
@@ -1833,18 +1833,18 @@ for more example of audit records.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b9601b6-f714-4ebe-b3c0-7bc5867a4175" control-id="au-8.1">
+    <implemented-requirement uuid="8f844c3b-c8be-427a-b5e4-de865825d22f" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="37dcc351-6bf8-43b1-b466-a2b3c06d4e78">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9684caf5-ee2e-4181-898a-125335cc9a9f">
+      <statement statement-id="au-8.1_stmt.a" uuid="0f7774f9-7015-46ca-8049-12d0303a4e3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce43980-d680-4af8-8d74-231f0e325343">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift synchronizes time by utilizing the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="aee6ca53-39b2-4cd4-8b9e-ee42519b48d4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="092ef0db-f949-4b86-810a-f725d629c466">
+      <statement statement-id="au-8.1_stmt.b" uuid="d10df678-a2c8-4dfd-a581-f78c81b4d714">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce43980-d680-4af8-8d74-231f0e325343">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift synchronizes time by utilizing the time services of the underyling operating
 operating system. This control is not applicable to OpenShift.
@@ -1852,10 +1852,10 @@ operating system. This control is not applicable to OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="322e5062-379e-41ea-a51f-e81c513fbf28" control-id="au-9">
+    <implemented-requirement uuid="55434d4e-d726-4f87-80da-a735bf9ddb65" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="a5e42df2-733f-43c6-8702-95475cfeafe8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="34a9ada2-f161-461e-9992-087296983f4a">
+      <statement statement-id="au-9_stmt" uuid="98139dd1-5cd9-4c5c-9450-60a7461da54a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7970ec74-624d-4dce-a658-d8c036036d1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1864,10 +1864,10 @@ https://issues.redhat.com/browse/CMP-232
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9054dd1-d214-4308-9f0a-2a7fce6c6e3e" control-id="au-9.2">
+    <implemented-requirement uuid="3b44ab3b-34bf-4526-88f1-7558a0573638" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="11fc864e-03c2-4903-9b50-7fc2319a5db7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6eea3de2-89e0-4b2a-8b82-489c70f1cd45">
+      <statement statement-id="au-9.2_stmt" uuid="78874635-1b1d-4ad9-b505-8c833b1126a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad51bfc3-0766-4dd0-8936-c1e95143c52f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -1878,10 +1878,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="157c8343-4b83-4a4d-a0fc-df920cce136d" control-id="au-9.4">
+    <implemented-requirement uuid="2e936dfa-c426-4c14-b9bf-b4a2585f877c" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="14bd95d8-4c21-4451-825e-9a83f2e940e9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b9ea6aee-2321-4078-bfed-203920609307">
+      <statement statement-id="au-9.4_stmt" uuid="67384918-d292-4ecf-907c-a9a006bd813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c316f2ae-f82d-4182-a625-9ce6bf288afb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be tracked
 via:
@@ -1891,10 +1891,10 @@ https://github.com/ComplianceAsCode/redhat/issues/863
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ec59f59-feb4-45b8-8121-5c9bdf2df288" control-id="au-11">
+    <implemented-requirement uuid="026a03b5-1bd0-4e63-93ef-7c513080917e" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="ef2dcc97-0a88-41bc-b10d-17be177d727c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2e5f0b78-6f93-4b75-8ce4-11465db85168">
+      <statement statement-id="au-11_stmt" uuid="0a9fbed7-ddad-41fb-b5c1-5966fd294dce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e8093cd-410f-44fe-8d14-44321f8fade4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1903,10 +1903,10 @@ https://issues.redhat.com/browse/CMP-243
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7f042aa-cb4f-4547-ad13-4a1d7c32a5ef" control-id="au-12">
+    <implemented-requirement uuid="8b0aaf71-f6c1-4a72-8eb9-2976dc14368e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="2d67c680-7c32-4f22-a122-803cecb23d7a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="25e911ec-88e5-43ee-8c3c-9c42e610c764">
+      <statement statement-id="au-12_stmt.a" uuid="1c08ede3-e584-4794-8904-53ff3fdd6fc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1914,8 +1914,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="96645c31-0a5d-4661-814d-08264c809806">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e24d9731-a5cf-4cf2-a1ec-2ad4aa47933a">
+      <statement statement-id="au-12_stmt.b" uuid="86eea62b-3469-4749-99b5-28a3e1314e44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1923,8 +1923,8 @@ https://issues.redhat.com/browse/CMP-245
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="86cefd18-5523-4592-8445-76a7e4928c85">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4166a6d8-e4a6-4d67-b9e7-17f447dd5ba4">
+      <statement statement-id="au-12_stmt.c" uuid="fa854ac3-30a8-4ed3-8a04-4ce10fbab35a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec9b22a8-ac56-470c-896d-257fdde990b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1933,10 +1933,10 @@ https://issues.redhat.com/browse/CMP-245
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="477c9b73-950f-4cbc-a2b9-7adf4b922bc1" control-id="ca-1">
+    <implemented-requirement uuid="fb9e823f-f30a-49cf-8e64-8b12563d512b" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="fb6dbdaa-1294-48be-8fa0-9e0c54090839">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f269a1a4-052e-44f6-bf31-039fc46ceeb6">
+      <statement statement-id="ca-1_stmt.a" uuid="e4ced95c-04ba-48ca-9570-5ec802f01701">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1944,8 +1944,8 @@ the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="cd1ed40e-fddb-4255-a6ce-7877a2991b28">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="453476bd-708f-4b27-9b50-5ea0f8755125">
+      <statement statement-id="ca-1_stmt.b" uuid="a65bb5b4-db69-495d-8756-9d322f94c158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7af7c9ee-8e02-459b-bcbb-31ae9fbc9d09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1954,34 +1954,34 @@ the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c3bba9e-b5bb-428a-9829-0dac315d6f4b" control-id="ca-2">
+    <implemented-requirement uuid="8d8afad9-0508-45b9-ba76-18768cd27aa7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="34f70f8a-087c-4202-9b5b-c7da36ae02c4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a8845012-276f-4962-adf9-c00f898820cf">
+      <statement statement-id="ca-2_stmt.a" uuid="5edc8cc8-7dd1-473d-ab0f-070f2f4287b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="b0c2968c-80de-49e6-8f6a-3f078b64a11e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="924be3fa-20bc-43f4-b2e2-7c5ae05e459e">
+      <statement statement-id="ca-2_stmt.b" uuid="0dd59305-6612-44cd-9bb8-3983326a6dd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="9af1cce2-3670-402c-80f8-d37dcc3d4cea">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="861b8af2-10ab-4daf-9d38-4b0ccfd5503a">
+      <statement statement-id="ca-2_stmt.c" uuid="fa943605-14cf-456a-ad67-8eac021ab68c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="f4ceb788-29a6-48ea-89e8-f1e19a7112ae">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="32571c9e-806f-43c0-acbe-3a075aeb59bd">
+      <statement statement-id="ca-2_stmt.d" uuid="8540655a-6e76-436d-8513-3723a102553d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96994c43-c119-41ad-b728-02a641623c3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of OpenShift configuration guidance.
@@ -1989,10 +1989,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bce5104-5fab-4525-ac45-4624b8fad173" control-id="ca-2.1">
+    <implemented-requirement uuid="08d49c7b-953f-4cd0-9813-50874951537b" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="3b9e262e-d82c-46f8-ada5-a9b9530c3f2b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8fa26bca-0d6f-4881-b9eb-3cc52ca94e5e">
+      <statement statement-id="ca-2.1_stmt" uuid="38aa23f1-4422-402a-924a-ec395b6a768a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3b9dd57-eac9-45a8-99ab-907dfa329afe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of OpenShift configuration guidance.
@@ -2000,10 +2000,10 @@ is outside the scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ba969f-bfd4-47ed-9753-b910565962bf" control-id="ca-2.2">
+    <implemented-requirement uuid="db5a2907-c1fd-4e4e-a6eb-61559c12003e" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="50bb208c-1f46-45f2-a3be-bf462106e3b5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3f2cb669-7e0d-4144-9c4a-513e73c05f5a">
+      <statement statement-id="ca-2.2_stmt" uuid="3fe6f2ca-381f-497e-a072-33027570ea25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f9a999f-dbf5-46ff-a007-43b2c21ab3e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of OpenShift configuration guidance.
@@ -2011,10 +2011,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e287473-b2c0-485f-a6d1-7cc311ec4efd" control-id="ca-2.3">
+    <implemented-requirement uuid="58a67648-ba68-4415-974b-61de7dc1c5b5" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="ddf78918-70b8-4326-b08d-ecd923f73233">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="251aae74-6273-4617-8f82-871dcff05273">
+      <statement statement-id="ca-2.3_stmt" uuid="11147258-cf14-4f88-a31f-b75bcdd421d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab0e3099-0268-4610-80d3-04805390b90c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of OpenShift configuration.
@@ -2022,10 +2022,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d642112-2c5c-42aa-a554-f800d8550f86" control-id="ca-3">
+    <implemented-requirement uuid="d852491f-4160-48e1-afb7-2e2ec47b7d99" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="d7d36009-a1db-49e5-80ce-b828d0e2c9d7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5aec180f-8219-4244-8df9-eeafafa811a5">
+      <statement statement-id="ca-3_stmt.a" uuid="2c3ee9df-91cd-437a-82c9-864e15531e98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2033,8 +2033,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="937f9e3e-3d31-4d72-b089-fd5ee341de31">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="dcafc8d9-66dd-479a-b1bb-3cb23f9b3fc2">
+      <statement statement-id="ca-3_stmt.b" uuid="4eb00eec-a9ed-4ee3-a6c7-484b670b8529">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2042,8 +2042,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="8de7e549-01cd-440b-bd39-d86233a247be">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c0249f3f-4a47-4b58-a062-e9798253fe2c">
+      <statement statement-id="ca-3_stmt.c" uuid="b11f5bcb-6d01-4308-8993-e1f6c74da678">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26325da6-645b-48ff-a385-1790501cfe82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of OpenShift configuration
@@ -2052,10 +2052,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1391cc69-680f-4a01-907b-833d6b08b7e4" control-id="ca-3.3">
+    <implemented-requirement uuid="85595d4a-3f82-4cd4-ae40-c9e1bece56df" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="ed4f0caf-b73c-43bf-a33e-86c6e6b596e8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bb818446-8744-4426-9337-b71ff43a246c">
+      <statement statement-id="ca-3.3_stmt" uuid="ff516853-42f1-46e8-aed8-dbc22157fe12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="558d97f8-5d6a-4aee-8a12-912b5f070589">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 OpenShift configuration guidance.
@@ -2063,10 +2063,10 @@ OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2572ae14-8237-4875-9aeb-475201e94a89" control-id="ca-3.5">
+    <implemented-requirement uuid="80d92939-b566-45ea-acd8-dad9640c46cb" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="a070638b-1638-4b49-8177-b75b39631376">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2c6fdef9-f2fa-4486-9f53-3e9a92a99064">
+      <statement statement-id="ca-3.5_stmt" uuid="25e4fad0-540b-4190-a0a4-0009d55b70e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbfd7e30-455d-49ee-9888-3853ccbfd5e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to OpenShift and applicable
 through host-level firewall rules.
@@ -2078,10 +2078,10 @@ https://issues.redhat.com/browse/CMP-253
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b7e89dc-8697-4630-acbb-8288e5eacded" control-id="ca-5">
+    <implemented-requirement uuid="4d507723-069b-4eec-b5c5-97cd3e94d334" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="3205ae85-39dc-486b-b6d8-7e06f396c732">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="38568c97-6d2a-4275-a94e-20c4335481ce">
+      <statement statement-id="ca-5_stmt.a" uuid="89655419-75ed-4ec2-bdc4-07f88fe99933">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7da1eaef-58ea-4508-bf86-2095cb61dfae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of OpenShift
@@ -2098,8 +2098,8 @@ https://issues.redhat.com/browse/CMP-254
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="d15850b2-b115-4091-96c0-bd510f500bec">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="470225c8-1536-4ab6-900f-4b24df257e09">
+      <statement statement-id="ca-5_stmt.b" uuid="8e8f321c-48f5-4ff6-8654-76986b9774e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd5cdde-ec46-4ca6-b2c7-ba5f7fd31de2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2113,26 +2113,26 @@ https://issues.redhat.com/browse/CMP-254
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8359a7a-b3db-458c-a6ca-9f8b04fff644" control-id="ca-6">
+    <implemented-requirement uuid="f62731c0-3032-42e8-8694-31c841118669" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="31f82a05-e28f-4ed7-91c0-307b7ad8c06c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8da39c0b-3ca8-41b5-97e3-d27913fda737">
+      <statement statement-id="ca-6_stmt.a" uuid="fe0d6c95-f1a6-4353-968c-b520c4853cb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="1e0b1ff5-a709-4c21-a8e8-0ee29f39612d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d6625029-d715-477d-9646-b23826a5cce1">
+      <statement statement-id="ca-6_stmt.b" uuid="4029322f-8f15-4f57-a0c7-70c8654c0505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="da6e381f-e4b3-433f-93c0-f1a5882783a7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c2430226-b475-4c83-bd77-47e31f0c04cf">
+      <statement statement-id="ca-6_stmt.c" uuid="f0742c71-cd50-4fb4-90bc-bc7b6839f689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2140,10 +2140,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cc54c27-ca88-42a1-bbb8-b4d1969450fe" control-id="ca-7">
+    <implemented-requirement uuid="55addee1-b8b3-4109-80b1-b8227770eb8b" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="d391988f-c757-4d7c-bdcd-b01627a39031">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="66b682d8-a7b8-4d81-8cfc-5973cce115f6">
+      <statement statement-id="ca-7_stmt.a" uuid="d6a330d2-df2e-4d92-9cd0-1956cc3c7781">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7b1e437-6967-48fe-bbfa-c7cd030c0de0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2152,8 +2152,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="48ff8dbc-740f-4fad-82c4-54ed7b2980c7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3a12fc1c-0a90-4597-8952-a8a21fa7d917">
+      <statement statement-id="ca-7_stmt.b" uuid="c4ca4be2-e8e3-4f6b-a10d-d7cac01ab064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="033b0fa8-776d-4796-bffe-cd824557b80b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2162,8 +2162,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="3d3d52e5-c43a-4530-8b48-cc07d479e0e8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e6ea763-f40d-494a-b4d7-cd0a0b802f6d">
+      <statement statement-id="ca-7_stmt.c" uuid="5b42c3ae-6d29-4620-8eb5-763e9fc22b2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2171,8 +2171,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="e8323f1f-1477-4517-b209-d177d8030031">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ebf884f4-9136-4b4b-ae77-9da9804a9bd8">
+      <statement statement-id="ca-7_stmt.d" uuid="09bfaa99-281a-4533-bdf3-e23b301b2fd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2180,8 +2180,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="b6d32b82-7fce-4335-988a-4a7cba857f08">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d45d113a-570f-4075-a886-c8afcca2ecb4">
+      <statement statement-id="ca-7_stmt.e" uuid="3e76aad7-24ce-4f30-8f9b-e94b515451b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caab80b4-b384-4fe7-b5f1-47c620bef841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2189,8 +2189,8 @@ https://issues.redhat.com/browse/CMP-255
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="cd0e494f-642e-4bfb-ac2e-7ed59a0fd198">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8a15c3d2-7f14-41a8-afb2-2d939e6aa348">
+      <statement statement-id="ca-7_stmt.f" uuid="b09f9aba-1b28-487c-997b-fd2a7ce6c033">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="291a33c4-ec9c-4387-bba7-db910c86c7a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of OpenShift
@@ -2198,8 +2198,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="910ca54d-ce6c-4c7b-aa1b-2ffed7375b4b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e7647118-9169-472f-bb56-4cea6a3a0196">
+      <statement statement-id="ca-7_stmt.g" uuid="a32b68f0-5ca4-43dc-aee3-8bf1d9e27165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c50876-9275-40f2-bc33-4ee44dcf13f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2208,10 +2208,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2425f52a-6a8f-4688-bb0a-21b0c7ce46ab" control-id="ca-7.1">
+    <implemented-requirement uuid="624d74b3-1731-42e7-8baa-7f3e97270e66" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="55043848-9a84-4b50-9119-8613a5682ca7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="32ff37a6-0abe-4125-9623-3883f9a8435c">
+      <statement statement-id="ca-7.1_stmt" uuid="e47b699c-612e-4f18-9c35-f1d70ae60f37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ee7afb1-daf3-4bdf-b139-e274fa0c1f1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of OpenShift configuration guidance.
@@ -2219,10 +2219,10 @@ scope of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00aad9c0-3838-4644-9762-577bcbb22d79" control-id="ca-8">
+    <implemented-requirement uuid="b716fb4e-3373-4b56-bfab-5a619dfb7650" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="ae67f874-5e80-4d67-925c-79585ca0ea2e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bab6981c-8026-4a45-95c0-370520a1efbc">
+      <statement statement-id="ca-8_stmt" uuid="e09a8895-1ef0-4139-a6a7-85714c2c9a97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a354f5f-f6a4-4922-9746-a7e30df42f31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 OpenShift configuration guidance.
@@ -2230,10 +2230,10 @@ OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41b132d3-da03-4951-8405-fe585511d325" control-id="ca-8.1">
+    <implemented-requirement uuid="3cd4469d-5efa-4a03-bb53-9e10f9cdc180" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="2bef1eb1-b703-447e-b358-a7ee3f81a46a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5ff9820b-615c-4733-8973-d796006c6435">
+      <statement statement-id="ca-8.1_stmt" uuid="4faa1b9a-6f58-4e69-bc7c-23c69dcc3e05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29136789-b5ab-4c39-9dd5-db08bfe1e3ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for OpenShift configuration
@@ -2242,10 +2242,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60ace56b-f0f1-405c-a975-c5384b38ed25" control-id="ca-9">
+    <implemented-requirement uuid="0d83447b-9daf-4a76-8521-2a6327fd9870" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="4ba29c3a-7246-4b7f-b864-dd143271a0f7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ec62d79d-4bc2-45b6-a105-96df5bd58f44">
+      <statement statement-id="ca-9_stmt.a" uuid="fa5fe87f-a834-4a5d-b458-0197740ca3b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2253,8 +2253,8 @@ https://issues.redhat.com/browse/CMP-256
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="e5abe47c-a995-4b98-aeee-2a1d3c3d441f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c8c16c9f-a552-4a8c-ad78-f9a5d590868e">
+      <statement statement-id="ca-9_stmt.b" uuid="3d7d9b31-e3be-4fc4-847b-8fbebcca9f5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3322771-7d3a-4e43-b2ec-0216de5044be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2263,18 +2263,18 @@ https://issues.redhat.com/browse/CMP-256
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e59f406c-b138-4244-8638-d94254cdc1c3" control-id="cm-1">
+    <implemented-requirement uuid="53b3abac-4a28-4161-959b-fa09347080a4" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="22fb79bb-1c46-4aed-a6b6-79097d90b507">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f23a5501-9cf6-49ac-85fe-f6d294d209fa">
+      <statement statement-id="cm-1_stmt.a" uuid="0e08d61c-98ad-4d8d-9cef-ca802b007cc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77ee3a9b-63d6-4f8d-bf3e-f10feb7ec653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="5dc52f84-4d28-4069-84d0-97c999977980">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="537ae6a4-af08-47a2-b352-c7eb621788d1">
+      <statement statement-id="cm-1_stmt.b" uuid="13dfc8dd-1b1f-4f8f-a824-fda32a269ecc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6eccf7c-0437-4523-a842-44769fdd2ae4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of OpenShift configuration.
@@ -2282,10 +2282,10 @@ management policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9b5d836-c630-4d01-b15f-9250a5b6133d" control-id="cm-2">
+    <implemented-requirement uuid="7ec7cc47-526c-4739-94f5-5362151297e2" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="a79436ee-efe6-4aac-94a2-ea6bbd0f4bfa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="842b8ebd-63c6-4da1-878a-4c720dc7c5d5">
+      <statement statement-id="cm-2_stmt" uuid="6aaa5474-1312-44d0-a614-bbcbc95a220f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e95a42-d853-44e4-8693-3cc9f20747c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management in the OpenShift Container
 platform is to implement the principles and patterns of GitOps
@@ -2314,10 +2314,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5c8de01-2de0-45a1-bdfd-72571c8a7055" control-id="cm-2.1">
+    <implemented-requirement uuid="15c843e2-7b5e-4cab-925c-949ff806ea4f" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="3e4d1e27-bd25-46d4-8ffa-40715b88f8c6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="25a88ed9-6be7-4ded-9be7-ca5a69d5b18e">
+      <statement statement-id="cm-2.1_stmt.a" uuid="b8bff285-b306-4a1f-a2c1-339246cfcc10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="120e9e6d-bc52-43ce-8533-674d957d6795">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift per an organization-defined frequency is outside the scope of
@@ -2339,8 +2339,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="cefc590a-2113-47b9-903f-71b559c2fffc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7a7e6ada-01f5-4072-93c5-89bc6f1ad8d0">
+      <statement statement-id="cm-2.1_stmt.b" uuid="3d12c2a9-9322-41c1-9e81-3bcc2bfb0e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95bbb4ef-965c-450e-93d0-3f0b25b55679">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift when required due to organization-defined circumstances is outside the scope of
@@ -2361,8 +2361,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="29afb3d5-d5e8-4508-ba8c-b6e4e4f886e1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b628c58e-0144-479d-b295-1da469b7c4e9">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5a93b6d5-ea2f-400c-861d-e393ddedb528">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e03918ea-9597-46d0-b685-77696fc48515">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 OpenShift as an integral part of OpenShift component installations and upgrades
@@ -2385,10 +2385,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83f917b1-e7b1-41a8-b0dc-5de244432f7d" control-id="cm-2.2">
+    <implemented-requirement uuid="9811f427-cb9f-4959-839e-c1ad0e3b1f69" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="785e278c-6ffc-42c9-bc84-3e07eaaa04c9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b2a1e74b-0e82-4195-a58e-b2fa050d0e55">
+      <statement statement-id="cm-2.2_stmt" uuid="1a85e226-7846-458e-87aa-daabb3024acb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbf585d-7073-4272-9b00-0e9a10603a48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2398,10 +2398,10 @@ https://issues.redhat.com/browse/CMP-262
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4cc23e7-3f62-4a90-82e1-dcb45358055c" control-id="cm-2.3">
+    <implemented-requirement uuid="68ad0e12-a096-4067-a971-c389177b7034" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="e054e63b-ac3e-4ebf-b102-0681be623195">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="50e570ca-1cea-4215-a2d1-512312348814">
+      <statement statement-id="cm-2.3_stmt" uuid="11312c94-dc55-4ed5-b885-e600694b3b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2045b012-4c73-4e3c-b73c-37eaf05d3dae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2424,10 +2424,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73c382cf-9420-43cd-a7b9-5ee80690e381" control-id="cm-2.7">
+    <implemented-requirement uuid="6459ecfa-b910-43e7-8965-3b3415c870db" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="69cae443-80a3-487a-9897-e1a1ea2d7494">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="764bd76a-4081-44fd-af83-3327db4c605c">
+      <statement statement-id="cm-2.7_stmt.a" uuid="4c10504f-e039-4f61-930c-576645e31828">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9178f438-9fed-4b72-8bce-95c1b53c7d2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2437,8 +2437,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="cd56f2f6-07b5-485c-a9b5-dc6d41b36c69">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="00c338e3-cc51-4422-9402-f1a8a58b3185">
+      <statement statement-id="cm-2.7_stmt.b" uuid="47b6c5a0-4926-423b-a81d-a279fde17855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d750095f-9a35-42fe-a0f7-57f49ced611f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2447,10 +2447,10 @@ outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d50e07e-81bb-4146-832f-a15ffd07c88e" control-id="cm-3">
+    <implemented-requirement uuid="d5803f5d-c744-42be-8dc1-112e58561dac" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="5e2e5ca1-4aef-4653-a3c2-319c2a636328">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e346e12c-21b4-4023-85c7-3d482a34fc04">
+      <statement statement-id="cm-3_stmt.a" uuid="cd86af9e-b2c4-42f9-bd08-622642ee246a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2459,8 +2459,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="312c2f93-102c-40ca-b327-bf3f12de5054">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b072a443-54dc-445f-9734-e8ea5086d5b7">
+      <statement statement-id="cm-3_stmt.b" uuid="55b2e92c-81f2-4fad-b3dd-456c93a1fbac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2469,8 +2469,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="3d2b218e-8bb2-4eb6-bab6-dc269f5dc7fe">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="05218f83-8270-4e3d-b075-1f04ccda9285">
+      <statement statement-id="cm-3_stmt.c" uuid="684a0521-4ea2-4b94-b6b7-7b7a50b3f2aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2479,8 +2479,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="4ae21fc9-c2c9-4b27-994f-48f3e9bda79f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="47618223-98a4-4453-8678-348117cd673c">
+      <statement statement-id="cm-3_stmt.d" uuid="b1245fb4-2e87-497b-9ad1-8332e3854425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2489,8 +2489,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="be4fe83d-8886-4558-ade2-87fb6720da76">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b8129824-c29e-4e0d-9f86-b8ce207ddcb5">
+      <statement statement-id="cm-3_stmt.e" uuid="2a387d15-e1e8-4940-bce5-98bf905dd8d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2499,8 +2499,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="a9b9e8ed-8149-485e-b66b-91b9fa9363ca">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="12e13d2b-bfc3-4b20-9c10-d23bedc8c0ac">
+      <statement statement-id="cm-3_stmt.f" uuid="dfaa0f29-9d3f-4979-97ec-a7128d6afa16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2eaeb47-e9d0-47c0-9a11-57510f38c504">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2509,8 +2509,8 @@ https://issues.redhat.com/browse/CMP-265
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="08018579-5893-413b-8546-31db4e817cd5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="787843da-78f8-4f0a-a08b-e3dcd9ce7987">
+      <statement statement-id="cm-3_stmt.g" uuid="f81d2b69-26cb-40d2-bd0a-e160c2e867d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2518,10 +2518,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74bc3d77-27c2-4a0b-a34d-79437bff5467" control-id="cm-4">
+    <implemented-requirement uuid="bf7559c7-c3f7-4b66-a683-9209b935cc2b" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="59b81f78-bcc4-4e08-b5fa-0ae32bcafcf1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="352ba8c2-3c2d-4e01-9e9c-4644aa353c00">
+      <statement statement-id="cm-4_stmt" uuid="07305a6a-1193-4962-8b48-f144f31e60c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbc8a0c6-4b3d-4773-98b0-3a137e065b28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2530,10 +2530,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea010974-1535-4e15-a6a4-5a1e522d2767" control-id="cm-5">
+    <implemented-requirement uuid="62eb973a-3540-44cd-b719-682e2649a54c" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="e57f76b3-ebac-4a8a-8329-2d3b2931d9c2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0d002046-95ed-4e2f-8036-6367af3257c3">
+      <statement statement-id="cm-5_stmt" uuid="781f8580-6098-441c-bc1a-43618deb6255">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21a2ade5-e577-4721-ad53-a1546e1d1b11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining, documenting, approving, and enforcing physical and logical access restrictions
 associated with changes to the information system is an organizational control outside
@@ -2551,10 +2551,10 @@ https://docs.openshift.com/container-platform/latest/authentication/using-rbac.h
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2778b293-421a-4b2d-bf90-68573e588198" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="56630060-0a98-4d75-9b52-d0f4056dce22">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f98bfcbb-7281-49c3-a6a6-590efdf210f8">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2564,10 +2564,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fd75b10-eca7-48a5-9ea3-3c62e158ae4b" control-id="cm-5.3">
+    <implemented-requirement uuid="49523066-b7d9-4d77-a2c7-59366937787a" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="41ad6f25-a7e9-4344-af3a-ff5a42a19442">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9e3cb500-48a3-4313-9c23-bf7e8d362b2f">
+      <statement statement-id="cm-5.3_stmt" uuid="84764f58-0c4a-4051-bc47-08d6a39f7317">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca577a36-3847-4240-9bff-912466fccf24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2577,10 +2577,10 @@ https://issues.redhat.com/browse/CMP-187
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca6783d1-ec14-4690-8eda-1d7b9776bdb4" control-id="cm-5.5">
+    <implemented-requirement uuid="10d3143c-c783-4b4b-b538-995e6714f707" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="994b05cb-6a9c-4c56-a3be-3c0853171bcb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="120f8985-6ff7-4d8c-9925-e98aa25281e1">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3dae2524-5241-4fdd-978d-beb381490964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d823359b-250c-49fe-954d-f6be6ba9d33a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2589,8 +2589,8 @@ https://github.com/ComplianceAsCode/redhat/issues/901
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="9c14fe23-c559-4cd3-8d4d-c01ee9a771d4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="644fe81a-7906-4d3c-aaa4-ad4477de1fb9">
+      <statement statement-id="cm-5.5_stmt.b" uuid="e1618798-a68b-4c5f-9a6f-c9bc608ebd80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2598,10 +2598,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3c252b5-99a4-4501-9487-b6543e654f8d" control-id="cm-6">
+    <implemented-requirement uuid="2f4b6122-9153-47ed-818f-839b33259939" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="bc4e02c9-d820-4d41-8a7b-b6d11e4967c9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cd8a1c5d-db2b-4b9d-b717-9df433b946e8">
+      <statement statement-id="cm-6_stmt.a" uuid="bbd6ce3c-7ef2-45b4-8618-7d4168d9bd32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2610,8 +2610,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="31998ad9-ae87-4334-8291-7f7e63d2e6fd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5305c05c-68b7-47d1-ad9a-8c41ba72b1fb">
+      <statement statement-id="cm-6_stmt.b" uuid="c26016e8-a231-4f68-b2a0-18de19f60eb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2620,8 +2620,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="afc21c63-771f-4d81-9b1d-0f8f6fd0c971">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3eb58ff1-826e-4ab5-862e-5d53f00046a4">
+      <statement statement-id="cm-6_stmt.c" uuid="d34a9516-5f0b-4557-996b-2d5d71b12864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2630,8 +2630,8 @@ https://issues.redhat.com/browse/CMP-188
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="ef5428e7-326c-4d16-ae50-3e0b0e908645">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5cf2bcb5-4383-426c-8dc4-fd5cc8a8c1f2">
+      <statement statement-id="cm-6_stmt.d" uuid="40dd9dc9-7354-4b8d-a07a-707c81fb4177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0557d99-daa7-4cd5-a5bb-79a2ef5df470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2641,10 +2641,10 @@ https://issues.redhat.com/browse/CMP-188
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="115c44ce-bc58-4a1d-b2f6-f60e71b77177" control-id="cm-6.1">
+    <implemented-requirement uuid="23adbbfd-9d1e-417f-934e-fedba07890ae" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="02fd36a9-80f4-41b3-8736-c9ae6355a758">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e7b4980-6201-41d1-b423-9c837f9cd8e0">
+      <statement statement-id="cm-6.1_stmt" uuid="2f1e18cc-ae8a-42f4-b1af-e6941dd5209c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4551de61-8db5-440c-bfab-68c6bcb8968e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2654,10 +2654,10 @@ https://issues.redhat.com/browse/CMP-272
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82785c34-e3f6-4c2f-aa36-9b7fb7d958cf" control-id="cm-7">
+    <implemented-requirement uuid="4e820a8c-dcd9-489c-902b-a072fa5c0b70" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="9b30872f-9903-4f08-baa4-dc1c3eddbf87">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7f6c1648-9fd2-43d6-9bea-909336a17e2e">
+      <statement statement-id="cm-7_stmt.a" uuid="b5871b01-e9c9-4485-a45f-3bdccb1c0a89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2666,8 +2666,8 @@ https://issues.redhat.com/browse/CMP-273
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="cddb7c89-1a5a-4cc0-8f02-f020786dc0d7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="48ba8982-bc94-4a72-83eb-231b9d19c195">
+      <statement statement-id="cm-7_stmt.b" uuid="a6b5f2d2-287e-406f-acdd-57fb518663a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c615bddb-a883-4ae1-a0ef-3f53a9833d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2677,10 +2677,10 @@ https://issues.redhat.com/browse/CMP-273
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="987e67a0-1388-4947-9e62-7ae449eaf36d" control-id="cm-7.1">
+    <implemented-requirement uuid="681bbf04-881f-448a-b207-3183b7066a64" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="c6749bde-f873-4c4b-a924-76bf9186a588">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="570e7d04-fff3-428f-afe9-085b88fc3863">
+      <statement statement-id="cm-7.1_stmt.a" uuid="712afed5-3de9-4f0b-a3cd-93267d37b136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2689,8 +2689,8 @@ https://issues.redhat.com/browse/CMP-274
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="64bfcff0-aa8c-4f41-b1f0-7eb0664b8f85">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="814b5a9a-189e-474d-af2b-134cedd690f2">
+      <statement statement-id="cm-7.1_stmt.b" uuid="ec980658-104c-4e52-8631-2d923aff4c85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fbaf0fe-904f-4f7b-b606-46d13f3a0500">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2700,10 +2700,10 @@ https://issues.redhat.com/browse/CMP-274
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="329c2387-a561-4bfe-8d10-09e5b3e6d9b7" control-id="cm-7.2">
+    <implemented-requirement uuid="2045f042-6725-4305-b4d5-dfab9f16e180" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="e950f521-5cb0-4e46-8ba7-03e309d9ee60">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ecc0a35b-e0a3-40d5-a655-a6f0335bca79">
+      <statement statement-id="cm-7.2_stmt" uuid="70ab7b0c-c1db-4c82-b9b6-f464a23a1371">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76bedc11-066b-41c5-b5b0-8b40dc36c3c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2713,10 +2713,10 @@ https://issues.redhat.com/browse/CMP-275
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c30e787-7f3d-47c3-8a24-472c1c59097d" control-id="cm-7.5">
+    <implemented-requirement uuid="afeb82d5-0753-4ca1-90fd-3866f47e1b51" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="10b8e86f-5d11-46e5-8f09-0c7170081ed3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="623d6bda-2c9c-4f9c-ba34-c99ed0a49dd4">
+      <statement statement-id="cm-7.5_stmt.a" uuid="664d44d4-5274-4bcf-b887-31cd4a5ac1d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2725,8 +2725,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="3b180c2f-2f0c-46a9-98b8-1d4a86336b2d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="da759696-5d99-4003-893a-a4858e380881">
+      <statement statement-id="cm-7.5_stmt.b" uuid="76448ea7-3d83-415c-add0-9cb8a842af1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2735,8 +2735,8 @@ https://issues.redhat.com/browse/CMP-205
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="1bc517ac-2824-41e1-8f2d-181435880453">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="68e5ea24-b665-491e-9e2e-326d57a6c069">
+      <statement statement-id="cm-7.5_stmt.c" uuid="3b3a6030-4ee2-4050-95a8-c28aaaa8e862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa24fa2-97b0-4e4a-a422-29a7e0f91a75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2746,10 +2746,10 @@ https://issues.redhat.com/browse/CMP-205
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fda4cb1f-5315-41db-baf9-a5c2e59a73fb" control-id="cm-8">
+    <implemented-requirement uuid="6ab840ef-1732-44c3-a612-787e7e545ccd" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="c3da2d3e-01c7-43f7-a72b-a1e0597e5cf3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a908a5fd-b038-4114-a828-e6cbf2474245">
+      <statement statement-id="cm-8_stmt.a" uuid="8981d481-fa58-4a47-863f-735659a75a57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2758,8 +2758,8 @@ https://issues.redhat.com/browse/CMP-277
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="346cc2cd-94d3-48f8-ac21-bedc16b4170d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="09bcce5c-e7a8-4a77-aaf1-fd30f15995a2">
+      <statement statement-id="cm-8_stmt.b" uuid="1831a671-8eb9-4dfb-84aa-c3ec5f2f24fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7eceb86-8630-47f8-be2b-a463c84ef6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2769,10 +2769,10 @@ https://issues.redhat.com/browse/CMP-277
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4111064c-c706-49ad-b268-edc6aa854620" control-id="cm-8.1">
+    <implemented-requirement uuid="a2d7594d-e346-4274-9265-d46540911822" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="ee050c6e-7a0b-4012-a4a5-bc192ecf7ab9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="59b0eecc-e43b-4a5d-8c75-f6b1897dc5b1">
+      <statement statement-id="cm-8.1_stmt" uuid="e8f890bc-f312-4f4a-b859-d8ae6b11b6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8df6da4e-b135-43b9-86fe-b966c8589097">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -2788,10 +2788,10 @@ https://docs.openshift.com/container-platform/latest/updating/updating-cluster-b
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="711c1d05-ea76-4d7e-84d5-7b2aa9f9f10d" control-id="cm-8.3">
+    <implemented-requirement uuid="9f65e091-76eb-4b8b-a90d-01dfcf2d492c" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="db8a710b-0dd9-4638-acff-b950cfb43ae9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="969b7a74-1a7f-425b-8481-9fb4a6466ee3">
+      <statement statement-id="cm-8.3_stmt.a" uuid="23171812-48fa-443e-9266-3902cb35ff08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2800,8 +2800,8 @@ https://issues.redhat.com/browse/CMP-280
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="7eacbb18-420a-499f-a850-e196d907eab1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7015166d-b14c-4d26-bc50-cf5071691bd7">
+      <statement statement-id="cm-8.3_stmt.b" uuid="7af95e64-9f75-464f-86de-26378e862fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66b06958-62a6-4f5f-971e-a8b18da94e42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2811,10 +2811,10 @@ https://issues.redhat.com/browse/CMP-280
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c49e7c21-c763-4f94-84e9-a78191851318" control-id="cm-8.5">
+    <implemented-requirement uuid="fb999865-9705-426c-b663-06b8c59c0c14" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="699e5329-1b81-4dcb-be34-d70a61353919">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9f00fbd7-2d65-4c22-a61c-8237a3f09500">
+      <statement statement-id="cm-8.5_stmt" uuid="00f44a70-1aee-473b-a536-43025be1335e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48b8fbc3-de2c-43d2-8a07-e28a178041df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -2824,34 +2824,34 @@ inventories is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09547433-42ad-4dac-8c29-98910925224b" control-id="cm-9">
+    <implemented-requirement uuid="7d29b633-bf7d-4c8d-a07e-e7da6bd0597d" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="f4bbaec4-f0fb-41a8-a4b2-e3c7788b0fb1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4bf7addb-ca2d-4d04-b5c5-366b71159a9e">
+      <statement statement-id="cm-9_stmt.a" uuid="4c2757ce-0736-4639-aa56-1445684f0852">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="8f2390aa-7b91-42ea-b9ee-d091b32464ba">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="20e112b1-a32c-4aef-8107-99606355d77d">
+      <statement statement-id="cm-9_stmt.b" uuid="ed8ce88e-7264-4d89-bf53-28942768311f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="ea30c42f-469b-40bd-8b1d-12e550a3dc12">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fe7eab1f-d8fb-45ce-8a09-3501e7cd2b1c">
+      <statement statement-id="cm-9_stmt.c" uuid="a54380f1-364a-4c9f-8240-adb67f10c541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="c5e447b9-0887-4e8e-b778-9317890ed55c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="07c27d25-cca3-431c-9702-37b894cb3360">
+      <statement statement-id="cm-9_stmt.d" uuid="f654475c-4631-419b-a63a-b6cd676d4b52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bd12b0e3-5928-4b48-a2f9-369e291305ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of OpenShift configuration guidance.
@@ -2859,10 +2859,10 @@ of OpenShift configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb7b55f8-e296-4c1b-91ae-8011fd73735a" control-id="cm-10">
+    <implemented-requirement uuid="7f6e0d1f-9540-4672-9ea2-87bc92bc1ba7" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="ec49c7aa-d94d-4333-8f76-44172962b8e0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="dffd77bd-6888-401d-9a2d-c052c19fd1de">
+      <statement statement-id="cm-10_stmt.a" uuid="651a8696-33ee-417a-a07b-c2e23bf1a7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4bf0668b-3ac0-49fa-aee8-01deec0592e6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the organization uses software and associated
 documentation in accordance with contract agreements and copyright laws
@@ -2874,8 +2874,8 @@ project with the organization.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="7803cd50-307b-4738-9116-9498ce7e3032">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0d4f932a-40a4-47aa-a363-6a2442f19b57">
+      <statement statement-id="cm-10_stmt.b" uuid="d39f780a-b0cd-4641-993b-431a62e3c29a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="be79d021-c2a3-4c06-b5c0-f455be84026b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking the use of software and associated documentation protected by
 quantity licenses to control copying and distribution is an
@@ -2896,8 +2896,8 @@ following the instructions at https://access.redhat.com/solutions/4930131
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="478787f4-27fe-4774-a5fc-32561a5c6556">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c3cb9873-db3f-49e7-94be-4bd8e1aefa4b">
+      <statement statement-id="cm-10_stmt.c" uuid="26789b14-6c9d-47c6-88e9-ddc4e67722bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b094128-1abc-4616-8b9e-00eee0d19af3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -2908,10 +2908,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67bd35af-d4c9-414a-b588-a30d39aa192e" control-id="cm-10.1">
+    <implemented-requirement uuid="9f8336a3-a24d-4ddb-8263-d39ba3eb5517" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="293d8b39-ee37-49bf-b2e5-bcaba34b67c6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a914d3e2-4af3-42c4-a1a9-0ffe1359ee9e">
+      <statement statement-id="cm-10.1_stmt" uuid="fe7b30a3-83ec-4fc7-bfa1-e26d1e9460a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f6cfd58-cd70-4d96-9805-94191f4b1f49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of OpenShift configuration.
@@ -2919,10 +2919,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1452bfdb-d2b0-44d0-9264-d7b8a93fb5b1" control-id="cm-11">
+    <implemented-requirement uuid="ebf6c80d-ae1e-42f8-ad2f-67e668acd79c" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="4a71bebf-a38e-4a8b-9121-22f1c74ff0cc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c30c0edc-b458-4f5b-80f5-0ef74820c15f">
+      <statement statement-id="cm-11_stmt.a" uuid="dafb6e21-48a3-48d1-8fa6-068e39577177">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2931,8 +2931,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="5d985d75-c2c7-426b-9469-500fc42c405f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0e92b967-a753-41a1-b701-37f54723bdd8">
+      <statement statement-id="cm-11_stmt.b" uuid="de36e5da-b64e-44fd-980c-889978e7567e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2941,8 +2941,8 @@ https://issues.redhat.com/browse/CMP-285
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="7365a575-1340-43a6-ba6e-70c7dd78507f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7a8bc80f-44f1-4f78-afc5-3d9751102c66">
+      <statement statement-id="cm-11_stmt.c" uuid="88121617-6f41-4a5c-90c3-9406735c881d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf9ce949-de4c-41e8-8028-a32657381e46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2952,18 +2952,18 @@ https://issues.redhat.com/browse/CMP-285
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afbd6a2f-5a0c-410c-9bbf-04b41e0c3f7e" control-id="cp-1">
+    <implemented-requirement uuid="771b728d-1714-4fd3-b5f5-a09573598f06" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="180d2e4c-cfcb-49e9-9378-4455edaf0a53">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="49530059-898d-4f87-a0be-5cb5227741bc">
+      <statement statement-id="cp-1_stmt.a" uuid="66819085-e959-469f-bd11-b640883f4a9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5292e97-ef74-4234-a89c-9a4db072d285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="63b588ed-5449-4fa1-818e-7ab2172339de">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c9a11283-99a7-4a7f-86af-8e7554ba6f7c">
+      <statement statement-id="cp-1_stmt.b" uuid="a502aa27-f4c0-48cc-aee2-a763691a788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b9fab65-b3f1-4cb1-a823-f55077e3378e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
@@ -2971,10 +2971,10 @@ policy is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03be43d8-5cd7-4ef0-9b46-be7dd37225c6" control-id="cp-2">
+    <implemented-requirement uuid="b9394721-3b8d-40cc-b02e-69fad58f7c0f" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="c6e869d4-b061-4497-9b32-c6dcb731ca28">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="85b94dda-6da4-423b-b493-143627d879c5">
+      <statement statement-id="cp-2_stmt.a" uuid="8a136600-d66e-4ae9-bfd3-b15b9507039c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2aa923a-7992-49a6-84d8-d04470b30ac7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of OpenShift configuration.
@@ -2986,24 +2986,24 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="b2a95253-ba28-4ab1-a082-6bc359e55fa6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="83cde010-08a6-4ac4-a58b-2461ad54232b">
+      <statement statement-id="cp-2_stmt.b" uuid="20c9cde0-812d-4c04-b472-bc27cfe4350b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="331d8009-959d-4fb9-8fe3-3b2a69179d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="089f71a0-5819-431e-bbbc-eb523a46c6c9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5fd5c6b6-58a4-46b0-88e3-bee11acbf433">
+      <statement statement-id="cp-2_stmt.c" uuid="54d178ce-a421-4486-9ce2-3d35d8e2a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe6802b4-1a91-4382-baab-2f3d7a1630f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="b2b6e94b-e759-4d3a-8e44-21122f23dcf3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="994cf0ab-0d2f-474e-918a-d318c0dea68b">
+      <statement statement-id="cp-2_stmt.d" uuid="9dfe91e6-60a2-4fc6-a292-26a3ca28cb37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6ef3bce-d733-47fa-a032-756fd0e81257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3011,24 +3011,24 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="bb86ded1-400b-4d4c-bc90-caec5948839e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f2a460d7-edf5-4a7a-82f0-b42bc2755946">
+      <statement statement-id="cp-2_stmt.e" uuid="12e03d0f-7239-43ff-8511-42826295c45c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8ffbee2-6b43-413d-9e41-723756839798">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="cd93d593-a5d6-47ca-8cae-ccf9d1985f92">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cdaf2618-2db5-4f94-aa48-596462a667e4">
+      <statement statement-id="cp-2_stmt.f" uuid="3953f722-8d58-4b44-8f87-62d3a9186cc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="263af822-5945-4071-b329-b0064d3a15f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="ce46195c-ee94-40f8-b647-27ccd50c1094">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="449ae70d-b412-4fd4-bd1d-d50f1c698944">
+      <statement statement-id="cp-2_stmt.g" uuid="80043547-0078-4f6a-8e9c-cd6eeea6ccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa9f95a9-c72d-4dbf-8f27-c6f8493a27ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of OpenShift configuration.
@@ -3036,10 +3036,10 @@ modification is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b74b9b28-9024-4389-9fd3-e6c2ed1977b7" control-id="cp-2.1">
+    <implemented-requirement uuid="68fcb3d9-e3fa-4f21-8c0d-4dca3070f58b" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="521e7376-50d7-495c-8f87-fc4452924bce">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c050efd7-23ba-4248-b30b-3a628f5f56a4">
+      <statement statement-id="cp-2.1_stmt" uuid="71aae42e-fd99-437a-8439-fccb5ca10dc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3396a14-d559-4528-a017-03f6b3c5c178">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of OpenShift
@@ -3048,10 +3048,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9fad252-32b7-4fae-9bbc-b5b9e1a6efce" control-id="cp-2.2">
+    <implemented-requirement uuid="7e03fae0-bd13-44da-9203-e5fa39f3d61c" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="3cd9e6ad-2621-4136-a1bc-7a42e37be8dc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7887c777-8393-4b43-be10-f0e677e1738b">
+      <statement statement-id="cp-2.2_stmt" uuid="68dd278b-6ed2-4ffe-8b6d-7b3ebcc9ad00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3059,10 +3059,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdc0b4c7-1813-41ee-a0ff-ffb2548fec77" control-id="cp-2.3">
+    <implemented-requirement uuid="9406b199-8f5e-485f-9269-cb66e3116867" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="c74a3380-8900-456c-a492-599ffb758f8d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3eb6028e-335e-499c-8635-8a171fcb47d1">
+      <statement statement-id="cp-2.3_stmt" uuid="10ab1719-eb47-4cd3-8405-36b41446ce45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84850209-159b-4f57-9829-7b4fffb823f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3071,10 +3071,10 @@ plan activation is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6d4ce00-cbc2-4bfb-8113-f1cb1e42b05b" control-id="cp-2.8">
+    <implemented-requirement uuid="b2b31d8f-c254-46c2-99fc-b70a66da07d5" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="164720f4-2be4-4bae-8bf2-bf2e5bd100a5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="670441ed-9273-4384-9826-eec90ae944fd">
+      <statement statement-id="cp-2.8_stmt" uuid="cdd60955-5d53-4dfc-9362-923094a064b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3082,10 +3082,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b67d636-5329-4edc-bc15-43034f67d332" control-id="cp-3">
+    <implemented-requirement uuid="f8334ecb-8969-46c6-9bd2-85a7c4939117" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="56dabda0-7ff6-4bc9-829c-be31d2a1a620">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1fc89f6e-ab92-4fd1-ab4f-307139cb909d">
+      <statement statement-id="cp-3_stmt.a" uuid="eacc635b-d7be-45c0-b1e1-a8c0caab0f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c46d9b50-b074-4b05-ad17-52cbefe2a778">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3094,8 +3094,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="819e1dd0-7fc4-4c69-8221-d723bfec6fad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ca011006-8b4a-4702-83f1-30ed53c78b85">
+      <statement statement-id="cp-3_stmt.b" uuid="55d0cf39-d41d-47f2-acf1-9611c9cd28d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e2deff2-ef78-4842-a130-31d1f96ef3c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3103,8 +3103,8 @@ system changes is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="58c53894-65e2-4d0c-84f8-54cda2f10866">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b7e293de-b1e3-4d2a-922c-90db8e37136f">
+      <statement statement-id="cp-3_stmt.c" uuid="84c463aa-dba8-43d3-9028-eb8251c5d259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5aadb256-2286-47f9-b444-493b37edbc52">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3113,10 +3113,10 @@ frequency is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba2b0a86-a76d-41c3-9726-7fac044b29da" control-id="cp-4">
+    <implemented-requirement uuid="37f1ec1d-eca4-4821-832e-60470f2ed2d9" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="4cd15618-ff7b-435f-a432-9503d59245de">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c6e9d631-31ea-43e0-a832-257397a63f83">
+      <statement statement-id="cp-4_stmt.a" uuid="a0121166-a8d6-4542-9a77-458b36f5fff5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2d078574-7f68-43e8-860c-e009ad734355">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3126,16 +3126,16 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="87f929ad-1712-48c5-b498-8dcdad5b4924">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7cc8557c-8f21-49f9-8567-2f8e3c5ee78a">
+      <statement statement-id="cp-4_stmt.b" uuid="cf743a34-3cfd-4fa9-a58c-07c4d34a9250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c86cbed-d193-4e6b-b255-6d100e78a57e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="14b66f9e-e68f-4e53-a1bb-bea5bbb3c76f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c792387e-e0cc-47fd-b2be-658211b50dc8">
+      <statement statement-id="cp-4_stmt.c" uuid="1f36412a-d485-4a3b-978e-d823b0c049be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8788b75-6ab4-44bc-b7fc-63dec92b1fbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of OpenShift configuration.
@@ -3143,10 +3143,10 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f617cd26-eb4e-44ce-8314-06da75a927e8" control-id="cp-4.1">
+    <implemented-requirement uuid="050446bf-fbd4-4e3d-9d30-0c8aee859401" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="ba21d037-b6d1-40c1-ba7b-3b1c20fda260">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="de4991b6-7ac9-4a9f-8099-100aa32d2a47">
+      <statement statement-id="cp-4.1_stmt" uuid="d18006e9-04d5-4afa-8fc5-e264bece5f99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e91bf2c8-c7fc-4ec1-ba01-eba54ef8f238">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3155,10 +3155,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86622e54-b5ff-449e-a5aa-042033be0bb4" control-id="cp-6">
+    <implemented-requirement uuid="50813791-4bfa-43e6-aac2-ae13162ae225" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="a358f59f-361c-4c0e-946c-4b396978eedf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6230eb64-73f3-40d9-a209-9f0f5494c668">
+      <statement statement-id="cp-6_stmt.a" uuid="dc5c0f70-4f4e-4c18-a997-ef9147218854">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9deee0a-874a-49e7-8410-4ff3290a8975">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3167,8 +3167,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="5bab74a2-2c60-4be9-b747-fdddbc9dd436">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d32ef394-97af-4180-95f5-3d3fc7385659">
+      <statement statement-id="cp-6_stmt.b" uuid="a82fa0e9-77fb-4cb3-9a23-d5aeb13c5ffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="85d3cd83-fd2e-4d38-a918-2b3c029a6c38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3177,10 +3177,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fbee3e8-7a72-4b15-bcd6-18ab6f7547f3" control-id="cp-6.1">
+    <implemented-requirement uuid="2f93c5cd-a5b8-4408-9f8a-92d665f353a9" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="fff32039-f9a5-450c-9253-7a2d81bd6c8c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2b673244-b8bd-4904-a8f6-e6a4b3997f97">
+      <statement statement-id="cp-6.1_stmt" uuid="2a4ba549-5501-462d-a560-9996fb05de30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3247ec60-93f0-4ea3-ad3e-a4d626f687d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3190,10 +3190,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e384ecf-9b1b-4f18-9efb-293bb6e5a041" control-id="cp-6.3">
+    <implemented-requirement uuid="81f7ebdc-7eda-44dc-940d-0038c9170894" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="36a006b2-1292-49e0-b98e-34764e31ccad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="01cd0a86-1a19-494d-9018-978a5167a70e">
+      <statement statement-id="cp-6.3_stmt" uuid="a20d4a43-8cc0-4ae5-bff8-8d97aa5e3957">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="231963f2-2910-4d08-b37b-9ada727c3578">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3203,18 +3203,18 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d8ad062-5dc5-41bf-85dc-6006a7cebe8b" control-id="cp-7">
+    <implemented-requirement uuid="5b1e832f-e657-4fa3-8390-1fa1ed85c210" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="bc301e0a-6a50-4d2f-9adb-b33d48859707">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bef866f8-5c74-4c0c-9e88-604665fc8d4d">
+      <statement statement-id="cp-7_stmt.a" uuid="a4d95e39-d657-4a14-a24e-2f29804706f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="095f6e1b-2d3c-4503-81e1-01772c56ce94">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ddc0132b-3e51-4bd8-9cac-ed8860c90e35">
+      <statement statement-id="cp-7_stmt.b" uuid="29a3c8f2-edcf-4336-a4ee-cc886ee3e60a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cef4bd19-d779-46ee-9794-575e3583566d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3242,8 +3242,8 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="715e79ba-367e-45bb-aef7-7ea95b18e10f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a8ddfd08-db6f-431c-8ec8-9c3f7f5d3445">
+      <statement statement-id="cp-7_stmt.c" uuid="8df8a76e-df2c-4ecc-99f0-f61d76d50ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3251,10 +3251,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59974ea6-9683-414d-8224-ca596da0adab" control-id="cp-7.1">
+    <implemented-requirement uuid="12045a31-1c7e-4694-b3db-ec5a872e954f" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="b7d8002c-485b-49a2-80c8-443ff6d7d83c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2dbc91ad-7295-4ae8-9709-00394b6dc599">
+      <statement statement-id="cp-7.1_stmt" uuid="f747f946-4067-4172-9e95-c3633e70e611">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8a07e0d-b993-4ff4-a806-f495649250ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3264,10 +3264,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="734732c9-dbeb-4efe-97eb-d57584c041a6" control-id="cp-7.2">
+    <implemented-requirement uuid="c820dad3-a791-4dd9-a00e-3d6dd5d77077" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="d08ac595-4e26-496f-9675-5c6ce8ac1bb8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f86ebf14-705b-4406-9c3d-5e976064fe98">
+      <statement statement-id="cp-7.2_stmt" uuid="deb477d7-3a25-4735-82fb-f9dbcc57ca46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fa3e2f6-646d-49ea-91d2-2759f78287bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3277,10 +3277,10 @@ actions is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3340d90d-fe4e-447f-a3b5-b949dabb4cc9" control-id="cp-7.3">
+    <implemented-requirement uuid="6984c5c8-08a3-4be0-8275-625e98ccc022" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="e4f3a8a1-1b1f-47e5-850a-5b4d8de7eaf2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ac2856f9-df0c-4a4e-8367-a19d9c3eaad1">
+      <statement statement-id="cp-7.3_stmt" uuid="2f1230e1-a882-4798-bfce-e3408837c3af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b00e22d7-881d-453a-b04f-9c548c765bd9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3290,10 +3290,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11f89712-3b44-4889-91fe-898c3496b9aa" control-id="cp-8">
+    <implemented-requirement uuid="cbed8a82-ee85-48ec-91ad-b1db2679462d" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="d3073b74-f67b-4141-b4f4-da2f60de416a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e30d31cf-6f7f-4a95-8f59-1df23ff862be">
+      <statement statement-id="cp-8_stmt" uuid="49fb40da-a709-401a-a4be-84aa59502424">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5078176d-b1cd-4ba6-b420-33f93f20dee9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of OpenShift configuration.
@@ -3301,10 +3301,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91744846-a324-47bb-966b-63ba561db7f2" control-id="cp-8.1">
+    <implemented-requirement uuid="52236894-a4ae-4f0f-b025-b19d4e0b017d" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="97847dc8-0da1-46e7-be21-72fcdab444fc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="37dacebc-4e74-4975-971e-d6a0d0d1b2ef">
+      <statement statement-id="cp-8.1_stmt.a" uuid="7222ff8d-4b03-47d1-805f-1ab4c66f5703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f7769c6-f2c6-488e-b9b4-a4f9538314db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3313,8 +3313,8 @@ time objectives) is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="3d1936ce-9ca9-4586-a04b-038e54687127">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8c4a9fe5-ff43-4ff6-a7a4-05bec884f514">
+      <statement statement-id="cp-8.1_stmt.b" uuid="e4a5ec7e-e81f-406b-ab83-4862700d0a7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ff082a8-f0d4-43fb-b6ff-3ed080e8d7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3325,10 +3325,10 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70ef4eb7-694f-425b-9fb6-5edb84bcf0bf" control-id="cp-8.2">
+    <implemented-requirement uuid="01062b08-cd1a-4b58-993f-faefc16c0206" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="7159325c-51eb-4384-b457-469951e89080">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c255b2e1-4c7b-434c-849e-cd42a96adf60">
+      <statement statement-id="cp-8.2_stmt" uuid="93f2e67e-599e-43fc-a131-9fc9c848cdc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a39e3b0d-95c1-4bd2-921e-7e7f3b156405">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3338,10 +3338,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c6e1704-25ef-4b73-a31e-a56dcd399780" control-id="cp-9">
+    <implemented-requirement uuid="b8ed0b80-8f2f-482a-9ecb-036cfc41ec26" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="a0b3049f-3abb-400a-8e15-7eaf013d4dad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="56b01dc5-74b6-4adb-967a-e1006f6eac51">
+      <statement statement-id="cp-9_stmt.a" uuid="baffa994-23ab-4ef5-a98e-935efbb3a03e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91111cd6-ceec-4076-b4db-2f7432fbe684">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3362,8 +3362,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/backing-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="7b409225-d069-43ac-947a-4b11da10832e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a376e8f8-09b0-48e4-90f6-56aad525a24a">
+      <statement statement-id="cp-9_stmt.b" uuid="5c32e132-5d18-45c1-9044-08de5dba08c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4e1dc78-ba58-44a8-b06e-7e3bdd228353">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3384,8 +3384,8 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="280abf83-9e78-4204-a8f5-15f9384f2e0d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f2d4a642-7d2e-4d52-a3da-0c4885933895">
+      <statement statement-id="cp-9_stmt.c" uuid="614e4499-f6b0-4795-b027-fe80018d5f71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef25c499-5b9d-4e9b-8c6e-c1087e8a0da9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3396,8 +3396,8 @@ is an organizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="110f4e59-db50-4190-8021-1b0b3ca0a3b2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="217d77a8-a9f7-4c95-b493-5afa5761cdf7">
+      <statement statement-id="cp-9_stmt.d" uuid="75fb35ed-6e72-43da-8708-2dd633909bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677d27ae-b6f7-4418-ba56-2171679e535d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3414,10 +3414,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09163b89-48e6-4088-8217-5a2ec54bcd7a" control-id="cp-9.1">
+    <implemented-requirement uuid="2028a7bb-9a66-4854-931b-e4645f62f474" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="d4231166-0500-4915-8f7f-0f9a69566974">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e04b212a-cd85-46de-a4ef-b5305dcc4791">
+      <statement statement-id="cp-9.1_stmt" uuid="4ab62c86-5c04-4a4a-899d-ef04a43c3f6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19ed4134-a2ff-47ca-8b6a-f1646595bb99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -3426,10 +3426,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="448229b1-f918-4f40-90b3-e67a8a44e94d" control-id="cp-9.3">
+    <implemented-requirement uuid="373ffff3-37fb-4fba-b48c-39ee152839b4" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="773358a7-1225-46c6-a6ec-c5319edbd1cd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3973b36e-bc08-4c8f-99f1-fb590afe48f1">
+      <statement statement-id="cp-9.3_stmt" uuid="e20bb8aa-12ad-4f56-98c1-246c171c7d8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b74d6d9c-72f5-4449-bdeb-4e8e12738eec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3439,10 +3439,10 @@ operational system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe52e313-1543-428b-aa11-c884721ec1b7" control-id="cp-10">
+    <implemented-requirement uuid="60c05e35-8cbb-431e-be0e-7298fb2e3885" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="919ea9b0-693b-4a4b-a34b-583502067118">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="72228f50-8a6a-47c1-860f-d8a97f6c9d87">
+      <statement statement-id="cp-10_stmt" uuid="4cfec696-2533-43e2-8cd4-d83034a25b0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc615e64-aa2a-40d5-9bf5-f9fec7b0860a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their OpenShift environment. A successful control response will detail
@@ -3457,10 +3457,10 @@ https://docs.openshift.com/container-platform/latest/backup_and_restore/disaster
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29828a3a-5f63-4b62-9e42-e09063e5663f" control-id="cp-10.2">
+    <implemented-requirement uuid="f38b682d-5a68-4e3a-93ea-77d208867808" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="baba72f8-5c33-4d29-9c95-e4c3cadb1241">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="dd47005a-23fc-4cbe-a548-911787667ef7">
+      <statement statement-id="cp-10.2_stmt" uuid="1e5bdebd-7dc2-4315-954d-3e911ac29edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -3468,27 +3468,27 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="788ca355-224e-4e2b-93c7-6650e51272ca" control-id="ia-1">
+    <implemented-requirement uuid="7a63474b-62ca-479d-964b-d58bce457f95" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="e331d1ee-c2e4-4587-b4c3-e3ada8fdc302">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="52fe5b47-e056-4659-b35d-452e0b9ab734">
+      <statement statement-id="ia-1_stmt.a" uuid="a36fe514-78f8-4e92-a6f5-ffbdbac40098">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a33d8b8-0bdb-4d23-8859-0363adaacce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="50053840-4ee5-40eb-829d-9079923082f1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a68a0a93-d3d9-46ca-afc5-5cee9d79033d">
+      <statement statement-id="ia-1_stmt.b" uuid="1ad8b1ab-65d9-4977-9a6a-3dd415e440ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe0d32dc-7657-41d6-8617-03d01c8d0590">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2f8d2e0-8ae6-4048-9d06-5f6e4ebff29d" control-id="ia-2">
+    <implemented-requirement uuid="d5bf1824-63d0-459f-8124-139f199c926a" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="426e8db0-025a-4044-b084-4da5838c99fa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="43f0c6f8-f1c5-43de-b863-07eeda193f12">
+      <statement statement-id="ia-2_stmt" uuid="69702027-98b2-432d-9be3-8816afa66b86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e572a34-7d36-430a-acde-f6d4ece3a6b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Unique identification and authentication of organizational users
 is deferred to the organizational identity provider (such as
@@ -3507,10 +3507,10 @@ container image, is provided by correlating system audit logs.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c55ce4e8-329a-4162-b201-329374ea93bc" control-id="ia-2.1">
+    <implemented-requirement uuid="31ff8a91-b777-49fb-b8a8-89cb0b4aae44" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="9a57d9ab-53e5-40e3-a490-5a42b09be0fb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="274cd6da-e91f-4747-b793-d739d15f2612">
+      <statement statement-id="ia-2.1_stmt" uuid="eca3dba3-92b6-4796-8f9f-3b9c961260eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11288f65-ae11-479b-8f16-163d14246986">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementation of multifactor authentication for network
 access to privileged accounts is deferred to the
@@ -3529,10 +3529,10 @@ needs and requirements.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a29ec9ec-2d4e-4554-8505-45358bf03661" control-id="ia-2.2">
+    <implemented-requirement uuid="cf7c767f-0055-41ca-a1da-6d732b6a37e8" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="1f0fef02-76e9-43b2-bfc8-6413aa7ddf1e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ce6c3b1b-e715-43cc-9b3a-f3b28c267aad">
+      <statement statement-id="ia-2.2_stmt" uuid="1fb52b9e-61c3-4c51-9616-d746b5dde22a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c7f868-8a40-432b-85d7-a6dda1c95ab3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing multifactor authentication for network access
 to non-privileged accounts is the responsibility of the
@@ -3547,10 +3547,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9df30ef9-6bbe-4921-a083-42215d24496c" control-id="ia-2.3">
+    <implemented-requirement uuid="3d3e27ed-6394-4013-886b-40269120234d" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="3f3791c4-1a8f-481b-8658-5cf15b59968c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7b74a585-4917-48e2-b2f4-e9cb3049f007">
+      <statement statement-id="ia-2.3_stmt" uuid="d683d036-9850-47a6-a23b-a45c5f4db720">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2319b2df-e057-43dd-9df2-f329809aae78">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift has no concept of local accounts and was designed without the use of local accounts.
 OpenShift relies on a centralized identity provider rather than a local identity provider.
@@ -3564,10 +3564,10 @@ is not applicable to OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f83241b0-b86a-4176-89ab-e77e30ac0f89" control-id="ia-2.5">
+    <implemented-requirement uuid="70fb0a1f-4d52-4d3a-8bd2-76bad2982a11" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="f53e8d67-9639-4203-ac2c-8597dd167f65">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6068ad98-a4a4-45da-914b-f4fb5a6fa072">
+      <statement statement-id="ia-2.5_stmt" uuid="171afaa9-5c54-4280-b995-6a326913f866">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8db01236-9ba8-4e4d-89f2-befea2e69992">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3575,10 +3575,10 @@ https://issues.redhat.com/browse/CMP-314</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5cd74ff-29ed-4779-a23a-a6c78c8e923a" control-id="ia-2.8">
+    <implemented-requirement uuid="58b65007-7944-4515-ac3b-eb32c8217053" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="9a0cce07-ee3f-4e8b-ab42-e809d76b5b62">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="504ff480-9549-453c-aee9-d8d3eb8f520c">
+      <statement statement-id="ia-2.8_stmt" uuid="44133dc6-7f85-4bd5-8e92-7c3503592a8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befd7201-c418-44f9-b539-54f1d723941b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3586,10 +3586,10 @@ https://issues.redhat.com/browse/CMP-573</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51c8d2fa-8c1b-42d0-a1d1-7a675cd060ba" control-id="ia-2.11">
+    <implemented-requirement uuid="362d4418-8240-461c-96e4-ef5fa30ad4dd" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="c2fb577d-b8ea-4d48-bdb6-3eed57eb923b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a12ae61e-12b8-4d25-9f0c-165485537200">
+      <statement statement-id="ia-2.11_stmt" uuid="e6bd6d01-26be-45fa-914c-f0a6287cda05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d93e23f-8b49-4528-960a-997f4e43f8c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a separate device from the system
 gaining access to the information system using multifactor
@@ -3599,10 +3599,10 @@ guidance of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79f79ba8-c937-4d47-a64c-4ead55af3d86" control-id="ia-2.12">
+    <implemented-requirement uuid="cd277188-f18d-4c2f-81d1-52b4f05d4850" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="d4b5255a-6236-46ca-a6aa-2ab53995790e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="946b777d-5984-45b9-8178-cefb3919db45">
+      <statement statement-id="ia-2.12_stmt" uuid="c8df24aa-90fc-40ce-8b44-eb61bf261d49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8a27df5-d2b4-454c-9d33-ff6bf5108270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronic verification of Personal
 Identity Verification (PIV) credentials is the responsibility
@@ -3617,27 +3617,27 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3dfbbba-f504-4807-8e8f-281e618c8973" control-id="ia-3">
+    <implemented-requirement uuid="affb7bbc-ba2d-4d82-81ee-3b12c82a0240" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="a1da07f1-b21c-4152-bdd3-a44c626ea871">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5e7d589c-1cc9-428e-b94a-2d169f8d0609">
+      <statement statement-id="ia-3_stmt" uuid="b0106689-c877-4dd2-b7fb-48be934113bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4094f41b-39e5-4be9-a5c0-2b03948cd290">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7437ec0-cba3-457a-a352-82509dcfb665" control-id="ia-4">
+    <implemented-requirement uuid="f8c650c8-2244-4408-8c43-b7d628cddbf9" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="2146a494-2143-4dd5-a3aa-c11c10b58e2f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5b14350a-bcc5-4c9f-97af-aa83fdeb0248">
+      <statement statement-id="ia-4_stmt.a" uuid="af77be7e-e7ac-43f6-838e-93a7def235f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ae35092-d4b9-46fc-8151-a7c985b0cf73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
 requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="7685b5e6-ed0f-4a5c-9fb6-1af2d1fc06ac">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7ce31066-c900-48c2-901c-e9a2e1b361c7">
+      <statement statement-id="ia-4_stmt.b" uuid="d4c31b6a-6158-43f2-8271-7bbe4f914cfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae5e68fd-d86a-4fa0-8600-a3560f6361b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift
@@ -3650,8 +3650,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="3dd4ec8f-0335-42f4-b114-f7a3db40040b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="46461cdf-50a7-4e45-ab26-1fd8bb641870">
+      <statement statement-id="ia-4_stmt.c" uuid="4cadb32e-e9a0-46fe-9a9e-2b5198cf8dc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23c9fe46-b3b5-49ac-9dbd-091b95caffa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3663,8 +3663,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="4a88c2ca-6a55-4829-a3f9-c9cc6ad48c25">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="65cb4f8c-2f78-4b7b-9e6b-2cea443c78c5">
+      <statement statement-id="ia-4_stmt.d" uuid="c1c3dfe5-dc9c-4795-b8f3-d4781b33a61d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b50a8422-1e67-4289-beba-bfac3b80e45a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of OpenShift configuration.
@@ -3676,8 +3676,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="928fd7c6-7341-4a26-8a2f-e04c17b78a93">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="18dac6f8-cf97-4736-9826-5c9dbec7504e">
+      <statement statement-id="ia-4_stmt.e" uuid="1ef28ca6-a1b3-4310-99d3-4d5b9d555331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78d3d56d-9076-495a-9b79-451d78c74481">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of OpenShift
@@ -3691,20 +3691,20 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a28c937-5bed-4323-b996-a36cb47d36e0" control-id="ia-4.4">
+    <implemented-requirement uuid="ffc6660f-49c7-48d6-ae0d-e730ffe55e55" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="2fa97e49-3691-4fc0-8b6d-e180650a5f97">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ceb9f6da-f73c-470e-87c9-fc93e6f4277e">
+      <statement statement-id="ia-4.4_stmt" uuid="fc0b706c-b313-47dd-b2b7-ed57cbd810c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d818cc45-a56b-48ea-95ff-0dd9de956381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ca515d1-d733-4cb4-8d4d-9c888fa9a66a" control-id="ia-5">
+    <implemented-requirement uuid="f45786b2-8ed7-4ee6-9977-1cbfd8439463" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="c3c47937-0f32-4413-8beb-29e909f7d97a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5e529a9d-035e-49d7-ac26-742b0c33505d">
+      <statement statement-id="ia-5_stmt.a" uuid="b77b381f-73ee-45d2-b1ee-6dbd2a271b05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="035e502e-7530-462b-af9e-ef68b2c1e6f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -3712,8 +3712,8 @@ is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="7375e29c-a67e-449d-bb0e-5410a7c21fdd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="38e82a56-be03-437b-93b5-a0e85c32b920">
+      <statement statement-id="ia-5_stmt.b" uuid="9edf37b0-e399-4984-80d6-d022fb4db90f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7bf9a1ed-032c-440f-9e8f-68b7c4658645">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3725,8 +3725,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="80c52645-511b-45f5-a8a8-433dc142fa3c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1e1ec223-fcdd-4e26-bd77-3302318e2210">
+      <statement statement-id="ia-5_stmt.c" uuid="a5fbcaf4-4a96-4c7a-86e8-1cc7eb2bdfb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f524611f-505a-4fff-9a00-9f2e38d9fecd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3738,8 +3738,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="70af25ad-a340-4630-8eb1-1c162d5e5d69">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8cdfb6ec-e9d0-4ee9-8cef-dd275c5f0b35">
+      <statement statement-id="ia-5_stmt.d" uuid="fdc6a0b9-914a-4099-9357-a8cd1607a7a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f6ba12d-0e6c-4f30-b8ed-d623e84a01c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -3752,15 +3752,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="59999bdd-954c-4bd7-bd62-bfe2fc50f4a7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="737a4be8-34d7-4fd3-b6af-6b190edb4168">
+      <statement statement-id="ia-5_stmt.e" uuid="a8b479e6-63c8-478a-8ff7-d4d29749603e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c4e68b-fded-4a39-87a1-bb4af4c888a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="946ab64c-f2a6-4c22-8974-47e9371f54e9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0b28a79e-d512-4630-8f09-207810ca421a">
+      <statement statement-id="ia-5_stmt.f" uuid="21d07f6b-a8a0-45f8-a9fb-77e8c140557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b95f8b1-9bc1-4f9d-a602-132c9801e281">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3772,8 +3772,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="455f4b72-18d0-4194-aec0-a22ca237d6bb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="de68cc3b-f225-4f21-842a-dc24a018d7fb">
+      <statement statement-id="ia-5_stmt.g" uuid="f196ad36-8645-4831-be4f-7284660a97e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5be5103-5818-4050-861f-4c8878a5535e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3785,8 +3785,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="dd93a535-bde1-470f-8afb-1118fe17ada8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1be7e019-262d-4e81-9c1e-9e71db05a851">
+      <statement statement-id="ia-5_stmt.h" uuid="ae312eb9-a9b1-484e-837e-55213c542bec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3253f21a-52de-4279-81f7-050827a480a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3798,15 +3798,15 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="8009cd38-d12c-4d85-9306-2d0581c2c8c3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b823a999-a6ec-430f-bb54-86112041b3b8">
+      <statement statement-id="ia-5_stmt.i" uuid="1103eb61-2511-4e4e-9dc8-ae2e27ee4fcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="858b0f18-ca29-4ecb-9da4-ebe49a3ddf8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="98f728f2-c4f8-44f0-a9ee-5ca789d11b56">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="65e271ae-8a80-4d96-a7ed-9a240a0b8d9a">
+      <statement statement-id="ia-5_stmt.j" uuid="0d9d2135-b850-4062-9382-e6e1435da287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="171d97d3-9690-4d1b-849a-ae505ebd52d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of OpenShift configuration.
@@ -3819,10 +3819,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b13523c-d258-4ef1-a775-01967038de91" control-id="ia-5.1">
+    <implemented-requirement uuid="c840dd2d-2134-4106-b0e1-cdbdf942e3ee" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="769c8588-2581-4dec-817f-4fe0388b0b2a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4c7e86e8-d30a-42d2-a547-ce854ff6d13d">
+      <statement statement-id="ia-5.1_stmt.a" uuid="5494089a-1a35-4115-88e3-cf817fa662c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0080de48-f09f-4e25-84a7-d8fdc5704bb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -3836,8 +3836,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="58936f46-b50f-409e-b618-4e23d5144977">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d49b34c7-fd9f-4ab9-9983-8aa07017e891">
+      <statement statement-id="ia-5.1_stmt.b" uuid="af6af93e-ea08-4c92-ae76-993187816f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="affed9b7-8fe7-49f0-92ea-6d594ebc48ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of OpenShift configuration.
@@ -3849,8 +3849,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="8e3ea654-06a0-42f9-9d40-bbabf4585008">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6436c9e2-efe4-4bf0-a52e-b0c9eab10586">
+      <statement statement-id="ia-5.1_stmt.c" uuid="3ecfcdf9-1a50-42d6-b687-328fb6f3d17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e124b321-8080-4d56-a14d-45aef97161fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of OpenShift configuration.
@@ -3862,8 +3862,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="83e675e8-d6d7-4400-a321-d06b6df3ec2a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2c97527b-29f3-4ad2-9bb1-e5e16599e293">
+      <statement statement-id="ia-5.1_stmt.d" uuid="59ef1f9e-aba7-4b83-b9f3-9e580162fffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67102d51-3421-49c3-8272-98e08992dca4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of OpenShift configuration.
@@ -3875,8 +3875,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="8b13fac6-e8b4-4ab5-b995-44135bfbdc5c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9a8591ac-9c59-4ee0-963e-20dbb658bc8f">
+      <statement statement-id="ia-5.1_stmt.e" uuid="a1ebe259-90ce-47a3-89b7-3a836ba771ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7eaf0053-9ecf-401c-8c93-a735e11b7306">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of OpenShift configuration.
@@ -3888,8 +3888,8 @@ can be found in the OpenShift product documentation:
 https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="dfe71209-9a1e-43eb-abec-87e9ea3aed2c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="95fc0aac-08cf-460e-81f4-1b1dd832a8b2">
+      <statement statement-id="ia-5.1_stmt.f" uuid="256c38d6-45fa-443e-907d-ff06e549ccf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f4d75ab-40f3-4890-97bc-bd148fe15e9c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of OpenShift configuration.
@@ -3902,34 +3902,34 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea44a5c6-abe1-4225-b420-b37502b3798d" control-id="ia-5.2">
+    <implemented-requirement uuid="3d445664-31ad-44c3-9a73-e966b555a4e1" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="b161826f-44bd-45ba-9f3e-86381ff1c11c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a9438b5e-3d0c-4d2d-b4b2-916598f5ee96">
+      <statement statement-id="ia-5.2_stmt.a" uuid="a2b1037b-32b1-48d7-b633-f389aba90736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="451b006e-60c2-4291-a699-4338c0e2fd1d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="008b64e4-aadc-403d-8c59-39376cc5d92c">
+      <statement statement-id="ia-5.2_stmt.b" uuid="e0bce06b-3ca7-4c6b-b737-8f7b277f03ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="804c0aef-cb0c-45f4-988b-e94abfc5c082">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fdd2cee9-50a4-454e-b108-be773e83d16a">
+      <statement statement-id="ia-5.2_stmt.c" uuid="0bc48b29-44a3-402f-8bf4-891ed7bfaaeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="aef17a2d-1371-4236-9d97-6be884e4bc1f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fdaf7345-476c-4811-8aa9-f2473f3e76b9">
+      <statement statement-id="ia-5.2_stmt.d" uuid="e6f5339f-55ea-49b8-8b36-6ca9d24cbd37">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="541735ef-84f2-42fc-a606-f0ebd03a99e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3937,10 +3937,10 @@ https://issues.redhat.com/browse/CMP-327</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95ffd8c2-c13e-4d87-b8bb-32b6032ba237" control-id="ia-5.3">
+    <implemented-requirement uuid="087b0337-b603-49f3-9da4-561f46d5a5fb" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="181c9b2f-de7d-4d9d-b275-7bba37863e61">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b5a7036f-447a-48fd-b169-a6894fbcc50b">
+      <statement statement-id="ia-5.3_stmt" uuid="a788ca9d-d74f-4362-872e-c0972bbd9917">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="847c4dff-2b19-46c8-a1c4-14fde9fa7f1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -3951,10 +3951,10 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed229744-5bda-41b4-bfce-dfb873af0edd" control-id="ia-5.4">
+    <implemented-requirement uuid="a0eca32c-d306-4f23-8e9e-96b6402ed104" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="08900b95-a481-417f-af04-135aa656a270">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7fbdf549-9718-4a76-be2f-4e0f3acb3a9f">
+      <statement statement-id="ia-5.4_stmt" uuid="9ffddd5e-d96b-41df-b35b-8dbf74ca432e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c609ea35-e7b3-4483-9223-aa8bc09e7ff0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3962,29 +3962,29 @@ https://issues.redhat.com/browse/CMP-328</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f11f0f2-aa4e-4418-ace3-051a16dc191e" control-id="ia-5.6">
+    <implemented-requirement uuid="571b39b1-f0a6-4dc9-a6a1-760fe8f05b3c" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="ad12c92a-2a5a-4bf9-b135-491b5f4d0452">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c6579c7d-f234-4c5c-b609-cdd00a5ee41c">
+      <statement statement-id="ia-5.6_stmt" uuid="1db6648f-b34c-453e-a1a7-ada8b0930096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d818cc45-a56b-48ea-95ff-0dd9de956381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fb78dad-ef76-4ee7-872a-a257b2782dc1" control-id="ia-5.7">
+    <implemented-requirement uuid="a80217f5-2e7e-492e-b63a-d015ffb4b031" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="0507a6ca-9c0e-4b5f-b0e2-776735658df0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1f2dffa4-b7a0-4332-90d5-9c90d2359b78">
+      <statement statement-id="ia-5.7_stmt" uuid="dab7d254-8dfa-4536-9227-25dc1a71046f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3422ee35-1c97-4e63-b358-ad7a35d6837b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-5(7) is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99b0872e-6837-42bc-83f4-d426a57ad837" control-id="ia-5.11">
+    <implemented-requirement uuid="aba44873-a665-4cf3-972c-4bb448283d71" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="8dc532a9-8fc8-4b2b-9ef8-51f6fdd1cd86">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d1e67a36-1bd7-4f38-a083-e5865c507c4e">
+      <statement statement-id="ia-5.11_stmt" uuid="dc253871-14d6-47f5-8139-0a58bffbc0c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98b4157c-f7dc-44e4-b6fa-2621e57af0de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -3992,20 +3992,20 @@ OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43b03829-7159-4433-b92a-227b5aad25e9" control-id="ia-6">
+    <implemented-requirement uuid="d82ede4e-b4c6-4df6-8637-06ea271f4988" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="a9135c65-3aa0-411f-96d9-cd4c28620362">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="900d22ff-d878-4f75-81b3-ec2043c0edef">
+      <statement statement-id="ia-6_stmt" uuid="954333a6-db59-4363-84ff-4a093276cc26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1de62daa-6d58-4197-b444-1f300cfa16bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, OpenShift Container Platform session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="100696a7-422d-43f9-84a7-31d727ea597c" control-id="ia-7">
+    <implemented-requirement uuid="15f30ea6-ea07-4a5e-8f4b-911b2b9913aa" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="8238beec-4658-41be-bd7c-9b87dfaa322b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f3f766be-8201-428f-897f-7d019b0c370c">
+      <statement statement-id="ia-7_stmt" uuid="8036c5d4-0735-4d3c-b75b-9a1e12ca4425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f49ea9da-eda7-48e0-9efa-58caf64c9e50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4013,19 +4013,19 @@ https://issues.redhat.com/browse/CMP-334</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f487768-1ec0-4d08-a3fe-b220cefa782f" control-id="ia-8">
+    <implemented-requirement uuid="40dc1e99-1157-46e8-93e9-b91aaacf5722" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="e5f38743-d10b-46a8-8121-c9abc2b150a8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="101875f3-f60f-414d-a311-488a2bed64cd">
+      <statement statement-id="ia-8_stmt" uuid="5f420b03-beea-4c0d-84b5-4039a12d1577">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bed8babc-a810-411b-bd12-deb0cca5d951">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-8 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="920ad26d-d40e-41d9-ba03-7e7a618d207a" control-id="ia-8.1">
+    <implemented-requirement uuid="e36cd541-c9e8-456c-9a9c-4e897c58bcd2" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="ee60b24f-8cb0-42a0-be57-62a4361af06d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0bf774f5-f6b4-443c-ad1c-5b97940018bc">
+      <statement statement-id="ia-8.1_stmt" uuid="6430ab3c-8226-489a-8a51-ceb2ca7c2b16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64d3d4db-549b-448a-8308-d9e57759b155">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance and electronically verified Personal Identity Verification (PIV) credentials
 from other federal agencies is outside the scope of OpenShift configuration
@@ -4039,10 +4039,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6177991b-c5f3-4821-8b49-3181a4a27666" control-id="ia-8.2">
+    <implemented-requirement uuid="1571fa34-2c0c-4837-8eb0-728567db9222" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="1d9181f7-36b1-4c04-a86c-dd49491a2d7d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bfa8ed1f-361b-4a5b-8134-66dc2d2e22cd">
+      <statement statement-id="ia-8.2_stmt" uuid="ecb2f8e0-c4f5-44e9-ba59-b7122437ab7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8dd8b698-d621-41cf-bb38-a1e0e4f77cf6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Acceptance of FICAM-approved third-party credentials
 is outside the scope of OpenShift configuration
@@ -4056,10 +4056,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98f5ccb4-8276-4716-bf46-70d94d6db361" control-id="ia-8.3">
+    <implemented-requirement uuid="086a9f3b-16b7-469c-958f-5a46a1b81120" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="b012b431-a1a2-47c6-a02b-ce0e43fa0a47">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="32861004-9480-4150-b823-64da4c66e32e">
+      <statement statement-id="ia-8.3_stmt" uuid="59f3a1d3-380c-4767-8cbb-61c59d4f0b35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f50b47b6-83f0-41a1-b836-bb5aa76bbd31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of only FICAM-approved information system
 components (e.g. cards, card holders, physical access
@@ -4076,10 +4076,10 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd6af0f0-cd25-4624-8692-07d7eb97b543" control-id="ia-8.4">
+    <implemented-requirement uuid="68413d07-5f0c-48dc-8329-bbd634cd2aa6" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="1a594296-777d-4c7b-a8b1-7578b7f1532c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0a035bd2-4726-4521-ad0e-b8879f29cf1e">
+      <statement statement-id="ia-8.4_stmt" uuid="3691e247-fa06-4e02-a52b-87472287de3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="451ba487-859d-46d2-be66-364a4f621a92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Usage of FICAM-issued profiles is outside the scope of
 OpenShift configuration and is the responsibility of a
@@ -4093,50 +4093,50 @@ https://docs.openshift.com/container-platform/latest/authentication/understandin
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="214e0503-ed30-4cce-8f3f-745d60d20ea4" control-id="ir-1">
+    <implemented-requirement uuid="43039241-d333-4db7-9609-9b77b28a3f0f" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="c5dbe33b-4d20-49de-99e7-534c1e10fb92">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="50692c41-0478-4cb2-a33d-38e72885c9d6">
+      <statement statement-id="ir-1_stmt.a" uuid="88eda018-bd0b-418c-9cb2-47118ed36ced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="13a4108d-a80a-4481-8914-b2d1d3465d81">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="22eb0ce9-3cbe-472d-af73-1610d67f8c31">
+      <statement statement-id="ir-1_stmt.a.1" uuid="f3fa3086-4945-4831-bbe4-9e049146b989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="e334458f-3fd2-461f-a3f8-df4941cea699">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="749a6100-86e9-472b-bb71-b3660d7aa7e9">
+      <statement statement-id="ir-1_stmt.a.2" uuid="d6827642-8b99-43e5-bc4a-cea9fbd10cbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="c625665c-f173-4b3d-8e5f-29353c934706">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0ada8a2d-d16c-4e17-84f7-fcba5c7937be">
+      <statement statement-id="ir-1_stmt.b" uuid="383de702-72c9-4a0f-846f-47cd60669782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="14cbb687-61e3-45dc-8f90-21d46e9ed5df">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="11c31cd1-1e0d-45a3-add9-bcc0cb9ee1ef">
+      <statement statement-id="ir-1_stmt.b.1" uuid="bd1976e1-fa73-4ef6-80b1-4eb2e9e356b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="e747ebc8-f9ea-4629-9cd9-eee9a06d1eb7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="dc751c40-b92a-444c-a251-1df50ed32914">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d6cd467e-3cf8-412b-ab91-6b316fa4a606">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4144,26 +4144,26 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fb181a7-dbe8-4abe-8b88-5543fc3174d6" control-id="ir-2">
+    <implemented-requirement uuid="81b56ecb-1a80-4e29-afd9-836933f1776d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="d89d5cf5-542d-4d38-847a-dab5230541d2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0f7b4e20-0a14-45f3-a6a7-e8f0f19d9ad2">
+      <statement statement-id="ir-2_stmt.a" uuid="9984f5c1-9b0f-44f3-bb44-4013df8aae5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="d1acbb4d-488b-4a34-9f88-d533ff346e4d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5b18a1af-2f9d-4fb7-bc41-f6c7c0181bb1">
+      <statement statement-id="ir-2_stmt.b" uuid="86b318cf-5287-4082-8c9c-2264b4717d66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="1999a216-188e-45d0-9115-0c6ecab065cc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2d60e68c-f920-426f-a884-a44b383a35df">
+      <statement statement-id="ir-2_stmt.c" uuid="9742cc48-f755-42e6-8abe-e19985c32dd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4171,10 +4171,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bed08f5-6879-4b74-930b-356664f26765" control-id="ir-3">
+    <implemented-requirement uuid="fb508091-0909-4671-b454-7a461004d6d1" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="282b2d38-8e68-41c0-8bc2-e53e2a177620">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="829eb85d-c6ec-4ef5-93d1-34f635cc4500">
+      <statement statement-id="ir-3_stmt" uuid="37fdd0d5-0d8b-448c-8f9d-2bb6c5cfe139">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4182,10 +4182,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1a3babd-d39f-4f1e-9d3b-d1d4be328089" control-id="ir-3.2">
+    <implemented-requirement uuid="ad715b1a-2e93-486c-8561-073e5a82ab87" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="2354c509-014c-4079-ba42-7e989d2e77d2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7922643b-985d-46c8-9950-31a5546c7cda">
+      <statement statement-id="ir-3.2_stmt" uuid="efdd36dd-4bb7-45ba-af25-6d6cecb488ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4193,26 +4193,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e495a8b-434c-4b74-bd80-305d1661c19d" control-id="ir-4">
+    <implemented-requirement uuid="c394eb2a-4cec-443c-a6f7-77349352fc20" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="5e848894-3014-4f0a-a56e-e0e6236a02bc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6be289b8-36dc-41a7-8e64-eee8a87ad66e">
+      <statement statement-id="ir-4_stmt.a" uuid="b6252153-ddba-4952-bd97-39f0d104771c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="713ebddd-b205-4233-8555-78633e905412">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e89b3855-f6a2-4fcc-9563-ee607a6b95b8">
+      <statement statement-id="ir-4_stmt.b" uuid="e2104fee-fb83-43a6-a09a-85ce5502df00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="71470e46-95c2-4b93-9f7a-da5cdce59c94">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9c3527e3-8348-4920-a542-9f09dfcfde98">
+      <statement statement-id="ir-4_stmt.c" uuid="457b25c6-28f9-464f-b964-cdc84235bf82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4220,10 +4220,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b8211a8-4073-46d1-97a0-825dc603488a" control-id="ir-4.1">
+    <implemented-requirement uuid="cce7723a-f25a-45c6-bf29-6a38860ebeab" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="aeabb089-e576-4222-91f7-d8c4079c7b60">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="72447ae7-bd1e-4ccf-8268-736911f64d64">
+      <statement statement-id="ir-4.1_stmt" uuid="12b13f92-8631-4e3b-bd23-1f1d938505cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4231,10 +4231,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b984eab-eee9-4a9e-ae58-2ae330fa41bd" control-id="ir-5">
+    <implemented-requirement uuid="f8e53718-6179-495d-b4bf-22d1d2d49121" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="f26fe213-b51b-4110-af78-ae6eadc96a75">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d2514e2d-ff16-4247-88ff-70d6513aee81">
+      <statement statement-id="ir-5_stmt" uuid="c6ed00f0-aa54-42cf-9c24-3206ba3d77a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="367e314c-be0a-4933-8e01-8ac474a58997">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to OpenShift configuration.
@@ -4242,18 +4242,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47d48d78-67fe-44ba-9db3-e77704097f9b" control-id="ir-6">
+    <implemented-requirement uuid="85d0cae6-52cd-4630-9774-5f89fe81b838" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="fba47f70-edff-4e46-9177-4503fd75713b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="002bb30c-877e-45a1-82cb-3adb2f6357d2">
+      <statement statement-id="ir-6_stmt.a" uuid="c3241b05-d5e4-4a28-9f92-42b18719d3ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="7880cb8d-2697-46f7-85c4-760b63de421c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="85651356-52cb-45b1-b12f-843af2b41b03">
+      <statement statement-id="ir-6_stmt.b" uuid="5c775a24-b49c-4266-a483-e37d1d37f3db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4261,10 +4261,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39059592-8ed5-491e-80e8-28d5276e0ba1" control-id="ir-6.1">
+    <implemented-requirement uuid="7f80008b-3d1f-45ea-89f3-752cbcae9e61" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="fc7bea36-37dd-4a9b-a217-98364ff1eb6b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="eca85aeb-86a5-4ddc-8c1b-e92f42e83783">
+      <statement statement-id="ir-6.1_stmt" uuid="0bfb37aa-87c1-4fb5-bc5a-c515b6fb23e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4272,10 +4272,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d160ee54-a419-4757-8c21-f74bbe607f6d" control-id="ir-7">
+    <implemented-requirement uuid="11e39f52-40e6-426b-a23e-f889000bc40b" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="92f9103f-dd59-4954-92ae-e465facbb3ab">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="558b0074-25ee-44e5-8336-89de31eddb84">
+      <statement statement-id="ir-7_stmt" uuid="6bfe8a45-3127-4281-a47a-adf2f5554f47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4283,10 +4283,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4af45814-3ddd-4231-a200-f45bc506f0ea" control-id="ir-7.1">
+    <implemented-requirement uuid="624d9025-07d0-4fd8-a465-8df8b03abb75" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="1fcb2b2f-cac3-447d-be63-f0eedd4cb552">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a62a142c-0288-4aca-a7d1-d5dc1f48491f">
+      <statement statement-id="ir-7.1_stmt" uuid="d6cff08b-07c1-4b1e-8be3-357a62efd30b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4294,18 +4294,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0195694-6de1-40a5-980d-b49518e9e6a5" control-id="ir-7.2">
+    <implemented-requirement uuid="2752dfd4-738e-4eaa-a8d0-29a1dffa058a" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="f0d1d655-1157-4050-90ad-c73f7c33c3ec">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="677058c6-4496-45a7-bde1-611dce1c8398">
+      <statement statement-id="ir-7.2_stmt.a" uuid="a4f32ff7-f55a-48a6-90f9-632f70aaf8f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="e2e2b7c5-0faf-4777-925d-cc53b5e9e14d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="98c6ffd9-ad53-45a3-bc65-d2c182b89cf9">
+      <statement statement-id="ir-7.2_stmt.b" uuid="6b0721c9-da4a-46f8-8a0a-a4f9a587196b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4313,114 +4313,114 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d231459a-c9b0-4ab3-8e53-3f3598a71d61" control-id="ir-8">
+    <implemented-requirement uuid="bb4e7052-02ce-441b-9c4a-89c532ecfb5f" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="22d2583a-cc8f-40fa-a1b5-568b5cd85bc6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9c6b982c-959e-43fa-ac20-b8c6feeef82a">
+      <statement statement-id="ir-8_stmt.a" uuid="227584e5-c6af-41d4-ab76-bc1381e3359b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="986ddb98-0a63-4795-a010-ea67ac6eed77">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="eebdc9c8-afb3-4eed-bbb0-23bfad645265">
+      <statement statement-id="ir-8_stmt.a.1" uuid="1c5de3cc-c433-4ace-91b7-6cd949843847">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="22ad614a-ca5c-4086-90a8-13f83e34425c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7fc40450-a5dd-4e2b-9e30-0d07e3304ae5">
+      <statement statement-id="ir-8_stmt.a.2" uuid="f0317202-3633-4cd1-872c-2f027b8756ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="30b5afa9-b0b9-4938-aa3f-b1c363b3bde8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="beea4c34-f458-4cc3-8c8f-1f3a0870201e">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b58411a1-bfd0-440e-9a31-8d9fd31edb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="7fbd38e5-f778-40ed-a6f8-a35e259cd131">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f8d764f3-380a-44ad-b6e3-578fb8444d9c">
+      <statement statement-id="ir-8_stmt.a.4" uuid="569d6e87-911a-4a6e-be38-a2813bb5e02e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="4c34a015-7a0c-4950-953d-355d384a996c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d6c7c192-f052-4eed-beb3-fc5c973d5a9d">
+      <statement statement-id="ir-8_stmt.a.5" uuid="efaea696-1fea-4abf-95b4-39344e4724e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="3ded7416-bdc5-4645-aacc-b5f33f4ad25e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="dda572f1-cbb6-48f1-82e6-f33d8c978fa2">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c1b60d11-37c5-455f-b47d-c5c278638a8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="9843717e-9406-4b47-956c-1c991813e344">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2079a0c5-ac8a-4d42-aebd-0c2f9f37b259">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d58998e9-3310-4ec8-b6b7-73f1c1ffbd36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="020e08d9-a330-4bdf-bc25-ac7f49efcbd9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6db17357-2713-453d-8ecc-9d6859ba3186">
+      <statement statement-id="ir-8_stmt.a.8" uuid="b66a3b8d-6cda-4aee-a38f-a0d4cd1c6bc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="2f5eed25-ca19-4b3e-ac75-86350a276951">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d9aedf8f-f3d5-4ff7-a113-ccdb1213ca40">
+      <statement statement-id="ir-8_stmt.b" uuid="5c02f03a-0779-439b-86d5-7106516fda13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="348b1621-3397-4572-9f5c-6b89e938e294">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e9dfa45-ccf6-4dcb-bf0e-e75f55565c24">
+      <statement statement-id="ir-8_stmt.c" uuid="d239bbba-139c-4c7d-a720-3a66d534c6b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="976ef987-6257-4822-bb90-4bcceb4c7e6a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9ba65239-5087-46ad-8c9d-40ef10c12cc9">
+      <statement statement-id="ir-8_stmt.d" uuid="edabf95f-64af-430d-ab6d-5f04c028889e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="54ead1ac-a52c-4d97-93e2-9872da76043c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a54af81c-9bf6-473c-acf8-7824ad9842e1">
+      <statement statement-id="ir-8_stmt.e" uuid="5cccbc53-1a22-418d-b3d4-026759960888">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="a21d6d32-af1e-4bc3-871f-df6c97d382f4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="92da0ac2-e9c7-48dd-baab-12e6ee09c45c">
+      <statement statement-id="ir-8_stmt.f" uuid="361269f5-7504-4190-b4d1-a73bff1622ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4428,50 +4428,50 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2090e47-0c6d-437c-9e56-0f4995d9007c" control-id="ir-9">
+    <implemented-requirement uuid="b2e348a3-31bc-433d-a2f8-b5c241ef86ce" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="61821716-8244-4501-9c18-a8ab992ccf53">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e78683e-3327-47d4-a7be-20ab5d2ba9e6">
+      <statement statement-id="ir-9_stmt.a" uuid="6da22d0f-ddb7-44c5-b7f1-53d7984979c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="a30f323d-ee1d-42b2-9c78-e94dbbddb174">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="969d48b2-7222-4bd4-b0df-9de3ad8513ff">
+      <statement statement-id="ir-9_stmt.b" uuid="f96ad164-4bab-4324-a1e0-8437001f03a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="40336bd2-4fe4-4dbd-9fe4-5f434cc48bf4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e143cda2-1822-4bc6-8da5-70d87e4cf7f6">
+      <statement statement-id="ir-9_stmt.c" uuid="ba4b075d-cc24-43f0-9a07-8ced5d7c0916">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="28c8c426-72c2-4236-b4d0-8c1eff84ffbd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2fe1d0ab-667b-43de-ad3f-2bde5a6f7e40">
+      <statement statement-id="ir-9_stmt.d" uuid="c9c9321b-a290-4831-869d-5cdb693c0f86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="2d8438f0-39e7-4ff5-95d2-98d7fd6601fc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="63c6b34d-6b11-4c11-9e00-d94f1b4c22bd">
+      <statement statement-id="ir-9_stmt.e" uuid="aab8ed8e-18a9-40e7-8eb9-c09674ede8ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="b0b35a42-0a65-4a0d-ac8b-bad1d8604694">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d67b652-ee29-4e56-bd6d-07405501d22e">
+      <statement statement-id="ir-9_stmt.f" uuid="41ca2980-f5f5-4f5d-8aa2-8995a707f80e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4479,10 +4479,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e566079b-4eae-4e40-a9db-fd19e637afd7" control-id="ir-9.1">
+    <implemented-requirement uuid="ab55c7b3-b446-485f-908a-ee269a195e13" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="2cd4870f-8c4d-4af9-bcea-739294c0f6d5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="520fc246-cf0e-4c4c-81b9-e71c09a9dc08">
+      <statement statement-id="ir-9.1_stmt" uuid="500fefa0-05dc-4bbe-9745-a7e84326bd99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4490,10 +4490,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40211d6f-3888-4112-985a-d50d9cffd69f" control-id="ir-9.2">
+    <implemented-requirement uuid="4f887b13-7b13-4e2f-a5b0-acd743b1d1d3" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="3ed3ee9e-a05e-40b8-bafe-8bdc5a85541d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="85e66cab-2bf9-471d-98fc-cfafdccddef0">
+      <statement statement-id="ir-9.2_stmt" uuid="eb82f482-7a0e-4707-b926-83e064fa27ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4501,10 +4501,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5e0ccd3-a5cc-4e08-94e6-2876040aff97" control-id="ir-9.3">
+    <implemented-requirement uuid="22cf8a39-b2d5-40be-a422-0ae21886871a" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="1b809023-0e18-47a1-ba65-5eef78f5aa72">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a00889e6-993d-4cb2-a80a-d93cc85a8890">
+      <statement statement-id="ir-9.3_stmt" uuid="3fd83d97-1751-44d7-998c-879ebf776087">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4512,10 +4512,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f891161a-3660-4251-b462-0d8c0f210cdb" control-id="ir-9.4">
+    <implemented-requirement uuid="1098c877-c428-4909-ab14-b74a151fccf2" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="98d47598-8a47-4142-b5e3-734d1929fc61">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="769e1c5f-ab36-41ce-9b2f-9e65d3102489">
+      <statement statement-id="ir-9.4_stmt" uuid="e0ea69aa-daab-4b9a-9cf6-b5e89c485168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3c3f81f-a1af-442e-9c07-828b6dbd4cb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to OpenShift configuration.
@@ -4523,18 +4523,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ad5db02-9208-4907-88fc-d07f3daa49b0" control-id="ma-1">
+    <implemented-requirement uuid="b10fe6d1-8b4a-4355-a102-d7114483e66a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="4f676839-7028-4956-be45-262a89d5d704">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2b1fb19d-7fbc-492e-8317-eba5a04e0739">
+      <statement statement-id="ma-1_stmt.a" uuid="f9871dec-e863-4601-a0a3-6cf618410383">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="18e4e26b-8183-4278-a337-3704313fe496">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="97dc2b3a-1f08-44c6-b106-37bf998d0286">
+      <statement statement-id="ma-1_stmt.b" uuid="70066806-55a5-46af-81bb-ef96b7601008">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4542,50 +4542,50 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56a311ab-455e-42fd-8221-301e471a620f" control-id="ma-2">
+    <implemented-requirement uuid="2ed3fb53-97c8-4f9c-bcf3-320460f9f3aa" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="d1a21289-bda3-4c7c-ab48-ddb04af06a7f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7ecd3001-d07f-4292-aa58-8de928948a1d">
+      <statement statement-id="ma-2_stmt.a" uuid="d3d3bf14-2476-4700-8e56-50f6c4c33e47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="1d661d5b-d2c8-4efe-8920-dec3be584bfe">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0bcc8fea-e964-46b4-af6e-c5abb861de4e">
+      <statement statement-id="ma-2_stmt.b" uuid="e1493534-bb33-4385-b0a8-011771101e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="b3843e09-8a1b-43ff-967d-40f6a26be8b8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d8f0bb99-6596-443a-943a-bcda32abce6b">
+      <statement statement-id="ma-2_stmt.c" uuid="c45aba08-33ca-41b6-8c61-3173a666e4f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="448e571a-53e0-4be6-bddf-8b56ecd09ebf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="563f3ba8-b7b8-415c-95e8-2758ea31c73a">
+      <statement statement-id="ma-2_stmt.d" uuid="5188a418-51bc-4418-ad92-cd6bc24d9d50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="a575fc2f-826e-4cbf-918a-abd1585483cc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e95e0b9a-43e9-443c-ac05-de84325ee705">
+      <statement statement-id="ma-2_stmt.e" uuid="e664b60f-5935-4125-a2ac-3d4f42040367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="2fe4a318-a50a-48e5-927c-27d9c328c98b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b2f68dc7-5cb9-4174-aba1-2e4691aef3fc">
+      <statement statement-id="ma-2_stmt.f" uuid="237d6190-6c08-44c2-a328-2ed9e6c838c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4593,10 +4593,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a98094da-8356-46ab-9019-7f8c17f9d4e4" control-id="ma-3">
+    <implemented-requirement uuid="fdfebb36-1e7b-420a-a053-b946e0071adb" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="cd336e63-516e-4796-b72c-f96693106836">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="245b7095-d142-4f85-9b83-4be80c0a61a6">
+      <statement statement-id="ma-3_stmt" uuid="b4529b13-c674-4f08-9427-dbd97694278e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4604,10 +4604,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d1e9c18-96b5-4a97-a8b6-a512862d107c" control-id="ma-3.1">
+    <implemented-requirement uuid="0e77dc6d-69af-45e9-a308-375db32617ac" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="c301765f-5347-4dc1-88ea-883cb3492271">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4b13ab38-fe52-4aac-bb74-74d2731b7440">
+      <statement statement-id="ma-3.1_stmt" uuid="e691a20f-9488-4437-8b9c-50e6b0666184">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4615,10 +4615,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="571035fd-2cf1-4c35-9edb-673ad2ec9399" control-id="ma-3.2">
+    <implemented-requirement uuid="6a636ca8-7aa1-42f7-b901-174ecfbc3de4" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="644d556b-cd2c-4cdb-ad14-783f70019a65">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cfc168cc-92f9-4554-9476-67bce372c476">
+      <statement statement-id="ma-3.2_stmt" uuid="42b75ed1-c31a-4c6a-9e60-2bf2e42d5f58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a13a2bff-16cf-4b17-aae8-777d336bb39a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -4627,10 +4627,10 @@ system is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="103fdab2-8ec7-48a2-8b71-371658d1b224" control-id="ma-3.3">
+    <implemented-requirement uuid="870bfe36-974a-4c0e-9e27-e9a3ea93294e" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="a2bd1dcc-746c-4479-b80f-c06cc5348e0f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b19aeb41-5d27-4130-afeb-98c813a0a938">
+      <statement statement-id="ma-3.3_stmt.a" uuid="bf170846-fe82-434a-b6bc-bca8b57a4021">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a388243e-007b-4ea2-be24-332d8780977f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -4639,8 +4639,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="fd3e6829-3162-4ab5-9320-2d47d8a8e40a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="131e06b9-ccf1-4a9e-8e81-bf7505770aca">
+      <statement statement-id="ma-3.3_stmt.b" uuid="7c27499d-28f9-4871-8065-d32c1c74aa7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="771c277e-946c-4a50-b2ef-93dccb7e35c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -4648,8 +4648,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="e4aa0e42-f8d9-4568-94c5-7699ba3431ab">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8547f6e5-4839-4a18-b8ef-916f7097d996">
+      <statement statement-id="ma-3.3_stmt.c" uuid="37b48713-246a-4b65-a9dc-fde415f29e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd7ef875-1eac-4e79-ada8-7644963c1d05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -4657,8 +4657,8 @@ facility is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="881d570c-f648-4a43-82e3-5203cc7437c0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f74e6a3d-0035-42c8-8bfb-b251afd3773f">
+      <statement statement-id="ma-3.3_stmt.d" uuid="10ebb45a-1949-467d-b9e8-b2fbacf9a9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8143f81e-90f4-4697-96e1-801032cd2b0c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -4669,18 +4669,18 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7406442-98c4-4cb1-92bf-bd22ce7a8eaf" control-id="ma-4">
+    <implemented-requirement uuid="204c3081-9db4-477a-b1b7-acc6123933ee" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="c26f5160-2f62-4e6a-83ec-2aa178b6749a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="514fe14e-dc94-4303-865a-54bbe40900be">
+      <statement statement-id="ma-4_stmt.a" uuid="50345522-239b-4d9a-a70d-7b5e6e2b3cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f83d066-75c3-4751-9058-9a0072ba2a51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="0623ed21-5f47-4e6a-bb8f-09bce8bba9ae">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f490f69c-7c63-4d41-a5cf-154ed9325b00">
+      <statement statement-id="ma-4_stmt.b" uuid="9ef16448-cbe4-4c91-80da-e1cb54be20d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e80348b7-25d4-4d89-b28b-0882198f6646">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
@@ -4688,8 +4688,8 @@ orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="3b353b64-ede0-452f-b00f-a79ece05d399">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cf51b761-a9b3-4bbb-982b-c4df8c84d4b5">
+      <statement statement-id="ma-4_stmt.c" uuid="bdb17a60-8fb0-4004-a01b-04fb5bc7b795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4697,16 +4697,16 @@ https://issues.redhat.com/browse/CMP-343
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="4d72afe1-80dd-4604-a11e-74515e9fd003">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c98a2931-cec5-4598-95ea-58f912f0fc12">
+      <statement statement-id="ma-4_stmt.d" uuid="29005666-5e5d-464f-8b34-73b8095d773b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74202b5e-92f8-4be5-a08c-b07c9b0f8149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="e5d11cc4-81e3-434f-8031-7121d8a1c1bb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="724f3558-ba77-4ac5-9ab7-a9b5f3362265">
+      <statement statement-id="ma-4_stmt.e" uuid="bf8f5d8b-bbcb-4b2c-ab1c-9b30498eb630">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76a89fd3-8d46-4f5f-a2b3-ae12e81ef4f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4715,10 +4715,10 @@ https://issues.redhat.com/browse/CMP-343
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffb5bc06-a665-4df8-98f1-b38fa72135fa" control-id="ma-4.2">
+    <implemented-requirement uuid="5ce2c17d-db54-436e-bcb3-fcdbed7a3f45" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="5c0cd07c-943f-44da-948d-0b81c4048c8e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4d690554-bdf0-4f0b-afc6-6fcf0ab3a3af">
+      <statement statement-id="ma-4.2_stmt" uuid="8eabb2c1-31b0-4785-8a44-5054c8050fbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4726,10 +4726,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33e0114f-e708-42e2-a943-43b6c1f51a7a" control-id="ma-5">
+    <implemented-requirement uuid="c6462421-f340-4b02-9572-80913c2f5646" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="09c43102-af7d-4590-a026-73594ab1a297">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8636b044-af54-4803-9943-bbdff44baa5e">
+      <statement statement-id="ma-5_stmt.a" uuid="4dc39efd-5d7f-4b4d-866e-04a28ffdb2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="124aa32b-c8d1-48cd-a8e4-ddaeb3480877">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -4737,8 +4737,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="82ee758c-b67c-446f-bee0-2dcc916bcc8a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1c87f002-3168-405d-a6e0-5080e18cdccd">
+      <statement statement-id="ma-5_stmt.b" uuid="b242b08c-223f-44d2-98b8-691eec589cf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72e60fde-d698-45ba-8c34-7bb3e0c6c8ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -4746,8 +4746,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="c1138722-462c-400b-bc07-3312e557d000">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a7a82d1-0fc6-4b4b-817f-0b1d1faf91c1">
+      <statement statement-id="ma-5_stmt.c" uuid="0f320f71-ba98-423a-adc4-5a126367dccc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e90741-c6f7-4d1f-a9b0-167c1eeb394c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -4758,10 +4758,10 @@ scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29f3aba3-cd2d-41bb-ab6b-13f7fd51a991" control-id="ma-5.1">
+    <implemented-requirement uuid="a966e130-70ce-4e23-a70f-6310f3ee8639" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="dc5ec28d-45b9-4926-9a0f-a748a1e4f4d8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0d31200d-e358-4908-8337-d4d91a20dec8">
+      <statement statement-id="ma-5.1_stmt.a" uuid="d563fffb-51f2-46e6-958f-c39290a08cef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28f67c55-45d9-4c06-9922-4473114ed208">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -4769,8 +4769,8 @@ citizens is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="9fc43e35-8499-42d9-a89a-810f85e54adc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3ce5b42f-ddf7-4b14-8f58-07d82d9243dd">
+      <statement statement-id="ma-5.1_stmt.b" uuid="fdfd32c5-c193-4bef-8d31-615380d02da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="362916b9-da8f-4aac-932c-10a264871562">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -4780,10 +4780,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0832bc1c-5de7-4853-8573-0f66294e4442" control-id="ma-6">
+    <implemented-requirement uuid="ef948e47-fbc9-4af5-af58-e14406af116f" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="6efaa927-337b-44fd-aee7-5708086c9d64">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="650318fb-7b01-4731-9285-f61421982446">
+      <statement statement-id="ma-6_stmt" uuid="9434df4e-b1ff-437a-9cbf-578648ebd922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -4791,18 +4791,18 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="845800a2-406d-49bd-8285-cca45147abb7" control-id="mp-1">
+    <implemented-requirement uuid="1c2b137c-e0e6-4383-8c59-bb398437a58a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="692bc2e0-de8d-4982-96af-06e96391edd3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6c1bc938-5fdf-4ff4-a446-e685751449ca">
+      <statement statement-id="mp-1_stmt.a" uuid="a90905bd-7ee4-459d-9fde-427e6ae14845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="3eb2f6ac-0caa-4e98-8d31-e95ee1770ec3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f003951f-2ff3-4e03-8e2e-691db42e70fd">
+      <statement statement-id="mp-1_stmt.b" uuid="f16f66b5-c2ba-45c1-8f16-8e3252f197ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4810,28 +4810,28 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f26ecb6f-d9de-4b78-a7e9-fc6f91454598" control-id="mp-2">
+    <implemented-requirement uuid="108dc458-f5dd-4887-a989-5927a9611045" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="dbb8308b-aa7e-43f4-b515-99c0d676d009">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e3ef673b-361b-46be-bbfc-1aaaa0961b66">
+      <statement statement-id="mp-2_stmt" uuid="4d8f11fd-331c-4950-b137-f08af8a0083d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ad988c3-921f-485f-8d66-4137bca2cb4b" control-id="mp-3">
+    <implemented-requirement uuid="d0b6544e-44d1-4edd-985e-a6b6d54a5e81" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="11b94876-a408-4c45-a730-c134518d85c0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9bc1a339-ea67-479a-a809-74944f559830">
+      <statement statement-id="mp-3_stmt.a" uuid="b3630488-66ee-4d51-909f-058e6d757cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="464de59b-78c8-4dbe-8229-206f4b692266">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6cd41342-01c2-47c5-aded-6aac73c1e930">
+      <statement statement-id="mp-3_stmt.b" uuid="04252dcc-ea70-48c2-a81c-48226104f7f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4839,18 +4839,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d580b0a-274d-4402-a644-c43dcc63c854" control-id="mp-4">
+    <implemented-requirement uuid="5cee2b9c-bd47-4d33-b57c-22d9f82041e5" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="4212a33d-2cce-412c-a8cd-a2c7738cabce">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8f0c02f4-8865-44c3-8ae0-e971becea6bb">
+      <statement statement-id="mp-4_stmt.a" uuid="edd4c6d2-e1c1-4c98-a7ad-1cdee99c6e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="dd5a1bdc-f18d-4eb5-b897-1027bb5e1f95">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="51ac5bf9-4725-4fa2-8539-d6ada5da6627">
+      <statement statement-id="mp-4_stmt.b" uuid="45b21575-6f5e-4763-a423-d07380760015">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4858,34 +4858,34 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dec2aa6-918f-455c-bc77-d62e0edf92ba" control-id="mp-5">
+    <implemented-requirement uuid="68193acc-d0b9-4a4c-a3b5-b5bda72630e6" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="a3755304-4778-4454-a338-faae9f2174b6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="993f0b9d-d37c-419d-9baf-f3af57005599">
+      <statement statement-id="mp-5_stmt.a" uuid="8c404d88-0d1e-4d18-b9d2-517af9ccdb23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="150e2b71-f6c7-4313-9a4f-dd06b942fee8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ceb54a3b-2298-4e19-9c5b-4943fcb692c3">
+      <statement statement-id="mp-5_stmt.b" uuid="77d67d4d-5f52-4bf2-9b32-49c94ecb5530">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="8da70da9-e1d4-456c-a5d3-349c401baf04">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c92b7965-42a8-4efc-a2c5-7dd32ab4f18c">
+      <statement statement-id="mp-5_stmt.c" uuid="7cc6e721-c756-4423-bae8-109e9a62cc41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="ad0cc6ce-77a2-40dd-bfce-9367520ef1a6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3cdec582-6198-4f55-b8e3-8efd116ea401">
+      <statement statement-id="mp-5_stmt.d" uuid="a0959b9d-89cf-4ea9-a20d-5d9c5f00303b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4893,28 +4893,28 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8ce28a1-1458-41ec-a2d8-b496a275413b" control-id="mp-5.4">
+    <implemented-requirement uuid="037a54ff-d1cb-4118-a65c-7704aae71480" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="bfa936c7-09fd-4731-b351-04cb79bff947">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="340a9546-1dc1-4696-a801-3b244b10175a">
+      <statement statement-id="mp-5.4_stmt" uuid="e8b83342-3687-453b-be2c-a9364b11df2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3003d8a2-d95e-4abf-bc79-7cbdda47835a" control-id="mp-6">
+    <implemented-requirement uuid="0427c8d9-1658-43bf-b365-c2d8b57f973c" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="aa2ee9a3-1d27-4e2a-b0f7-ee1afc246798">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="223b9f41-3ce2-46ad-87e9-fae5a1c6df13">
+      <statement statement-id="mp-6_stmt.a" uuid="f49bef15-aa6e-4f61-b787-ba9c4c2b1372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="c4125855-a003-43e3-a81e-fdebf1be704e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="adcfb732-ff53-4a66-9b4d-91100d0534d3">
+      <statement statement-id="mp-6_stmt.b" uuid="31236cf3-7eb1-4545-8a44-72cec9a91f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -4922,20 +4922,20 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fba1d584-b1fc-4a88-a41d-571eca2019c1" control-id="mp-6.2">
+    <implemented-requirement uuid="f186bd35-b47c-4277-821b-d9595a39f9f8" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="08051527-c3aa-4cd4-834c-38a2ce7d7aa8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2675ef97-6ea3-4584-961e-8ced15603261">
+      <statement statement-id="mp-6.2_stmt" uuid="0145b297-a828-4259-b7ee-8235e00c827c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6eb72768-4870-4c03-b215-eafb5c623498" control-id="mp-7">
+    <implemented-requirement uuid="ec9f0f5b-634e-4648-a0bb-f90d4525af78" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="aa380702-ef63-4b5b-95e7-26428115bfa4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7b443af8-df92-415a-9ccf-9cf4320ce490">
+      <statement statement-id="mp-7_stmt" uuid="864e4639-60ca-43bc-a00a-8ce2fb547d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab02986d-bfed-4206-8c15-412836e72d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -4943,20 +4943,20 @@ Openshift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edfb1ba8-7e58-47a1-8aaa-1053fe694e3d" control-id="mp-7.1">
+    <implemented-requirement uuid="13df7266-0297-43fa-8cf1-abb43b354911" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="d055b7ed-74a0-4488-bd9c-f1e8da6f269d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e0697870-b429-4510-a9d5-08402d51b7cd">
+      <statement statement-id="mp-7.1_stmt" uuid="350395f8-7774-4c2b-8069-93b3a13a0b6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bfdf96c-06c6-4444-94f3-165abf56435a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cc94a99-38fc-4514-8d25-23f9f6071857" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="56a056aa-1a26-4698-890a-7063ab485d3c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="125b00ad-f79c-4187-be61-665b800f52b9">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -4965,8 +4965,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="b1cffe8b-f0f0-4d2e-8593-5838b81f1864">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="732ef0f1-8bc7-47fb-b6dd-6aec5cdb63b1">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -4976,10 +4976,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65708c16-ef84-4d72-b949-08f5a6e19580" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="84ff2f77-48eb-4df2-b6cd-efdb2f7c8c83">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="79b3d5cc-5379-4a48-9e7c-9b1bf8345a1b">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -4989,8 +4989,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="d91daf5a-b2e8-466c-8085-9c41c52d2a8b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="89c1552c-711a-4999-a816-c422da659074">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -4998,8 +4998,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="90989119-7e40-4102-a4a0-88e4ab5ec650">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5e6075a1-faa5-4b93-9d83-5441e80831d0">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5008,8 +5008,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="7e8f0502-80c4-490b-81f3-0469f892eedc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f34bb159-8765-4467-b9ae-185b990e684c">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5018,10 +5018,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72be3bc4-5c67-40a6-ba33-c9f0be64c205" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="576ec30c-ea6f-4da2-90fc-1841d0003c1b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="48de6b66-4ded-45c2-a128-a8ffb5b29f7b">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5030,8 +5030,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="412391d2-5e6b-413b-aa1a-3a12523414d9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a6f51a5-febb-4577-a947-a740e91c54ca">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5039,8 +5039,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="fc533283-0a73-41ed-b317-558851a51fdb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="eb0da908-b327-42bf-a5ee-ee24a00872d2">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5049,8 +5049,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="331c50f0-1a6e-44aa-89e0-92ddceb4fcc9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="72cf8fbf-bab8-4fe1-bb6d-90b3019aac0c">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5059,8 +5059,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="4c332049-1fb6-4813-ac5c-ad9b2ce91dfd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c12ca2d1-1a7b-42b7-81b8-8c1d6fe7b144">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5068,8 +5068,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="9a486bc9-3de6-4205-bf89-1d2ab3e5b121">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="47298069-c6dc-48e4-888c-fd2c29e95a22">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5078,8 +5078,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="f830546d-44ed-43f4-90f0-6dc60cab2850">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="32a6aebf-7a32-4ed0-9444-14558c0d6f4d">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5089,10 +5089,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c6cb124-7be3-4b73-a7b8-14e8a3e79658" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="6f7f7bd7-3f28-4ac1-89d9-85fa4f13979e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9cba8e31-9219-49c0-b52e-836a60a2ea49">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -5103,10 +5103,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5093d55b-f969-48f5-a9a3-8fc4851f96f4" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="a8fac944-e9c6-431b-a821-1258e162b281">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8238b2b0-8d7b-492e-a5f6-fbe7571a9ff8">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -5116,10 +5116,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9adc1045-a559-4195-aecb-bbd1b36a3068" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="bd7624e5-e21b-4405-8dc9-bfcfd6eee392">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3d785202-db76-4df0-bf52-ca68429be9fd">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -5128,8 +5128,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="08098a5e-f808-47c0-bf51-26108930185a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1c4fa00e-164f-4333-8d57-96d713cc14d4">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -5139,8 +5139,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="8928a4d5-93bd-404e-94e1-87bd625c9645">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b7a92479-e066-4e79-a0ed-9fc6b71005d0">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -5150,10 +5150,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e8ab464-0b0b-4248-a152-a43a6e205596" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="3160b04e-192d-4c87-9640-efc239e8abfc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="efa07bf0-a43b-4ede-a554-64ca8a29edec">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -5162,233 +5162,190 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7fafadb-8e17-459d-9730-f368cef63041" control-id="pe-8">
+    <implemented-requirement uuid="f095e424-f8ec-49c7-9bcc-f96ddcbb3d15" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="c81d9e43-7b18-4a38-8f2c-03c67eebfbf5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f2b59a49-7e39-4ee0-9195-000187a575ef">
+      <statement statement-id="pe-8_stmt.a" uuid="3ad283fa-6c9a-4617-9d2c-02d449dcbcf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="19b45148-5e60-4f76-bcd1-99248a1187ed">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3dbc7b35-2185-4dd2-90f3-5582d14384a1">
+      <statement statement-id="pe-8_stmt.b" uuid="b0ba16aa-b9c1-4dfe-b376-cda0ce550a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49a6fed7-11d4-4c20-9c60-7fb762c1e4bd" control-id="pe-9">
+    <implemented-requirement uuid="0635d150-3a98-4e98-a667-6431990f587a" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="e3c0edbe-cc0d-42b5-899b-3015bd5a0b26">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="71e3c275-87b3-4b48-b789-4fe46d3a67e3">
+      <statement statement-id="pe-9_stmt" uuid="c19229f8-a84f-470a-84ed-de7df10f336f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b2606e6-5944-4f06-b8ea-f10517e3038e" control-id="pe-10">
+    <implemented-requirement uuid="a57e4d67-c598-4182-bd57-56c2b2317c43" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="3de67e36-3706-4342-ae2d-7a9c3ac83d32">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d7a7ed8-cbe4-47ac-9864-966637447f81">
+      <statement statement-id="pe-10_stmt.a" uuid="d343c585-7b02-4533-871a-c32b446362d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="19214375-8688-46e2-9f98-4dc699c407b6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="627b9aa9-82ff-4735-90d7-39cd39f7fed4">
+      <statement statement-id="pe-10_stmt.b" uuid="9edbcd42-3377-482d-9c61-3724cd426484">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="75e408de-1012-41f9-93c2-0a41c179ed6f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ea144e40-beb6-4436-b587-e6025845577b">
+      <statement statement-id="pe-10_stmt.c" uuid="80b74763-f418-4932-b9d3-26a22ae47b8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1840471-4dc6-472a-ad90-881fc5596106" control-id="pe-11">
+    <implemented-requirement uuid="c691a5ed-fb84-4f08-9ccf-013cfdb3d933" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="7f316537-3bd8-402f-8208-3796b661204c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d12d1e8-6b12-44d6-9345-bee1be74d322">
+      <statement statement-id="pe-11_stmt" uuid="2c09299d-b3f1-4751-ac40-2dc19f06db40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d69bc54c-e6a0-454f-a576-b1a5b137b624" control-id="pe-12">
+    <implemented-requirement uuid="814d78db-2372-41e9-a7c2-86eb5e84b3bb" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="f069ae90-22f7-4896-8760-353591dcf284">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a0c50f53-1b5d-41a8-a931-1eaa0a58eecb">
+      <statement statement-id="pe-12_stmt" uuid="f57faeee-5800-434a-aa8a-947a9ae886f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7f27c1a-6269-412f-aab2-5b83b40081fc" control-id="pe-13">
+    <implemented-requirement uuid="4fb04d5d-82ac-46c9-a0b6-bf1bf7855bd7" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d0e2d952-0f06-424c-bd03-09b1b7017aee">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e9f98ebf-1684-49d5-92c4-7dd4769230db">
+      <statement statement-id="pe-13_stmt" uuid="abdc8068-bb34-4683-b938-e70eb7d36f5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="523eab1a-af87-4126-a16b-865b07ce3ec9" control-id="pe-13.2">
+    <implemented-requirement uuid="0cd48fa2-10c4-465d-837c-c7baefec9389" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="db53930a-afd9-4ff2-862a-c6bb1b924cce">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="545c4507-50ed-4c55-878e-3bbbf689e845">
+      <statement statement-id="pe-13.2_stmt" uuid="4fba5a01-28f4-4cd7-ac08-c79049d5e88b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcd3ddfd-b863-49e1-92f5-6969898a1060" control-id="pe-13.3">
+    <implemented-requirement uuid="f16ae8a9-7174-4efa-ba35-2c47d2b91a24" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="6fb84545-900c-4c3d-b59c-0373b44dba89">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5ccaeaa9-7bc1-4e46-a44a-01fffab95005">
+      <statement statement-id="pe-13.3_stmt" uuid="f92fa53e-d3d6-4c4d-b955-24ab2fa05540">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d096dfe-6dcc-48a8-a0dc-496fa02795f0" control-id="pe-14">
+    <implemented-requirement uuid="a8b0df72-c643-45b3-b800-1b06d1eb1d99" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="4ec8e564-d76f-4136-8fe2-55a6d55d6c38">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9aec7778-563f-47f4-b3c8-7890cc73da24">
+      <statement statement-id="pe-14_stmt.a" uuid="15495bed-f082-405e-b69e-c743c8c3c20a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="4046f1dd-cbeb-42e9-a1b4-a1fc29309a33">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7b8cb075-532f-40b4-8a5f-821dd59537b0">
+      <statement statement-id="pe-14_stmt.b" uuid="a0d0eda2-1aa8-4afb-a24b-7c95d233bb3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e40521ac-9629-45c8-8c7d-5a4ff27cf7ae" control-id="pe-14.2">
+    <implemented-requirement uuid="f98f1c09-8ebb-4c9c-ae89-c4eeeac91bf3" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="204afce6-d734-4195-9c6f-181d18ae812f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9e28bdc0-97f8-460d-b7be-5736ad5d481c">
+      <statement statement-id="pe-14.2_stmt" uuid="2512deb0-8e8e-427e-b878-20df59f6bc92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddd85082-53b5-46b7-82a5-a127728bad0a" control-id="pe-15">
+    <implemented-requirement uuid="901a3457-97b6-4093-bbe0-31ce3a1cdcf6" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="eaf9c723-4997-42e4-88e7-86edb5120d25">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2ddfa41d-3ab8-4186-8f41-08793d3511cd">
+      <statement statement-id="pe-15_stmt" uuid="61425ee7-5b2f-4888-8373-62f378945ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="170847b2-721c-44d3-ba86-6795b9a87488" control-id="pe-16">
+    <implemented-requirement uuid="17f3da9e-c287-44a5-8169-28cf3375c1d3" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="3f57b16e-2ca0-42ce-898d-b35229ed9314">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b1aedc02-7647-4ea7-ab3a-675e33cc8cc1">
+      <statement statement-id="pe-16_stmt" uuid="feaebed6-68b5-4c4b-8b88-883a8038ae9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f8f685c-c2b2-4e7f-a145-e5c0793a2599" control-id="pe-17">
+    <implemented-requirement uuid="a8903585-dab4-48bf-885a-8d4239c0a146" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="b009b06e-baea-4bbd-9d64-0af8528a5f9b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d33c91f2-6034-4f8c-9e42-56787c0b96d6">
+      <statement statement-id="pe-17_stmt.a" uuid="4e5ec6fc-d0eb-4ade-a6a2-3155cf00d493">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="827225f1-6892-4582-8c0b-5b299fae8732">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f9f36214-5504-4b48-9a86-227f01fa89d0">
+      <statement statement-id="pe-17_stmt.b" uuid="f9b94f04-f1a9-47d0-b956-3d8a01fbfe9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="e5109e59-03e7-47cd-880b-c64639cd859d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bb3f3bdf-8a51-4e24-a492-e58d79320336">
+      <statement statement-id="pe-17_stmt.c" uuid="71d51466-6a5c-4e73-be85-8281000132ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="714dfd58-b575-491d-970d-f81615036e09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c059e52f-4d8e-43af-b998-384baca842dd" control-id="pl-1">
+    <implemented-requirement uuid="89868230-0876-48af-8880-46230d2f29c0" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="129a311e-c03c-42c9-a888-69e7d6100e25">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8b596562-65c5-4236-b29e-39c19bfaa739">
+      <statement statement-id="pl-1_stmt.a" uuid="8661b679-96b7-4c77-b230-bd4a38abe4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="efe301be-e87e-41ae-9951-e8dc54128b8f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="296a1f75-c1cb-4e06-befe-8d886f74b363">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="b8634a0d-910b-4254-8ebd-9fb7cb826bbe" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="1ab39adf-7636-4c7c-81f5-6947edf3c21f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="08b3fb65-d2ed-44dc-b02a-c3f3a7bd42dc">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="1bc3994f-62dd-41e9-bfb3-87943bb3f0c1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="62b8956d-d35c-460c-a901-e92e0d8758d2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="174a1219-67d5-428e-8733-508d6394a204">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="39596e0c-7ef1-4352-89ba-35d78f0a0b99">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="5cbb4f92-e78a-41b7-aa60-ac81d7941135">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="83b330f2-cdd2-4fd9-ae24-124bb4913831">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of OpenShift.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="c891e0e2-87c1-4795-968c-a2b3543ba081">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fe28b2ec-e3bb-4084-90c0-3d9376443e98">
+      <statement statement-id="pl-1_stmt.b" uuid="8ece81dd-536a-424b-a2fb-61952dd53bdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5396,10 +5353,53 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a08f72ac-3687-4c0e-b156-a519f25c1c61" control-id="pl-2.3">
+    <implemented-requirement uuid="9afad57f-6172-4f87-b55b-8cd68079e3c8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="5c697c87-4cfb-42b6-b2a2-2063e2518652">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="350bbb84-f995-4872-adb3-05c2f4db23b1">
+      <statement statement-id="pl-2_stmt.a" uuid="4b7ed71e-ba46-4d43-b6b7-ea99bc5dcd94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="9a4add41-bc05-416c-a9e4-229cb6f61367">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="fb20fcf3-5cd7-458f-8fd4-edf1306f9d1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="06fb5ceb-ddd2-4c39-8ccb-356fb02780d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="782bc7bb-1af6-4c75-ad8e-769f8830e159">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of OpenShift.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="cfb0e9c7-e02e-48b9-9545-d7f1079f3841" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="e0441873-fe4c-4ba7-b968-b8f5bff5c152">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5407,34 +5407,34 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="577b00fa-b143-4ef0-93dd-2f0e26f49f90" control-id="pl-4">
+    <implemented-requirement uuid="98e11268-47c9-4eb2-bd17-5bcac114ab5c" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="889c1582-7d12-4c19-8026-860b10c5d692">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e47977d-3ad3-4c7a-9f8c-12123aa4b00b">
+      <statement statement-id="pl-4_stmt.a" uuid="499d42ac-5c67-46fb-9e18-149401fb3abf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="a6cdb4f4-c1e9-478e-96d1-6542b24dd79f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="369b14c9-98a9-4651-acd0-5194c90cfd5f">
+      <statement statement-id="pl-4_stmt.b" uuid="f9388bac-7d81-4eb5-8343-4962c303ffa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="c3886278-b9f2-4d2f-9a55-b86aad01286b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="841b3d2d-47fa-4346-b21c-12479dc2070e">
+      <statement statement-id="pl-4_stmt.c" uuid="8f371b57-4152-475c-90df-2b05ffc39c5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="5276efb2-cba1-413a-949b-4f564d5eed51">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e33124e2-02e1-461d-ba1b-553b91fcfba6">
+      <statement statement-id="pl-4_stmt.d" uuid="96b2d54b-376d-4317-94b5-152505a1a8d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5442,10 +5442,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c82c8c9-e53e-4275-be14-0f1b40395edb" control-id="pl-4.1">
+    <implemented-requirement uuid="0631ed74-f5ea-4d53-8e4f-2a04944e15e6" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="bc022ac0-394f-4167-9d1e-6f5fd5f5f03a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bcb68e6b-9f85-40f4-91f8-789a8d8d8e8e">
+      <statement statement-id="pl-4.1_stmt" uuid="3720957a-be86-4c93-ae1b-88066debe321">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -5453,26 +5453,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31d05e18-7106-43a0-a4d5-337d42a9e6f6" control-id="pl-8">
+    <implemented-requirement uuid="8c9309f3-7b5d-4459-92fc-36d4590cfd4c" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="32baf586-cfcc-4466-b5cf-747b1b89d61a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7010c1b0-223e-4897-8f05-fde88cae49bc">
+      <statement statement-id="pl-8_stmt.a" uuid="0f57aec2-e9c4-4376-948f-18a94d9b9083">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="12993f0c-3740-4c28-8564-15c9f0800683">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="70b12bb3-95c6-44a1-86ac-e4980836d12e">
+      <statement statement-id="pl-8_stmt.b" uuid="ed59aefa-4b9b-4a10-85a7-0b44cf3e104c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="80ff906f-e67c-44e6-8bc0-cda801a813c7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c1f908f8-4567-4657-82ee-25ec64626607">
+      <statement statement-id="pl-8_stmt.c" uuid="35f39cbf-20b3-45fe-b2bb-22d0cc4477b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -5480,10 +5480,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26a9ea25-e8e4-4e14-8c0c-cb5291e56c7e" control-id="ps-1">
+    <implemented-requirement uuid="6418d139-6314-4ff0-af50-b28e66b16261" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="23628397-894c-4006-9020-76abe8908d7a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="55a08dfb-219f-47e6-9a21-054510d9b2d0">
+      <statement statement-id="ps-1_stmt.a" uuid="b24ac5ec-0704-4378-998a-e73711c1f6e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5491,8 +5491,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="ef598339-060b-4fc5-92a5-723f2b96427b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bc115fa7-0c2d-4fb1-950c-615dea3d88d7">
+      <statement statement-id="ps-1_stmt.a.1" uuid="f3c6288f-f0e2-4ff3-9e85-02a37d7ace14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5500,8 +5500,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="3217fcf7-7046-4f8d-be39-4825bc640bb1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a66adc7-559b-40bd-871a-5dd202abbaa7">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9b53e6dc-8b9b-4147-9b13-709f2495c207">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5509,8 +5509,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="9d17a057-f3a8-4c56-8654-2a100d6260c9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="142bfcb5-fc02-4cb6-a3af-e8de6ca3d0b2">
+      <statement statement-id="ps-1_stmt.b" uuid="4f650c83-ce49-4c48-92a4-2c894efc17df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="337e7f04-ade2-4095-b026-96842ddb9414">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -5518,8 +5518,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="96266984-47fb-49c5-b637-0a7ac1cf0166">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f07e80e5-2f8b-4f59-851b-514f43d7b262">
+      <statement statement-id="ps-1_stmt.b.1" uuid="81dcc255-fee1-488d-8ca0-dd88f7c2ded1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5527,8 +5527,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="ba8a9da7-f1fc-40ba-b166-d922d5626d20">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a71ffaa-6441-4c53-81d6-1e5859659703">
+      <statement statement-id="ps-1_stmt.b.2" uuid="7785900e-402f-4ccf-9bc0-597a2e7eb688">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62dcd424-6492-48c6-9817-eceeb62df311">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5537,18 +5537,18 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea78160f-6c3c-4eab-b664-ed5f329b9108" control-id="ps-2">
+    <implemented-requirement uuid="37d305bd-2e58-4cc3-8fd7-311c59020818" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="b9aec58f-8c2e-41a5-9bdb-e318f3c53757">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="54020d3b-76e1-4281-9240-07acaa03661d">
+      <statement statement-id="ps-2_stmt.a" uuid="e24c75d6-3b6c-4d16-83d9-036d896f93ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae453aca-5f7f-4c57-8ad3-40b0a9929f33">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="565e22da-992e-4000-8e22-d2c95fb5493b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="add932ea-11e7-4ed1-8af5-66cf284f66c0">
+      <statement statement-id="ps-2_stmt.b" uuid="85ed1245-db1e-438d-96de-61ac6fc21ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955de2dc-b541-4f89-87be-be3aa93b2b96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of OpenShift
@@ -5556,8 +5556,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="5baf4ec2-a9f8-4b90-9f9d-f6bcad11ba36">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="414285f7-60af-491e-994c-f7df6364c4bf">
+      <statement statement-id="ps-2_stmt.c" uuid="82eb9502-0431-4a91-ace1-25f947087689">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1cdb5679-ba64-4c52-aa04-49a4040f8b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -5566,10 +5566,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="916f0fd7-3836-4537-9103-5f021fcf9bd0" control-id="ps-3">
+    <implemented-requirement uuid="50b3ccf4-7437-4b9d-a4e9-2bd2111d0712" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="6e81c488-e380-4165-86de-bec27ebce75a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="09425729-1e71-4f81-a44d-c24f57dd0d64">
+      <statement statement-id="ps-3_stmt.a" uuid="ae898ca2-4245-47a2-b67e-9cb04cd16b60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d1537c-8e3a-4d4c-be9f-106f6072d75d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of OpenShift
@@ -5577,8 +5577,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="7501ebe8-179c-468f-8ec3-769fbb6ad824">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="affeb0b2-f58e-4857-84c6-4ac070230fb9">
+      <statement statement-id="ps-3_stmt.b" uuid="9e412acd-66d6-42fc-a874-60196f12e434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5544b6cb-8c54-4e7e-8726-4b2ce8114fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -5589,10 +5589,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8503a8d6-0b0e-42c9-9733-d78e810cec51" control-id="ps-3.3">
+    <implemented-requirement uuid="56352245-c717-4c44-9855-540a11d30de5" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="b702ed8e-441a-4134-8ad6-3314756550e2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="67c3a11d-a288-49ce-a79a-0348a61f7839">
+      <statement statement-id="ps-3.3_stmt.a" uuid="c1108de0-83ed-4d8a-8a7c-53749058ea9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d09c04bd-7810-41e4-bcb0-225d8ada0f30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5602,8 +5602,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="bbfbd923-861e-4254-a8c6-06dca87a0937">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="70c6db19-1ce2-4d75-9b6e-98345496bf22">
+      <statement statement-id="ps-3.3_stmt.b" uuid="16039ff5-0c13-49ca-8051-f02fcf6ae567">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c7e61d0-4736-4a25-88b8-6262505d4d16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5614,10 +5614,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc625660-026f-4605-b85a-dcd3afc57c68" control-id="ps-4">
+    <implemented-requirement uuid="a058b4a0-06f7-4cca-a104-955e4193ff8e" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="b42adbce-3849-4a62-ae59-ff2f389f5d29">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="129d6143-420a-45cf-a531-48094a03e69c">
+      <statement statement-id="ps-4_stmt.a" uuid="3c96cf7b-382b-4d78-803c-13d0c4c75b46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e47fb61-98cd-40de-a48c-3038ea513aad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -5626,8 +5626,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="2cc1d2f2-4efe-4bc8-893e-4c1003f153ec">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3d8319fd-9ab1-4fd2-85ec-ba9d3674ab1c">
+      <statement statement-id="ps-4_stmt.b" uuid="35295a74-1026-436a-ae0e-6ec855cf798f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12f961d4-848d-40f7-8f40-40e10e88d0df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -5636,8 +5636,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="99889c6e-9cc1-4c30-b98c-79bfea9ae150">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="912b78dd-a2ac-46ee-a0a3-e5c1c63bc2be">
+      <statement statement-id="ps-4_stmt.c" uuid="af8c79a4-798e-4bf9-a02e-140e04e48d10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec36ccaf-c3ab-4747-a425-c6bedc278aeb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -5646,8 +5646,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="cf6db93c-a85a-43e3-85ce-3080f86527bb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8de4c5f9-350b-4826-b3bd-5c299680b5ef">
+      <statement statement-id="ps-4_stmt.d" uuid="8ea327e5-5a11-4a98-8827-eca5a7049fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d80627a1-8f9e-43a4-a7a2-a75249dc410f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -5656,8 +5656,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="a6e6e3c6-9b0f-489d-8541-e946f9fdac04">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1d7a14e7-b59b-483c-b266-8cc5d5dfacc8">
+      <statement statement-id="ps-4_stmt.e" uuid="f0301041-d18b-4c26-85b7-9b08eb82f8dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69d0287a-bda0-4d09-a48e-89d9bc9d50f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -5666,8 +5666,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="e32eb104-9db9-4e03-a4cb-cb7bf64e3483">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5784e21a-ae7c-4de7-b88e-a4a1394add6f">
+      <statement statement-id="ps-4_stmt.f" uuid="011f2825-4703-46b3-96d7-51cb5008f740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9264a668-6ecd-4ad9-ad90-bf8e50a666bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -5677,10 +5677,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3bf5217-b99d-4dbf-ac37-191b42787ce2" control-id="ps-5">
+    <implemented-requirement uuid="f021987d-0773-4783-8fe5-638a1887ad41" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="cc024d9b-d5a1-4374-969b-bb69e531f69a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="609177a2-a553-46eb-abe9-a664dc8cbd15">
+      <statement statement-id="ps-5_stmt.a" uuid="71f7e07a-0962-4f69-8159-2e9e25384f86">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="046ba626-c644-49c6-b052-fe0a5a90ddb7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -5690,8 +5690,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="cf59d164-c152-46c3-93e9-03d549b20774">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8aa04992-fd95-48b6-99d4-ef988011a894">
+      <statement statement-id="ps-5_stmt.b" uuid="9b950b32-4306-4b6f-b8fd-daecabbae7bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35dc728a-280b-490f-81d4-af07110b288c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -5700,8 +5700,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="b460fd7a-d8c9-47fa-bcfb-bee81684f37f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="562ec185-4832-4e36-8531-40670afc174b">
+      <statement statement-id="ps-5_stmt.c" uuid="3fc5d320-e25e-4155-8a39-2f19efb6f270">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dae94fe-dbc1-4081-8464-f551f752798b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -5709,8 +5709,8 @@ or transfer are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="0763b528-03e5-46de-a5f1-fa493b9476e3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bdb902cf-2428-4dea-a1ad-8eb9fed54cd5">
+      <statement statement-id="ps-5_stmt.d" uuid="411f7849-0de6-4bfb-b74f-2172c0af25b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e1cf303-9747-4c4b-8012-ed16c6dab514">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -5719,10 +5719,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="096c7527-2ee1-47c4-9bca-9a1fabc5aa71" control-id="ps-6">
+    <implemented-requirement uuid="1a89d281-0763-4c66-a8df-f4c676911d94" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="41a86926-46bf-4b7c-99a2-a89a44861b64">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="181ec008-1442-4869-8bf4-ea5cc4c8bd25">
+      <statement statement-id="ps-6_stmt.a" uuid="0bbdf0b6-33f4-459b-bf47-0aef0c11860d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7a359d9-81cb-434b-a2be-7979b7e4a973">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -5730,8 +5730,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="fae1e81d-6a27-4d3c-85ff-b0bb6315fd5b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3964df49-af49-4544-b664-986f6c22ff14">
+      <statement statement-id="ps-6_stmt.b" uuid="6ed74614-2509-4ef1-8412-0d72b7724797">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a45644f6-3dd6-4597-8ef5-3645ccdb53db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -5739,8 +5739,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="a92a8c89-6631-474d-b977-9e891c9b2a51">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="453aa9d2-c75b-4b70-a6bc-bd1db9069055">
+      <statement statement-id="ps-6_stmt.c" uuid="ba99c181-39cf-4f21-8687-44efca1db67c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5748,8 +5748,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="feb709c3-5d96-4d1d-9cae-b13777b7dfed">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ffb1c36d-fa8c-4e41-ad9a-408e5d4ede92">
+      <statement statement-id="ps-6_stmt.c.1" uuid="8b6861d8-67c6-4ee8-85fb-940265a98402">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5757,8 +5757,8 @@ access agreements are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="330e6332-7724-423a-b58a-a02c1e4c37ab">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="02a459f8-43e4-4478-88a8-f510fb4e51c8">
+      <statement statement-id="ps-6_stmt.c.2" uuid="9b14e8e1-6706-4803-9305-4e39b807b3a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b8e4e85-2021-46dc-a624-b1eb6a3017e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5767,10 +5767,10 @@ access agreements are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="690214eb-5b82-4a77-90ac-13e128cfdafe" control-id="ps-7">
+    <implemented-requirement uuid="9823674e-6560-4272-9878-ac4ccf6265ff" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="da83b97c-2f7d-46b8-8f6c-1c88aa07d220">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4a30f780-efdc-4b80-9565-2b9e663bb6a6">
+      <statement statement-id="ps-7_stmt.a" uuid="fe812d2b-7c23-4aac-a3ea-551fdeb52599">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5a4573f-c61a-433c-9c26-244b43757c7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -5778,8 +5778,8 @@ outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="4d58627e-1d2a-4435-90e4-b78fcdef4a54">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="645eec9c-053d-4cf0-afc3-dcf63578c5aa">
+      <statement statement-id="ps-7_stmt.b" uuid="760ce5b7-396d-4b48-9d82-4a58a0dadac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3a927d-e9dc-4fae-9fbb-26b02455e8a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -5787,16 +5787,16 @@ the organization are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="2fbffd78-b3f3-4840-ab4d-4daf95fe17fb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="61c28481-1d4f-48e3-b411-0ea90f14925d">
+      <statement statement-id="ps-7_stmt.c" uuid="8f063b21-41fd-48f0-bdfd-e9be890bdc0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ee8df1-b100-4388-a721-41e512901fdd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="367851cc-8a24-4c21-89ec-a403203200db">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b98d2bc2-70ae-4377-8820-b2d3edeb20e5">
+      <statement statement-id="ps-7_stmt.d" uuid="83a11cc0-7793-4d8a-9e90-76993dc991fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d3a188b-9d80-4557-8ca4-b66bc1df60e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -5807,8 +5807,8 @@ scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="352037dd-fe97-4337-a60c-c5653b2fe6bd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b2bbddfa-03ba-4b70-9596-64e3026ebea5">
+      <statement statement-id="ps-7_stmt.e" uuid="09ffad36-86ce-4a99-98d9-3b1ae3af8ff9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12999939-abc7-4215-909a-394cf63184e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of OpenShift configuration.
@@ -5816,10 +5816,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="321c9190-6d1e-4240-a084-cdcfd3f6212a" control-id="ps-8">
+    <implemented-requirement uuid="aa9d1f60-1c2e-44d5-9f55-7d7de80fd800" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="b3eaff2e-888d-481d-8904-ba1069cb2da3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="299de5af-cba5-448d-8f58-a57ee69150ce">
+      <statement statement-id="ps-8_stmt.a" uuid="f8d7d00a-923b-46d1-a7e7-331808aa594a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fcb49196-9d3c-418c-9242-85e984011583">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -5827,8 +5827,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="ff346ce3-1bbe-478b-90d6-5acd8b8c176b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="249c7294-32fb-4973-a82a-e7df75e0dae7">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -5838,10 +5838,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10a090de-380a-4232-a156-f6f01f23e0f1" control-id="ra-1">
+    <implemented-requirement uuid="3bfbc934-621c-4c62-a8f3-c59fa780cc7c" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="eb5d4dd8-7957-4d62-a7e0-b046f4cc353f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a58ec19c-40f2-462c-b5ea-bde63f07cb8a">
+      <statement statement-id="ra-1_stmt.a" uuid="c39e40d4-607f-4cd4-83fa-cecbcd6c3166">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5849,8 +5849,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="19ca2ea4-8cb2-4b29-9f82-6332b6020750">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e96a2c9-f8b9-4dec-9ae5-0140279460d2">
+      <statement statement-id="ra-1_stmt.a.1" uuid="91c6f409-6df9-4a9b-ab2f-42edea1fcffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5858,8 +5858,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="040b8d63-fd05-4e38-b98a-bf853b9679fa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b4a15415-3455-48a7-b8f0-f3462f5d2df0">
+      <statement statement-id="ra-1_stmt.a.2" uuid="bf7f3604-2e9b-4d59-9a2c-d0d031beadf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="213d7bbc-cff7-4e68-9c54-b7877b691d94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5867,8 +5867,8 @@ and procedures is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="d45251ef-1df2-4ca7-aacc-bfc310cf5ae2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4e1cf88b-be22-48a5-ab44-f3829b1795d3">
+      <statement statement-id="ra-1_stmt.b" uuid="f7c298b7-b302-4c3d-a246-7184dcfddc45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5876,8 +5876,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="e4070632-afa8-4c45-a527-360610a3dcc9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6f2179db-80a1-4d4f-a894-3f3c26774021">
+      <statement statement-id="ra-1_stmt.b.1" uuid="72741310-7fe8-4032-bf53-b655ea2af645">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5885,8 +5885,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="bb3ab03a-97cb-49dd-b9ca-e6d17dd48a77">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bf088fa5-5565-4a8a-a5d8-f25b69e815cf">
+      <statement statement-id="ra-1_stmt.b.2" uuid="5792d319-a3b9-4692-8e69-f2b76bd23587">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a153aea0-e388-4ac9-83d7-f7c7476466f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5895,10 +5895,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44c4a9a4-60e6-4aaa-9eb8-d9aa00136a1e" control-id="ra-2">
+    <implemented-requirement uuid="31deea7c-6add-4a41-8588-b35cd74200e2" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="73da5732-8f29-434b-bdf9-992d2a21ac75">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e1c8c33e-837e-4e72-bacd-96918aee7c1e">
+      <statement statement-id="ra-2_stmt.a" uuid="e425d113-cb52-4770-a787-dbfb9283baf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b646a97c-a692-4944-81b9-d72d1a1dbfa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -5907,8 +5907,8 @@ guidance, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="29ea01ab-5d58-4db2-b6e5-a10a5701e67a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7850b401-de75-4b8e-93fe-670b7b1e07d0">
+      <statement statement-id="ra-2_stmt.b" uuid="180f1b32-6728-4307-bb8d-e5f3e11616b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e4bd24f-ef83-4d22-ba7f-9e298da40889">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -5917,8 +5917,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="194ccc75-263e-4a90-992f-8ca47b74e927">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="69f70e79-504f-4251-94dc-ca9214d32bd0">
+      <statement statement-id="ra-2_stmt.c" uuid="6d002ff0-ef05-4c3f-8bc1-22eae07f0f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67fdd016-131f-4800-b183-bf0316142769">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -5928,10 +5928,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc66a4dd-6350-443c-8725-e92787ba218f" control-id="ra-3">
+    <implemented-requirement uuid="4eef68a0-d37e-4d8b-af8c-932640baa277" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="5779ca90-17d8-4a39-8ab6-386755579146">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f4af1a7c-18af-4c23-bf3b-76fe94d51912">
+      <statement statement-id="ra-3_stmt.a" uuid="de140349-fc88-4c48-99d7-6d6e5f160517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc7839ff-252e-4d8d-b76c-ba50c8fab112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -5941,8 +5941,8 @@ transmits, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="508d636d-c246-4d4b-abce-3c1a05eead23">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3845ac3e-6c23-4448-bf47-a4765937ebaa">
+      <statement statement-id="ra-3_stmt.b" uuid="648e4432-a1ed-4d2d-a44c-72cb255d638f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2898b82-0d1a-43d5-8b7d-6eed5da1f17b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -5950,8 +5950,8 @@ documents, are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="aa4f9457-2ab5-438f-ace2-13081e605cb5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2eb72910-9cfc-4145-bf63-b6ed648935b2">
+      <statement statement-id="ra-3_stmt.c" uuid="ce4d2f6f-9c07-490a-8ade-90d59226f649">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2b4dcf0-4978-45a4-b3f6-1a5fa0895772">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -5959,8 +5959,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="64580ad4-fe45-4953-ba61-0e41dccfe219">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8496c94e-2e17-4a0b-9524-5281d79fe0b3">
+      <statement statement-id="ra-3_stmt.d" uuid="f3b2eb0d-d1ca-4e6d-8d42-d52cc870a44c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ca46929-3bb7-41eb-9c71-ef2dcda81be9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -5968,8 +5968,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="4ea68c9f-ac5a-4dfa-b68d-773184305d0a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8098f5ca-c8e9-4aeb-8af7-84add257126b">
+      <statement statement-id="ra-3_stmt.e" uuid="afb420a3-1588-43c0-8d92-1d6a19c26a4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ebb371-bbba-4b7a-91f2-0ac7bb23304d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -5981,18 +5981,18 @@ are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7684c61-5623-4fdf-a91e-d846af9f1b70" control-id="ra-5">
+    <implemented-requirement uuid="d4d65759-0b51-4008-b230-13f0cad39da3" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="d4e042be-fe23-4a7c-a9c3-c795dcbd8b21">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="aaac4239-15fc-4d89-b94b-2615da8fec72">
+      <statement statement-id="ra-5_stmt.a" uuid="f17a8ec1-9d5d-4580-bbc2-b4353fee950c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="649fafd8-4bf1-4116-afbd-3fb9a6f18c0a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="05092e86-4113-411d-a96d-4a46f4520641">
+      <statement statement-id="ra-5_stmt.b" uuid="32452604-d567-4f57-9297-989800a25777">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6000,16 +6000,16 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="34e0530c-6aa9-4efa-84a5-cd4c7a2dc8ec">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="813241da-8af2-4a2c-8fce-050beafa35e7">
+      <statement statement-id="ra-5_stmt.c" uuid="836b92c2-8835-4d79-926d-81f585abb42d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="7a9665a7-3d0d-4d3f-8bca-f1f221c8931e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e538c5fb-b693-4367-a5d6-335fd02a28a1">
+      <statement statement-id="ra-5_stmt.d" uuid="251084fa-f276-473f-814f-ab0b8af395ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df419c09-815a-4da6-b94b-910a483031f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6017,8 +6017,8 @@ https://issues.redhat.com/browse/CMP-352
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="d52d4679-a0d2-460e-a1cc-2a012cac7253">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d840324a-0961-4d56-976c-4036f06445af">
+      <statement statement-id="ra-5_stmt.e" uuid="37953ae8-a61c-4f2d-ba69-7c11b415b703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bd9f1ee-7804-4aa2-b15e-03a253025368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -6030,10 +6030,10 @@ of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f0d0636-8f3c-4113-b948-0fe02b25a874" control-id="ra-5.1">
+    <implemented-requirement uuid="99bfb322-3894-4141-babf-b99bfe1d7692" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="bf51f56f-5b86-48c6-be21-c48c47456ba0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2be3cc82-7ac3-45bc-8726-5c4cd87355e4">
+      <statement statement-id="ra-5.1_stmt" uuid="c78f080b-6d2c-4038-830f-eb3c7e1ae855">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e39b5519-8ce6-44bf-b85b-37b0f2295593">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6042,10 +6042,10 @@ https://issues.redhat.com/browse/CMP-353
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a69d6ae-d905-4750-b291-6056416204a4" control-id="ra-5.2">
+    <implemented-requirement uuid="252c6ba8-177e-4271-9d60-77e94367b757" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="e9d7b9e8-4361-4eca-997d-f714c069503a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="25b32300-bf54-4a87-b761-985340b7a414">
+      <statement statement-id="ra-5.2_stmt" uuid="efd7ce58-8caa-44d2-a557-2e1a8bb106a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6053,10 +6053,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fe87a5c-6b2a-4f1f-bea9-317cba625cde" control-id="ra-5.3">
+    <implemented-requirement uuid="e8f78c47-1c52-4c94-9072-eb04448803bc" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="ffd726f2-0e05-4db3-8507-37fe0408d5aa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ff1401f7-6d9b-4411-9683-fd6697e020f0">
+      <statement statement-id="ra-5.3_stmt" uuid="81d05f8b-1150-4907-a6fb-fadfb30f5f2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6064,10 +6064,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11a530cc-0d6b-427f-9f4d-4b14fc9eb80a" control-id="ra-5.5">
+    <implemented-requirement uuid="d3e5fad0-3c63-4c9f-8e76-12ad125bf340" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="df6957cb-406c-4724-b065-6b371e92d7f0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5a052656-2dc2-4693-a6a1-e25bfdf766e6">
+      <statement statement-id="ra-5.5_stmt" uuid="bb4660d7-4f44-4c2b-9f1c-c9bfb7183ca9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c5bf90d-ac0b-4600-95e9-897075990aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For the purpose of conducting a vulnerability scan of OpenShift, the OpenShift API and nodes
 should be scanned using the OpenShift Compliance Operator. OpenShift supports
@@ -6078,10 +6078,10 @@ Cluster Administators are able to access and run the operator for compliance and
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="724f33b5-c06a-4662-9cf6-456aea15b48c" control-id="ra-5.6">
+    <implemented-requirement uuid="3a66b623-7a77-4166-9bc8-fe36369d6a66" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="597f4a88-becf-499d-bfa4-79442765a0ea">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f882c7e9-bd95-4322-a292-ea819e855ba7">
+      <statement statement-id="ra-5.6_stmt" uuid="42e81289-d5c0-4fb6-a470-ca1b979a6f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65f278f2-f1de-4fc4-a2a8-625d8839df42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6090,10 +6090,10 @@ https://issues.redhat.com/browse/CMP-356
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="161a7ea1-3da2-4d8a-9ac6-a4ed34c26dfa" control-id="ra-5.8">
+    <implemented-requirement uuid="95a86ba9-c73d-4ea6-bf2b-3925b389493f" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="18ddaa02-8aa0-4d92-949d-aa5f9737b105">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="39382de8-4b04-4976-b43d-10173e836dd0">
+      <statement statement-id="ra-5.8_stmt" uuid="f664f019-6de1-4755-9f04-9e25964a1102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67e7e64d-1b94-4fc9-9749-2ca36805a52e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -6103,10 +6103,10 @@ OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4ef9694-dcb5-4687-96f8-1068064d1576" control-id="sa-1">
+    <implemented-requirement uuid="46175d8c-c262-4815-a381-7c1f4872a44a" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="43315208-3c4e-45a5-b397-a292088b8a76">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f71d1f34-eb35-441e-8e99-ac468474034c">
+      <statement statement-id="sa-1_stmt.a" uuid="0c2fb97c-2841-4c9c-9c64-3a30cfa2c885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6115,8 +6115,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="62160228-c45f-4d36-bff4-bef518327dfc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b30614bd-d173-4936-bd6c-1c00659e576c">
+      <statement statement-id="sa-1_stmt.a.1" uuid="a7bad430-0d6e-4e8e-9df8-113430accf6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6125,8 +6125,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="1393a1ec-fc2b-47ee-afcb-830916806832">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="131fe8fc-ea00-42b8-a031-9ff8552b1831">
+      <statement statement-id="sa-1_stmt.a.2" uuid="e946d4ac-cf58-49aa-b1ce-1f1f4efa6a1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="429545fc-4635-4006-a3f4-8345e1c4397d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6135,8 +6135,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="f2c4f735-cdc1-4d41-84f6-9d4d29158aee">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="149171b5-b8ad-4d08-82fd-187d4f37a851">
+      <statement statement-id="sa-1_stmt.b" uuid="93ca6950-0e3f-44a1-805e-a64737d09b08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6144,8 +6144,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="edaa23fe-7258-4d3b-9672-a969e41fb0c5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5edf5b51-2105-4817-9851-446935f9a5e9">
+      <statement statement-id="sa-1_stmt.b.1" uuid="bd4f2cb4-847f-4f4c-931c-948b2e7476aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6153,8 +6153,8 @@ is outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="191ff7d2-f02f-4654-8745-3a5d3e1ba4d5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="22af9066-8a81-4877-8441-1a3bd8ddf9d1">
+      <statement statement-id="sa-1_stmt.b.2" uuid="826cee26-2ebb-44a5-8a0a-26e4fe4d1a6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="218f11d3-f7f4-4efe-9f7a-cdee5754e5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6163,10 +6163,10 @@ is outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25ede939-c0a7-45d7-af6f-7479c871fb71" control-id="sa-2">
+    <implemented-requirement uuid="880a9424-3bc8-47b0-8d90-7a7cc8f08023" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="0b4bab0c-059e-4ca0-b993-1d6a97d6c6b1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7ce1d91c-872d-4a30-a2b8-3d6cc8e81d59">
+      <statement statement-id="sa-2_stmt.a" uuid="fc47bc65-d051-44cf-b98a-5d9a0356f474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dcf71d-eac7-4ce3-af35-7b3e574997c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -6175,8 +6175,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="31a4f03e-bdd8-4e48-b1fa-cf367fd5e15a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cde7dd3f-524b-4398-b42b-c8efa23586c0">
+      <statement statement-id="sa-2_stmt.b" uuid="3685259c-66b4-470c-9da0-6fad099d6e5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c829fb17-abe4-457a-8451-75ad86d36f38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -6186,8 +6186,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="6d13481a-50e0-4e7d-be07-5c45388a0980">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1c93d48e-5917-41bb-af7c-ef0d414f5cd8">
+      <statement statement-id="sa-2_stmt.c" uuid="2b7c4ef2-c540-4683-a633-795c99f687b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f21e997-d0b1-4d3f-abab-e7b6b5743832">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -6196,10 +6196,10 @@ documentation are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e46623b-9417-4271-b06c-db8d97bf59ab" control-id="sa-3">
+    <implemented-requirement uuid="4b3cd903-81fc-4a32-9832-6b967acb18c8" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="5374c656-60f4-45fa-97c6-2162d192c63d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9b48c7ef-9f7b-4a76-8510-a25759e80c05">
+      <statement statement-id="sa-3_stmt.a" uuid="9a15d6de-18c2-47f2-9622-c7d39deb8f8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a4ae5ef-fcf4-41e7-a41b-d8d300d1c57b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -6208,8 +6208,8 @@ of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="6c346f33-0766-43a1-a16b-737c92e566aa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="492e2ba7-2d61-4267-9c60-b3ff201ff2cb">
+      <statement statement-id="sa-3_stmt.b" uuid="1a183eb7-9f87-49da-8f1b-ba580be9bdd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd84749-931b-4fca-8d62-9f7ea3cdd3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -6217,8 +6217,8 @@ life cycle are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="6cf51653-8aec-4f3e-af85-62a7519c709f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0deb53a7-5b27-433f-858f-4e0b5a9e174f">
+      <statement statement-id="sa-3_stmt.c" uuid="030a665c-8a6f-4f0e-9f26-3521e733f7d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ed7cb61-e7fb-4e18-b55d-f4f171158807">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -6226,8 +6226,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="19110cb0-773a-4bd8-80f1-1c9f7c380bf9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c801f102-97a0-4830-a5e3-e51e003af2b9">
+      <statement statement-id="sa-3_stmt.d" uuid="5be291c8-e453-4828-9224-37814c38ccd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7461713-8ea2-4840-ad52-c9e877e7f51e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -6236,10 +6236,10 @@ activities are outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f18f392-5d8c-4751-82bb-251dcaa0de9a" control-id="sa-4">
+    <implemented-requirement uuid="4c425b9b-a871-4e71-9d35-ab1990789375" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="f85d9ccb-74b1-4a3b-8167-6ad95760a741">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0f5d3e4f-cb05-473d-8c20-35c6a9963645">
+      <statement statement-id="sa-4_stmt.a" uuid="f9dc2050-658f-4d3c-ab5a-11221a03656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdcf642f-0ad8-4f50-94b5-cc8b29f9d090">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -6247,8 +6247,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="a1068415-826e-491e-80ef-4a64169d4821">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e8aaff89-092b-430b-9f07-1ad4f2a31f35">
+      <statement statement-id="sa-4_stmt.b" uuid="1444637a-9f7b-41f2-bfcb-9e5f8b359517">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0fba4bd-1c76-40ec-9a33-1ed138551a80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of OpenShift
@@ -6256,8 +6256,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="aa0625c6-988c-4d2b-a761-8377f7c1e2b5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="08cbb65d-e216-4e51-a784-c03d009b7d5a">
+      <statement statement-id="sa-4_stmt.c" uuid="5046dcd6-30b8-49a6-8774-93e0ffef45c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf529bd-91c3-474e-b0c6-777fcc5cffbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -6265,8 +6265,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="43a4148c-d312-4d46-9f29-39888258faac">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="782d4364-9eba-4deb-9280-55fc2f24806c">
+      <statement statement-id="sa-4_stmt.d" uuid="a704a7c4-133e-4b37-8c2d-ee72fe0d0247">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="733da578-3bab-42b0-96bf-5ed6c85d832b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -6274,8 +6274,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="bad49bd0-c932-45a5-a0ef-04fd36db87bf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2fda37f6-95e5-4895-812a-9dd29b5c4d66">
+      <statement statement-id="sa-4_stmt.e" uuid="5a1d9736-3556-40c8-9120-303349cfc92b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a079f5b3-49e3-460d-8778-5098f04705ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -6283,8 +6283,8 @@ are outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="91d34f28-8c75-4ab4-99b0-b1c0095d4270">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="841593e6-127e-4032-8165-9144ed825803">
+      <statement statement-id="sa-4_stmt.f" uuid="41f8de4b-2c62-4d99-ab89-1f0303738385">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ce208fb-60c3-47f5-855e-9fc2e5bd0db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -6293,8 +6293,8 @@ OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="ae79bfcd-bd5e-4300-8018-66dc219454f2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="176153ca-0c73-4207-934b-2da59c2682fc">
+      <statement statement-id="sa-4_stmt.g" uuid="6c8fb61b-8dc6-4391-a608-d0941b0d093f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66030e0c-d706-4d48-a588-f0f4cbc62d79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of OpenShift
@@ -6303,10 +6303,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d055d7c3-88be-445c-8e7a-f3d1cc6bf5da" control-id="sa-4.1">
+    <implemented-requirement uuid="5304b0c8-226c-4b93-8016-3c5d124f854b" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="add0922d-bea5-4619-ade6-b45032c95718">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d1923cb-d94a-4399-8959-51caf3725e05">
+      <statement statement-id="sa-4.1_stmt" uuid="64169bbc-e536-4a43-a859-591743b4b950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d3defd9-e7ba-4864-8474-4487cbcaf84e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -6316,10 +6316,10 @@ https://issues.redhat.com/browse/CMP-360
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a5b0ba2-5218-4f2b-975c-389a1661df77" control-id="sa-4.2">
+    <implemented-requirement uuid="44c7e4b7-6adc-4f5b-9dc5-e761001d8982" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="dd5448bc-b0a7-4434-b830-700b402cdc72">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3260868b-2082-4da6-8830-fa62ff285d28">
+      <statement statement-id="sa-4.2_stmt" uuid="59c5a200-46b7-48ab-bc21-d6932d43a016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e6535c33-0142-4714-8f10-09335fc6dc79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -6329,10 +6329,10 @@ https://issues.redhat.com/browse/CMP-361
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43069609-dff3-45b6-8afd-7a7444baca13" control-id="sa-4.8">
+    <implemented-requirement uuid="11659e90-59b5-4173-b43b-1812ae1883b6" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="e10b0f1f-dab8-4bee-bad6-af49231152c8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="919ffe05-f5a7-49fc-a8aa-ce9787ab8f05">
+      <statement statement-id="sa-4.8_stmt" uuid="4b9d4eea-be9d-4f5f-9a67-ce7e25a48f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597f1282-83d4-49ec-8766-9be0dbbd2f16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -6342,10 +6342,10 @@ https://issues.redhat.com/browse/CMP-365
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="944c61d1-ed57-4ed1-8eba-d9e6dcdc8b1f" control-id="sa-4.9">
+    <implemented-requirement uuid="9ff8b64a-8a54-4e48-ad70-1fdaea27c11e" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="0ecf1813-fef7-43da-9859-a7e47ef46068">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fac11180-c634-40bb-a959-3ec3b2f54d09">
+      <statement statement-id="sa-4.9_stmt" uuid="267db06e-5550-47ff-9734-f9d2e6f704f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d42c837f-2526-4ac8-8d24-1add8af53ab1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -6355,10 +6355,10 @@ https://issues.redhat.com/browse/CMP-366
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fad4ebd-37cc-45db-9f7a-a94087fc6798" control-id="sa-4.10">
+    <implemented-requirement uuid="8ee28a5f-de3c-47d8-a3d3-863e2110d3d2" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="fe337d52-8575-4270-bd4b-bf52bbed2f16">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ec6f22c7-69bd-4bcd-9577-c162c8405c92">
+      <statement statement-id="sa-4.10_stmt" uuid="6712c5ae-4df1-4d08-99cf-b2387507074b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6366,10 +6366,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63aaa11d-8562-4b29-a6e5-2def04bd3df2" control-id="sa-5">
+    <implemented-requirement uuid="f45b1f55-9edb-45f4-85ed-b1bbeac70efb" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="3a70e391-4292-40e8-9156-bdec4a2f8a44">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="168dd29f-2f0f-4a00-81be-4eb453e7e1e1">
+      <statement statement-id="sa-5_stmt.a" uuid="5400ac5f-a05c-423d-9858-4e7a2e44378e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42bf9c8b-4898-4c22-97ab-2981a11dbf97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a) is planned. Progress
 can be tracked at:
@@ -6378,8 +6378,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="a84cdde2-7fe4-4b44-8c21-d0a7ab47ed95">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="44661847-699e-442f-945f-82599de92f7b">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5a53656d-14da-4d06-999c-983cc9d37122">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af70c3e9-9576-4846-b323-7dbe56661237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(1) is planned. Progress
 can be tracked at:
@@ -6388,8 +6388,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="bc760e84-8e27-4951-951a-a499bfee19c9">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5f1d32c9-eb54-4637-8675-de8a2af11d84">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e26b3796-8741-4dc5-8d4d-16a2c7a71a0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f82b93c-e880-4b4c-ad58-29708bb30021">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(2) is planned. Progress
 can be tracked at:
@@ -6398,8 +6398,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="50898fd2-c8d1-4c4e-8278-cba724318878">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fd77b2b1-74f8-4929-84d3-a626f5ceb0ba">
+      <statement statement-id="sa-5_stmt.a.3" uuid="6d3e15fb-088e-4975-8e2a-ef236040f900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="738ba6dc-d4c4-473b-a84c-99df0db4f66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(a)(3) is planned. Progress
 can be tracked at:
@@ -6408,8 +6408,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="3f9e789c-4ab6-4113-b6a6-a0c6b0566b1f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9a94cb6c-c322-40d4-b6fe-1e7c54a772f2">
+      <statement statement-id="sa-5_stmt.b" uuid="cf2048c2-2512-4cfd-ae44-0f73cf2af6b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a92105-5236-4d1c-8eca-c15293889034">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b) is planned. Progress
 can be tracked at:
@@ -6418,8 +6418,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="96f46098-3cf9-4168-9d46-34ac0130ac13">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8f0ce252-83af-4f63-b7a6-010385b919cf">
+      <statement statement-id="sa-5_stmt.b.1" uuid="ee4d5460-7e0b-4df3-8026-16f46504764a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c852d52b-4e78-4f86-ad39-3c2fb8feecda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(1) is planned. Progress
 can be tracked at:
@@ -6428,8 +6428,8 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="9b96c6fd-5547-43a0-9699-3bbb642cb485">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ca43a55c-c36b-4ffe-a247-888d45e79833">
+      <statement statement-id="sa-5_stmt.b.2" uuid="9c0b5a9e-55ce-4084-94ea-c2c588d22212">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f899b09b-7f2f-4d5a-ae7e-41bbc4a0841f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-5(b)(2) is planned. Progress
 can be tracked at:
@@ -6438,32 +6438,32 @@ https://issues.redhat.com/browse/CMP-367
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="54715b8f-bb17-4324-9d24-2398ee61c45d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5bf6398f-5a59-41ee-b475-2d24ff2760ff">
+      <statement statement-id="sa-5_stmt.b.3" uuid="fb21bfac-d62d-4932-a2ab-7c929fbeb2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="8df2a951-2388-41fc-b212-fa8f17a82201">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5df80d1d-f93e-481a-9736-334a7a6d6148">
+      <statement statement-id="sa-5_stmt.c" uuid="fee19988-cd1f-4ba4-b170-f6bb31cdc115">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="2316057e-4201-4dc3-b902-ef7ff6ba6a57">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cc522bc2-a548-427a-8d61-0a5473d8c02c">
+      <statement statement-id="sa-5_stmt.d" uuid="c8689aa5-cc05-4fb0-bcf0-0e767c9df94f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="0ee90b24-203f-4361-8457-d54f8587e56c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="221dc568-7bef-4395-9adf-3947cd6d44d0">
+      <statement statement-id="sa-5_stmt.e" uuid="a19603a4-be8a-47b7-b182-7357f7f0bcd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6471,10 +6471,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1f61466-dee8-4b2e-9f3e-b2144e473a29" control-id="sa-8">
+    <implemented-requirement uuid="3d9caa00-cb96-42c9-a63a-8d818f7d9c2e" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="37b727c2-eeff-4c2d-b383-00070beb6d52">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2c8594c8-e7bd-4aac-afb1-4a2dd655c12a">
+      <statement statement-id="sa-8_stmt" uuid="1fb6ae20-07e8-42bb-a7dd-0ed7c6828623">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6482,26 +6482,26 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ffebc98-d54d-4846-96a9-cab92969912e" control-id="sa-9">
+    <implemented-requirement uuid="4f3d3760-6a96-4488-9064-b66323171ff5" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="ae3d047d-a9e1-4c54-be59-e1edf3bf8d9c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8014ff7b-db1c-4593-ab0b-84e308fa87f4">
+      <statement statement-id="sa-9_stmt.a" uuid="790594b4-8dc9-4e6d-a7be-8a4f821d60dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="16597f94-0cdf-4fb1-8646-c191a9d34812">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d16b32e-976a-4181-9d04-95f92595105b">
+      <statement statement-id="sa-9_stmt.b" uuid="2fdee7a6-17ac-4f3c-8234-e51975aa8bfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="1c161867-1142-4689-a2be-38368b79fb1b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d5b02aff-9e83-4bb5-8709-f0aa3db222fb">
+      <statement statement-id="sa-9_stmt.c" uuid="f91bbfe1-2590-4996-bbf3-5a931f802ecf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6509,18 +6509,18 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1509ecc5-f8b9-4e9f-9f55-41ae48e03e14" control-id="sa-9.1">
+    <implemented-requirement uuid="1e0c024d-da7f-4c3c-b6fa-9f35abb7d991" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="d3f8def5-b1be-4cc9-9a3c-de51aa61128a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="247bed9f-e688-4c4f-980d-9f0c9ff18613">
+      <statement statement-id="sa-9.1_stmt.a" uuid="77d286f1-3862-4fdc-b034-1cbec7788df0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="80699bc6-82a8-4e1f-b363-cc67215ceecf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="26473f04-9294-4f80-b7c1-37f75ae87a25">
+      <statement statement-id="sa-9.1_stmt.b" uuid="5b440203-0c98-4a61-94bc-1739bd25a350">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6528,10 +6528,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a952ad1-5f8e-459d-866a-0d42c59e46a6" control-id="sa-9.2">
+    <implemented-requirement uuid="16385c4e-e3fa-4c22-8028-e9141a389fe8" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="8f949f1a-f59e-4b0c-81e0-87b93e04fc68">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="83a62ff9-3a79-4ac8-888f-247b2f721630">
+      <statement statement-id="sa-9.2_stmt" uuid="16f50ee2-60ed-402e-a770-f49fb83f6d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6539,10 +6539,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c17f76cd-a594-4ce9-b816-8cf5e699cabf" control-id="sa-9.4">
+    <implemented-requirement uuid="73a17370-4c1b-477d-a0a2-43c24dee33fb" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="251039ff-37bc-4b3a-8321-ab76c2852d3f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e344dad8-fa98-4221-baf2-17591284f1d1">
+      <statement statement-id="sa-9.4_stmt" uuid="4b181d05-f0f3-42e9-9466-6aac04d5e824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c35e9a6-06e1-4006-8a41-cfa8cf5ddbb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to OpenShift configuration.
@@ -6550,10 +6550,10 @@ applicable to OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28465b05-6381-4873-8001-59a108f7a69a" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="8a64021f-662d-46cf-b8db-d1fcf7e45de5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4b4ac801-8951-4ab6-ae3f-3ab2bd3afb1f">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -6563,10 +6563,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b74e4f1-5666-4e7c-a79d-423edcc1c633" control-id="sa-10">
+    <implemented-requirement uuid="23e70356-2035-4233-a7f4-8370b3d60157" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="f234b3a2-9bcb-45a6-affc-eab945b2e75d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="58615cff-afa2-4bcd-a807-6b37b768e4b9">
+      <statement statement-id="sa-10_stmt.a" uuid="95684487-9444-4195-8dbb-962f685d5bd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ac6e51-7ce3-4f56-bc71-b6ee264973d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -6575,8 +6575,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="9cd8b3d1-df2c-41fa-b13d-d77dc24c45a0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c6e9a2d9-91ea-42f0-aefb-50718c9088f1">
+      <statement statement-id="sa-10_stmt.b" uuid="3f0d837b-9027-4ba8-ac9e-9b4f1b9544a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa90dca2-ea44-4706-8cb9-2280b5d5f2d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -6585,8 +6585,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="65b2afc2-a17b-4e2b-84d3-d30337558aeb">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="37d5e9ae-412a-4a49-ab38-ba7da0eca577">
+      <statement statement-id="sa-10_stmt.c" uuid="40f2740d-7c38-4a52-aff6-f09b9240678b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe37bd74-209c-4b2f-acfe-3da20c65069b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -6595,8 +6595,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="a6fd8942-eb79-4f63-8a98-f5711852501c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9502f563-95bf-4928-b7b6-b10fdea60ab2">
+      <statement statement-id="sa-10_stmt.d" uuid="a1e3cfe6-bafd-4bcf-add0-e2df6c385eda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51149b43-7746-4674-81e0-9343b6556130">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -6605,8 +6605,8 @@ https://issues.redhat.com/browse/CMP-369
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="cd2ce689-0768-4f55-a5d7-7345171dfe47">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bb2559c2-654f-4912-b7ce-9d268fb3efb3">
+      <statement statement-id="sa-10_stmt.e" uuid="1d119dee-e436-41b2-ab4d-2dbd8a87a222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4b6d4be-f2c6-43b7-9f49-133379f30817">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -6616,10 +6616,10 @@ https://issues.redhat.com/browse/CMP-369
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59ae8e4b-3af9-4005-bdcf-e420593b4984" control-id="sa-10.1">
+    <implemented-requirement uuid="4c64a19c-d9a6-4f5f-8362-95028e8a5a27" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="83663dca-4dd6-4b9a-a37d-2cf96f73eb1f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a13cd07e-dc39-43f1-9ee5-4efff8bf560d">
+      <statement statement-id="sa-10.1_stmt" uuid="3893e7a9-f701-4695-bb10-3c715ec900de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5a26a-f4da-4af3-97c9-1b9cd4601ff9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -6629,10 +6629,10 @@ https://issues.redhat.com/browse/CMP-373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afba7852-61c3-4a43-843f-6953d3410be5" control-id="sa-11">
+    <implemented-requirement uuid="a86926a5-e735-4a73-83bc-60bc088ce819" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="a21e20ea-9046-44aa-8463-953f065c8385">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d9e81858-39b4-44bd-a1f3-adc0ad00b63e">
+      <statement statement-id="sa-11_stmt.a" uuid="46fc688a-6a7a-491d-8c9d-f3ca597d33eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f34b6662-ab38-41e3-ac72-b08cb8675a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -6641,8 +6641,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="b4b33146-fa06-420e-a58c-6ab4c1b7bfdf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a3047453-d727-45e2-a524-d8add84c53a3">
+      <statement statement-id="sa-11_stmt.b" uuid="3c6b0a07-19e1-4b56-8978-84f78e5d41b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c00fc148-bd08-4f25-aee0-9ad9d3760062">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -6651,8 +6651,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="71dfb4a8-c7e2-419e-9538-5a3eef5af430">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ec5f2ab4-d5d7-4421-9cf9-562898d98345">
+      <statement statement-id="sa-11_stmt.c" uuid="95db2f92-ab21-4cdb-bf9b-41002f9858be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c0e9f2-6558-4dd6-b14e-9a254d3cd9c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -6661,8 +6661,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="89194158-783c-48ce-95cd-897a73ccc648">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="09c71553-5558-437b-9ed5-163ab84403bd">
+      <statement statement-id="sa-11_stmt.d" uuid="efebb503-1b64-4ce9-832c-3be4e01cc4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b2f4dcf-5965-417a-8706-e9e23c034690">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -6671,8 +6671,8 @@ https://issues.redhat.com/browse/CMP-374
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="5a44ca98-bb2d-4b5d-a83f-172a8263c022">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fa252b88-cd0c-4bc5-b394-a7ebcec80104">
+      <statement statement-id="sa-11_stmt.e" uuid="fcf54721-40fd-49b0-af2d-7c710acfa862">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="528f9b93-35a6-4d13-8a0f-acb56b90303c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6682,10 +6682,10 @@ https://issues.redhat.com/browse/CMP-374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ccbbb16-ac68-4153-9a99-bd56f45e4272" control-id="sa-11.1">
+    <implemented-requirement uuid="390d4359-e23c-4ea7-a03e-33ab0f771c89" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="2b025c7f-97a5-4bae-bfec-6ba9ef41c524">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3b066061-6b57-4946-bce1-c73ed8e657af">
+      <statement statement-id="sa-11.1_stmt" uuid="78fa5d63-08f1-40f8-aa7f-302d689735df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3953a8df-4a05-4b03-811c-eecbc5b1115f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6695,10 +6695,10 @@ https://issues.redhat.com/browse/CMP-375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfa4ac00-9d48-4dc4-8d1e-38e454ab1498" control-id="sa-11.2">
+    <implemented-requirement uuid="f6a79121-574a-4870-8fd6-f0b7f8e8264b" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="83b560c3-a1f4-4bd9-befc-3cdab85a69dd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b48ec10d-983a-49db-a533-1e143dfb81a9">
+      <statement statement-id="sa-11.2_stmt" uuid="bc1c0016-a06c-4757-af0f-2bebb94fb87b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a25713a-4531-486b-bb1d-534a8fd9065e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6708,10 +6708,10 @@ https://issues.redhat.com/browse/CMP-376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40cfb1e9-6fd3-4654-800a-296a6e9961ad" control-id="sa-11.8">
+    <implemented-requirement uuid="b2c4d52c-2d22-410b-91fd-6adcafe27600" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="6075cb16-7748-4c82-92d2-619ff6f215e4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="069b55a5-6231-47e0-9d85-a13777c4cb93">
+      <statement statement-id="sa-11.8_stmt" uuid="6bb50194-184f-4669-9484-5e251888ba63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5626f4d-3991-4663-8a15-b4c106696880">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6721,18 +6721,18 @@ https://issues.redhat.com/browse/CMP-381
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35923341-7599-4998-a216-a359a3cb5bb6" control-id="sc-1">
+    <implemented-requirement uuid="6f1144bd-a44c-4b04-997c-b59d54a710d2" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="0a8f332a-4e2c-41c7-a239-825421423613">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="58550295-0ab4-498e-9d36-9f4ee8795f5c">
+      <statement statement-id="sc-1_stmt.a" uuid="1fa652f8-6db2-4210-a8eb-f51d9dc94c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="91599da4-bc39-46c5-b2a3-3acfb097c1e8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5027020d-70b2-4a29-b019-37111e5beafa">
+      <statement statement-id="sc-1_stmt.b" uuid="ab7e745f-41f6-47a2-a535-600910be8e7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -6740,10 +6740,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c19b7613-e6ef-4143-baac-c41df5de08d8" control-id="sc-2">
+    <implemented-requirement uuid="591ef3b8-6fee-4e3f-a241-82278e96a4e7" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="7f59dc2f-908a-4864-8e13-a3bddfee697d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bc318f2b-80ff-4a0f-a42c-c26d6836049d">
+      <statement statement-id="sc-2_stmt" uuid="143cf0ca-c117-4586-a1cd-91947e3f1a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa072737-5175-4d0d-a2ab-e535883b1181">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -6758,10 +6758,10 @@ https://issues.redhat.com/browse/CMP-429
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49f50b69-5d7b-47c5-a2ee-6f2073c91d77" control-id="sc-4">
+    <implemented-requirement uuid="96f7fae4-b1c4-4625-92ac-3353f07bb6ca" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="735b3e80-915e-47eb-95e9-96e226309b16">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e717ddff-a134-42b7-8901-46787c36953a">
+      <statement statement-id="sc-4_stmt" uuid="deb25b8f-b7c0-4ffc-87c3-ddb3e0e9e98b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="617b39ae-8abc-4fb0-9c00-c50746b0d781">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -6775,10 +6775,10 @@ https://issues.redhat.com/browse/CMP-428
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9d6bf29-63e8-42c9-9d8b-c97c7a67c93d" control-id="sc-5">
+    <implemented-requirement uuid="7c68bba4-5d9c-44f2-aad2-9eb8cadced49" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="50c09e93-f06f-43cc-bb41-8a5de2ab148d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="293ee884-0c98-4065-b4bf-4d3954e0a767">
+      <statement statement-id="sc-5_stmt" uuid="03ef8862-55de-4b8e-89ac-f0803b4547c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d12aca87-769c-4968-9b71-135e5bb3a73e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6788,10 +6788,10 @@ https://issues.redhat.com/browse/CMP-427
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d884121-0abc-44e8-b4fe-e8c40d2a0e72" control-id="sc-6">
+    <implemented-requirement uuid="2ecd1aa4-1ec5-424c-8299-2f1847c78d2d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="874d0c28-b9da-4bbd-957b-f25a246af617">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c89c9c8d-03e6-4e6d-bbd6-dc62f796fc1a">
+      <statement statement-id="sc-6_stmt" uuid="1c65ffd6-790a-45be-9f96-dae549f63731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb086507-2e55-4213-b420-2f757534f30d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -6806,10 +6806,10 @@ https://issues.redhat.com/browse/CMP-476
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e6a470a-1a71-454c-a88d-9735c69019b7" control-id="sc-7">
+    <implemented-requirement uuid="368ba890-8f67-4d46-a377-ece589a2d2de" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="804b5a47-baed-4d2e-abc3-be67685b526b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="246be22d-5216-4f2c-b333-5ec8e9536107">
+      <statement statement-id="sc-7_stmt.a" uuid="8b3435a7-a508-43df-8f6a-b33ed3730c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6818,8 +6818,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="7eb29732-44eb-4fb7-8998-95c5478e76f2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8c940dea-d650-4be8-8fe8-af8d503295d1">
+      <statement statement-id="sc-7_stmt.b" uuid="98ad9fcb-fb9e-49b2-a07d-5d680ff5b394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6828,8 +6828,8 @@ https://issues.redhat.com/browse/CMP-426
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="cc383d29-bdef-4b6d-813f-0a0eabe71122">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2bec1ca4-473a-44b5-8747-34fafb5c19e0">
+      <statement statement-id="sc-7_stmt.c" uuid="1ac5f104-c3ac-46ce-a444-15d4ac4437f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="625c4e28-1da7-40ae-bd8e-10d07390c4ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6839,10 +6839,10 @@ https://issues.redhat.com/browse/CMP-426
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce713b4d-ddcf-499c-a541-2b5b378a3466" control-id="sc-7.3">
+    <implemented-requirement uuid="186b2385-1f1a-4a9f-87cb-fa9ba58408bc" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="d789ca62-5797-4efa-8e07-ac20910d5baa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ad802d39-dc84-4b96-af7b-bc5b92b472c9">
+      <statement statement-id="sc-7.3_stmt" uuid="34c09b45-a0e3-4736-b446-a55a9b2a919e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c23c58f-8d5c-4070-a9c0-8ae34f8b5eb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -6852,10 +6852,10 @@ enforcement.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="090bfb1d-cfbe-43a7-9cb4-305c83375fb9" control-id="sc-7.4">
+    <implemented-requirement uuid="40c87c66-53dc-4c7a-b967-a4c56d768cad" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="db0e7b5c-054a-4d54-bb35-94117e5fd2ca">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="36af90cf-b8ed-40e4-975f-bf16a0c7fb2f">
+      <statement statement-id="sc-7.4_stmt.a" uuid="b9b8c5f1-be1c-463b-89a6-f55da7e89336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42b18df6-6a61-45a2-bbbb-8278df55804c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication service
 is addressed at the network infrastructure layer and is an organizational
@@ -6863,8 +6863,8 @@ control outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="8a835c50-33c5-488b-8ff4-ed48c48504f1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="deb61b21-0f87-473b-8e99-2d8f12fafd1f">
+      <statement statement-id="sc-7.4_stmt.b" uuid="535c8a55-e076-4c4f-832a-0689111c527d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f000ffd-6bcf-444e-86bc-0d6240403c42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside the
@@ -6873,8 +6873,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="89b05591-3fdf-4072-9954-bebfbb867cb8">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="eb90a860-6735-4e0d-a398-b34199f22d13">
+      <statement statement-id="sc-7.4_stmt.c" uuid="09f0b017-481e-45d6-be8e-58fd0c6249ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1129c924-e34d-4f9c-9c92-f732ba16c7ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being transmitted
 across each interface is an organizational control outside the
@@ -6883,8 +6883,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="88779c7e-83b7-4d37-a5b3-c120cca30a48">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ba09efdc-cd5f-4a6b-b05c-ffdec66ffda8">
+      <statement statement-id="sc-7.4_stmt.d" uuid="99605571-65d1-4b0e-b820-6f6d4cb27321">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecf8a969-d110-4dd2-b016-c66831f9c91d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational control outside the
@@ -6893,8 +6893,8 @@ infrastructure layer.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="e2509c16-9ada-4246-8245-83f290b0f09f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9b0089b0-15ed-4485-9cec-549b3336c368">
+      <statement statement-id="sc-7.4_stmt.e" uuid="8f644a62-bf77-4048-aee7-d660628f64dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3de3cfe2-e7c1-4cb1-b7db-5a472f4b0f84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally defined frequency
 and removing exceptions that are no longer supported by an explicit mission/business need
@@ -6904,10 +6904,10 @@ handled at the network infrastructure layer.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92f5e497-efb5-4710-b529-bb73ab2065fc" control-id="sc-7.5">
+    <implemented-requirement uuid="299dcdaf-d2bd-44b1-9f34-7a83c829a2b4" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="910823f7-10f7-476d-8015-65312aaa8af6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b6da27ac-d1bf-409a-818a-165599b2cc0f">
+      <statement statement-id="sc-7.5_stmt" uuid="796764c4-2388-42ab-99f8-bdf5a00fb0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b15b06f-d5dc-4fb0-af24-596c93208d35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -6921,10 +6921,10 @@ https://issues.redhat.com/browse/CMP-424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5be246b5-e8d5-43ae-8b79-68d13fe255a4" control-id="sc-7.7">
+    <implemented-requirement uuid="bcea67a7-eae0-48d6-aa01-b4e2a3a68210" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="89f47986-82ee-45ce-b5ea-47b0a522f02a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7c390bfa-dc86-4632-9cc1-c4d022307b2e">
+      <statement statement-id="sc-7.7_stmt" uuid="cab35424-140c-42cb-9ab7-deae4b0da66d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1152f196-9746-4432-a593-6ee4a6ff7334">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure OpenShift nodes do not act as proxy or relay servers between
@@ -6933,10 +6933,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00bbedf6-0b70-4691-b698-0c080638dafc" control-id="sc-7.8">
+    <implemented-requirement uuid="7decfaf2-b8e3-498b-ae55-671b24506ec9" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="cfa1e061-33ef-47a1-82fb-5e1bbb740dc5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="83103958-40cc-4bd5-b262-cc54584b677f">
+      <statement statement-id="sc-7.8_stmt" uuid="833f91c1-8eb3-4422-8059-f8d05cfe7237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adba8470-6219-47a4-aeb4-ba166c6b610a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6946,10 +6946,10 @@ https://issues.redhat.com/browse/CMP-477
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b131c1d-3069-44bb-a1aa-f937b36d4306" control-id="sc-7.12">
+    <implemented-requirement uuid="7bcc9d61-0924-4650-a79c-d2bcf6e0bfde" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="c0714e4d-8621-4152-8df7-a318b700db66">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="646ac5a8-205e-47f2-9e40-935823efe757">
+      <statement statement-id="sc-7.12_stmt" uuid="04b972b1-e2d5-4deb-868d-b1a1bb971393">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c721f916-ebf5-44d2-930a-0f52d3887fec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -6963,10 +6963,10 @@ https://issues.redhat.com/browse/CMP-483
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c2ee7dd-5087-41f6-93be-9f30c1e97b80" control-id="sc-7.13">
+    <implemented-requirement uuid="f1197a21-c333-4172-a38d-61974c0d7104" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="177f8bc1-9e50-43aa-a033-a2207b0de853">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="5e2f6569-1361-46ad-9d5e-1b181a638405">
+      <statement statement-id="sc-7.13_stmt" uuid="24191c4d-9451-4c9e-abbb-6b1e57bf12eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ee1f34-09bd-4973-b7ed-91901cf226cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that OpenShift is
 isolated from other internal information system components by
@@ -6983,10 +6983,10 @@ https://issues.redhat.com/browse/CMP-484
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07c77e41-23a1-4e07-bc89-106dc39991d2" control-id="sc-7.18">
+    <implemented-requirement uuid="7e0070ef-c09f-48d1-9579-efebc49bb27b" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="0c3f012e-7ee9-4a6c-b39d-4529d8ac87f1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0f43235a-9ad3-4262-b34b-b113815c3020">
+      <statement statement-id="sc-7.18_stmt" uuid="6bc5981d-371a-4efe-91bb-23f0994ae97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f446eca6-5b4d-47c8-815d-301752b4d6ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6996,10 +6996,10 @@ https://issues.redhat.com/browse/CMP-488
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f509b71d-b441-4723-92b0-78f945877e3e" control-id="sc-8">
+    <implemented-requirement uuid="5204cabf-dbf5-4d92-9cd1-804354d80d7a" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="9239257c-6a54-4ba9-91c6-877211a2680a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="aa0a8b33-0d4c-4049-8334-5e6f4115dd72">
+      <statement statement-id="sc-8_stmt" uuid="10ab3b1d-fa32-4dfb-b7f0-c5c4f924b33c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fee56b6-5600-43e3-9132-b328cd2e17aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -7007,10 +7007,10 @@ information.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4f80cd9-8cd6-4b1d-8962-93ce53b1f7da" control-id="sc-8.1">
+    <implemented-requirement uuid="d79b39ec-b75a-4d9d-b839-2f28d69d9e98" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="c1f35c59-5e1b-44a6-985e-6d4efb003339">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="b64ffb2a-96d6-4587-9835-5d6f9bc9bfa1">
+      <statement statement-id="sc-8.1_stmt" uuid="84d59cbe-40c4-4f22-8df4-1246640eef00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acd8d90a-0f39-4844-acf7-6a4ed7f9b815">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implimenting cryptographic
 mechanisms to prevent unauthorized disclosure of information and
@@ -7021,10 +7021,10 @@ network communications that carry customer data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="032ffb4f-83cf-4b4c-b45f-23c2e33d60da" control-id="sc-10">
+    <implemented-requirement uuid="df5e51eb-966c-402f-98c6-1bc7cb654de8" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="81760a99-b97e-4005-a39f-9af3699338bd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="8748e12d-224b-4804-9101-2a964107a339">
+      <statement statement-id="sc-10_stmt" uuid="49fd79b3-99f8-474f-82f2-797e2fcb4835">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fcef049-edaf-49f1-ae92-34545047b7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -7039,10 +7039,10 @@ https://issues.redhat.com/browse/CMP-422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be83f8b5-712b-4e0a-9240-c30548bf848b" control-id="sc-12">
+    <implemented-requirement uuid="a74d4d8e-2ecb-4aac-9c24-abeeed19850a" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="4529e9a6-ae79-42d8-8dc5-73b24b93769f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0279b20a-942d-4828-89a8-e63609019632">
+      <statement statement-id="sc-12_stmt" uuid="85337f2d-857e-401d-8a16-ff1cbaca80dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ed18e31-b4b0-47a5-a053-e139ca63c5f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7052,10 +7052,10 @@ https://issues.redhat.com/browse/CMP-421
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f119eb7-4b60-4671-b8f1-adcf408ff06c" control-id="sc-12.2">
+    <implemented-requirement uuid="f654668f-472a-4fbf-a522-57b6eecda6b0" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="ff1dd377-aa01-4319-87d8-eab01e2d378e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ce1eaf4b-b3c0-44b1-b925-1d1e8beb2ddf">
+      <statement statement-id="sc-12.2_stmt" uuid="67ed0c07-b5b2-435c-bf22-d186feeafb91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7cd35cb-8dd1-4c8c-be3a-46ce4c45892f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7065,10 +7065,10 @@ https://issues.redhat.com/browse/CMP-498
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="def53d6b-f7ce-44ef-943b-7b941ad9cade" control-id="sc-12.3">
+    <implemented-requirement uuid="573937d5-283f-457f-8b61-cf35b660c70a" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="37be01f9-387a-44c4-af64-72692486993f">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="53c27b64-6465-4b0c-a142-12b680104c54">
+      <statement statement-id="sc-12.3_stmt" uuid="a440cef9-784e-4366-a8cb-6d94f9df94bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90872c45-14ad-48c2-8509-c00f5833d23f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7078,10 +7078,10 @@ https://issues.redhat.com/browse/CMP-499
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61b1ea94-0660-4150-8970-c9d4661d69fc" control-id="sc-13">
+    <implemented-requirement uuid="03947a78-12ad-4fc8-a947-cd02e7de8fdc" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="a0d98a9c-b783-41e2-aef9-0e6055e42f23">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="86a4347c-3a27-477b-981e-42ff57e3a11f">
+      <statement statement-id="sc-13_stmt" uuid="abbbba59-7105-407d-8a2a-47371938c821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="928ec4b6-10a7-478e-b5fb-95abffde0a9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7091,10 +7091,10 @@ https://issues.redhat.com/browse/CMP-420
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66189bf7-1d77-4b82-bcdc-0f1f24e112c2" control-id="sc-15">
+    <implemented-requirement uuid="33b5b086-7214-4783-a0c5-ba185fda8e71" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="a52ac20a-a234-4cc9-8a00-6022580620bc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6fa8bb15-a616-493e-98ce-e0076fd26a88">
+      <statement statement-id="sc-15_stmt.a" uuid="22e07405-dd19-4fe8-a698-f29ef5735dd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7103,8 +7103,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="6222e2f3-3f6e-4e00-90fa-f6d4aa1a6375">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="d5b048a6-cef9-4c0e-ab32-dc8d5e9cbf64">
+      <statement statement-id="sc-15_stmt.b" uuid="ca736a8c-d2fb-4c10-8a69-03137dea9b7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad2a338e-3009-48c4-b0d5-ef04fb863b32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7114,10 +7114,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e539e2f-65ae-4438-ac7f-c748c7b3a4c3" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="7420db06-9987-443e-8567-270cdca3accd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="e0d071aa-edc2-4624-96ce-3cd82b4f154c">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7127,10 +7127,10 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="110b317e-b494-4dcb-98ea-8995bef57b43" control-id="sc-18">
+    <implemented-requirement uuid="59ba49a5-f687-4224-aece-d0a9bb94e1b5" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="87a96892-a687-47b9-bb88-90f3813789f5">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="857986c3-ca5e-4c49-8c5a-8021599a458e">
+      <statement statement-id="sc-18_stmt.a" uuid="d1b9d625-add0-4a4b-85d4-9bd95d0ec719">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="114c57ea-d393-4155-aeae-c3fc55e99699">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Defining acceptable and unacceptable mobile code and mobile code technologies
 are organizational policies/procedures outside the configuration of OpenShift.
@@ -7141,8 +7141,8 @@ web console that is accessible through a web browser.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="413cccb1-8439-40ef-9c9b-a5ac522ecf3b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2967c308-8f3b-4e2b-a45f-1568e0747771">
+      <statement statement-id="sc-18_stmt.b" uuid="7ec821bc-9bdb-47cd-b102-c239b04cf6e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8eeef5cf-f7eb-448a-926b-3bbc65e5784b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing usage restrictions and implementation guidance for acceptable
 mobile code and mobile code technologies are organizational policies/procedures
@@ -7154,8 +7154,8 @@ that is used to power the graphical web console that is accessible through a web
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="0b2bab51-e233-434b-92f2-7254b7d35f13">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a5858fe5-dd9c-426c-a07a-a75936ab45b7">
+      <statement statement-id="sc-18_stmt.c" uuid="21b3f744-2fa4-4360-b635-fb0433a7c833">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef9f9588-dbed-4a4a-be56-40eb10bbf0fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -7168,18 +7168,18 @@ web console that is accessible through a web browser.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93dfff6e-a291-4967-8f2f-6197a47c2910" control-id="sc-19">
+    <implemented-requirement uuid="bc408d6f-99ea-4a9f-b808-c973d7933495" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="abf55bd3-eaa3-4a7e-bf09-bdf0bc7859d3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="324de3dc-fe39-4dfa-b9f4-568e71dd47df">
+      <statement statement-id="sc-19_stmt.a" uuid="267f7ba8-5551-46c4-a4cd-b91d6b92c2ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="55e1165e-32d6-4431-a16d-a9858c36da71">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="08d91bb6-1634-4ae2-80c9-97d86ccc3ad3">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -7188,10 +7188,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc8886c1-7b82-4e7b-8a83-d51508803dbf" control-id="sc-20">
+    <implemented-requirement uuid="e8aba7c2-acb4-4654-b1d5-e600a651d4c3" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="aca3bc86-ca1f-411d-a62d-a6b58066d7f3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2059f0f6-fb14-4ca1-b029-5b775efa1be8">
+      <statement statement-id="sc-20_stmt.a" uuid="a438c5ea-e94c-44e1-9c84-4d29a630732b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60a17e-515b-4a94-821a-de75ff70ced1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -7206,8 +7206,8 @@ https://issues.redhat.com/browse/CMP-417
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="59696208-8100-4b15-b88d-6ebdaa028a6a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7f2d946d-fd88-46aa-872f-41a012bd68a8">
+      <statement statement-id="sc-20_stmt.b" uuid="3b9bf6aa-8da0-4050-bb86-c3357e8d9f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76baf97e-0a1f-4b12-bb26-a59e03124332">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -7223,10 +7223,10 @@ https://issues.redhat.com/browse/CMP-417
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8aac1cc-384d-4892-931b-2cfaec3aaab3" control-id="sc-21">
+    <implemented-requirement uuid="da3b2e54-60d1-41e3-b896-f2a552c14e83" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="6eaa4610-faf7-4819-80f2-71a23cd5d378">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="47a6bca1-f931-4377-84ea-99f130f1132f">
+      <statement statement-id="sc-21_stmt" uuid="f867e4c6-14b4-4a68-9487-4ddc85948e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf848318-eaf0-482c-9d30-409fc7062381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7236,10 +7236,10 @@ https://issues.redhat.com/browse/CMP-410
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a37f142-ccea-472e-8d2c-810343001df1" control-id="sc-22">
+    <implemented-requirement uuid="5fee0dd7-b1f6-4891-98bd-848c114c8822" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="df9e6917-f6d9-42d0-9681-047492658ea6">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3da4647d-2c87-4083-a30e-01e760822a9e">
+      <statement statement-id="sc-22_stmt" uuid="81094d0d-abb6-44fe-b96d-302346ffb9a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec8d8758-4010-4e53-bf8f-07d498fe1433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift administrators are responsible for ensuring
 services are fault-tolerant and implement internal/external role
@@ -7253,10 +7253,10 @@ https://issues.redhat.com/browse/CMP-409
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c9c2048-d89e-4e8d-93bd-51a957e77c54" control-id="sc-23">
+    <implemented-requirement uuid="55f35173-b26b-446c-84e9-4d9c3403963f" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="db9cb6de-2151-4542-847f-d076d5d11910">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0a5d6ce0-7d85-4e97-a38c-9853ff5af001">
+      <statement statement-id="sc-23_stmt" uuid="c6fbdad1-b354-4172-bf6e-6d9004084a83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d91fa822-db8a-44f5-8ade-232b776bd79a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -7276,10 +7276,10 @@ https://issues.redhat.com/browse/CMP-408
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8eecf79-ce28-4458-864c-9a6172213213" control-id="sc-28">
+    <implemented-requirement uuid="2f992720-6db0-4356-8634-6339b0d6cda8" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="ee57f053-a763-4c24-9afd-87a2f68d8ca3">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="53e086e3-a455-4091-8d52-fb5c71c98ab4">
+      <statement statement-id="sc-28_stmt" uuid="8ef6d238-c643-47a9-852d-368fa7d3e931">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32649326-f922-49d4-bd77-0b13901bf763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7289,10 +7289,10 @@ https://issues.redhat.com/browse/CMP-407
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28b598af-1ed0-499f-bf28-88b62344a1d5" control-id="sc-28.1">
+    <implemented-requirement uuid="2fdd7a56-3726-4eb1-bfcf-5e176b9a3034" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="11056f76-1ce4-4b9c-8632-37db4ee54e34">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6032f098-006a-4c20-880b-1bc7f7afb19b">
+      <statement statement-id="sc-28.1_stmt" uuid="71a057ff-989d-433f-9ba8-138a0d68cd4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e0ee74f-bb55-464d-aee1-4aac52eb7bb3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -7313,60 +7313,60 @@ https://issues.redhat.com/browse/CMP-509
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="863c2c0d-5055-4496-9276-7ebf4ae86206" control-id="sc-39">
+    <implemented-requirement uuid="3acd7bd4-240b-494c-8272-e84c423da259" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="affbb7e1-1e61-4b35-bc67-d80c2335f5fe">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f4f8fefb-c5d6-4cfd-a39f-3a89a24a199e">
+      <statement statement-id="sc-39_stmt" uuid="5172fcb7-d81e-45a4-83f6-e6231c3cc750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e973918-9963-4200-bcef-aaa99887d3a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The control is met when SELinux and namespaces are enabled and used.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d5c93b9-081c-488b-bc83-5771703f2adb" control-id="si-1">
+    <implemented-requirement uuid="0e8f74e1-33d5-490e-8ac7-915f29de22fd" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="ce47aa69-1278-45b5-9e15-9fe7ad6cc357">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a557cb87-0e00-434e-80cc-1e6a6707dd33">
+      <statement statement-id="si-1_stmt.a" uuid="89bb11fc-5456-4431-b5f0-9f781b3a5730">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="b9066529-ac68-47d1-90a1-581731a070c1">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6d506596-a1a1-48ea-bc03-63bcdf722781">
+      <statement statement-id="si-1_stmt.a.1" uuid="11d47f68-9baa-4b99-8e12-9ea77692cd34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="dc4ddbf0-5f9e-4aa6-a97b-c9264afe9b59">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7a2ce91c-1ab7-4e8e-986c-4a04c259c4bb">
+      <statement statement-id="si-1_stmt.a.2" uuid="41bb516d-57c2-400a-aa40-9bdbda591302">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="8640d6aa-89fc-43bf-a5f1-a684b2887737">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6a0bd691-b6c7-4e4e-a271-5849a9622855">
+      <statement statement-id="si-1_stmt.b" uuid="448424c2-d63d-47a9-820c-f87eb4d1d61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="6723d0cd-1064-4a8b-80c8-c41351923587">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="92afc1d3-dc53-479d-a18a-b30b26dbefd8">
+      <statement statement-id="si-1_stmt.b.1" uuid="15a10a6e-2916-42cc-a2b7-02aa6cb1c31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="237ebac9-abc2-4b02-ad5c-5921f15f38b2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="412e59a6-95b6-4fef-b35f-3f7e3295617c">
+      <statement statement-id="si-1_stmt.b.2" uuid="1cedc5bd-d780-421e-af4f-0cb3453299cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7374,10 +7374,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a17c0e4-0dbd-4516-ab8e-85b5436a6301" control-id="si-2">
+    <implemented-requirement uuid="acd2c7f7-78db-433e-b76e-fb6644fa7a8c" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="a33489f7-abc2-43c4-8c23-c4de0f119a37">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="537a6a7c-2fb7-4dc6-ac08-28993fb13907">
+      <statement statement-id="si-2_stmt.a" uuid="150a4ab4-9760-4f58-8c29-f44da3d0a040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3fc37ef-182c-4e56-bfb4-7aa0866c8659">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their OpenShift deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -7387,8 +7387,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="1cafa0e2-241c-4d91-8c60-b380fa9c18a2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bc8b2848-9dac-4fc2-ba39-adc11c73c440">
+      <statement statement-id="si-2_stmt.b" uuid="75906d70-3ce6-45e4-b658-5eb304210d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ced799b7-8fcf-4128-ada3-51e5a2540b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing OpenShift updates
 related to flaw remediation prior to installation. A successful
@@ -7398,16 +7398,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="3e9b407d-61b2-4647-a7ae-62d6655890cc">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f8261194-8f0c-4fd6-ad28-eb892ab4c563">
+      <statement statement-id="si-2_stmt.c" uuid="2aca2ec6-b658-4a2a-9869-7a9cd31e5aed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="a50e79d6-9541-4d1b-b697-121f6115a076">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0318a0cd-99fd-4f33-8955-a19942b56457">
+      <statement statement-id="si-2_stmt.d" uuid="eb56e9a2-e774-4c5f-b5fe-252e51a2ffe2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7415,10 +7415,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="688b88da-6d47-481f-b7df-08c2b2033e5c" control-id="si-2.2">
+    <implemented-requirement uuid="25e6bb3e-56cc-4987-892a-3e681e6f3441" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="63b0c23d-f103-4f30-9b98-01de9b9b690c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="355fe1e7-a273-4340-86ff-eccd1c23f7b0">
+      <statement statement-id="si-2.2_stmt" uuid="166767a9-51b0-49a0-a1bf-86af3fa2e962">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d5517-24f7-404a-ba5b-c641b36f0d73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -7436,10 +7436,10 @@ https://issues.redhat.com/browse/CMP-405
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc8549b0-ec04-4188-a950-db9d2ef7ca1b" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="598213b1-d071-4faa-b70f-b970e105932b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="db03c17e-e6bc-4066-a9d4-ded8d1477953">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -7450,8 +7450,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="776a7930-d5f0-461c-be8b-bff552b0bf03">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="18595285-1d99-4e5d-9462-f78c2a55b809">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -7463,10 +7463,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3d661f1-6915-4b9e-b5d6-c3da9dd996f7" control-id="si-3">
+    <implemented-requirement uuid="d03e35c4-20d8-4401-8054-29203a44f102" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="54d15f68-e46c-4821-bdd1-2ba8d881c104">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c05cb2b9-805b-420c-b2a5-30ccc3b0fb06">
+      <statement statement-id="si-3_stmt.a" uuid="cb35531b-7b7e-4234-a016-f42f9495dedf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8feb56f5-7538-4f7d-9600-abf7be214a63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -7478,8 +7478,8 @@ the use of third party tools.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="77760411-6947-4f8d-9427-f2b3a0193948">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f139d294-ac4b-4ceb-b212-8439711b7194">
+      <statement statement-id="si-3_stmt.b" uuid="1f80555f-bc6f-4222-a1b9-328f6e963a2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40235cf0-b670-42af-9cce-e65e5d66994b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -7488,16 +7488,16 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="2723efc7-8e80-46b7-a005-a658f1e3dd51">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="af441a48-0a87-4a16-82a2-5a22668994ae">
+      <statement statement-id="si-3_stmt.c" uuid="93198438-e9d0-4c8c-85f9-69a2fe14725e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="62b6ff60-503b-43b8-b8ce-d55f1b66f3a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="8da2eaf9-fed1-4c98-b743-63709f0a78b2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="33e4c71e-8a08-4f28-9918-379e11f377a3">
+      <statement statement-id="si-3_stmt.c.1" uuid="c8b61a4d-ef1e-4312-99fd-46a971c468ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2fe1168-6387-408f-a6ff-ffad317babd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -7507,8 +7507,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="0a2c889d-230c-410a-b875-e4bdb9370744">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7e87a1da-9c16-4f7f-b088-71d9e4268a5c">
+      <statement statement-id="si-3_stmt.c.2" uuid="dbbf2830-fcb7-43e0-a25f-462b52458e6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="843974a3-151a-4498-b7ce-bc4b79db5ba8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an organizational control outside
@@ -7516,8 +7516,8 @@ the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="2beeaa94-2eb8-4586-916d-4ac6c13059e0">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2a9b28aa-7b34-4584-aa9a-fece509fa1d0">
+      <statement statement-id="si-3_stmt.d" uuid="756f51fa-f7b8-4e68-8136-c111a2527e73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38eadf00-e46c-4362-bef2-72cbd283d26b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an organizational control outside
@@ -7526,10 +7526,10 @@ the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35788fb3-a665-4886-98f8-e13d4a5a57a8" control-id="si-3.1">
+    <implemented-requirement uuid="1cb9ce8c-a065-4e29-8ce4-cf2326fb5635" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="1863470a-eea6-492b-942a-91382b671b7d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="f3961c7e-d611-4d1a-ba20-275212e09005">
+      <statement statement-id="si-3.1_stmt" uuid="eb659309-6941-4e3f-b759-e9650d65d7f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3e4d451-1297-4cb9-948a-5c981fa69b20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -7540,10 +7540,10 @@ protection mechanism is centered in one location.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4af0bf68-ebed-40bb-aa8c-efd5447a8d15" control-id="si-3.2">
+    <implemented-requirement uuid="18ccdba5-ad8c-4be5-bc88-3d1aa521f7fc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="b11a7974-7467-44ad-b16a-5b24cbf79952">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c3682695-a017-48fe-84d3-7333a363fe3e">
+      <statement statement-id="si-3.2_stmt" uuid="f025634a-0829-43ea-a63b-43512c51068b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9640d91-db08-4e76-86bd-d5f90fb4fe43">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -7554,10 +7554,10 @@ mechanisms definitions are configured to be updated automatically.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a9a567a-2724-4b33-bf02-7fb61ddbcff0" control-id="si-3.7">
+    <implemented-requirement uuid="cf3810d4-c2f2-4aae-9d19-8a62dc9eff70" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="17cab2d9-0a3d-4d58-96dd-8584bc68d3fa">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="70ed7251-29a4-4085-bac6-2333e7fdd660">
+      <statement statement-id="si-3.7_stmt" uuid="c8f35cf2-5a10-456f-ae5d-d11ebbb2e481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cee870d-007c-4f0a-a265-2c7467b1ffd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -7570,26 +7570,26 @@ do not yet exist.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b75a2dc-9937-405d-9ed3-60d5b14a6052" control-id="si-4">
+    <implemented-requirement uuid="25c959c5-8a92-4f38-a617-7cae7084371a" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="047db3be-7790-4789-9684-782034590fbf">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cbefb9cc-c060-4050-87f4-70bf6baa0d28">
+      <statement statement-id="si-4_stmt.a" uuid="f7f8ef33-a9ed-4edb-bb56-258b61657b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="03460acf-b62b-412c-b730-46006a577637">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ed20afbf-a34b-405e-901d-1a6182b2e532">
+      <statement statement-id="si-4_stmt.a.1" uuid="5da408eb-abe2-4c82-b6c7-92a1a4a90cb0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="e6292452-ba4b-4e92-9d44-04545b7947af">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6c1f411e-1aa3-41d0-9877-8465260aff40">
+      <statement statement-id="si-4_stmt.a.2" uuid="1397afde-4529-4488-9431-5793335b0f1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37ed665d-3ebe-4bfd-9e6f-2ef07d234d14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections
 is an organizational control outside the scope of OpenShift configuration.
@@ -7597,8 +7597,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="0d471e3e-1010-4534-b9f6-4eaa1bb54455">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6ac6c853-3b32-40d7-87b0-c09d38d05a7d">
+      <statement statement-id="si-4_stmt.b" uuid="927dcfd6-d65d-44cb-ae8a-0262022e472e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8643ab34-5004-4e6f-8d27-7b6cf51c3d30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope
@@ -7606,16 +7606,16 @@ of OpenShift configuration. Functionality to meet this control can be provided b
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="d96a4341-66b2-4190-b84c-39f31cfa36ad">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="58053a5c-9b10-4486-97b5-58f70cb7b441">
+      <statement statement-id="si-4_stmt.c" uuid="3b2f5ae7-8a1c-4e5a-976e-98a5c25e7920">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12e67e7e-f874-4a36-b1ff-cdcf0b59eb76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of OpenShift configuration.
 Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="21e3dfd8-d8c7-4ef4-8aa1-b49d0fd8a8cd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4f2eae97-5011-4ac7-946f-6343066d14bc">
+      <statement statement-id="si-4_stmt.c.1" uuid="c7b17e51-9eb3-4bde-946a-5caae90737ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="955c6e53-d7bb-4843-bf72-663b90900ff1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect organization-determined
 essential information is an organizational control outside the scope of OpenShift configuration.
@@ -7623,8 +7623,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="c27dfd4d-8c1a-4088-bc40-423c8fe2e804">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6c151c0a-f6b5-4e5c-9abb-81b6fc00f401">
+      <statement statement-id="si-4_stmt.c.2" uuid="993e77dd-845f-42e4-998b-bba17a7296b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dac05c6e-105b-45b6-98b5-fb90db5d1d65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types of transactions
 of interest to the organization is an organizational control outside the scope of OpenShift configuration.
@@ -7632,8 +7632,8 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="cca4d190-b884-48e5-9795-3ed26ddc958c">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="327d146a-9b5f-4d9f-862c-204fb8920049">
+      <statement statement-id="si-4_stmt.d" uuid="394a954f-2bd5-4ae9-8746-3fbf6c212a1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efcd1844-0d69-4003-85e3-9e4ca79094f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of OpenShift configuration.
@@ -7641,24 +7641,24 @@ Functionality to meet this control can be provided by a third party vendor.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="0cd0f6b6-7196-4813-b270-e3b4538c6838">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="4930ac06-23aa-4e61-9d99-8c015484866e">
+      <statement statement-id="si-4_stmt.e" uuid="d65da8b5-977c-4240-80b8-a8313ff5d93d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="ab3e0a36-e327-4732-8ce3-47664a9217cd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bbf2b872-c368-4860-8b71-9c07a89509c5">
+      <statement statement-id="si-4_stmt.f" uuid="294b5994-af2e-48bf-b955-944a37af62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="89f1e8d9-7564-4e95-97b8-783e65e4ca46">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="05ce1c15-4b74-401c-85f0-1162d2a49306">
+      <statement statement-id="si-4_stmt.g" uuid="e2f86efe-2dce-4ca9-b769-a2abe286e1ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="434e2e8f-99a5-403b-af5d-747b508b2d22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.
@@ -7666,10 +7666,10 @@ applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9594562f-b147-4b73-8732-9821d9984ed1" control-id="si-4.1">
+    <implemented-requirement uuid="66008e4c-18e0-494c-a330-a7bd09ee451c" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="4e947f93-82f3-4b38-aeac-742702185ad2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="813477bd-4ae1-4d8c-97b9-ff53a90fb329">
+      <statement statement-id="si-4.1_stmt" uuid="08000796-1afe-454a-9a67-eeca19611a96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ac18faa-f282-461c-b17f-e9c723ac1768">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the OpenShift environment, and documenting how this
@@ -7681,10 +7681,10 @@ systems.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aeb276d-8a6e-426e-b5cf-188c833dcb3c" control-id="si-4.2">
+    <implemented-requirement uuid="a466564a-c24e-44f5-a371-0d118c5aad09" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="f9f93c94-bc72-4a22-94e1-f475145f1d8e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3f711f0c-f550-4559-885c-8dbd0a5d0050">
+      <statement statement-id="si-4.2_stmt" uuid="bfec4448-35cc-4e5b-95c3-e12ba645a0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="158a60d2-2cb0-4c25-87b6-2a893330343c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -7698,10 +7698,10 @@ analysis of events.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5850154e-a513-484c-8299-049fe4cc000a" control-id="si-4.4">
+    <implemented-requirement uuid="7b2489d5-2f6f-4d1f-b59f-dca4ae41798a" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="1f65ebda-2e60-4fb2-a10a-1f3eda0412ae">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="837b2ce5-88d6-48e2-a256-b123f3f36e73">
+      <statement statement-id="si-4.4_stmt" uuid="ad0d0571-b244-4c86-9d3d-b043dda2a718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e96419b-1e8a-4449-84f4-3d330c160a20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -7713,10 +7713,10 @@ not, how network traffic is continuously monitored.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24af6cea-e0f0-4cc1-a222-0caa55d6a907" control-id="si-4.5">
+    <implemented-requirement uuid="9ed28fbd-039e-4879-824c-5fb5fa40ada4" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="e2fc1913-d2c2-4eba-9455-1b22ea074554">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="1e335154-1482-4fae-bfa0-ca5609cadbf8">
+      <statement statement-id="si-4.5_stmt" uuid="7d9d1d38-f847-436f-80f1-5f2040122816">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae281442-f332-407e-959e-52cb7a2dd9df">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -7728,20 +7728,20 @@ the notification.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89f6e41d-5d52-4438-871b-327cd951bb81" control-id="si-4.14">
+    <implemented-requirement uuid="77b509be-7cf7-42e8-8ff7-b10b248717d5" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="3f84d3d0-32ac-4c8c-b00b-9a52289fbd22">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="61c3244a-e87c-4fc8-a0c7-db247c6d29ce">
+      <statement statement-id="si-4.14_stmt" uuid="27cd3a44-7a05-485e-a403-03f55d64a5d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="532e540d-6cc1-47a9-b4d8-2ff09efdef2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An OpenShift infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9288b123-fea6-41b6-8846-d0d01399bbec" control-id="si-4.16">
+    <implemented-requirement uuid="07d7972f-8d1d-4f42-ad1a-42cede0f3a4c" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="29f62dba-53ec-4af2-b05c-0e516e7012f7">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="0087ddaf-c673-41a4-8d54-4629e8f9456d">
+      <statement statement-id="si-4.16_stmt" uuid="816c1b9b-678c-4cd0-9101-99a2ad18fea9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9202c5d-7097-4f4d-95f1-5de0b334241b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -7756,10 +7756,10 @@ https://issues.redhat.com/browse/CMP-536
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac030240-52eb-4d78-9fee-05655288e322" control-id="si-4.23">
+    <implemented-requirement uuid="98028f8c-5930-4998-bd26-08155dabbfa5" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="bf69bfde-055b-46bc-9598-aa6e58be8e33">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c2b0f2fb-1ea8-4b2b-98b0-7da5ca090c4d">
+      <statement statement-id="si-4.23_stmt" uuid="adcd815e-3474-4e31-83ee-9a98d83170b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="542dc884-02ac-4274-8e10-10149db2dcfa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -7773,10 +7773,10 @@ https://issues.redhat.com/browse/CMP-540
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="776a008c-9039-4633-9127-f7aec1e42d08" control-id="si-5">
+    <implemented-requirement uuid="8ec27eb7-4619-44ff-822a-10bd87aac4bc" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="2cecb866-83b5-4456-94f2-233c71b9d305">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="cfe4ae69-29ab-464e-ba1a-4f15cfe7ba83">
+      <statement statement-id="si-5_stmt.a" uuid="c8795528-b8a9-4880-8f17-7a55bc53c906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94eea260-5303-4773-96a0-4cb854595954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -7785,8 +7785,8 @@ https://issues.redhat.com/browse/CMP-396
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="99e83bf0-41c0-4456-a6d5-9d574536e5d4">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="ca682b8a-057c-4117-b410-f307b69722ce">
+      <statement statement-id="si-5_stmt.b" uuid="2e01a8dc-26a1-49f5-bbd9-392a1a482ed6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e219191d-4e17-405b-b8ea-02e60bccd5ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an
@@ -7799,8 +7799,8 @@ https://access.redhat.com/security/updates/advisory
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="0d04a14c-b921-4fb9-8f5b-b35afceb7160">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="c67b4ea9-8084-4a70-9e86-70f2b4459ca4">
+      <statement statement-id="si-5_stmt.c" uuid="b95cab0b-0eb3-47e7-9811-d137e81fcaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d1ce87e-ebc5-4d36-a0cc-af9f4a4e7285">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined
 personnel or roles, organization-defined elements within the organization,
@@ -7809,8 +7809,8 @@ procedures/policies outside the scope of OpenShift configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="2f665f7d-01eb-4493-ad43-5d1c98041149">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="52cdd434-a4d3-49db-afed-0ace8770589b">
+      <statement statement-id="si-5_stmt.d" uuid="b2a66012-d185-46c1-b29d-7bacf1416509">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e91ce37-4368-4594-a977-44aba9a99ac6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -7819,10 +7819,10 @@ procedures/policies outside the scope of OpenShift configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bedfeea8-a4ca-4162-9f78-a5849f08890c" control-id="si-6">
+    <implemented-requirement uuid="db734672-4491-4bc0-83df-6e1c367064c4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="db76376e-94ee-46a5-86b4-9a88c67114bd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7b2f214d-85f3-437c-82ef-333aa34c723f">
+      <statement statement-id="si-6_stmt.a" uuid="705d5b25-1cc4-4a17-a467-dcba7f7eb858">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1be72547-09fa-4e5d-97b8-90d5d6f5c3da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -7837,8 +7837,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="90a8ead5-a91a-4c8b-9829-b846a2602628">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3c189b1f-44f5-450d-897d-98364f5eab13">
+      <statement statement-id="si-6_stmt.b" uuid="c8938a79-90df-4705-8f84-0851a5571634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df99302-8afa-42b5-ad64-d171a878c25c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -7854,8 +7854,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="8818a1f0-c938-4a60-a538-3c7d5fa4651a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="bb11a912-c06c-4421-b7af-89fc78e448d5">
+      <statement statement-id="si-6_stmt.c" uuid="644fd87b-44c6-4637-a737-837a44d925ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0edc2e83-d6aa-4a31-9980-0091fa7f777d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -7869,8 +7869,8 @@ https://issues.redhat.com/browse/CMP-542
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="76c3e396-77f0-4a0e-90c7-16759433857a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="2ec60913-1845-4f52-9200-8b1c9fde89cf">
+      <statement statement-id="si-6_stmt.d" uuid="ea6a903d-35f5-4cb6-9fb6-1b881404cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="474dceb6-7148-4aa4-92c1-2489caded95b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -7887,10 +7887,10 @@ https://issues.redhat.com/browse/CMP-542
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b515260a-f82a-453e-9c93-330b6fb5baed" control-id="si-7">
+    <implemented-requirement uuid="75b37a46-3c5d-4af3-b138-3dd476964635" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="ce0cc843-1b0e-4dd3-890c-3aa67bf05f07">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="a3833e1a-1259-41c0-9491-7c5e086e6e9e">
+      <statement statement-id="si-7_stmt" uuid="8f7edc4b-595d-481e-95ef-290b4ef632cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="51c1d92f-ecb2-4ea3-a509-a65151878115">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -7905,10 +7905,10 @@ https://issues.redhat.com/browse/CMP-394
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="496bd30e-deec-4936-8281-34467f7ca106" control-id="si-7.1">
+    <implemented-requirement uuid="ca455f35-8815-4603-b38f-dbd91fcb6a79" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="bfffc136-fdf6-4890-a5e1-027255f68dfe">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="fca77cdb-6e2a-4922-b47a-aefe9cbe4c76">
+      <statement statement-id="si-7.1_stmt" uuid="b9e27bf9-5e74-407b-bc19-f1ee19c96e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a3da903-2950-443c-ba74-bffeec06af44">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -7925,10 +7925,10 @@ https://issues.redhat.com/browse/CMP-395
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2f35b54-8ccc-4fea-ab98-b93e89d09a83" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="604c90b7-e345-4734-b536-7160056ca4fd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="86dcd952-79bb-4eb0-847d-c6334fe56918">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -7940,18 +7940,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe37a41-ef82-46b0-b7c9-fa37eb7e96d4" control-id="si-8">
+    <implemented-requirement uuid="6f5a333b-f2ff-476c-b54c-74553e72f6a7" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="3ed931c5-5937-44f6-acf3-810d375690ea">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="793d6607-9645-48b7-94fd-59f9efa55324">
+      <statement statement-id="si-8_stmt.a" uuid="ac0f7d09-61f4-4a9c-a2b9-525120f97297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="91fbb8d9-9c23-49d6-823a-5dc97ee5d8b2">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="7d6553c2-bfd4-418a-bd24-9d04f713e9cc">
+      <statement statement-id="si-8_stmt.b" uuid="f31b8176-bb94-4199-9f49-82454ea49c29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -7959,10 +7959,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee75fb9c-f516-4db6-9198-2d60af71a931" control-id="si-8.1">
+    <implemented-requirement uuid="a1b96e2a-325f-4eb4-b83a-96ba0aac1dc5" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="6f86df44-f0c1-4983-a5c1-8eb807db094b">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="3b9d346c-cb6e-4697-8c89-bd46e42d15f3">
+      <statement statement-id="si-8.1_stmt" uuid="6e868698-9ad3-48a4-a4d0-fb0e39d54cfb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -7970,10 +7970,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca62d6a1-e364-4367-b643-13bedd0c14c0" control-id="si-8.2">
+    <implemented-requirement uuid="cb776500-b818-4fe9-b109-bc38c53e9c2b" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="d792946d-c092-4580-89f5-3748984a34fd">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="874ed073-6b31-4e38-8206-5ee90750f4f7">
+      <statement statement-id="si-8.2_stmt" uuid="219a5678-ef0b-4908-a040-fc3001dadb7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4cb9324-8810-4f94-bd8c-0c85b6ce695a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of OpenShift.
@@ -7981,10 +7981,10 @@ are not applicable to the configuration of OpenShift.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6b4e2a3-827c-427b-ad69-5f065d1d4c65" control-id="si-10">
+    <implemented-requirement uuid="5637a065-2c41-4b1c-8392-b5ffc146062e" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="9bbdb928-a4ad-480c-a3b7-ed4a2529521e">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="6ec6e2df-6a52-4f24-bbf9-d208f4e7321d">
+      <statement statement-id="si-10_stmt" uuid="ed487876-7061-4778-96a1-04a08a800007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="230d9846-c77c-44ce-970a-06f688716e92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -8001,10 +8001,10 @@ https://issues.redhat.com/browse/CMP-393
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2eeb423-bf40-42db-b9e2-a340be8a36d5" control-id="si-11">
+    <implemented-requirement uuid="9d4f8c58-966a-48c6-ac16-f1be1ae2dd35" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="962d6135-224f-45d2-8769-7dd61a6dca03">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="9da1a7a4-7d0b-4343-aa05-eba29bd46e42">
+      <statement statement-id="si-11_stmt.a" uuid="a55473ef-7114-43c7-98ad-4015560fa82c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f9fb551-baaa-44eb-94b9-d95e13448ee6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In OpenShift, the logs depend greatly on the component. Some
 components would just write messages to stdout that the cluster
@@ -8022,8 +8022,8 @@ security information, account information, etc.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="5eb85b7d-d4ab-4a50-8e3c-66d19e9b4c24">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="79efae22-b7e9-494e-b01e-b800a2020014">
+      <statement statement-id="si-11_stmt.b" uuid="0e20cfd6-f6a6-484f-9b51-643953bd0ce2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06c151a0-f34d-4bf1-a89b-fd089b157b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, the API server logs are protected by UNIX permissions and
 only cluster administrators are allowed access to logs.
@@ -8031,10 +8031,10 @@ only cluster administrators are allowed access to logs.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5d3a5d9-eb9b-4f81-9955-de5593334921" control-id="si-12">
+    <implemented-requirement uuid="b1a1d601-8791-4d0c-8bbb-027ee58dcb42" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="5007b670-a192-4c28-9cc0-99b564dcef4a">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="23b6044a-a8dc-495d-81a4-9dcee35ddbfb">
+      <statement statement-id="si-12_stmt" uuid="d5b07424-e2c1-4d00-9ec9-19ae396fdf63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b53f03e2-1235-4a29-ba26-5b7ebc6674a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, OpenShift in
@@ -8048,10 +8048,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56a8849f-e097-4bae-a000-68a1d445e602" control-id="si-16">
+    <implemented-requirement uuid="07b05c21-ca99-4770-897b-7afb45267bc6" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="ef2bf16e-e185-475b-aaf8-c72f4a673e9d">
-        <by-component component-uuid="ac28a952-b554-40c6-85cd-93292b142f78" uuid="db21c314-66b2-49a7-9977-a2bec4f3b34e">
+      <statement statement-id="si-16_stmt" uuid="82384d89-06fa-413f-b7bf-575a6a296515">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a0cbc1f-3514-414b-90d4-49d2a3e0eebe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat OpenShift Container Platform inherits memory protections
 provided by the underlying operating system. This control is not

--- a/xml/openshift-dedicated-fedramp-High.xml
+++ b/xml/openshift-dedicated-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="7d7974d7-5263-45a4-b0d3-443ca9a61271">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="74784296-292b-4ec3-829f-ffc210d53842">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.05+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.76+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="14d4b563-f3c2-48e8-96b1-4c3124b2ac44">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="11a36839-203e-4333-bb2c-55a738520b6f" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,1754 +484,1754 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="adea3f41-a6e6-43db-9225-d928b27a5f57" control-id="ac-1">
+    <implemented-requirement uuid="39a1b693-1d3d-42df-a7d4-f62ed63b754c" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="e4df1a8d-e216-4f54-9b6d-be73250d906a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c5377067-5c79-4e91-9c73-93f4aa83feb3">
+      <statement statement-id="ac-1_stmt.a" uuid="324dcda4-4f96-4ff5-8427-f924b21a8d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5309070-b957-4a26-8a72-9142200914d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="0e0c680b-b6a5-4c48-acff-20a1e2aa8fd1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="6fa62f09-16f3-432e-919d-bc40254ffdb5">
+      <statement statement-id="ac-1_stmt.b" uuid="887641c8-6db9-493c-8ead-40bc3f2279d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da0449ac-a99c-4e11-a5d3-aefae5063f81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5babaccf-e03d-49f2-8681-cc1e604d137d" control-id="ac-2">
+    <implemented-requirement uuid="308f2ab9-f2fb-4ebd-bd22-6f26a99c54a3" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="5274e8ed-84e3-4ed1-a74b-5206cd9fa52d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0c5d6621-da29-49df-a18c-e350072a03c2">
+      <statement statement-id="ac-2_stmt.a" uuid="18e57d62-e667-46fe-858e-91af9c9f0477">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ead5e410-8afd-480c-bade-088a12eef60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="c34e9901-58f7-40c7-99e8-1efaec56e489">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="42958b6c-9bc4-4ccc-8531-c28b518f31d6">
+      <statement statement-id="ac-2_stmt.b" uuid="b7e2816e-2be0-4f16-95a4-394a2fd00758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="048adc9f-d720-4d87-bfcb-643ff1c62695">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="92ecd808-364b-4743-9614-a45b48e5ebc4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="af693e6e-2bc2-4037-9d32-86c9d32204fd">
+      <statement statement-id="ac-2_stmt.c" uuid="b4009d35-0f2c-4fa2-ac5b-348f424d348f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18af0d86-53be-49b8-a66e-a54267998f90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="d9aad879-2370-4272-bab1-ae51a75ad77c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c0afc629-5fe8-4b9e-90ac-f6d2b9d972ed">
+      <statement statement-id="ac-2_stmt.d" uuid="0c23a834-cae8-4a5b-9db7-00b2ddc807b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22a7c136-117c-448b-a504-ac996979de3c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="c9c9ad7e-17b4-4453-84d7-f52d3df057f7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c31f4b39-e41c-4129-9c07-c68d8751f29e">
+      <statement statement-id="ac-2_stmt.e" uuid="58c0cb86-c145-435f-a0d8-757dc7ac9fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9eeeb20-47db-4e6d-9154-fc86fc11fe10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="640fd4fc-8767-49f5-a743-9b3d8a59f457">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fa814c65-c2cb-4cf1-b735-045fee04b996">
+      <statement statement-id="ac-2_stmt.f" uuid="1a1d724e-24dc-46d7-8c21-2f08da427696">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f5fbaa5-af8c-4109-a130-4d5c42713c9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="3aa7d997-a2a7-4b7d-a992-b02cc6773125">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="83bd8d32-655b-4d18-9691-88bdf564d9bd">
+      <statement statement-id="ac-2_stmt.g" uuid="461e9ffa-c9ff-4936-ba8b-71d1ad995fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94bc620f-e15d-4880-a056-abb577b18005">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="92de4c72-1be3-4e0e-8a0f-d2026e10cfef">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="041c61ac-3d5b-474d-8450-73f4d851cc6c">
+      <statement statement-id="ac-2_stmt.h" uuid="63220789-6f43-4e94-b50b-33138a10b46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a3f1c4f-8287-401a-a2d5-d383ecbf12a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="1875449a-12b8-4fc3-a0ae-b55add8c2a7d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="554eca99-c372-4f95-aefb-5dc584df9af2">
+      <statement statement-id="ac-2_stmt.i" uuid="43b7976d-f5d1-4355-b32e-6bde93f63664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1155986e-c445-4ba6-9173-ec12fb48c8d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="4ca23314-48f4-4b99-8552-aea8e1681edd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="239fefed-113d-4742-97e9-e0560e565ed4">
+      <statement statement-id="ac-2_stmt.j" uuid="e637623e-534f-46c5-a039-1f0931b14fa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff4fa720-c1b9-4840-8240-99543669ed40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="ad76514a-2473-4d17-9194-5c25191f6588">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="557a4c3e-3353-4776-a828-8722af3c23ca">
+      <statement statement-id="ac-2_stmt.k" uuid="f26cf7a0-d40b-4cad-8582-76bdfa8ca372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d24c07-dfad-4e80-8794-c11b3b1b2707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd518efa-fc45-429d-bc37-1b92051601be" control-id="ac-2.1">
+    <implemented-requirement uuid="e8c03b47-302e-4dfa-acc7-aa39624182ac" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="c7640230-6e45-43b7-9324-ac490ce22bdc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bd3ced12-5a0b-4933-ae96-2716bb97d62d">
+      <statement statement-id="ac-2.1_stmt" uuid="3da628a2-3db1-4308-b090-6b78a447b0d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31ec83bb-59ff-40b1-a077-1260da6b76ea" control-id="ac-2.2">
+    <implemented-requirement uuid="47e6f61a-b1d2-49a4-a122-fa99f51ba7e3" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="1ab1be97-a682-4ae5-95d5-a9b403698b62">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="11064294-c132-4c06-82d1-b3dfbd1c3f0f">
+      <statement statement-id="ac-2.2_stmt" uuid="ea1fc28b-24bc-49b0-b5f2-1367977532e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1edc5157-b0dc-45e2-85a8-c27ce421678e" control-id="ac-2.3">
+    <implemented-requirement uuid="1edba262-35e5-44a0-96ea-bc090abb6764" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="cb7f0859-776b-48c9-905a-70f7d2452d9d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="61f1f181-1f26-47bf-b255-c20403740440">
+      <statement statement-id="ac-2.3_stmt" uuid="a1e9ab12-2a19-4e37-9b75-8f361c825231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42b9924e-efc3-4842-ac42-2fa98254b022" control-id="ac-2.4">
+    <implemented-requirement uuid="d73283b6-7199-4143-914f-6a337202f4ea" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="858ef326-f14c-4247-932c-0541c090f6b1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="30118fde-e68e-43ad-87f6-14f5f3b9d20d">
+      <statement statement-id="ac-2.4_stmt" uuid="aecad161-6461-40f8-9506-6b3727207d68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14a77578-71f4-4a02-a73b-f6c3a7973fe4" control-id="ac-3">
+    <implemented-requirement uuid="e69b7912-dc17-439c-9d84-b50501ec5536" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="5750418f-b4e0-4877-8c08-fd1527b45910">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="60d4b5fa-1852-4411-ba65-965271e69805">
+      <statement statement-id="ac-3_stmt" uuid="7bb7f069-70e1-426a-82ce-a6e8d2dd3fe3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9ab986b-fc58-4892-8ff1-1fc74500438b" control-id="ac-4">
+    <implemented-requirement uuid="71e43e55-ded3-408d-a47f-8389825c94fd" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="787682df-c2de-408c-a11b-0e9e9607a6c4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="746cec33-355c-438e-93b8-f1840a7bcdd5">
+      <statement statement-id="ac-4_stmt" uuid="316dd639-50ca-4348-8750-8079ffbfe80f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8d5a6cd-1da0-4fa8-b1e7-410eedbd3213" control-id="ac-5">
+    <implemented-requirement uuid="bac6dfb9-5b2d-482c-99d1-eac9b5b2b99c" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-5_stmt" uuid="fff1efbf-2a08-4207-beb7-ef3610a125fb">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c26e47c2-c533-4625-bc49-da1bb02517b8">
+      <statement statement-id="ac-5_stmt" uuid="a9d2b65a-c0a2-44f4-ba68-32d11fb2ae5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61bbf9a6-b882-4e91-a953-7e838da69b76" control-id="ac-6">
+    <implemented-requirement uuid="c8a8f396-46b5-46d1-bd5b-37e3d2f5cf77" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="789265b0-c1a7-4a52-8131-1eea8e6a23b6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="03e9b474-0ff4-4d18-8146-c82ebd852dd9">
+      <statement statement-id="ac-6_stmt" uuid="f8551c48-88be-4c5a-bc02-8439040acb73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7680668-3028-4600-b335-fd494df6b28d" control-id="ac-6.1">
+    <implemented-requirement uuid="d944e809-82f3-460c-a16d-ac248cb87766" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="475d6832-8b45-45db-854b-4f4ff62f8087">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="306ea297-ba88-447f-a77a-2f10e0c51d15">
+      <statement statement-id="ac-6.1_stmt" uuid="32c35c84-6287-4b62-b2e9-e1620227904d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8c702d8-9e47-44d4-aec4-357d9abf2526" control-id="ac-6.2">
+    <implemented-requirement uuid="2d4b876d-0dc1-4ad1-914f-f37de5e17ed3" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="7d84cee8-e2c1-485f-ae1d-cd63791d110c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8277211e-8f81-433e-8f54-be6af47b20e6">
+      <statement statement-id="ac-6.2_stmt" uuid="fb6f13a9-6670-400b-a131-8019e78e14f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0792004-a12e-4834-921a-5aacd71d6bf7" control-id="ac-6.5">
+    <implemented-requirement uuid="09e12c67-8c64-4c69-ae5d-435871af86a6" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="a5571a01-3e20-45d8-aa9b-6e002fed7542">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1987d91d-9f48-43ee-a92b-08d4d11a17c5">
+      <statement statement-id="ac-6.5_stmt" uuid="63c65ff0-b2c8-4527-a4d7-f2db05b9a98d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09236bbe-4897-4514-8f48-83279650a3c0" control-id="ac-6.9">
+    <implemented-requirement uuid="a68b7c48-097c-4aa4-98df-b0b8ebc764b8" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="f5be7c30-c36a-4084-bba7-ee3418449a85">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="addc6454-dc88-4a9a-8f3f-315846e4de48">
+      <statement statement-id="ac-6.9_stmt" uuid="3ef10200-8642-41bc-9170-3f13044d5f42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7030141c-d58e-4b3d-9060-24eaff9d979e" control-id="ac-6.10">
+    <implemented-requirement uuid="99e6695a-3847-4432-82a0-c1dcce9c8e31" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="873c2045-db2a-4f65-bdc5-061a58741c2a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d2969603-5757-4fc3-bff3-29b4c2738529">
+      <statement statement-id="ac-6.10_stmt" uuid="1afdc7e7-716a-48ea-bc84-0ea931f485f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="309c4764-4163-4cb7-9e9e-4f3bf23b1477" control-id="ac-7">
+    <implemented-requirement uuid="34c744db-4973-418c-94fe-d132d3582c89" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="a9513279-b5ff-4f5c-9774-17dd2f629f90">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="140e44f5-208f-42b9-a623-23e419ed1208">
+      <statement statement-id="ac-7_stmt.a" uuid="0ce553e4-fe3a-4e37-9835-fef4fa7649d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="8514a843-694b-4dd1-af76-9ec487d744c6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="de7db3d3-b714-490b-bc15-830f30da4e4d">
+      <statement statement-id="ac-7_stmt.b" uuid="4fa082e8-6eb4-4e3a-b627-5f0658b016ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6f2ac9f-6372-4bd6-8cc4-bf3b64a975b2" control-id="ac-8">
+    <implemented-requirement uuid="acbcd64b-c787-4c14-bd1e-3adf9ad25d14" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="d874186c-8228-4a9b-b67f-c2058063730e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ab7c697d-4426-4f8d-b3ff-3cd021317d6f">
+      <statement statement-id="ac-8_stmt.a" uuid="f891ef64-ff0d-46d4-b5e8-27410f1b96d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="19ef0753-6ddd-415b-8bd9-c33401f6f97f">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7bc352bf-e984-4015-917b-21472fe2590e">
+      <statement statement-id="ac-8_stmt.b" uuid="f2446ca4-cf6f-4158-b73a-dcbd92583a5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="dbde5ec2-bc0d-4fdd-b7c9-ca3ece95a6d9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d348d9a5-4e0a-4c22-b8b7-4e5ea9e3d21d">
+      <statement statement-id="ac-8_stmt.c" uuid="8537cf10-713a-4183-8ff8-6ae3ea21364c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0a53832-cd68-4de5-afb6-feecedfa63ca" control-id="ac-11">
+    <implemented-requirement uuid="ebfa466c-6513-48e0-b16c-8e4664d3acae" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-11_stmt" uuid="c4bb4be4-96f6-44fd-8656-16a585b44fc1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="df2a772d-7413-4880-9022-5ef1dbd0cbef">
+      <statement statement-id="ac-11_stmt" uuid="fdd54146-084d-4907-8ae0-cab0e39e2da4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edaeb7cd-2bca-4df9-89ef-e1b88be56f06" control-id="ac-11.1">
+    <implemented-requirement uuid="d111fe5f-30c9-4c34-b812-1adaa9808a74" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="50de65b1-e5a5-4187-bd58-8d6ffdf7bd9d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="283f8746-1d55-4ec3-9482-e8000276fe57">
+      <statement statement-id="ac-11.1_stmt" uuid="dc4ec50f-df76-4cc4-911f-b4ac0ca8a14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4bc9f651-5bcf-4def-b3c7-46c1d47b1bdb" control-id="ac-12">
+    <implemented-requirement uuid="3e86bc55-b3d0-430d-a558-da100e16e440" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="3fd9fcb2-32d9-45d4-913f-c8c312a9008b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="72f8bdeb-eee5-46d0-8414-2afca3a0a442">
+      <statement statement-id="ac-12_stmt" uuid="5a6c3a55-11cb-45c9-9bf9-2add957d87eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afd1afc0-b672-4904-ba9a-36b2fe16dea6" control-id="ac-14">
+    <implemented-requirement uuid="2f0f0ead-5fa5-4682-a174-7800552dedce" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="2004432e-57cc-40d9-aeab-2f6dfd99a93a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="68015fa8-4b9c-4e87-b174-81fd1a9b4f33">
+      <statement statement-id="ac-14_stmt" uuid="17e1ab2a-d00e-469e-8692-6b38e0f65a14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe2da9aa-f1ae-49e9-8c95-ceea3e508ec4" control-id="ac-17">
+    <implemented-requirement uuid="320c1d9b-b2b2-48bb-9c34-17fae95a4dcc" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="a051ce4c-0eb9-4505-b94e-192955414a2c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5f90c53b-c8dc-4c20-b668-6d3fafd5dadd">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87fcf2f3-3609-47c2-9c70-1887877fdb97" control-id="ac-17.1">
+    <implemented-requirement uuid="626329d3-c0f6-4dbe-b213-a539d1a2dd6a" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="4cac7692-c86f-4ff6-92d5-86eb14a39be5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="67346afb-65b9-42f9-b751-d3024514f61c">
+      <statement statement-id="ac-17.1_stmt" uuid="b422b35c-cfbb-4c39-901a-4b1b13c64ca2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed081100-da18-4b17-bff1-55af83709f46" control-id="ac-17.2">
+    <implemented-requirement uuid="c832e5c9-3edb-458a-8137-1b42ab16c13e" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="29e9e98b-d35a-4529-82bd-19af3c2661cd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c0e5ae15-79cc-435f-a0f5-4c3bd5cdec88">
+      <statement statement-id="ac-17.2_stmt" uuid="7194261c-7f01-4acc-a845-200978219a9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a83465d7-d741-4f09-bab8-951aead1a8cf" control-id="ac-17.3">
+    <implemented-requirement uuid="49cc8838-2e3f-4732-83e8-6a5fe3b7756e" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="4fd8dfca-e1ff-414b-84f8-dc84616ab6b2">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cef2724b-43c6-4ef9-8225-d326c06c462b">
+      <statement statement-id="ac-17.3_stmt" uuid="899e2598-6344-4130-84cf-0a80cd57e5c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2dd195bf-d587-4c44-b0f6-fc610f7dfeb0" control-id="ac-17.4">
+    <implemented-requirement uuid="d45c7a34-3c7f-434f-8e3a-8a9871913b1c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.4_stmt" uuid="157d7d78-366d-485a-bc53-9958d1486077">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="85b25aaf-8fe3-437c-b207-2c5503a6dccd">
+      <statement statement-id="ac-17.4_stmt" uuid="caa76b51-69e2-4b05-8c48-1aeccc2f7702">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e70761fe-9763-430d-a9e2-4b28ba43dfbe" control-id="ac-18">
+    <implemented-requirement uuid="cf4f32c5-c564-4155-bb9c-f9503665fcba" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="e8a82292-7f1c-4b33-91c7-20d47fd4a4de">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9ea46f3e-15de-41c9-a8b6-0d8e69bb1fc2">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4bc597f-52be-4480-8765-ed1f18524f9a" control-id="ac-18.1">
+    <implemented-requirement uuid="264faace-8c8b-4a88-9d5e-77b44a5ff92f" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="99bf8203-73a0-44ea-a87b-d70b58c949f7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="babb9dfc-74bb-46bb-abc5-891c3dc36375">
+      <statement statement-id="ac-18.1_stmt" uuid="8dfd26f1-7e77-43f7-81ba-b2daf416b4dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e6d7ac1-a2dd-42de-af4a-66f1d820b2d3" control-id="ac-19">
+    <implemented-requirement uuid="1f782fa7-e28e-47fb-ab66-2a3924b4e768" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="2ad53364-e611-4ac4-98e3-09b8ec262b64">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="109211ab-36b8-450b-bf2f-d200977190cf">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24dbe9b6-8a78-40f2-8bc4-55d79df1eefe" control-id="ac-19.5">
+    <implemented-requirement uuid="bc7e60a7-b03a-4d11-bb24-cd0bf4d7697b" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="c6e4e6fc-5968-477b-ba4c-44706d8e5e26">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3f3c5560-3469-4b28-9ae2-f7fcae93eefe">
+      <statement statement-id="ac-19.5_stmt" uuid="9fdfee96-2ee4-4eae-8fc9-6c8ad51cff13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c82ca3cc-84f3-4746-afb4-10b8edfd11f3" control-id="ac-20">
+    <implemented-requirement uuid="c3be2813-ce58-4647-8d38-acd11c0b09fa" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="fabc4fde-c76f-4f3c-91be-442a1ab5e96d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="97745980-62eb-4f5d-a262-9e17e7533b7a">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23fd4506-83ce-488c-a13e-41317251c082" control-id="ac-20.1">
+    <implemented-requirement uuid="6349eedb-335e-4949-a6bc-0cf3807c9998" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20.1_stmt" uuid="3dce441c-4d2d-4219-8917-9ad8e9935b97">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e706b179-0cb6-4b0c-93c1-ad658f7ba5d9">
+      <statement statement-id="ac-20.1_stmt" uuid="f7a3c913-3a12-4cc3-aa0f-05f43f886597">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c74607ff-054f-4780-a1ce-72d2cb895ed6" control-id="ac-20.2">
+    <implemented-requirement uuid="b41ebb26-af1f-4e54-a6a7-0fb4f4b4df73" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="a68e4185-f679-4b96-b2f8-edb1e5a12f44">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a3a7dc54-a039-409f-83f2-42134a063c08">
+      <statement statement-id="ac-20.2_stmt" uuid="1defb44e-3bf3-4b2f-8ace-c6632f9ca07d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd6b2715-54e2-4a16-8cea-0f7def66f591" control-id="ac-21">
+    <implemented-requirement uuid="b26be87c-63c8-4b79-97bc-072aad71cda3" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-21_stmt" uuid="4ff0dc3e-811a-455b-9d72-9d4ed92f7785">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b1a098d1-b77b-4e04-80f5-14c2bcfd936a">
+      <statement statement-id="ac-21_stmt" uuid="99eeb87f-3920-404a-b9af-e8426878e46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="450752e7-b6aa-47b8-aecf-2c91b203cf94" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="aeb25bcd-d0f4-4a36-8dcc-92ada19c497f">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4eb76e22-bfa5-46a5-be56-1150431651db">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="381c6407-908f-4b4c-99c3-8a41dad6eabd" control-id="at-1">
+    <implemented-requirement uuid="7f5357fb-e9ff-4372-8dfe-30971d1d15a4" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-1_stmt" uuid="67f54300-3da8-456c-a050-6ed3945d0040">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="50372d0c-7978-40c4-aa69-44e79a9ec171">
+      <statement statement-id="at-1_stmt" uuid="25f73115-0474-4dd4-9bdd-401954c96b87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33dbff4f-a2b4-4b4e-921b-c8e252fd874e" control-id="at-2">
+    <implemented-requirement uuid="9165e48c-47b2-45c6-9ef9-1be15d4bee34" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-2_stmt" uuid="b653751f-ec10-42fb-b974-628a372ecf3e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fe2a2194-99b7-41b8-b93c-51f92120ef0f">
+      <statement statement-id="at-2_stmt" uuid="777b75c3-3c9e-4be7-ae9b-83d323694887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bf4cecf-f8fc-46d3-b867-e40943cb7276" control-id="at-2.2">
+    <implemented-requirement uuid="8c583409-381f-4a7e-8e7c-7f1e4a75c8c5" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="eaf8446b-2a54-483c-8677-5eeb21e3ff2b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a62901e8-d722-4184-ab48-fa50512019fc">
+      <statement statement-id="at-2.2_stmt" uuid="ddbcb366-d536-4ac3-a7e3-0ccb970101f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f493e9ff-5127-4f59-81b8-aae2cfd1524c" control-id="at-3">
+    <implemented-requirement uuid="70995a7e-a4d6-4c67-bdd1-ca7e9e0213d5" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-3_stmt" uuid="3a7fb9d7-b334-4def-a8e4-028c6a3c006d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7fcc6908-c243-4e63-8dba-b26a013511cf">
+      <statement statement-id="at-3_stmt" uuid="21d83bc7-fb3b-4876-a7d0-683325d30d77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="deea9eab-addf-47a4-9944-5676db2f1643" control-id="at-4">
+    <implemented-requirement uuid="9f744156-db76-4f8c-a95b-c73ad5c5a9e1" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-4_stmt" uuid="6eed64e3-12b3-42a9-a341-5e764f951501">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ae65fb17-ab3d-48f4-9604-0dd41c656164">
+      <statement statement-id="at-4_stmt" uuid="2d36c3d1-c630-494b-ad2b-3dc40d0b15bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fade2463-3152-4ba1-8a16-d1db1bb8513c" control-id="au-1">
+    <implemented-requirement uuid="1e2c00bb-257e-4c9a-8976-4ce731867b45" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-1_stmt" uuid="3f61faa9-3cc9-4915-9af6-43641dde303e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8b84e4d3-8625-43c1-87d1-2359257efed4">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f83014f5-34d5-4923-ae87-3fd74343d4cb" control-id="au-2">
+    <implemented-requirement uuid="4c08c196-0de3-477f-9170-57f638549f6a" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-2_stmt" uuid="6394227c-c227-471f-b5c6-f5197198b837">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ffddee92-0194-445d-aa8c-23b1ca6f9eb1">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af29bb4f-ad72-4c1b-8816-61b4df68cd6f" control-id="au-2.3">
+    <implemented-requirement uuid="3bc17cbf-609a-456f-ba2f-2aa175ec2829" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="97ea2206-ead1-454f-8f71-e175f76268cf">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="edc41f7a-24af-4744-bba2-c9a101780cf2">
+      <statement statement-id="au-2.3_stmt" uuid="c4ae0ea3-7e03-42d6-8cfd-ceb4281bd941">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2eca453-5a4f-466d-bff2-172c1784ef33" control-id="au-3">
+    <implemented-requirement uuid="af56a0ad-445f-4a57-97a1-6f48aff745d3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-3_stmt" uuid="9497d51b-4e73-412c-968d-02e35acff61e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8e1a14cd-586a-4e0d-8078-1c1a463b7311">
+      <statement statement-id="au-3_stmt" uuid="20ff5cbc-f1db-45fc-ae63-36db96309b77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9ccc74b-7a82-4afb-91b6-c430ad348623" control-id="au-3.1">
+    <implemented-requirement uuid="7f2849b7-9dc0-487b-a7ac-a87636504674" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="e3571140-3d20-4d93-9bcb-8c8613fc31e6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="60d3b8d4-1e21-4c34-aed9-7ff66921dffb">
+      <statement statement-id="au-3.1_stmt" uuid="5bfcd2c1-e90e-4993-9d4d-6db4fc6129a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bec466a-5723-45c0-919e-b1afb86819f4" control-id="au-4">
+    <implemented-requirement uuid="0ea0d8e8-ffa5-4ecf-979f-c63a5f0da105" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-4_stmt" uuid="4d9b9220-56cb-4e33-af13-db3773e56154">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="02de501a-dccf-47d0-9ffd-feb1a3307491">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d62e9e8c-c84c-43ca-a01c-1930d4e2b833" control-id="au-5">
+    <implemented-requirement uuid="5a3691b1-30a2-427a-abc5-fe83986ca715" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="741224ab-db7f-4f9b-8fe4-379eeefd40d4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4b007bd7-c163-44c4-8607-90cbacf55eac">
+      <statement statement-id="au-5_stmt.a" uuid="7889bdac-bfb0-4861-aac0-cc136c1c2b4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="f1a81c00-2a9c-444f-bcce-8bcae1bef4fc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3616851d-c387-4192-bc08-923f1274f73d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="79b27755-3db7-4b85-aacc-15d5c97117c3" control-id="au-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6_stmt" uuid="0fccb1cb-ecb9-4221-a8bc-478ba9a6949d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1c0c40aa-d927-4237-91ea-73cc8088b5bb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="16c9de05-a5ac-4188-afec-dfdc13a97662" control-id="au-6.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="06ae1447-a0f1-489e-aa23-72076624c3d8">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5d549c18-a32b-479d-be2b-7e1241b06f63">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="12ae1568-33b0-4815-9ae4-a60a6736f856" control-id="au-6.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="4f857789-e659-464d-b83f-c542ce460481">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b95e4851-7174-4c2e-884d-adb6cef9c283">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="7adebd17-cce6-4d7d-958e-65fd443de855" control-id="au-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-7_stmt" uuid="515d0089-4b0e-458b-8e3a-f6b5c5ca9457">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5ed392c6-af29-4153-a5c9-e2afffaad095">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="50dac279-d6e7-4727-9f89-794392f34e70" control-id="au-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="2aa9fc9e-b273-4ac4-bb6a-113b2fb5b498">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="510acf5d-69ec-4130-8f98-088e4f1b6516">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f88fd3ff-eae3-4cbf-8f45-c8aa86971e8c" control-id="au-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="85562ce7-de47-4971-8a9f-2536cf1204e7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="02166411-b2fc-471c-bd76-191a45ece549">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="au-8_stmt.b" uuid="241197a0-9250-4d2f-907d-7db857fd75cf">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5c68b494-3a8a-4b35-9470-c07cdbeb3ac3">
+      <statement statement-id="au-5_stmt.b" uuid="252cd8e0-2732-497e-bbb6-7b5062eca13e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16e1d865-9b50-4729-b84a-3128466e20da" control-id="au-8.1">
+    <implemented-requirement uuid="1f6efc7f-06cf-40b6-a0a9-650c53e0f178" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-8.1_stmt" uuid="48151ddb-a353-4faa-a086-f4881f870967">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4d78d9e4-faf4-4cce-86f8-3ed0d5e8f150">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7a1b4aa-ae2f-4db3-b7c9-b1130daf521b" control-id="au-9">
+    <implemented-requirement uuid="86c8a666-b7cb-4108-853b-567eb8bf4238" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-9_stmt" uuid="63767541-f48e-4049-8398-aa3c3f1158af">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9aa139c0-d41c-4092-884c-c1a10768fba0">
+      <statement statement-id="au-6.1_stmt" uuid="278d0664-63de-4e5a-ab0f-c9ca5bfb276e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d16e20c-c13b-4be9-92b5-e499fda3d066" control-id="au-9.4">
+    <implemented-requirement uuid="5a95c446-2b3e-46f5-a57f-14a058b7f57a" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="1f20528c-64d4-4a73-b4e2-4f5dec18dc0b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="6b7347b2-c507-4e6a-9688-f43b474385b6">
+      <statement statement-id="au-6.3_stmt" uuid="7ea83329-7711-4dd3-a35f-ec8e5e422fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a344cc6f-73ad-41a9-a3a3-3d1efc97acbd" control-id="au-11">
+    <implemented-requirement uuid="9f8dc33e-8cb7-4eaf-9357-3baf7c120cb1" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-11_stmt" uuid="d6d1d31f-8958-43d5-ae41-047d997cf598">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c49a3726-113d-4607-a615-9c8cad818520">
+      <statement statement-id="au-7_stmt" uuid="b1bc0029-2fde-4d40-840f-9c818566f414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="443b3114-78d5-43e9-92ee-2925c79ab420" control-id="au-12">
+    <implemented-requirement uuid="1ac38bc6-2270-4b2c-a40f-b5f2c888e646" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="25503e07-d6ac-4464-9d64-c4d83524c3bf">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d7af1116-58a6-4220-b588-47165d84f075">
+      <statement statement-id="au-7.1_stmt" uuid="9098cc15-34b5-455e-94cc-1309592fcbcc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="86503bc5-38e0-4f6d-bf8d-331ea3d1a2b8" control-id="au-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-8_stmt.a" uuid="51d7e171-b44e-4ba9-bf07-0dae8326dac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="bba62e03-d272-4dd2-b209-fe4d267d7521">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="82059f84-430e-4b7e-a474-657d755f4c50">
+      <statement statement-id="au-8_stmt.b" uuid="3ddb5ae8-d5ea-4655-87d3-058e32962850">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="752bd03e-451a-40f0-92b6-c66d8bffca01">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c8a636c7-6679-48f9-ab94-9e411801b261">
+    </implemented-requirement>
+    <implemented-requirement uuid="d597c550-7f60-4e79-9713-7c8d24b29fa5" control-id="au-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-8.1_stmt" uuid="5c59fe74-8d55-42c6-a1ca-111c169a49fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9e7467a4-dad1-4276-bf08-d8d34380831e" control-id="au-9">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-9_stmt" uuid="399a2a67-60c7-4f14-8a6a-b073089ead3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8877d82d-0b9d-4232-8f63-15a7ce719c30" control-id="au-9.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-9.4_stmt" uuid="7916cc4f-c84a-41fc-b4d9-8d5ff5b68845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="325e4141-ff18-4912-8ca2-fac8295c5172" control-id="au-11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-11_stmt" uuid="ae2204bf-c4d7-49c8-859a-829d982f7803">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17a6e0b9-18e4-44c4-b7a8-a80b7c808622" control-id="au-12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-12_stmt.a" uuid="6db41abc-586c-4d6d-b231-639e07256b3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="au-12_stmt.b" uuid="e53a6c7a-39a7-4a40-af2e-f7898cf0fbc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="au-12_stmt.c" uuid="3baa0952-d9bf-4d8b-be5a-72ee07bf17e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87a68b97-3ec6-4ce0-921b-c08922a1d44e" control-id="ca-1">
+    <implemented-requirement uuid="971e9508-426c-4403-a87f-f0ffbb29a222" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="61607ef4-f46a-4416-b34f-5b61233142e9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b7746cbc-cbf4-4e61-9d31-992c4ed62810">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abc146c1-6101-484f-8293-abc9862f581b" control-id="ca-2">
+    <implemented-requirement uuid="5261b627-d858-4901-934a-e370806710e6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="b4e3bb91-6f32-41ba-b0fe-e9429e36f796">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="edcf4ffe-5bbd-45c7-8375-d20d4579a702">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6f38d52-dfda-45ce-8603-875033c3dbbb" control-id="ca-2.1">
+    <implemented-requirement uuid="feb6cf0d-d8ae-4f12-8a00-eb9cd47740b8" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="610871d7-26d3-4686-8457-98a95ae8e658">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="eaf9bbe6-1952-49eb-bb5c-9b477d6f7f31">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="169a96f3-62fc-40d4-8bdb-79dd2bc67956" control-id="ca-3">
+    <implemented-requirement uuid="af5a6093-d245-4da5-ad1f-d99f2d2df6ef" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="ca1b86e3-4271-408a-ba1c-46a1d56b44f0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="98bcffc1-b219-4d51-b9ca-ed9925825f65">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4faa87db-1d21-4918-88fa-3dbf1cc12cec" control-id="ca-3.5">
+    <implemented-requirement uuid="f92ee641-231a-4bb7-a4bd-316f7d190cdf" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="0418fa01-8fa9-4f17-a82e-b4a764fb12e7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d6da2e11-42f3-478e-95dd-45029c3f18e3">
+      <statement statement-id="ca-3.5_stmt" uuid="4c9c3596-df43-469c-b5b1-fcf54739b744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ff2440a-a816-49f0-8eec-86e1e9baa456" control-id="ca-5">
+    <implemented-requirement uuid="1b914e6e-95e4-467f-aded-d23dd5e9d7bf" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="25a16ac2-f9ca-4c12-ac05-b72c4635384a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bae14ae3-ca38-4caf-8a14-b378560fe46d">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9de6d7a-b05f-4762-837d-a259b4dcd9d5" control-id="ca-6">
+    <implemented-requirement uuid="bb0b9ff7-b5d0-448b-9dd0-4dcd974b1738" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="77ee6983-3545-431f-a42d-96c74fdf7933">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0ba256d2-53df-4602-a60e-b6d7e5f3bda2">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43d53804-4255-4548-ab77-f8270b99d15b" control-id="ca-7">
+    <implemented-requirement uuid="567d50d9-72bb-4086-8068-58e1b8e9c1d5" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="7a49c6f0-c102-45a7-aa04-2be26b37ab52">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e2294b3b-34a3-46c2-8ae5-06721fc6f9e1">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c636865f-bbe1-4c3c-be2b-d9d3127b28d4" control-id="ca-7.1">
+    <implemented-requirement uuid="ab50e11c-6cd2-48df-97d4-cbb119d1c6f6" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="905646a6-a94e-49e6-af9d-ae7380e04874">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8896bae6-d517-42cb-8eeb-d19f5d900ff8">
+      <statement statement-id="ca-7.1_stmt" uuid="9375a78c-bf7d-419b-8bf4-b2e91b5da8f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cba657e-4989-4b65-9788-ff63b3863ba5" control-id="ca-9">
+    <implemented-requirement uuid="64db1d9d-4002-4019-bc0e-7d5edd01ea32" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="7ea4a537-de23-40bc-9958-5b4fb2f25981">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bbb97e72-f3ef-425b-8b22-f99df82065a2">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90cae77f-9b81-41c0-88ce-56db6e3f3d4d" control-id="cm-1">
+    <implemented-requirement uuid="380e7a14-e061-4121-a8bf-79d0005964ac" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="40f842b8-ad8e-43f0-94f0-67457a399685">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c583f8f9-deb4-41d8-9ff4-0d638182ad4a">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4baa443-0a48-4ed5-b4a3-35eef0ce169a" control-id="cm-2">
+    <implemented-requirement uuid="722eab9b-ec8c-4e05-b741-b75eb4b0784f" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="82a75d97-0395-4c18-818a-2198ce3797ea">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7acf9bf6-c2dd-4277-9cb5-20e1e8348a81">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b060802d-f41b-4ae6-b239-65a5619496b6" control-id="cm-2.1">
+    <implemented-requirement uuid="4ecfbc5b-4bf9-48fb-b59f-fdbd0b9f1be4" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="fa406565-a348-4d23-8c65-7b8db28ee9fa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3e3bf2f5-a74e-4660-a196-228bd203a7b2">
+      <statement statement-id="cm-2.1_stmt" uuid="e551e386-023b-4d62-8437-6955d2400e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5432613-2e3f-496a-9f19-44d9a2089b36" control-id="cm-2.3">
+    <implemented-requirement uuid="633cd543-b971-44e5-bc81-fdfd8c2a3221" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="b85d175e-a13a-4ed6-9311-6b825ba3bd4e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="81c8cbbb-9640-4027-b08d-b9d0fce4ef3c">
+      <statement statement-id="cm-2.3_stmt" uuid="1095cbcc-c7c8-41aa-a8af-cf0e92f116a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a340082c-176d-42e1-8f49-9be7d42cf430" control-id="cm-2.7">
+    <implemented-requirement uuid="6829d65f-ab65-4e03-a5d1-abd0f9fbee6d" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.7_stmt" uuid="cb025a03-648f-4267-8b77-f172cc861e89">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="55b3226d-d846-4de4-b5fb-d1ad8d5bec51">
+      <statement statement-id="cm-2.7_stmt" uuid="d5f826cd-0ece-4d0d-b103-d3a2edc624c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b26e25e5-5816-4dcb-862c-8a65ff464b79" control-id="cm-3">
+    <implemented-requirement uuid="6a3bf7bd-328b-4941-8256-b5b93419ce18" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="82e7cca1-f847-4743-9779-a40450f0a8ba">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9da6a1aa-1a8e-4be7-ab0d-033eec30628c">
+      <statement statement-id="cm-3_stmt" uuid="9796b833-efa4-4000-9687-e129cb2cdf05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff4ed2c9-f4c2-4167-a51b-8430b791794c" control-id="cm-3.2">
+    <implemented-requirement uuid="61e9db9d-b5b3-48e3-8ecd-17854d476cc8" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="be1b3757-d4bb-4694-93f7-b86f15ac8f52">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="31c1ccc2-86fb-4a1d-85cc-d556ffcf2961">
+      <statement statement-id="cm-3.2_stmt" uuid="af7a20ee-7425-4ed4-a322-bbb57e66d23f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd22af8e-2754-4181-b8de-32c470436b16" control-id="cm-4">
+    <implemented-requirement uuid="f9d4934e-52e6-471a-9b01-b234b2bfe396" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="7ea7902e-14d6-4108-b620-e353665e1ee4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e30bb131-33f4-43c8-9cab-1ea7746f314a">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1b048e9-cacf-47fd-a7db-327469f43b64" control-id="cm-5">
+    <implemented-requirement uuid="c7e1a67a-1209-457d-8b72-e79f9b00c7f6" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="728c0ec2-79dd-4b14-910e-9be3ba1a8b65">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f4523935-0904-4ecf-9508-b4c19cd8d568">
+      <statement statement-id="cm-5_stmt" uuid="f44ee25b-cf19-497f-8ce8-101924d33c3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3e0dbd7-cce4-4663-929b-20e061d96599" control-id="cm-6">
+    <implemented-requirement uuid="d52b144a-784f-45bb-902c-8c75d7c29f61" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="9f84e932-d19b-4201-9a12-49620d560ba5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="22565552-13ec-4b5b-a513-d60846cbf0c9">
+      <statement statement-id="cm-6_stmt.a" uuid="df3d7a5e-5965-40bb-9507-2c7d8e25635a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="34d63968-2c89-4671-9947-598361b9e849">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c6d98908-765e-41d5-b5bb-bd737d49047d">
+      <statement statement-id="cm-6_stmt.b" uuid="50e28883-5f66-44ad-a4d0-58f966e9fcb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="943d532a-9abb-446b-b101-9a335124a7a7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="863ca081-2edc-47fb-87bc-ad6f0bbfa2de">
+      <statement statement-id="cm-6_stmt.c" uuid="4967c4ad-f6bd-46e8-8be3-a82ffb6df199">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="048415b9-a0fc-49e8-ae60-1a02e0342c19">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8ff277d2-b449-4042-907c-218975fb8804">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="6f383c2c-44ee-4b72-9895-fcd886ee434f" control-id="cm-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="be762ab3-b4b5-40a1-89e0-e2dfa1cc625c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c6121293-9902-4574-b40a-0feca6c0347d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="0b02e28a-9dd3-435b-a16e-134c3d6c8afa" control-id="cm-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7.1_stmt" uuid="33a797eb-ad95-4b1c-9692-200f96e235e9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ae50deb7-827c-430f-9457-63d43d6e6452">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="31cc95f1-2131-442f-b19a-2e658251b2dd" control-id="cm-7.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="7681f08d-b974-4fd5-b5e8-7ee1a27b3d65">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fa72da52-6e34-4823-92aa-909effe90ddb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="6ec33473-25ae-418c-953f-eac96d318912" control-id="cm-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="29f65444-1c2b-45e5-93c7-2fad4af813cc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c2dc33ab-1fb6-4152-8a29-9e591ebddc47">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="17dc9116-daa1-4bf3-a8d5-1709d8b4da1c" control-id="cm-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="2d5dcef9-0013-4151-a18c-784f73452495">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="63828128-f212-4096-8101-7241e269c780">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="66fd79e8-ccf0-4e46-b480-001eb616b311" control-id="cm-8.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.3_stmt" uuid="864c4103-94cc-4dc5-8914-9411ff9428b2">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="6bd44bb4-181c-4b83-984e-e93987242062">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2e316e03-c96a-41ea-8580-b115cfb2964a" control-id="cm-8.5">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="b2ada962-ae37-45c0-aa14-d02c96650eb2">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="dcb78eef-15de-407d-a906-59e8330ced18">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="602655e5-7e38-4661-83a3-e747a319016d" control-id="cm-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-9_stmt" uuid="91e04d44-2a32-4052-9db2-eb9421fdcfc1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="86cfd225-6d40-4f98-bf07-1fb3c2ba866d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="135e789e-02b4-47a4-a42c-6d0dd4436669" control-id="cm-10">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="c2369687-16e1-4530-9648-2996e0d6e425">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c28c36b1-30a2-4445-bec3-f162f46f15a7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5e26e314-c422-4df3-9581-f0428b34a217" control-id="cm-11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="15c4a33e-231a-4b63-91b2-ee43656da40c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="126c2f52-a333-4b05-9102-8c3bb0898e09">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2baa7d36-3281-4e24-a795-c0e6efda3aa7" control-id="cp-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="306a013c-b57b-43ac-9cb2-66e78286b4fd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e5f84260-82dd-40ab-ac49-f2ffa74ba199">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="44225012-c19e-4f9e-8f59-2244b734f421" control-id="cp-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="368d5120-7c97-409a-9fab-2a6ca5a66458">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="72fda9be-e221-4939-8ab3-61ad75c0de79">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="523439e9-513b-4298-88f4-2b26b8f8608f" control-id="cp-2.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="49eba6ea-7cce-4fc5-924a-e0340b9846e7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="baa29bf3-9f0a-4c04-948b-6fded75b452d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fe995bce-2b5c-4887-964c-8dff7ec1aba0" control-id="cp-2.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="befca55a-a029-4575-8f5c-ae6cdd933665">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ea695094-96e0-42c6-b0cc-d8b6170e5b7f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="581ac18d-6168-43ad-a30e-c45b8a9d84d9" control-id="cp-2.8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="418a8f85-31be-47a8-87a2-9305cb0d8f2d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4da1e441-0455-4cef-9fdb-76ad6de28799">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="651da166-5316-4066-b9d6-d9991a79da2a" control-id="cp-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="e1d137e4-2e38-498c-977c-4fe3d97371c0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b9c2f0d8-b087-40c9-9875-3226327f45fb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3f04d4f3-984a-4171-97fd-42da1f028e0e" control-id="cp-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="3bdb666e-bc6b-43a6-a637-80f23cdcd004">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="84c98834-f98a-4fcc-be30-b3e6b891d0a7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="eb175de1-d549-44e6-bbbf-0e44d0e2572b" control-id="cp-4.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="b6841978-97a5-4065-9b28-6b978ab48c69">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ebe6d09d-8d30-43a4-bef8-21fd0e0a28ed">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="195fb02a-51f4-498a-a790-e21a6377cb70" control-id="cp-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="3528ea26-b619-42ef-b326-0091ece36e0e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="709f62ee-5cc8-4205-9d5e-e5b6e5a2478a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f4d9f7ca-0950-4712-85f8-bf91168558ae" control-id="cp-6.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="33684f91-2083-4d12-a452-7dde3833b905">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9da2ad7a-fb70-4757-b426-2e6f273b9459">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9faedec2-41d3-414c-91a5-dc0b7aa16ac4" control-id="cp-6.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="1d8cc560-97ab-4eca-994c-d86b0ed118f9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="54153c46-4e32-4819-bf25-564b8b945239">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ac66d56f-d9a1-4553-b7ec-4dae737fddfe" control-id="cp-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="af23570d-331b-4440-9b9a-42cbfa1eece4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="433d6958-19c5-4a8e-912f-d5b715c97637">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="0f2934ce-353f-4014-9e5a-0a1ed6832c06" control-id="cp-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="de3aaf1b-1b92-41d3-ac5e-dbc692e3f48c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c48ebdb8-59f7-4fcf-8129-e333886e2b4c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2f34a6d8-5056-4e06-8bee-f320db7feea1" control-id="cp-7.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="ba1209eb-e683-415f-9a78-7ab3ef08b0f4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="dcff2269-6d5e-42a4-9cf6-a57465adbf71">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8cb9f601-9ca0-4d99-a1a1-7a7018e4c151" control-id="cp-7.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="d3fd7bc5-24b7-4cef-8021-8d7fe88f0704">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="053d3484-24e4-4240-ba69-935270a8992e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d4b8deea-c49b-4230-b9bf-4f4b69f19b42" control-id="cp-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="64c4139f-9ea8-4157-9107-ee20895cf90a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3f7c2da7-c416-48b1-b421-7f0c4d1cb4ae">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="7f9497f2-78ec-46c7-b3f8-ec51613e16bc" control-id="cp-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="3a9de614-26d4-4f1b-9497-a8ef2cc9dc14">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d7d84dd4-9d40-452e-9762-cdcfb039c3b7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2ba9b6d9-90cf-4b24-a69c-d5a6ff805dd3" control-id="cp-8.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="35fc7ce3-924c-493b-9579-c163d987596b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="790cef5f-d11e-4805-95f3-edfcfe41c7a6">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="283e5599-a427-4ae9-a8f5-0f588fa31eb5" control-id="cp-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="b0ff6ad8-b773-4073-8352-a57e856f99c6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="39caafbc-4611-4677-aa7c-1390f9bcef84">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="6d3a376d-7662-49dc-9377-9946fc260273">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bb4053e0-fc36-4181-bd75-08d3c51a444b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="ece1305a-8432-472a-a982-e51b2a12213b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c1b64a32-8956-434f-b3b8-1c6439e31aec">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="c643c323-465f-4269-b871-a40d9624f27f">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bbb017b5-b62a-4cc7-af25-3b15b5f95fd7">
+      <statement statement-id="cm-6_stmt.d" uuid="8bac2c7a-dc9c-4a45-b5f0-6b01f311534a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8a63e90-f1f9-4688-8de2-3ebc63c2f070" control-id="cp-9.1">
+    <implemented-requirement uuid="eeb4a8f0-0297-4da6-b654-c419632fef88" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="76d6d758-2e71-4abb-89e2-8c305b70a310">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ee1232f9-8683-4826-b697-135b6f31eada">
+      <statement statement-id="cm-7_stmt" uuid="3dce3505-f872-402c-9895-140c2bf099b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c407e55-c8a1-4348-8ac0-99128b953232" control-id="cp-10">
+    <implemented-requirement uuid="200a629e-6011-422f-9772-f4f1aa4307f7" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="502c9ac1-e4cf-4fd2-8437-9fb436d18207">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e6fbbbc9-251c-41c2-b194-194ad61ad7de">
+      <statement statement-id="cm-7.1_stmt" uuid="20f53a62-43ef-4dee-96db-2a8fbf44d057">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c38034dc-1fc9-41cb-bb35-483a457bf1ea" control-id="cp-10.2">
+    <implemented-requirement uuid="83263317-803a-4663-9c39-412771b42a4a" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="8597ab60-2544-4fa9-93d9-1824200ac6bd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5e440ae5-fd6d-49b7-8781-7f25aa3de0d6">
+      <statement statement-id="cm-7.2_stmt" uuid="d00ff979-6dcd-4de8-bb64-df12ef40a9eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a13a663-ec54-434d-9700-096b9ecf4dfc" control-id="ia-1">
+    <implemented-requirement uuid="16693daa-98d2-43b7-baff-aa83a4ad25db" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="03547104-e015-4bee-b137-642e5d92d6d7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8cfb3b3c-78a5-476b-a52d-0ee92d1f15e9">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe8b7785-c123-4006-ac51-0c0faa6ae868" control-id="ia-2">
+    <implemented-requirement uuid="8855e841-3cea-4f02-90b6-f51f7d2f0368" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="0d81ffc8-51dc-420c-b563-d85e9b2bc3fd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="79c16314-a872-449a-b4f9-4c39c3d7084b">
+      <statement statement-id="cm-8.1_stmt" uuid="8fcc881a-5b37-4d7e-a813-71d4a3521582">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0810745-4bc8-485a-96e7-bb0769aedc60" control-id="ia-2.1">
+    <implemented-requirement uuid="4ab2215c-384c-4dbe-bdac-256daed01585" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="46709299-62bb-498f-849b-4ec55323d1d5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="725ad537-d6fd-4a9d-aa56-da61f9f94fa9">
+      <statement statement-id="cm-8.3_stmt" uuid="a9a10e8e-e0f5-44e6-a44c-7fb1b2b0d53f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d6fe83b-a954-4f06-bcff-ab53b7772720" control-id="ia-2.2">
+    <implemented-requirement uuid="5b44f2f8-094b-4ec6-9a75-df1dfc66f323" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="8c3e2808-be69-49b1-8a37-4eb5cef2e481">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fc931c09-6c1f-4786-904d-8caba62af7d7">
+      <statement statement-id="cm-8.5_stmt" uuid="cec41ce7-379a-4422-a578-98ef0f0a9c36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c13a6434-4198-4687-8926-aac7658e3ee9" control-id="ia-2.3">
+    <implemented-requirement uuid="e258cf48-9f04-4638-9794-380abd4e9731" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="065ab95a-6b9e-451b-9b69-6035b45eae65">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ee5159ed-081b-493c-bf04-4a03d21137d4">
+      <statement statement-id="cm-9_stmt" uuid="c54a38a3-8371-4695-9666-a12a4e2420b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efe6c900-bf3d-44b8-a997-bdad5490488e" control-id="ia-2.8">
+    <implemented-requirement uuid="f19518a1-afae-4380-bcd9-24be30a53938" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="37a01165-e2e5-4957-bb02-bf698e6996e0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8326378d-ef33-4981-81cd-b035cfdf3da9">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="544fa6fe-ee06-4dce-a73c-134076243c40" control-id="ia-2.11">
+    <implemented-requirement uuid="a65ca1a5-22db-4288-8611-563896620700" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="16a3c617-ad5d-48b4-9879-370fe11af3b1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="453b7d45-cdd2-44bb-97c4-dc28345e75d5">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66f2dded-e2fe-44fc-97b5-6c40340f7508" control-id="ia-2.12">
+    <implemented-requirement uuid="ea6dee5d-c9c3-4065-b507-1c156b3a9faa" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="f88145a9-332a-4a75-95da-ab70e9234523">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="6049674b-cd2c-40f5-85f7-8d2b2e89f2ea">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="419e8530-9f5a-48a5-ba93-f462f4141764" control-id="ia-3">
+    <implemented-requirement uuid="723a02e4-1c79-4718-bc38-ee38752343b1" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="6f02d8ea-f83e-4716-b021-7e2d1c93e5a5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3b8e9cb6-1819-40d7-bdc0-846d02b8a3fd">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62bf0881-48e8-4424-bcc2-aeaad65ba857" control-id="ia-4">
+    <implemented-requirement uuid="c6aca99f-1f55-429c-bcb2-80ddd7966792" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="b7a14b58-390c-442e-a74b-a17e23d60cd7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c2b1b72d-1f5b-4e3c-acc3-289f2adcf27d">
+      <statement statement-id="cp-2.1_stmt" uuid="3fbf6d5d-7dd3-4f36-a24f-dc24e4cf4750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="00d3044b-80ff-4c14-973e-ac8cfc422f27" control-id="cp-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-2.3_stmt" uuid="7616f896-3052-4311-b55f-1abd450d081e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c3e82ba4-9c71-4e11-84c2-b0aac7638a46" control-id="cp-2.8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-2.8_stmt" uuid="d9ff945b-acf7-4268-afc3-517e7db25dde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8d4ca3f2-090a-4ba7-b7c7-7ebcf314ed38" control-id="cp-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="fb214c5b-30b7-4b32-bb7e-06cff0651262" control-id="cp-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9719f1ed-f7ff-4fc1-aa93-99beca590cb1" control-id="cp-4.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-4.1_stmt" uuid="c8aea2e1-2176-487d-8c8d-6c57a6854319">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b49fe7f5-1f08-4c87-8c47-36e4e4b03a7b" control-id="cp-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6_stmt" uuid="01ea60dd-11b4-40ca-b7c4-7f6ddf79ee17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="5642bd90-d270-4c41-9ba4-5bba6cacdd05" control-id="cp-6.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6.1_stmt" uuid="4462fe05-f95a-413e-9507-96e07d5e3041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="dc23d0bf-7977-4e62-b615-6b549582cc01" control-id="cp-6.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6.3_stmt" uuid="44757adc-738a-4fe9-82f9-fdabaeef1444">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ce458fc4-77ae-4e4b-9e1a-f362a6186a90" control-id="cp-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7_stmt" uuid="97e24600-21be-46a1-bb11-46bf2e3f16be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ff101a61-1a8d-4eba-ac71-c18aefff863d" control-id="cp-7.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.1_stmt" uuid="d2b8d434-4fda-41a5-b1dd-814b1b7abe45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9007a1f3-919a-4273-b329-05e492af1c4b" control-id="cp-7.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.2_stmt" uuid="0051a470-c75a-4f6c-9960-f30576e7567c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9f0f9c2d-14dc-4580-82cc-f2abb6983c4c" control-id="cp-7.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.3_stmt" uuid="d0e0685a-549a-47b9-b22b-d3ef5ec2124a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="538b675b-5f1c-4062-9c79-364688fc8847" control-id="cp-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8_stmt" uuid="594c4d1c-c4bd-4bd9-a559-83fd9a90d4ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="6c4c0d80-7252-4b6b-b971-f1b2a32a1422" control-id="cp-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8.1_stmt" uuid="39f1588b-498d-471d-b58e-22807f1b6514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="34bd1dd3-d7b7-448f-a673-6c856f2b4df7" control-id="cp-8.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8.2_stmt" uuid="20f298fb-3706-460c-8f3b-fc2fc477f1c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="fefe0445-0e64-41c9-b480-338a4c5bd9ba" control-id="cp-9">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-9_stmt.a" uuid="57ff7385-77cc-4cfc-a336-272d1beb7567">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="931f280f-e66c-42a6-b272-6b15d9d53403">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="26c69bae-72bb-4cec-aa68-83d5b1419a46">
+      <statement statement-id="cp-9_stmt.b" uuid="60b825b4-2b2a-4a27-b9bc-e4bd83daa5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="125350db-b6db-43aa-af9b-e6631cb81aa9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="31e35f00-dca4-4549-8358-446d7d27ac9e">
+      <statement statement-id="cp-9_stmt.c" uuid="69f94737-48c2-4b8d-9802-0e9e5e8aa97e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="3eaa3e58-ec0a-4fa0-86e2-cbc51b2aa1ed">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7cc07d1e-1080-44d7-81ad-8d196adbff36">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="f1752cd6-011c-4a26-afdb-7145a87ec4d0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9d81adea-4fb7-44d1-9b66-d013f8d81d14">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="a7d49e6f-8e09-4944-aa34-0e87fc8a1d97" control-id="ia-5">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="5a2bc22f-1c26-4d23-9105-5a50eb7df7fc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b00dd17c-dcac-41b6-9065-8b334c1bd28f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="8dfc8452-f86f-4441-865d-c78cdfe24811">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7a280285-9e2a-41df-b8c9-3548f7a033fc">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="93dedf29-86f9-49f1-98cf-51ae136c367a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9071a08d-9d12-4a83-9fb2-b3e30fd8b489">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="2c43ad32-3436-4040-a2c5-94c4eec58111">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="014db8e6-7ecf-43ef-b52f-8fc615501373">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="5e355286-78f3-4445-a36b-8f9929fa7bae">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1f38977f-26a4-4fa9-b163-ef4370ee131a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="19dcc4e8-c1f6-465d-b5c2-7ef9e80b75aa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1cf8b251-9df6-4004-919d-f38c4ad52979">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="192b304b-bdfd-4436-9d39-91305147b9b9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b2c648bd-21fb-4ffa-88e5-a5810651a6e3">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="eb510400-e937-416b-9eb9-de2e8fa04901">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fa71ef09-c0ea-4e77-aa98-55d3508415ba">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="6741ed70-6f27-4bf7-86cb-83d665bfd530">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3d5d6a63-2e1a-4d44-a921-bf6246d1e2b1">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="10042a69-e94f-46ca-a36b-52abf286543e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="96605073-6c6f-4cd4-90eb-8c69a8b3fe09">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3d50b1b8-747d-40e5-a061-d2a2dd2d2509" control-id="ia-5.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="b3612325-6e67-4d5a-8ed5-0afa2d1ace36">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="862f6b0c-6531-4afd-884b-47d2c732bdd6">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="1b2d567a-b736-4557-96c8-6037346d23e6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cf4efc58-dc29-405d-8366-973aed9ff1be">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="8e330341-e0a7-45d9-a31c-18b780df6bcc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ca0af679-d045-4db6-9271-bc6f8382a390">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="38b47f09-f3bb-453f-ae81-4b56f025aa4e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="65b28658-b38e-4471-a381-8ab522cc25c4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="a292ec86-d3d4-4d16-91cc-1ff5940e11ea">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="97acdb6d-57f6-476b-b452-2a30fba85a9b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="6615b055-9b30-436b-907a-14f1b3c7dffa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5578dfcb-52f7-4ac4-9555-8aeaf60d741f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="0f82baa7-14e3-4f71-aa27-2ef4742a0af2" control-id="ia-5.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.2_stmt" uuid="642e2704-8357-49f3-9984-80152769a21c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8ecd9570-7b01-4123-982a-8411e9be527e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="72047f35-d463-4b3d-9397-6b2ffd1a67fa" control-id="ia-5.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="9f35321f-f734-4747-81b2-50c8ab9525e8">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="44033960-fa6a-4a93-b72b-779bd5ae050b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f2a324ed-2d70-4a08-82d4-4856a9dc01ef" control-id="ia-5.11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="21e318cb-e0b8-492d-b887-ecec35e345ce">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bab37fe9-8aa0-45ed-ab1b-1e39ec2f6f49">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="6cb1e0b3-db70-4267-8db2-c94c023cf32b" control-id="ia-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="0ee467bb-6ad9-4854-8f6b-89e50b559a49">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7d57a982-a3e6-4f8f-97d5-463e01e2eda9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="87c294b1-96d3-4a11-a8a2-f1079b94c746" control-id="ia-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="942d6cf1-85f8-4084-b7ea-1d88bd7b1eb6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5d4bb31d-07e6-447e-ac17-d268658ef634">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5bc21020-0ec4-4476-b2e0-feed633fc384" control-id="ia-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="4d43090e-dcd5-4a31-a933-1e8dcb33db1a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7a915367-b2da-409a-8a3a-595766be89d6">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d28543b2-6b30-45f2-af9b-bd9ab0fb4099" control-id="ia-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="09cc6fa3-2c57-4f24-8cb7-8e4358bc58b3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f37c50f4-fc1f-43f8-881a-3ef1f148f081">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="536af929-c9a8-468b-a696-5d9001c22374" control-id="ia-8.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="1256a223-27c4-4323-a604-9e966c881004">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="56b68af7-8c42-4129-bea2-6866c226e817">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="27fd8dfd-76b3-418a-a825-887e49fb6fab" control-id="ia-8.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="648d37c6-3c9b-45eb-876c-5a427cf5f608">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="69dad63e-5759-4b57-9e49-5e563a00647c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f534bf14-83fd-4c8e-ba1f-48fe22b9f53a" control-id="ia-8.4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="90f1ffa8-bd17-4c6c-aafd-9324aa65ce61">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bf778df8-b588-4009-9286-695e0f98c642">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ff1a6541-11b5-485c-8c67-e2875949f614" control-id="ir-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="348c396d-ef6f-411d-af4f-f6581c48ac08">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="798ae9e0-f994-4f44-8864-f54fe02276e6">
+      <statement statement-id="cp-9_stmt.d" uuid="69738b01-a603-4de2-a97f-b09db026e408">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b5b900e-0b34-4eb6-80e2-3bbe4d11774d" control-id="ir-2">
+    <implemented-requirement uuid="6990152d-2af8-40c1-8df6-63f2b1819ae7" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="f8320285-e83e-43bf-befa-38fc2110594d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="39a836f9-30d9-4316-8c31-7ca993f43721">
+      <statement statement-id="cp-9.1_stmt" uuid="8dee39ec-4d1f-4e79-9506-61cd32be6d30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="492337f8-10a6-4327-a66a-ea1bdd457586" control-id="cp-10">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-10_stmt" uuid="d1cdfa3b-767b-42ea-9551-29a60119e39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="f26994cc-add2-4188-acc0-d4de3134c43a" control-id="cp-10.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-10.2_stmt" uuid="4211b0f6-8bb1-4cde-89d4-fe88e1957a4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="3d758108-acb6-4eac-9b0d-915d022c8d76" control-id="ia-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="82903ec3-33bb-4857-8cb5-f56d44ec0560" control-id="ia-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2_stmt" uuid="188213c0-2886-4654-94a7-d3d29f60238f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="4541b2e4-a651-4dae-bc37-0c55789025e5" control-id="ia-2.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.1_stmt" uuid="0ce9f0a7-76db-445c-9400-e6ff2b4fc7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="05cb299e-6620-4365-9ed3-f6a996230932" control-id="ia-2.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.2_stmt" uuid="37704307-6f19-49cc-ad8a-4754438002f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c863808d-8249-411b-9791-dd188f771fbb" control-id="ia-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.3_stmt" uuid="36985d66-8ddc-4203-b3ec-7cf9e7f39c2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="957230d8-6844-4a3e-a948-47d81f94eb60" control-id="ia-2.8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.8_stmt" uuid="4201bd75-9e51-40e2-aa08-099d8ed4a9b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="0a955489-b3e4-47f9-a4e8-b4fb4ea22003" control-id="ia-2.11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.11_stmt" uuid="d43bb82d-7878-47e8-a97e-ee90ab2b748e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17ceb079-816b-4d76-b5d7-e9ff38e520be" control-id="ia-2.12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.12_stmt" uuid="42bb9f64-b1eb-4b59-ae75-8bce8d6cea87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9a473d99-6efa-4156-8488-83fb851b8aab" control-id="ia-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-3_stmt" uuid="9a42056b-e053-4832-b9f0-0555d69b9d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c4ce1586-af7c-4486-99a4-a2135d320661" control-id="ia-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-4_stmt.a" uuid="cfaa44d0-6476-4a3f-b1aa-bb081ff43f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.b" uuid="758139f6-3cd5-40b9-91c4-38775ebc6fdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.c" uuid="79b1819c-ff07-4803-b426-7994dfd3734e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.d" uuid="b3a202e3-f292-4ba2-b5d8-bae09f051787">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.e" uuid="5a3ed097-5611-49d3-a1ea-5f3ed83758d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7732dca0-bd7d-486f-ab02-e1c1a53bb36d" control-id="ir-4">
+    <implemented-requirement uuid="3fb902e3-a4df-40ad-8c86-9e5b88d9e17b" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="6b159a8f-b017-4991-b22c-9b4c843a72a3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9e525e0c-4201-4ac8-a59f-a6369ada94ea">
+      <statement statement-id="ia-5_stmt.a" uuid="e45f25ba-f806-4e4c-a2df-f23d1aa3f319">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.b" uuid="42462fae-3f29-46c9-a22c-8c9f2a276623">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.c" uuid="34bee8e8-b77b-483f-8c75-546a85ee209f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.d" uuid="d63b5685-fcd0-4f75-a3b3-1ad69b91d414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.e" uuid="e45c697b-8dfd-472d-9f9c-ecacbfda96f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.f" uuid="77011543-3370-4773-90e9-b1b265ce0d76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.g" uuid="acf4cd95-c065-40d7-8fc5-baeee3682049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.h" uuid="c2a4d63d-209d-4a49-92f8-b5d10f50dc4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.i" uuid="de33cfef-2076-4db2-92af-a4ea950a13f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.j" uuid="ed0b7320-a255-426e-ba0f-1b271d718687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d9a87ed-d8d5-4cbb-8ffa-a665a2c2be13" control-id="ir-5">
+    <implemented-requirement uuid="aacd4c81-3fbe-41ef-a1ae-375c10e04ddd" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="487674d3-c1d7-4ce0-b32b-182a7b1330ad">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="70a0d904-0799-49b4-93c7-bcce8bd4e489">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba6d6897-8997-4bb4-9530-1b5b548dddb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.b" uuid="5dcfe43e-28ac-4e71-9b64-c0c94455dd73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.c" uuid="1b44b970-a455-4465-a491-9a439d16a0f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.d" uuid="fd847861-5041-443e-b446-9a29dc75fe26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.e" uuid="a8d49da3-e616-4399-854d-5976bf4642e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.f" uuid="86e222e6-8aee-4d6a-87fe-50a30a57e002">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e61371c-dee9-4e55-902a-64f114fac6bf" control-id="ir-6">
+    <implemented-requirement uuid="401d1a24-c155-4c7f-9983-d6fbc97a85c2" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="c5ca04eb-85ea-490c-ade3-9e6a19804b45">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c57f2e8c-be9a-43e9-a528-feab1900c65a">
+      <statement statement-id="ia-5.2_stmt" uuid="d27f42c1-8b69-462f-8c0f-efb29c5fbecf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="99b8a2ee-d23f-4675-8451-7fbb0f8504c2" control-id="ia-5.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-5.3_stmt" uuid="2373f55f-4fba-4086-89e6-6a12eedaeb52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2eb13d36-5514-496b-b454-31c775a1fc70" control-id="ia-5.11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c6b95d74-8648-4b21-9c78-39550972de14" control-id="ia-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-6_stmt" uuid="ffd86149-b84a-40f5-9fcf-adde40f974d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="cd0b8d25-c145-4d15-be94-07bacf532824" control-id="ia-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-7_stmt" uuid="5354e6b0-a65e-4aca-8e86-a9a289c7f61b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2888bfcc-e194-422a-8825-4f53bdb20d89" control-id="ia-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8_stmt" uuid="3cb73140-4585-4e6e-8417-c1ec9ff7b55b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66f0b14b-5d6f-4ae9-b8bd-a9c2164a8aa2" control-id="ia-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.1_stmt" uuid="06757d86-2146-46c7-bdce-dad895acad87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="316b86bf-44d2-4fa6-a4f5-7833eb8452c2" control-id="ia-8.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.2_stmt" uuid="4b9c3d26-d95c-4161-b3de-5b333fbdf6c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66acb44b-508c-4e55-88c6-6db3bbc366f3" control-id="ia-8.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.3_stmt" uuid="593b1940-e12f-4507-9d3d-acb1bc340259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8eec4d41-4452-4ec2-8a6c-540cbf19cd0e" control-id="ia-8.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.4_stmt" uuid="992d4863-d8ca-4ed9-a82b-59fdccc1b1eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="28ff4a5c-d327-40e3-99aa-bedf8fb5203c" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-1_stmt" uuid="07381d25-127d-465e-9c8c-b64f43fd04f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93c6e229-59df-4273-aeee-f2d1a5ca25dd" control-id="ir-7">
+    <implemented-requirement uuid="3d26ebe3-7f91-44d0-a3e4-f44192791ec8" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="75398517-0692-4c55-bd18-6762bbc878f1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1d570560-5995-404f-a9d0-4ee67b16da6d">
+      <statement statement-id="ir-2_stmt" uuid="34942c74-95ac-4599-b551-7397d0d08f99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f278e0d-7868-4383-8c76-69368f1f93cd" control-id="ir-8">
+    <implemented-requirement uuid="632ff990-7955-40a0-83e6-81ba280c93a4" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="a0e7c865-553a-41f5-813f-dae2f187334f">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="63ebd50d-3de5-4b49-a709-e025bd94ad06">
+      <statement statement-id="ir-4_stmt" uuid="4eedad3d-d67c-408e-b55b-44b72a18ea2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="574fc5b9-736c-4981-8b61-81029f472771" control-id="ma-1">
+    <implemented-requirement uuid="4780a3da-36e9-45ac-9448-246d9de52d4d" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="ebbfb1fb-8f20-43ef-b28a-e3761eddd0c7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9d777af8-70dc-40fa-9b32-8f2e976874e1">
+      <statement statement-id="ir-5_stmt" uuid="934c7912-3aa8-4b48-ae97-b62c5a5dfda1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="90dbe198-eaa1-424d-bbbc-aa898e2f8910" control-id="ir-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-6_stmt" uuid="63df69cd-4851-45f6-81eb-006fbd9b0ddd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="65889916-6ebc-478a-9e11-9eac2f138f8b" control-id="ir-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-7_stmt" uuid="8fd6efff-d8f2-4c7b-9fc9-2593323d8bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="81dc3c73-edd1-4c6d-bb2e-95e9ddecdad2" control-id="ir-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-8_stmt" uuid="ad980c89-acc1-468b-b401-1263a56b1090">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="624adb57-c624-407f-8775-cdcc75abe075" control-id="ma-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42462c9e-e9d3-4285-ad12-0974134bf269" control-id="ma-2">
+    <implemented-requirement uuid="ddcb61f4-5048-4ab9-973b-490a5db3c808" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="dc36cbdd-8c30-4029-bb96-79f8e3a7c33a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a25d9d53-1bdd-4c5b-88fa-e784f109ccb8">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fedec4f-ac67-4442-9412-a6821dc0e1a5" control-id="ma-3">
+    <implemented-requirement uuid="8d4df011-385b-46c4-a9c3-1dcc81a39c87" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="7ad2825e-219e-40f8-902d-ec774a7440d1">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="45bc058e-3a55-45bd-8fe2-2148297203dc">
+      <statement statement-id="ma-3_stmt" uuid="1a8a743a-f6fb-4783-94c8-96f103d8dc08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3528775e-1235-4aa6-a971-2a1ef33aec20" control-id="ma-3.1">
+    <implemented-requirement uuid="2687c70f-75ba-482b-9dc1-84b6954ce4e6" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="89994bc3-d6fb-4fbd-8300-50463254f917">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f91c7eb4-54b0-4371-86ca-a588ec553cd2">
+      <statement statement-id="ma-3.1_stmt" uuid="c286a8ac-629c-4de6-9128-4ab059ae6b3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84d35e7f-b7d1-410d-8287-e02ca9645874" control-id="ma-3.2">
+    <implemented-requirement uuid="c89c8c5e-69bb-4d8c-856e-58169fc2cfb5" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="6501deaf-f1ab-4c0b-a031-d67d162afad8">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="99667af0-e35a-407f-b26e-2f3ea844c036">
+      <statement statement-id="ma-3.2_stmt" uuid="9f3c30fc-4943-4742-bcfd-031db91bc94e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cf4517d-2cd6-4e66-bab1-515c20a7cc10" control-id="ma-4">
+    <implemented-requirement uuid="59b21f81-8979-4404-a720-f32cf697b4c1" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="0ee37da7-a281-4344-9dc7-2fe78a4e48ff">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="96b820f0-2503-4828-bea4-f1dc562b8d10">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb0906fa-e3eb-44d1-b142-f0f98541a459" control-id="ma-4.2">
+    <implemented-requirement uuid="daf0e985-dcd3-4523-af89-fd37e966ecce" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="cdc432f7-05f9-4a81-9a22-88f7ad523b90">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="619ba4c5-30ac-42dd-94c8-8ad92219add3">
+      <statement statement-id="ma-4.2_stmt" uuid="4052ef6c-7601-4f55-84eb-b9d7dc40781c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fc5a010-e0cd-4125-ba1a-3349fa3172cc" control-id="ma-5">
+    <implemented-requirement uuid="46e83d36-ea11-439b-bd56-a355174a7d12" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="171e8929-c734-4bec-a7f8-e763b4e8c52a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c810f49f-949e-47cf-b38a-88fd2872b263">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fd63832-8a4b-416f-a6f2-51f0174fff2d" control-id="ma-6">
+    <implemented-requirement uuid="a74f38c2-d5ea-4ef9-ac48-a76b0ff1dc63" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="9d8207ad-fa9c-491c-a04d-a89813e73263">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4c9cc702-0a12-48e1-b70e-d5fb3b855ff2">
+      <statement statement-id="ma-6_stmt" uuid="b26d2ae7-8b2c-4e3f-b94a-46de28fc5c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ccc7472-924f-4543-9606-6ce7735dcbb1" control-id="mp-1">
+    <implemented-requirement uuid="cce0658a-b46e-425e-a359-ccbbdadad9e4" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="ba7bbb0e-1c65-4dcd-9f5c-aabbc49ef014">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="930101c2-4be5-49e2-95de-70ea233a40f7">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff20d514-0d07-4cbe-bc32-521c60a54829" control-id="mp-2">
+    <implemented-requirement uuid="f9b2e3ea-90a8-4e2f-9dd2-c8bfd1883265" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="4eecb1fc-3157-480c-afc5-caf90b9c0457">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="93ea101a-2a0c-4aef-b09f-12acc31199db">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4246cb45-a8f4-4690-9d45-1b0ec2b1ecae" control-id="mp-3">
+    <implemented-requirement uuid="f17ea9d0-451a-43ad-9800-ae4eb4f9b321" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-3_stmt" uuid="d273bd18-e26e-4ba3-b2e2-600fc8dac9c6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a76a40d1-f35f-43d3-b954-024c58562143">
+      <statement statement-id="mp-3_stmt" uuid="47fd6b98-fe60-457e-a54f-64bd3e19341f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="feff52be-bcf8-4ab9-814a-8b6faf53d5e4" control-id="mp-4">
+    <implemented-requirement uuid="c401e303-8756-47a3-a636-a6c8c4f91678" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-4_stmt" uuid="cbbd939d-4c15-489f-8e28-0944d4d61e3c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9c058bd6-cea8-456e-a400-999471aa1c1c">
+      <statement statement-id="mp-4_stmt" uuid="17ff3f7f-a367-458a-857b-9da507e60341">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="711b31c7-e198-42a3-bc92-90b1cc2091b3" control-id="mp-5">
+    <implemented-requirement uuid="4d7cb2e1-e250-439a-8d9a-28775bdb8bed" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-5_stmt" uuid="d0e5233b-7100-4c7b-a114-151073a60992">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f7b0aa4a-c874-4fec-a102-67d826caca81">
+      <statement statement-id="mp-5_stmt" uuid="2d3c86bc-25c2-4ea7-b3ad-0c11a4315b13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44c03c06-eebc-4ecc-9e7a-ba848d45c55c" control-id="mp-5.4">
+    <implemented-requirement uuid="f052427a-7c13-41c2-b1fd-8aa70947c65b" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="44a4cc95-d029-4f0a-adfa-cfb2571a1e6e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0644e817-c4b8-4cc2-b2e8-eb34b51d5251">
+      <statement statement-id="mp-5.4_stmt" uuid="1ea3e9a2-1134-41a3-bfff-0bfb734f129c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cfd3559-72e0-4d8e-893e-4750d5bf11fd" control-id="mp-6">
+    <implemented-requirement uuid="c4c70fa8-e2de-418c-af96-5aa873793015" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="a35774e7-b437-4988-9bb3-d4f7d9a6f1e9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ed0483c0-298d-44a2-87ae-68bde9fa7ef2">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c9d7e18-eacd-435e-aafa-1802946f62c8" control-id="mp-7">
+    <implemented-requirement uuid="e85261f5-5f7a-4602-bfcc-c91fc07fad67" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="58d65b0e-0d0d-43f5-9166-9499896986c5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8953bbe4-ca4b-4bac-87e3-a427e48f0bf0">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82ebc4fc-829b-4c5c-ad9d-bbe8d4db8177" control-id="mp-7.1">
+    <implemented-requirement uuid="275bf8d8-d80a-4025-8992-b2c664737bd7" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="ce832479-26d4-447e-9788-b20f62c73389">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e6668ec9-0d22-45d6-88c4-f9a7d027a24b">
+      <statement statement-id="mp-7.1_stmt" uuid="ac6d868a-b18f-471d-98ad-6b9bd12ca221">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="895d213a-e92f-419b-a9a6-73bee9c79e04" control-id="pe-1">
+    <implemented-requirement uuid="a936699e-188b-4365-b8c8-ac27c7c551ef" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="20ebc041-22b3-47d9-9595-8eb42adbdb30">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a1c6d0f9-d3f1-4315-ab2b-485bb0823a1f">
+      <statement statement-id="pe-1_stmt" uuid="9eeaf67c-b116-4010-bf82-2cedced92bff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="635e39b2-31b8-4559-8baf-bbac88e50381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked
 via:
@@ -2241,10 +2241,10 @@ via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4952e184-ce7d-4d32-800e-7a67c1dbf367" control-id="pe-2">
+    <implemented-requirement uuid="357f50ff-894c-415a-8eeb-f49f3d068779" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="020ce190-26be-4123-a693-b5f472821070">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="566b8fbc-d135-49e0-9794-1340c27ea01b">
+      <statement statement-id="pe-2_stmt.a" uuid="b57fbab6-6e7c-4331-88d8-b80a3510b436">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2253,8 +2253,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="1402abbd-683b-44c8-91df-d21a161e9bbc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7d651474-a6e1-4b21-86e0-f635911d40f5">
+      <statement statement-id="pe-2_stmt.b" uuid="aef52af3-fe2b-4d6c-8571-7f9fbc647e97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2263,8 +2263,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="c45f704a-7b47-4ebc-be67-6d8b10e4c58e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ff824a37-63e1-4f83-a1d3-c779c0d97915">
+      <statement statement-id="pe-2_stmt.c" uuid="ef527317-5209-4c89-926c-78c14b1fa41a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2273,8 +2273,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="11ebe800-3a1c-42db-a2cb-761e5fbdb313">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="7ad76637-5b35-4d35-b197-bddf1e139a07">
+      <statement statement-id="pe-2_stmt.d" uuid="10afcd59-4906-427b-9948-baabd570648a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2284,10 +2284,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b079058a-f60f-418b-901f-b959c147f4b5" control-id="pe-3">
+    <implemented-requirement uuid="8c21f041-ad73-49a3-9294-c789ab513d8f" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="30be8f58-9d4e-4b6a-9e41-825e0744372b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="22a5a624-d12b-4952-9bc5-eb33e33dad41">
+      <statement statement-id="pe-3_stmt.a" uuid="666d7036-90a5-40a9-854a-0a1ee6a21363">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2296,8 +2296,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="279be653-0c37-415d-a5a1-14d7f3694439">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fe7e99ed-9f78-4d2f-b3c8-4f5e2bc983a2">
+      <statement statement-id="pe-3_stmt.b" uuid="fd166ad5-7fca-497e-8e51-4c8a4cdc28d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2306,8 +2306,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="4c8f6ffb-fda5-4c85-bbc6-a240ed9701d5">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0519d5eb-c3f8-47b2-a998-8fb6a51a5910">
+      <statement statement-id="pe-3_stmt.c" uuid="25ed7e5f-2cdc-45f6-af02-9a0c77db04e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2316,8 +2316,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="48cd2ed4-b954-4d8d-8849-b0d41761fe18">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="53649814-ee4e-4c52-9c0a-a60722c01e46">
+      <statement statement-id="pe-3_stmt.d" uuid="9960adac-3249-426c-9d36-6586f4ceadf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2326,8 +2326,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="ac14a304-49af-42ef-8a1e-6094b9bb193f">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5d43eed9-fda8-4c71-b860-28cf4fe9e1a4">
+      <statement statement-id="pe-3_stmt.e" uuid="58a40390-8a4e-459f-9e58-368a83aebeab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2336,8 +2336,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="f4fbdb13-ad3e-4b9e-a285-6369784caaf3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0e409fdd-1dd2-4181-a7fa-b12e4de62a32">
+      <statement statement-id="pe-3_stmt.f" uuid="cd0ce203-100c-4430-87d4-3b5c3387f9df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2346,8 +2346,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="473b5c92-d4fb-406f-b24a-3e45f1a62068">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="96d95e9c-381b-40c3-82d2-43f4e2a7e773">
+      <statement statement-id="pe-3_stmt.g" uuid="07f74625-38ac-4ca8-bc8f-4434d856d129">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2357,10 +2357,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06434f45-a224-4ac6-a639-a87d56f07a03" control-id="pe-4">
+    <implemented-requirement uuid="d3462df0-aee0-4239-a596-a9f078af13a7" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="859cf923-668f-4bd6-a95d-d7e63b588bfa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3b17dcd7-cc04-4230-8e1d-6095f7caaede">
+      <statement statement-id="pe-4_stmt" uuid="36ec06b7-9a42-43be-b7b1-a7595dec2dcf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4806905a-5a17-4e91-8527-d57c46c4d5ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the information system distribution and transmission lines.
@@ -2370,10 +2370,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f440cadc-9539-433a-bd5d-086df729256d" control-id="pe-5">
+    <implemented-requirement uuid="15955cd5-0a86-4916-93d5-00f3d6df5156" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="98961efd-9df0-4bef-8734-eb0b9f567889">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2c0a463f-bf25-4c09-baa4-3ac42e0caac8">
+      <statement statement-id="pe-5_stmt" uuid="577e2491-1086-4f53-a7e6-b95f1c21e6b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dbc7f1e-df28-4da7-8e27-2aee9ede6c31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 information system output devices.
@@ -2383,10 +2383,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="babe89f5-a543-48cd-ab52-c4879f257dca" control-id="pe-6">
+    <implemented-requirement uuid="ea3b1ae8-ca6f-4178-a120-def72eb0edb4" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="80e56086-d5d4-4465-8d45-4963e21b09e3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3c95a3d5-7c2f-4b64-9884-90665655726a">
+      <statement statement-id="pe-6_stmt.a" uuid="adc055a6-c4df-48b1-8df5-e825566ed731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2395,8 +2395,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="69fc3abb-891e-49f9-bf6e-7528b35eb4c4">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e746ab38-235d-49ab-b157-8501c9320589">
+      <statement statement-id="pe-6_stmt.b" uuid="7bdf5f6f-2836-4984-b5db-b5ffd79be70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2405,8 +2405,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="b026aa8a-d7d5-42de-a5af-853f3b89b85c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ee306e8b-53cc-4496-b2df-7094d70b390b">
+      <statement statement-id="pe-6_stmt.c" uuid="61e0973f-7994-43ba-9bb8-62a5fa0f0b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2416,10 +2416,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e72708a8-a616-44b0-a0e8-78ceeea76fdb" control-id="pe-6.1">
+    <implemented-requirement uuid="1f9da45e-a2c8-4327-86ce-d911cdee70f4" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="bdaa8d72-72e6-40e4-adda-e4336d2105df">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="703826fa-6a72-4a92-aac7-a73f9322bf26">
+      <statement statement-id="pe-6.1_stmt" uuid="447cdf5c-1a84-4105-8c63-d2eaef6c741a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7485b727-b740-42e7-b9a4-508a375eaddd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not monitor physical
 intrusion alarms and surveillance equipment.
@@ -2429,10 +2429,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea606556-d3c5-4788-84a2-9c72bfd61a8f" control-id="pe-8">
+    <implemented-requirement uuid="e4f2790e-8cdf-402e-b3b6-7805c45878ef" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="fae55119-fe04-4b54-9b29-8e962a593692">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="edf02e77-ff1b-4f00-bc13-9f183c9b0697">
+      <statement statement-id="pe-8_stmt.a" uuid="e3512a72-92e7-4983-8945-ee9a467eabc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2440,8 +2440,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="28e8835e-100f-49e2-96d9-754d211a60dc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="21339452-b30d-4ee4-90fd-495af70b3d48">
+      <statement statement-id="pe-8_stmt.b" uuid="dc35409c-4dcd-43a3-9bd3-53ec208e4f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2450,10 +2450,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="876718fb-f89c-413f-8afc-2f5f5d282925" control-id="pe-9">
+    <implemented-requirement uuid="01032f1a-2173-4a7c-89a4-781e2c9ef03a" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="2fb46346-394e-46c3-aa45-b9145e42d4f7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0f827027-62bb-40f3-bfc4-da8320584930">
+      <statement statement-id="pe-9_stmt" uuid="78f70808-7b68-431b-8ea0-373718038124">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2462,10 +2462,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16f0ffff-87bc-47f7-921c-1d495a7ad768" control-id="pe-10">
+    <implemented-requirement uuid="4ed859e5-774d-41c8-895f-baddf7735d34" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="ee175e55-a2fd-4c7e-b503-81416676d01d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b883ae23-e513-42db-b8d2-069ac9b7ca5a">
+      <statement statement-id="pe-10_stmt.a" uuid="4864cb7e-cb90-4a8a-acbc-d7299f9cdcc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2473,8 +2473,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="a899edf2-f40a-4891-b892-9a70fce06a85">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="216f70f5-8a84-4dde-8c6f-d0171b7f95ea">
+      <statement statement-id="pe-10_stmt.b" uuid="ff468a23-5814-4390-944b-08fa357c8f58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2482,8 +2482,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="a0735ce3-c528-4a4d-937e-b80a0b7c7806">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d9fa9cff-20f8-4536-9e86-1a63845863d4">
+      <statement statement-id="pe-10_stmt.c" uuid="ce90be40-54a8-4084-ad21-a1a768fc1cf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2492,10 +2492,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d353512e-5500-4d82-8618-29c2775a6177" control-id="pe-11">
+    <implemented-requirement uuid="ba6fd9bf-e51c-4950-addd-2113dc5c191a" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="473805be-7874-4e7c-9ce0-9ac9d473e48a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="27cac8fd-9d2d-4ac3-9b9c-431b01f4be02">
+      <statement statement-id="pe-11_stmt" uuid="5fd00de1-e820-4ec9-9a74-d571014e494a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2504,10 +2504,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ff17594-0bc8-4ff4-be5d-cb72f90190ec" control-id="pe-12">
+    <implemented-requirement uuid="3156bcaf-1fdb-4e58-9c33-41b74c964038" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="abdb33fa-58bf-4114-90d1-a412aa619616">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fffed217-f021-4c96-85e9-8b73cf11832f">
+      <statement statement-id="pe-12_stmt" uuid="162e05ce-172b-4055-9a53-5a5a466e62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2516,10 +2516,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3437af28-439e-432e-ab1b-850cf46529c7" control-id="pe-13">
+    <implemented-requirement uuid="2b8e5e39-05a4-42d3-879b-6c2d85fb6698" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="c46d8bc4-81de-4c6b-9fe7-b2df45746a88">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="88a16212-5e2a-4d8c-adce-d19a614ff136">
+      <statement statement-id="pe-13_stmt" uuid="e539b4af-1f30-4b7e-b7c0-a5a2e754eaa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2528,10 +2528,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb7167a6-af8c-4200-9836-abbdc71fe3c0" control-id="pe-13.2">
+    <implemented-requirement uuid="c388758f-8a6b-4809-95e9-652ccb5eece2" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="322cfdd5-f2ed-4650-8388-fbf0c156afbc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a230d770-c53a-4c78-a9c7-7b0871b6e304">
+      <statement statement-id="pe-13.2_stmt" uuid="db283059-ed26-4dd4-9f86-fe7f82d40324">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2540,10 +2540,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c6ee5fd-573b-4d66-810d-cbf4f415bec3" control-id="pe-13.3">
+    <implemented-requirement uuid="c8a56da2-768d-4994-8a7d-8119d8b0c04e" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="bc9baf97-608a-4835-a46f-3bb975c79fd6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="911bcce9-4d8a-4598-bdef-49ff4ff30fb7">
+      <statement statement-id="pe-13.3_stmt" uuid="859977d3-2f03-4b90-b293-f092f74bdfd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2552,10 +2552,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a61c29b-4b59-4504-ac2c-3ab23cb5f98d" control-id="pe-14">
+    <implemented-requirement uuid="95ec2fce-564f-4fd8-b858-b89af62566d3" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="dda04721-89e1-4311-8cd4-c2f6e45a2e5d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="28817be4-ad6f-419f-b7cc-ac9468b523cb">
+      <statement statement-id="pe-14_stmt.a" uuid="63ad4abf-3740-4e72-94f7-393c8625edd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2563,8 +2563,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="2f42214a-b65a-43fd-a21e-fb7a902aa7e3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="40e6a07b-2ff1-4f4e-ae37-c4a7760bad09">
+      <statement statement-id="pe-14_stmt.b" uuid="bec858c3-3512-418c-9c3d-902ceec3def3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2573,10 +2573,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="061a021c-e607-41e3-b210-839225e240b1" control-id="pe-14.2">
+    <implemented-requirement uuid="d8f37391-2361-49bc-bef5-954d32a40da5" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="b73ee821-d20e-49ea-a9b1-eac6042eb78e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="32bb3cc6-e34b-46ea-a788-c703d1eb8db3">
+      <statement statement-id="pe-14.2_stmt" uuid="5c21b98e-0119-48e3-99fd-d942c0665010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2585,10 +2585,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86a3a156-09dc-4a13-a59d-50f8cb953882" control-id="pe-15">
+    <implemented-requirement uuid="b8c2ad37-9714-411a-ad3c-ea5800b64aa1" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="769c5f96-e078-4beb-9f53-df28616fc679">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5495c61b-f2bf-4b92-ab63-d2b43f2c5e70">
+      <statement statement-id="pe-15_stmt" uuid="2d10e6f1-78e0-424d-a58b-4a2e01a3fb43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2597,10 +2597,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4a6b626-f291-4e34-8ae4-1d872376f5eb" control-id="pe-16">
+    <implemented-requirement uuid="62b24ebb-350f-463b-b9dd-d0a9f76644a9" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="529b94ba-380c-45b8-8712-d91e142aab01">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fcba29b2-b896-4ea2-bf29-60746457bed4">
+      <statement statement-id="pe-16_stmt" uuid="b71c7cb8-6d89-48bb-b6bb-5957ab08ce34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2609,10 +2609,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d9aaeaf-ead9-49b8-a44e-6710704eabbb" control-id="pe-17">
+    <implemented-requirement uuid="daaf181a-d178-4a0a-bedf-2cbd147ccc1f" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="a81b2d88-aa39-4033-89f5-01c12c7915e0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="434b7e67-fb24-4e9c-96e1-06cb7aec3541">
+      <statement statement-id="pe-17_stmt" uuid="87fc8de3-dcb4-48d3-bb1a-e84802eeb821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2621,765 +2621,765 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ae91546-31db-4b6f-9297-9baad513b241" control-id="pl-1">
+    <implemented-requirement uuid="1a5e4178-9df9-45e0-b04e-c88228dc5fd3" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="c1c3e8cf-853a-4f62-b91c-406536aaf463">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2d1ebc2f-0f44-402f-a731-fb04cc05619e">
+      <statement statement-id="pl-1_stmt" uuid="4f330b5a-3729-4854-bb38-91c48434723c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe7e548-ca09-4588-9401-c549f1ec04d3" control-id="pl-2">
+    <implemented-requirement uuid="0ba70246-52c9-4cd4-902a-b406fd162505" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="9c285e6a-bd42-46de-913c-48b3940a312b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="6f1227df-aab9-49cb-a63c-9a9372e0ed85">
+      <statement statement-id="pl-2_stmt" uuid="09a9c7b1-dfc1-4884-8a4e-f76340d26b5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75a75233-07e4-466b-af00-3a322a06ce81" control-id="pl-2.3">
+    <implemented-requirement uuid="1905e193-35b7-4aa1-b7ec-b941a3ba6e5d" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="483b1280-8e5f-4bcc-9b0c-1fad1d09e0c0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cc7b6e63-9889-4177-8269-478828f8d9d0">
+      <statement statement-id="pl-2.3_stmt" uuid="e4741e90-691a-4b42-8e41-a7574f7a0c8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="846d2593-5c0f-4bc6-9712-ae60792cfd27" control-id="pl-4">
+    <implemented-requirement uuid="7a0f5f95-640e-4569-ab2a-41be6b94bb58" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="6b8be07b-15e4-47fc-82b6-75fda49cd5fb">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f38802be-2dc0-449c-8a91-2cbe969ffc9a">
+      <statement statement-id="pl-4_stmt" uuid="12d94f45-18cd-4a10-b195-11cc6f6de5a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97084ab4-6899-4698-9247-bb5d6efb4186" control-id="pl-4.1">
+    <implemented-requirement uuid="3337e63b-f8a9-46c3-8495-c49059959114" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="da2c1948-fa3a-482c-b6f7-b5effdd397cb">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e9da49f3-6beb-4b5e-86ca-a4e0fb9b43e9">
+      <statement statement-id="pl-4.1_stmt" uuid="6695f9dd-25e6-45a6-8012-c39ac2d125bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="689ad400-ddd4-4674-a281-7f76da657e43" control-id="pl-8">
+    <implemented-requirement uuid="37d3fb7b-b734-4596-9738-05ddac23e28c" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="548cdb63-7da0-4dca-bc8e-507983249d46">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="21b27945-1d7f-46d2-a3eb-11658e01b56b">
+      <statement statement-id="pl-8_stmt" uuid="557cfa5b-b6c9-4bb7-9333-6a34fac04827">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09841a3c-922f-454b-8c20-4181ea031cbd" control-id="ps-1">
+    <implemented-requirement uuid="eb3dd41a-bbab-4d9b-ae5d-4b219bef17c1" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="8a5cd727-3215-404f-9b59-3040c29da12b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="924fc25c-e1a0-4af3-a5b8-17b721836d13">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5466332-e3dd-49d7-8292-5da6ee019feb" control-id="ps-2">
+    <implemented-requirement uuid="daa68232-f074-4b9f-a109-865771304d0e" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="84062068-094d-4a2e-b4e9-a1d8b452da0e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="f64e674d-c4cf-46d3-87bd-362faa80fa07">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0057b696-ff19-4a62-bf10-a29ae8f0ff42" control-id="ps-3">
+    <implemented-requirement uuid="49180b21-da3a-4e0f-9a97-011c62ae8e06" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="580cfebe-d1e9-4e2f-b702-6c19abb5b185">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cd3c185f-25ca-4ee7-ae5b-245f34f0eeea">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="441a5593-8f8b-481a-9edd-3bd173d61944" control-id="ps-4">
+    <implemented-requirement uuid="e2c40744-e377-439f-ac7b-2278f730964b" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="cd334841-97b3-44a8-92b2-483b33c1f869">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="92ad560f-e828-41f8-bc0e-04697757df1d">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec9e788f-69b3-4790-b1fe-d1cead566681" control-id="ps-5">
+    <implemented-requirement uuid="7909e627-5796-4305-89ba-5f66c9918ce7" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="7923301e-c1cd-482e-89ef-81e8906dc7ec">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c5f37bcf-056b-4eb5-9570-2be1182c0abe">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e195dc45-baf8-428a-a722-6611af86b09d" control-id="ps-6">
+    <implemented-requirement uuid="ac05a0ba-c487-4d5c-a072-9e746a101b00" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="38f07c5a-d706-41ce-8645-f40c88ab6421">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d48208be-6c91-48e5-90a5-c3539c142761">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8feb1955-202a-4a45-9d13-3bab7b4e4b2c" control-id="ps-7">
+    <implemented-requirement uuid="d0f887d5-2b2e-4de8-aa3f-c5490c35bab7" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="fe31c927-3922-4876-873b-c4237ca8f129">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d210d77e-b478-405f-8243-2b5d73d91090">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb8d1101-1b6c-411e-a5e4-ca79f8dee058" control-id="ps-8">
+    <implemented-requirement uuid="6da54514-da22-41d5-9c37-ed629645a10b" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="e3b9725f-90eb-4221-9af0-e945f9f4624c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="faa16ca7-2905-4390-8473-35405ef7f1bb">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b930d67f-3001-45d9-af48-b1edb2b1d5ab" control-id="ra-1">
+    <implemented-requirement uuid="ff695294-861f-41d7-b470-178d71912b8f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="bd309d1c-ee23-4509-b4fb-2ea070a84af7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5813ede0-e5aa-4c60-8e15-7cad4c07c8ec">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="433b06b8-5ed2-4443-b393-37d107d55ccc" control-id="ra-2">
+    <implemented-requirement uuid="136a72f7-d72d-4a7d-9dc0-499becbc392a" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="5a1fd215-1c88-4990-9ff6-a3f3dc6447aa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="622c5a9d-28ed-4e07-bb43-c2ef8a5ad4b9">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dea390c-270c-4c2e-aa17-065f08171bff" control-id="ra-3">
+    <implemented-requirement uuid="7dbe0353-27aa-47ed-afa2-2a6823696698" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="e013e3e7-1fd2-4ba1-a0da-17990b407d85">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="75534f04-f951-4c26-ac71-5429286f483b">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2e30998-9ea2-40cb-8ec3-6710e0cac5aa" control-id="ra-5">
+    <implemented-requirement uuid="9dfd0d25-bc22-41b9-b13e-08a0ed87cb85" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="c89554c4-4009-4e13-97a0-d22cb58f5524">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a3f8987b-929f-4007-b3fc-b5a22fdc881b">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bc8bcfb-0d59-44c8-bd6e-3d9238bda589" control-id="ra-5.1">
+    <implemented-requirement uuid="967171a0-ef3d-40c6-a254-dadb6a822dfe" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="d9d0155e-7c7a-49b7-b142-80b964f11e7a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d86d82d3-317b-42be-82d1-35545733f1fc">
+      <statement statement-id="ra-5.1_stmt" uuid="fa771de0-c72f-447e-b3ec-bccf04b6a21f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4eeb1e69-7a9b-45d5-8401-e385b5a00036" control-id="ra-5.2">
+    <implemented-requirement uuid="afbfe19c-3cf7-43da-b599-71673d84e1ab" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="ecc19489-6e0d-4cd6-b07c-18a0dae3f972">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4ad54fec-052a-420d-af42-783d59c4e419">
+      <statement statement-id="ra-5.2_stmt" uuid="9f514565-fdb5-4642-b4da-027eab07959d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="899f2970-612c-43e7-a1f0-ab4cce3b7803" control-id="ra-5.5">
+    <implemented-requirement uuid="3a5a530c-804b-4092-9dca-15cd27f501b2" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="78051837-725d-460f-a5d9-2679b6ccb3a9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2b9bc200-ee13-44d5-b2c2-5294f9c5210a">
+      <statement statement-id="ra-5.5_stmt" uuid="2bff8d5e-210f-411b-8261-f536ea5f25be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97e27cb2-9794-4d4e-91d2-a2a65a0518c0" control-id="sa-1">
+    <implemented-requirement uuid="cb54c9b7-9d11-4572-80c3-784ec67da4f3" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="e90f9d61-f09a-4164-a74b-d1ad3fbff26a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="9bc8095a-18e0-4970-a733-55b76ae797be">
+      <statement statement-id="sa-1_stmt" uuid="b7625cb2-66d5-4892-bbb0-a9d7d5faf003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42718e39-61b6-48d0-8447-ff0ef257b70a" control-id="sa-2">
+    <implemented-requirement uuid="c575a17c-62a9-4567-aa0f-9f26b4745496" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="c8011a19-422d-49ad-94e3-a670c4fefd2e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="124d9f3b-90be-47e2-a057-b29d4576d03a">
+      <statement statement-id="sa-2_stmt" uuid="bdc6558d-3570-4907-b9e0-64ef3e1e00f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e532e514-e3be-4cbf-a5cb-7349bda78273" control-id="sa-3">
+    <implemented-requirement uuid="740568db-cbb0-4ca6-a4ab-3f606104c86c" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="a419a733-df6d-4fc8-87e1-37b53e1790aa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="fb1b7871-ff7f-4159-aa3d-2b8756363808">
+      <statement statement-id="sa-3_stmt" uuid="8c037ef8-ea13-4df1-8f57-0d8131701f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65505940-bb71-4557-8a71-6666d3781803" control-id="sa-4">
+    <implemented-requirement uuid="fba35c40-c7d7-4c2b-9b9d-8f38770f4343" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="6edf9066-4029-4a5e-b2b9-e9b04f6f3308">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c17f4ce1-f0db-4cb1-876e-572d92c58607">
+      <statement statement-id="sa-4_stmt" uuid="cc86ae33-c11a-47f1-b346-5fcc89190585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66991045-0696-4c60-8b36-bb5cb19c755a" control-id="sa-4.1">
+    <implemented-requirement uuid="4a9c6706-2e7c-4409-9ba9-bb31cd708ea7" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="33ce3728-86c6-4328-a5f5-e93716e5593d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e5357c04-ca32-40c7-897a-c2ba53afe36c">
+      <statement statement-id="sa-4.1_stmt" uuid="6098953a-b156-4498-b200-01fd6df340b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9082217f-8198-4edf-84ef-836375a1075b" control-id="sa-4.2">
+    <implemented-requirement uuid="fd02b4c6-c9df-4490-ae08-9b73903022e3" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="588bfb0f-59e8-4da6-ba92-01250866b9ae">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3bfec456-199f-40f3-b825-8e5d2eff665d">
+      <statement statement-id="sa-4.2_stmt" uuid="012d0527-e9cd-4913-b788-0b4fbba641b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edf01da0-5067-4f4a-9e1a-cd6d802491bc" control-id="sa-4.9">
+    <implemented-requirement uuid="0bc0a158-ae92-40f4-8204-1edd757ed4f8" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="40878ba6-d2e9-4a34-9940-c96acad0ef1e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ad1bd5b0-0f88-498b-90ff-c7c5d7a24507">
+      <statement statement-id="sa-4.9_stmt" uuid="403f6f56-bd04-41f3-b065-f1d2368d715e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="044250ec-72ab-412c-8a35-2564489a9915" control-id="sa-4.10">
+    <implemented-requirement uuid="d3ca4c93-0635-407b-8599-5097ac00f4fd" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="4abd0078-77ff-4b7a-ac67-c114a5aea3bf">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d1409c77-1dfc-4fcc-b603-d2b9d174e52f">
+      <statement statement-id="sa-4.10_stmt" uuid="4180f765-02df-4f94-8c3b-dfd75684f316">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95e21416-e560-481e-a0c5-336920fd8d85" control-id="sa-5">
+    <implemented-requirement uuid="26cae64d-898f-4832-b702-1b228d6a7ce0" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="125037c1-24a9-494f-9df3-b5fae40d8bae">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="4b44d18d-f5e3-472c-a1a8-9f58ab1265a8">
+      <statement statement-id="sa-5_stmt" uuid="6304df28-0587-4607-991c-972dade816e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1bd4d7c-8158-4c04-840f-eb81e5563e1c" control-id="sa-9">
+    <implemented-requirement uuid="3dba2dd7-5806-463f-a2a5-f927c9f17197" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="befc5f24-cd88-44d0-b8c5-fd3b815dbb25">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2432c94d-a85e-4f08-912f-8932914c1f6b">
+      <statement statement-id="sa-9_stmt" uuid="5ce7182c-ceca-4e58-b733-ece84ff92504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4618ad83-4a2d-4f9e-85f5-e70d07cc82fb" control-id="sa-9.2">
+    <implemented-requirement uuid="c55b5e98-a606-42be-827a-7932c2e60fd2" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="3158016b-4e8f-4dc5-a5c1-5a5c6bf322c3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5fd8478d-d371-49a8-8922-b6c2637205df">
+      <statement statement-id="sa-9.2_stmt" uuid="ca1e3a5c-5b5e-470a-9b95-457e13ff0672">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b9ac5c7-7a4a-40bd-9001-2826065c4e8b" control-id="sa-10">
+    <implemented-requirement uuid="51bc3e94-1e98-4a22-ada7-bb6dfc661955" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-10_stmt" uuid="fb50cf04-279d-4c03-8251-c5099ddf1c0a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cdc98c5b-50f0-4f7a-8e1d-7fdd5a552b50">
+      <statement statement-id="sa-10_stmt" uuid="00033cf2-4ea1-4f05-bbf0-a98439127663">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6129934d-2bd0-4c76-b520-0d8e24b91771" control-id="sa-11">
+    <implemented-requirement uuid="02ea9daa-6c9c-4762-88d4-635f2689d70c" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-11_stmt" uuid="24ec9720-1b18-43ce-979c-3d84d94f3535">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="b5a853ad-d101-4a4c-b525-4b5ad1d6287a">
+      <statement statement-id="sa-11_stmt" uuid="66a9ba4a-b1e8-43da-be89-e5159018dc10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12770b88-f93b-4439-980c-89be45b1042f" control-id="sc-1">
+    <implemented-requirement uuid="b885d23c-98bc-4694-b3df-ad5e2d79b193" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="13e95feb-f75f-4744-8340-8ec6c6f9a85d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c7dc408f-8e35-4290-ab91-1075158808ed">
+      <statement statement-id="sc-1_stmt" uuid="31a28689-d22a-4281-9396-3e39aaf00400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbc6e9f6-7cda-4649-ad33-2179010e6400" control-id="sc-2">
+    <implemented-requirement uuid="bd828fb0-01e6-42c9-9737-7f0b6c7cc415" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="83945d0a-2b9b-49cc-b742-45521e1599f0">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="e6d9049e-acb8-41da-aab0-ccbfcec65f92">
+      <statement statement-id="sc-2_stmt" uuid="92dad8a8-645f-4b6a-b37b-24973bbcbdd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81c8d141-11a4-47f7-87b7-0ab8b5013f8d" control-id="sc-4">
+    <implemented-requirement uuid="f07499ae-3448-4736-866f-d3eaf2fbf4c6" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="623ea9ba-e449-4b64-b550-dbf1c91fca69">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2ba2e816-2df3-461b-8eb6-5735f29fca8d">
+      <statement statement-id="sc-4_stmt" uuid="b3bef6f8-ed25-480c-ae1a-aa2dc2205eae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="deaf7d8f-5204-4bcf-8c33-b282b6b3ac76" control-id="sc-5">
+    <implemented-requirement uuid="36d6ee6d-75a4-479a-99b4-18617dcb82b5" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="6766a254-b7b1-460d-b1f6-aad849a6c34e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="981a9ba6-53fd-408d-a438-62c0e13f1e6d">
+      <statement statement-id="sc-5_stmt" uuid="04f915f3-359b-4ed2-867c-c0d4ded64687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc2095c0-7c88-42d4-8d76-401e28cdc0bc" control-id="sc-7">
+    <implemented-requirement uuid="c79f28d7-1ee0-4de9-ac9f-b038234e264d" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="3fb404a1-96d1-45ce-a591-4db2768b46fa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8366d56b-8ad5-4e7c-a05e-4705e3ed0878">
+      <statement statement-id="sc-7_stmt" uuid="7bd816be-8571-4716-90fb-770dff3d90bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3d8edf0-dab8-4777-89ea-885dcb8a4101" control-id="sc-7.3">
+    <implemented-requirement uuid="a04d087b-3243-4998-b877-9b060f1a7668" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="3b1881fe-5382-46b0-93d3-ec5023ebb638">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a13e9814-36c3-4407-9275-c29b8fcd3c44">
+      <statement statement-id="sc-7.3_stmt" uuid="912fa1bf-7e93-4dd4-9f68-127badf64e79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3d4da69-f9a4-46bf-b41f-e79d48a800a1" control-id="sc-7.4">
+    <implemented-requirement uuid="c78e796e-1fa2-4462-8f71-db2dc29d7ede" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.4_stmt" uuid="3fd5ea86-fb9c-4ad5-957e-d5d8231547d7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="acab670e-32b6-4f7a-bf9c-44ebe16fffb2">
+      <statement statement-id="sc-7.4_stmt" uuid="e1dfd666-78b2-4ade-bbab-5628fc72512b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="088e7b4e-7969-40ea-ac9b-2ec407444f0a" control-id="sc-7.5">
+    <implemented-requirement uuid="4431f779-a58e-4fb7-845d-ea28b859d488" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="f7e7bb45-f1e2-4b8e-bb3f-321927d193df">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="8095840a-6fb8-45ea-bd51-3e97d3a3eb31">
+      <statement statement-id="sc-7.5_stmt" uuid="efa9dd88-8fb5-42cb-95fe-83ba78ed5c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aedffe38-0ea2-4611-8ec7-8f99babebe5d" control-id="sc-7.7">
+    <implemented-requirement uuid="cb7bf0cd-de6e-4a32-a3ba-ebcd26d36348" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="0722e5d0-9c9f-4a86-b2d8-69afee59a05c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c577ed8a-fea0-4c78-9fc8-c8c003ff1a5b">
+      <statement statement-id="sc-7.7_stmt" uuid="89cfbcd0-57a0-40d8-a266-ef14383eca62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdc1137a-bd5b-40e8-aaed-2e79a50ebaa3" control-id="sc-8">
+    <implemented-requirement uuid="e77d8915-773e-4021-af5b-d309f271e0a5" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="5b6eb41c-a2a7-40b0-979e-01fc8a72c966">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="049b136f-95db-4201-91d4-c8870a431fc5">
+      <statement statement-id="sc-8_stmt" uuid="8c21e59d-12b5-4c6f-93c9-26ffe32aa31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9ee560d-2986-4eda-8d0a-50ebc9d14e2c" control-id="sc-8.1">
+    <implemented-requirement uuid="cbf32005-5ab3-423d-b3ce-959705a54b13" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="5ceb66b9-19da-4339-8735-dc804a097d04">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c1b30193-2a57-4eb2-a263-d4ee7db8e3ce">
+      <statement statement-id="sc-8.1_stmt" uuid="e95b70fa-5d45-4af3-9e64-60407fa7d4ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90efc01f-6319-414a-8221-f595396d0557" control-id="sc-10">
+    <implemented-requirement uuid="fb8f824b-ce7f-4acc-98dd-5793a79de505" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="62172361-4d56-4fef-a2ad-123bc4a6ff72">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="eb4b3305-2d82-4c22-8c05-f766b680ac0f">
+      <statement statement-id="sc-10_stmt" uuid="eda80d21-77b7-4de6-9c4e-b43cb8bd8884">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e16f6fa-e60b-4de4-bed3-a13a6c5e11bb" control-id="sc-12">
+    <implemented-requirement uuid="fd9ed307-9307-48a0-b4df-23137355735d" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="b9b8e19a-60d3-493b-91be-0fe1bdfb2f7c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="24c6591e-e696-4e5e-80a8-47916371c8e5">
+      <statement statement-id="sc-12_stmt" uuid="1265e32b-2e01-4b72-9fd3-82ce6a990176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="907a4337-129f-457c-b99f-aeabfabee3a9" control-id="sc-13">
+    <implemented-requirement uuid="375718e1-a987-475b-b769-b532677acbc6" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="d922d036-03de-43b2-8b64-262375c10a95">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ed7be5c0-8587-4e03-ad30-de59dd457aed">
+      <statement statement-id="sc-13_stmt" uuid="5ca69218-91fb-48ca-ba66-733c6b941a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="352f1037-480d-4877-92d6-368ba40fc800" control-id="sc-15">
+    <implemented-requirement uuid="9f623733-ea80-4bb0-aae3-e74004c03fdc" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="366bf703-5030-4db1-b340-93c688465e7a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="1404b48e-7fa5-436b-8cad-ccfa82371464">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4425a45-ef85-4383-af98-b67d139f3b17" control-id="sc-17">
+    <implemented-requirement uuid="6fefe615-4b9f-4ea1-84e1-c932ad0b3e58" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="e96d6355-12df-46eb-a969-53c65549097e">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="ca838db4-8161-4d06-91a2-658a60cbb8f2">
+      <statement statement-id="sc-17_stmt" uuid="a9b6e346-aecb-4b51-b1eb-53d0a697d27c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e3c808c-f9c1-45ba-82fd-5fc819d076cd" control-id="sc-18">
+    <implemented-requirement uuid="fa7d30ae-c3c3-414e-a1a4-543c74462573" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="6eee8f93-ad44-49df-9593-a933aa5005fa">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="cf19f554-4514-4ced-bfe3-d648e8dce27e">
+      <statement statement-id="sc-18_stmt" uuid="f4128e89-150e-42dc-9d02-ad6322f2f8dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63258f2a-cf0b-4d2e-b22b-405a0328cf8c" control-id="sc-19">
+    <implemented-requirement uuid="81e53007-3c0b-4848-9315-b86300e4678f" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="86c5472d-c012-4681-9615-3978930fbf89">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="560f7d02-a726-4d8a-a4fe-a37d6d629c94">
+      <statement statement-id="sc-19_stmt" uuid="946691b9-efc4-4b9e-8f56-9699097030e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4bb9cabb-d730-4925-8aee-ef90a8afd8cf" control-id="sc-20">
+    <implemented-requirement uuid="8c87c369-bc5e-4588-97ae-ab413040e28e" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="935d45de-554c-462a-85bb-292792db42cf">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0f37a668-a49c-4164-b1af-0708e8ec1d9a">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd2f99a5-f735-4c13-acf9-139dceb13bab" control-id="sc-21">
+    <implemented-requirement uuid="8aa2a844-5c53-4ad0-96de-8b84998ddb1d" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="04dde93a-d6bf-4001-9b59-87999a743579">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2f7b7b9f-9065-4583-a864-98a3ffe3cc34">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6efc331-278b-4874-a1ae-e41b769d6c99" control-id="sc-22">
+    <implemented-requirement uuid="6aa8d7c2-44cf-4e9e-a7d4-2993d6428e16" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="280d4042-85c6-49a0-a4b8-d9c002037a49">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="5eea0e90-9e80-4cdc-bd6b-730e4ca35546">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd40c46c-b7dd-4961-b60c-1ba0e269fa52" control-id="sc-23">
+    <implemented-requirement uuid="c64e20e6-1320-4518-a825-825d9ad82726" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="80a3316c-93d0-441e-a3c8-d92cfa4c3bdd">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="95daed69-8584-46d0-8f15-cf0cb09efb10">
+      <statement statement-id="sc-23_stmt" uuid="3bc85eed-3358-4c65-9e70-461ac3982bc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aed4f936-221b-4123-b416-ab0a62034766" control-id="sc-39">
+    <implemented-requirement uuid="758e3f6c-4438-46ea-994f-e3b47147705e" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="86c37dea-49ff-4d73-8d19-3974c5925802">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a28457a9-cc03-49d2-8110-de89e1fd6a48">
+      <statement statement-id="sc-39_stmt" uuid="925ad4ee-2f66-4648-9a31-11916aaa7e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="303b6e40-6499-41f6-9e46-81dbe9c8a0b1" control-id="si-1">
+    <implemented-requirement uuid="fad37c51-3b6c-49ff-a563-6dd95baaadbf" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-1_stmt" uuid="a83021b4-f19c-4133-956e-134c33c1f81b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3660eee2-3e64-4dc0-8368-65998c28404f">
+      <statement statement-id="si-1_stmt" uuid="378180e0-e560-4d05-b874-93c566727297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a94f3d17-1510-456d-845c-0e431eb726cc" control-id="si-2">
+    <implemented-requirement uuid="d145ad6a-a7ee-4fef-b361-19e0901849ed" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-2_stmt" uuid="30a0a270-99ce-48b7-a1ec-6b362238b9bb">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="18a8aab7-1813-47b6-bf8e-f680d6c5d808">
+      <statement statement-id="si-2_stmt" uuid="fbd48d0e-3698-476b-b60b-cfd9e17d053f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d48cf845-c729-4156-b2e0-9de00ba850e1" control-id="si-2.2">
+    <implemented-requirement uuid="a997c594-359a-43b9-bbe4-1c655d9a4e09" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="36fdfa03-7d56-4bf2-adf2-88dabda69c2a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="2998de80-d16a-4c13-84ea-67d846a85ac5">
+      <statement statement-id="si-2.2_stmt" uuid="e44363f6-d1ef-4b2e-b9be-27dd06271e80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="395971ce-6b18-441c-8a80-066730ef575a" control-id="si-3">
+    <implemented-requirement uuid="12a9295d-25c1-4afe-bbb2-bc3176a0e6b8" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3_stmt" uuid="3b6f6102-81ff-441c-a3a8-046eb0a8c1d9">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="69f99d85-b775-4fb7-b66b-415a82c69da2">
+      <statement statement-id="si-3_stmt" uuid="4206e8f0-b3a8-4c9d-b5c6-3d40e0ae6634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f51ecb19-d5a7-43cb-af77-90a0cce7b6e5" control-id="si-3.1">
+    <implemented-requirement uuid="73958e84-b8c9-4a39-b4f5-34baf9d41605" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="250067ab-b59f-4c39-a783-7351bdf7ee94">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="aec5009d-aece-4363-a73b-42d94ec09a88">
+      <statement statement-id="si-3.1_stmt" uuid="67a90945-cc85-4044-b050-a54c4a082155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82f9fd80-dcdc-4d1b-9b8d-97bd4025f475" control-id="si-3.2">
+    <implemented-requirement uuid="3aa0dede-bdea-44c6-8873-de70f01af37c" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="2c33ea63-47c5-4bad-83dd-5b32fdb6fc30">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="18bff988-ac3b-4498-acb3-10af857322ee">
+      <statement statement-id="si-3.2_stmt" uuid="0f21275f-6e20-43ee-bf0a-6bb9b356236e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2f0f181-3932-40e6-bb8e-653341c4cbe1" control-id="si-4">
+    <implemented-requirement uuid="f808f76a-7dd5-40bd-b73a-0eacadd447a0" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4_stmt" uuid="4372aad9-c108-4394-a0b6-61dd858dbacc">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="0a1a876c-f5f3-4ff6-b3c3-98777f1c24ef">
+      <statement statement-id="si-4_stmt" uuid="901968f4-a0f8-416c-8212-dbeead97b485">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98c69d66-13b6-462e-9398-395d9e0a173c" control-id="si-4.2">
+    <implemented-requirement uuid="0f1f29e9-027b-4aa4-9207-57078514c289" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="3993cd10-fe8c-41cf-8676-3bf8d7ec5d52">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="eed0553a-b6f8-4799-9659-cafc5b6dc76f">
+      <statement statement-id="si-4.2_stmt" uuid="7f7cec13-2728-45f3-a8bb-8b79365ddc80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4899421-110c-4e06-991a-fb3c4c04719c" control-id="si-4.4">
+    <implemented-requirement uuid="f4f7a3ea-5d74-4e3c-958e-2d0c5413832e" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="228687bb-d331-4158-9173-0ddc039d132d">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="71e9e795-701d-492c-8b05-4f10bd2252a0">
+      <statement statement-id="si-4.4_stmt" uuid="de5d635d-a38c-4947-ae93-43fe08613ebf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8adc661-f4bf-4316-a1d3-9f11ae9c21ee" control-id="si-4.5">
+    <implemented-requirement uuid="2e87d164-534a-427c-a25c-28aec0cf0ff6" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="6888e43e-0a7b-429e-a513-dfc9e797de10">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="75778926-deea-479d-8ec9-c74134347ae2">
+      <statement statement-id="si-4.5_stmt" uuid="485fb0b4-dc8b-4b6c-bdcf-930727364793">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f974180-8546-4612-bbc4-11f4ffc58c43" control-id="si-5">
+    <implemented-requirement uuid="d246d1db-451c-42db-8834-5b50d8a831d0" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-5_stmt" uuid="14cfaabf-1284-4ddd-b2ac-d2710a0904a6">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="45e15443-e1bb-4341-be4d-3c4c9a1ffc76">
+      <statement statement-id="si-5_stmt" uuid="dc50f1f5-8925-4856-999c-7bc1960b9580">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93d7dbfa-5d39-4921-a82b-16c68090be8c" control-id="si-7">
+    <implemented-requirement uuid="8f3feaa2-716a-4719-a4a3-e52d4942554b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7_stmt" uuid="552e38b6-2f8f-4817-9c70-f7eb2376054a">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="85769015-1546-4a6b-8aab-a3a34df1f741">
+      <statement statement-id="si-7_stmt" uuid="edff0796-06c5-4387-bebf-791731cadcde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5218bae0-f977-410c-bab0-02dd541dc6be" control-id="si-7.1">
+    <implemented-requirement uuid="75e014e4-4322-47d6-ad1b-b66ef2366402" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="97976ac9-5ba5-43b2-8ae4-b26d5e73d9e3">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="c8743876-3758-4ba0-92c9-bf2bafbb2920">
+      <statement statement-id="si-7.1_stmt" uuid="de28409b-4d14-4a0b-91b0-ca32495d424b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0e95be7-88de-4f0d-9925-b5d4e1f326d9" control-id="si-7.7">
+    <implemented-requirement uuid="95597edf-2078-4477-b30d-c4c949062c68" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="80f1c107-68b4-4140-9110-d3404c278417">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="767a665c-e481-4c8a-8741-457de56474e2">
+      <statement statement-id="si-7.7_stmt" uuid="4c2458fe-26ce-4079-8348-5b17dfe69c14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb49d2ea-3b6b-4c14-a9ed-f14dd5490d10" control-id="si-8">
+    <implemented-requirement uuid="6f743189-5265-4f1e-9999-88d7bfd910f1" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8_stmt" uuid="e95bc0d8-e233-4eb1-8694-e6a9c910b8b7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="a3a7b138-f168-43b4-bb13-2e0a8c3997e0">
+      <statement statement-id="si-8_stmt" uuid="6b1ab2ba-f547-4820-b3dd-7a84fa66916b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f235c2a-45b9-4ee6-b9b2-6970fd182eca" control-id="si-8.1">
+    <implemented-requirement uuid="d2a0eadb-9acb-4422-b41c-e045abe62458" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="c544a448-b0bd-453f-b285-9919f0ea09ed">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="78f033e1-2373-49b6-950e-195c291027b8">
+      <statement statement-id="si-8.1_stmt" uuid="d1b9660a-5d9b-47ad-88f5-f8301ecf55b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15c65de6-07a5-40f2-b3d1-70e0b3cda511" control-id="si-8.2">
+    <implemented-requirement uuid="c9b4e825-808e-40ec-8410-4a2b9a7e4064" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="b4d53f38-457e-4e3e-a787-36dfc0ab020b">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="bd73c61b-6a06-4b25-b88b-a234336be582">
+      <statement statement-id="si-8.2_stmt" uuid="cf23cdf1-0af4-4c9d-a7fc-385734490740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2e1f4a8-bca6-4191-92bc-647fb9a945d7" control-id="si-10">
+    <implemented-requirement uuid="75b016ca-0db4-4e1f-88a7-832a6337baa9" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-10_stmt" uuid="e5b239b2-b829-4d1b-a8d0-eab3e22801d8">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="36732710-e141-46ae-9212-dc89364f354b">
+      <statement statement-id="si-10_stmt" uuid="0ecbd19f-a738-4d78-8d58-933e526286d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b66ff2d8-3df0-42aa-817d-55f05f6c3533" control-id="si-11">
+    <implemented-requirement uuid="25f86faf-aab2-46fd-acd6-3ef7dd989191" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-11_stmt" uuid="24778fad-9b39-41b4-847c-b5613922dfe7">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="067541eb-23c6-457e-bc15-11352dbc6374">
+      <statement statement-id="si-11_stmt" uuid="833af296-bd19-40aa-af3a-3a08aae4af7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f3c6a23-95c6-41dc-9e5e-ecf4c2d3b6f9" control-id="si-12">
+    <implemented-requirement uuid="d8df9871-e1d2-4feb-a760-893e044d0552" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-12_stmt" uuid="acc2129a-2c84-463b-ab85-6b5651456c4c">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="d8e63a2e-1647-4027-bb23-64cb07f67ba3">
+      <statement statement-id="si-12_stmt" uuid="71503f08-ca5f-4e1b-9cd6-3dbdb0f72c6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9737e46f-5165-4c2c-b462-35f9f35c2353" control-id="si-16">
+    <implemented-requirement uuid="b82a5b17-3cd2-4fd3-b74c-aa929adfe913" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-16_stmt" uuid="7635437e-3574-4885-b592-1fa8cb61cf56">
-        <by-component component-uuid="11a36839-203e-4333-bb2c-55a738520b6f" uuid="3c6d4140-fe85-41f1-a6df-19a4cc58aff0">
+      <statement statement-id="si-16_stmt" uuid="2695eee3-10b5-42be-b8f8-ca027016329b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d9d2d85-73e6-4152-82d5-cdfcee4ba9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''</p></remarks>
         </by-component>

--- a/xml/openshift-dedicated-fedramp-Low.xml
+++ b/xml/openshift-dedicated-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="a7a927c8-f65e-44fb-8908-2100dd83527c">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="69037438-3067-4ec1-920c-7c95a58e9248">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:01.97+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.65+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="096de29f-02a2-429e-bbdd-a4183663a60e">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,1022 +484,1022 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="8e01a904-fcc3-447c-9301-dcf3e9f566dd" control-id="ac-1">
+    <implemented-requirement uuid="39a1b693-1d3d-42df-a7d4-f62ed63b754c" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="618bfafa-0033-4d44-9019-f535cb41241d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="5195c249-0a41-4d33-b3dd-3a2d76add4cb">
+      <statement statement-id="ac-1_stmt.a" uuid="324dcda4-4f96-4ff5-8427-f924b21a8d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5309070-b957-4a26-8a72-9142200914d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="7fff1e20-4d7e-4a98-9f9b-c0985473e4b1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7e1fe1ed-d662-4939-b9de-b884aca7627f">
+      <statement statement-id="ac-1_stmt.b" uuid="887641c8-6db9-493c-8ead-40bc3f2279d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da0449ac-a99c-4e11-a5d3-aefae5063f81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e226959-a661-43fa-beb7-ca72dd52c139" control-id="ac-2">
+    <implemented-requirement uuid="308f2ab9-f2fb-4ebd-bd22-6f26a99c54a3" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="14dfe77a-f5b4-4616-a867-050b49d8358b">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="29da1792-fd50-4b49-a1f4-b861d523d83c">
+      <statement statement-id="ac-2_stmt.a" uuid="18e57d62-e667-46fe-858e-91af9c9f0477">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ead5e410-8afd-480c-bade-088a12eef60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="158a5c83-c219-4508-bf01-034d68c3be72">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="99331733-cc0d-401d-9945-203281ce34ad">
+      <statement statement-id="ac-2_stmt.b" uuid="b7e2816e-2be0-4f16-95a4-394a2fd00758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="048adc9f-d720-4d87-bfcb-643ff1c62695">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="fffd01a6-3a71-4de6-a6d1-c77219c625e1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="ba9b7ee5-d3b3-4b92-aa3d-a9df5c6f97be">
+      <statement statement-id="ac-2_stmt.c" uuid="b4009d35-0f2c-4fa2-ac5b-348f424d348f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18af0d86-53be-49b8-a66e-a54267998f90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="826e7642-147f-4235-83ae-5b09ec6a60fb">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d32a78fa-46f8-426a-b3b9-1b50f3d6df20">
+      <statement statement-id="ac-2_stmt.d" uuid="0c23a834-cae8-4a5b-9db7-00b2ddc807b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22a7c136-117c-448b-a504-ac996979de3c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="a1737714-2f43-4bf0-89b0-cc640f042a93">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0e846be6-2be8-4f16-ba50-fcc86efd44ab">
+      <statement statement-id="ac-2_stmt.e" uuid="58c0cb86-c145-435f-a0d8-757dc7ac9fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9eeeb20-47db-4e6d-9154-fc86fc11fe10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="4f595e3c-72f3-4bff-8829-8074ebd3458d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="a4ee362f-c61e-4af9-9455-7574fb1cd323">
+      <statement statement-id="ac-2_stmt.f" uuid="1a1d724e-24dc-46d7-8c21-2f08da427696">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f5fbaa5-af8c-4109-a130-4d5c42713c9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="43af2817-5527-4b7d-aca1-f88b0d91774f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="ad45285d-c9de-42e0-8cfc-b6dba90461fb">
+      <statement statement-id="ac-2_stmt.g" uuid="461e9ffa-c9ff-4936-ba8b-71d1ad995fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94bc620f-e15d-4880-a056-abb577b18005">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="e0d620c4-8467-4879-a3d4-ce71e03cdac3">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8740b86c-7ac5-4f62-8dde-9ace676c19d3">
+      <statement statement-id="ac-2_stmt.h" uuid="63220789-6f43-4e94-b50b-33138a10b46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a3f1c4f-8287-401a-a2d5-d383ecbf12a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="5ad59254-e23e-4736-ae1a-cb752f363423">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9f4add25-d0b2-4fdf-9e13-db428514b596">
+      <statement statement-id="ac-2_stmt.i" uuid="43b7976d-f5d1-4355-b32e-6bde93f63664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1155986e-c445-4ba6-9173-ec12fb48c8d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="159b3f6e-74e7-40c5-b8de-e116e7214088">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="4424036a-d520-4e8e-94eb-6b72be64eb51">
+      <statement statement-id="ac-2_stmt.j" uuid="e637623e-534f-46c5-a039-1f0931b14fa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff4fa720-c1b9-4840-8240-99543669ed40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="1d6a4ea6-0213-4087-b451-e9131f797031">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e1fa37ae-1516-4c1b-9f01-c6e9b355c599">
+      <statement statement-id="ac-2_stmt.k" uuid="f26cf7a0-d40b-4cad-8582-76bdfa8ca372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d24c07-dfad-4e80-8794-c11b3b1b2707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97e82d10-a95e-477e-a0c6-4261ef8fa067" control-id="ac-3">
+    <implemented-requirement uuid="e69b7912-dc17-439c-9d84-b50501ec5536" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="a43af501-ef4d-4480-9af0-93e9dbdd705e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="44168d57-d9d2-4828-8399-22e5a46ba9ab">
+      <statement statement-id="ac-3_stmt" uuid="7bb7f069-70e1-426a-82ce-a6e8d2dd3fe3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e7fb75a-5eff-4b0b-9cda-e1c9bf3daaa0" control-id="ac-7">
+    <implemented-requirement uuid="34c744db-4973-418c-94fe-d132d3582c89" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="637c43fd-efc7-42f4-a5d1-b318600fdb80">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6df44205-954e-4855-89c9-8e3c8fb86795">
+      <statement statement-id="ac-7_stmt.a" uuid="0ce553e4-fe3a-4e37-9835-fef4fa7649d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="93f92a59-fab0-4275-a7be-abe16829b643">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="719f9b87-1888-49fe-b8e8-f10504e9ee76">
+      <statement statement-id="ac-7_stmt.b" uuid="4fa082e8-6eb4-4e3a-b627-5f0658b016ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="600b4fb6-c406-4a2e-a237-bd705e0dac04" control-id="ac-8">
+    <implemented-requirement uuid="acbcd64b-c787-4c14-bd1e-3adf9ad25d14" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="39bb6525-fc95-4f9a-843c-b83385b5e742">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="42e8611c-e328-4738-8000-1b99724a38df">
+      <statement statement-id="ac-8_stmt.a" uuid="f891ef64-ff0d-46d4-b5e8-27410f1b96d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="82517b66-fabb-4408-90ec-89f242a66f0f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="20b985b5-1605-44cb-a133-a21cb94e0507">
+      <statement statement-id="ac-8_stmt.b" uuid="f2446ca4-cf6f-4158-b73a-dcbd92583a5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="303bada9-25e5-49b0-8a9c-4218eef3cd42">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="395a24b6-5ea8-499d-911f-2ed8faa187cd">
+      <statement statement-id="ac-8_stmt.c" uuid="8537cf10-713a-4183-8ff8-6ae3ea21364c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="825b0efa-473e-4368-949d-f33ded6f21ab" control-id="ac-14">
+    <implemented-requirement uuid="2f0f0ead-5fa5-4682-a174-7800552dedce" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="3d5ba2f2-c7d0-4e5f-89e0-e9ea5f3e7072">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d56634b6-0a5a-402a-8d22-01f883d52590">
+      <statement statement-id="ac-14_stmt" uuid="17e1ab2a-d00e-469e-8692-6b38e0f65a14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67385b58-6fdb-4d7e-b2b3-82a2edb2168f" control-id="ac-17">
+    <implemented-requirement uuid="320c1d9b-b2b2-48bb-9c34-17fae95a4dcc" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="38f1d204-ae83-4672-bc5b-7d478177bf34">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="38b09c38-1e3b-4138-9f2a-804dc227bbc1">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5f4e8a3-5991-4064-a67f-fb905c2fa3b5" control-id="ac-18">
+    <implemented-requirement uuid="cf4f32c5-c564-4155-bb9c-f9503665fcba" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="a406e5b9-0808-4d9b-b9dd-30ee86902da7">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="ffc5c40f-c505-415d-a1e5-e0c4b9721def">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d68addd-b3ff-4d7e-ba4f-fcbcc3e3b5f5" control-id="ac-19">
+    <implemented-requirement uuid="1f782fa7-e28e-47fb-ab66-2a3924b4e768" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="9963cc73-838b-4fb6-bf4e-d67514c3e1d3">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6379c1c8-1790-4ced-8ffb-3771eebf12f3">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2443c6c-ca8a-4915-b7d5-a1c019435299" control-id="ac-20">
+    <implemented-requirement uuid="c3be2813-ce58-4647-8d38-acd11c0b09fa" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="9e6955c7-dc3e-445b-b098-74a865917638">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="5a3fab45-7bef-491d-a45a-d760469f5f76">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7573e906-b4d1-4161-90b2-308d9dfab47e" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="084844cf-81cf-4a2e-a11f-7bf9c7a669c7">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f12fccb9-9b4b-4566-b92e-6aa6a5355da3">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa157847-a178-4c77-8299-b28919d3d741" control-id="at-1">
+    <implemented-requirement uuid="7f5357fb-e9ff-4372-8dfe-30971d1d15a4" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-1_stmt" uuid="e514b716-5127-4150-a984-0f8164aa2062">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="2081ad7c-b1c0-4909-baf2-f838c20e7a1f">
+      <statement statement-id="at-1_stmt" uuid="25f73115-0474-4dd4-9bdd-401954c96b87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b626522a-0116-45ec-850a-a8b6fadd6d5d" control-id="at-2">
+    <implemented-requirement uuid="9165e48c-47b2-45c6-9ef9-1be15d4bee34" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-2_stmt" uuid="db7eadba-4685-4d74-ace0-212160751607">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="cadc4b0c-6bd8-4439-9cac-1b75d099bc9b">
+      <statement statement-id="at-2_stmt" uuid="777b75c3-3c9e-4be7-ae9b-83d323694887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="071d9dbb-418b-401a-9f6d-eb2f4046d72a" control-id="at-3">
+    <implemented-requirement uuid="70995a7e-a4d6-4c67-bdd1-ca7e9e0213d5" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-3_stmt" uuid="4fc6dcc9-e0a9-47b0-b002-c462845a28dc">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="27cfd3fe-c4f3-41bc-a920-91301bd689cc">
+      <statement statement-id="at-3_stmt" uuid="21d83bc7-fb3b-4876-a7d0-683325d30d77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb20c848-8450-4f02-bc61-ca4a504f7d8e" control-id="at-4">
+    <implemented-requirement uuid="9f744156-db76-4f8c-a95b-c73ad5c5a9e1" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-4_stmt" uuid="a4241371-fc06-4563-8d85-ce2e4097f993">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="5936ea39-c365-4189-8ab7-602212943db4">
+      <statement statement-id="at-4_stmt" uuid="2d36c3d1-c630-494b-ad2b-3dc40d0b15bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e320e6dd-96df-432f-92e3-079271b1f5a9" control-id="au-1">
+    <implemented-requirement uuid="1e2c00bb-257e-4c9a-8976-4ce731867b45" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-1_stmt" uuid="51766b3e-18d6-4b07-82c2-46fcfbed4569">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e4b38f1b-1ad1-4026-987b-b99c8e3153d8">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c47e5037-b003-438a-998c-7dd9933291b6" control-id="au-2">
+    <implemented-requirement uuid="4c08c196-0de3-477f-9170-57f638549f6a" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-2_stmt" uuid="eb1cd358-fd22-4e86-be83-f0a5557711ae">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="bc524f29-4fd3-427e-836d-2a7448a10be4">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35097575-657c-4056-9988-19957f1a5db5" control-id="au-3">
+    <implemented-requirement uuid="af56a0ad-445f-4a57-97a1-6f48aff745d3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-3_stmt" uuid="ed871f0e-d42f-471a-9437-3f40347b6b6d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="b3068435-7e8b-4f17-a8ee-44f5b6e2c0a1">
+      <statement statement-id="au-3_stmt" uuid="20ff5cbc-f1db-45fc-ae63-36db96309b77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2450ebc-95cb-41a7-90b0-dbcbb15a8e57" control-id="au-4">
+    <implemented-requirement uuid="0ea0d8e8-ffa5-4ecf-979f-c63a5f0da105" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-4_stmt" uuid="fc9a0625-9f79-4cd3-9759-3d8a3d216efc">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0ada4dcd-640d-4f53-a11e-50c51707f00a">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95668e98-f5ca-46f0-af4c-f1e1d38f33b0" control-id="au-5">
+    <implemented-requirement uuid="5a3691b1-30a2-427a-abc5-fe83986ca715" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="7f3c1674-7d4d-43a1-aaf4-33f117cec6ec">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e5c06185-09a7-408a-add5-b5f1eccb408e">
+      <statement statement-id="au-5_stmt.a" uuid="7889bdac-bfb0-4861-aac0-cc136c1c2b4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="589bb2b9-9068-4e3d-a46b-251c356b4436">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="59c76c32-f361-4abe-8b42-618d7fef36f5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d38ee6f8-614c-4ac9-9525-24d4007d0717" control-id="au-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6_stmt" uuid="a2e3c835-73ef-4ece-8870-6329f01fb89d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="873e7e47-fc6f-448e-a91e-2d620eedadf2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3c938081-b4d2-4a9d-b870-acf7752bb847" control-id="au-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="e38db55b-3d90-4793-82ac-590d2cf5d6cd">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="daefa5fd-6a08-4eb6-b17a-b84e87cdf0bb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="au-8_stmt.b" uuid="4dbaeacc-53fa-492b-8e6d-b3962335f3c6">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="da37750c-6c06-4e3c-b011-e61df2a94b2f">
+      <statement statement-id="au-5_stmt.b" uuid="252cd8e0-2732-497e-bbb6-7b5062eca13e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43bfe1e5-33d6-4178-9177-95e110a94ec1" control-id="au-9">
+    <implemented-requirement uuid="1f6efc7f-06cf-40b6-a0a9-650c53e0f178" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-9_stmt" uuid="b30bf670-7908-4466-a0be-ae30427a7edf">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9b991132-e842-40f9-b2b0-dcbcc90cabda">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4657fd40-8355-48b5-add8-080fb3204167" control-id="au-11">
+    <implemented-requirement uuid="86503bc5-38e0-4f6d-bf8d-331ea3d1a2b8" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-11_stmt" uuid="562d7f84-bfd0-450c-a329-131c11eca164">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="02c885e5-f871-4b83-b55a-47f795f89f1a">
+      <statement statement-id="au-8_stmt.a" uuid="51d7e171-b44e-4ba9-bf07-0dae8326dac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="au-8_stmt.b" uuid="3ddb5ae8-d5ea-4655-87d3-058e32962850">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9e7467a4-dad1-4276-bf08-d8d34380831e" control-id="au-9">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-9_stmt" uuid="399a2a67-60c7-4f14-8a6a-b073089ead3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65943dc7-a29c-4274-989d-ae4cd5381579" control-id="au-12">
+    <implemented-requirement uuid="325e4141-ff18-4912-8ca2-fac8295c5172" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="5117fb0a-262f-40b2-816a-9cddb57a226d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="383a0615-da53-41d2-8af1-2aa20de23dd2">
+      <statement statement-id="au-11_stmt" uuid="ae2204bf-c4d7-49c8-859a-829d982f7803">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17a6e0b9-18e4-44c4-b7a8-a80b7c808622" control-id="au-12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-12_stmt.a" uuid="6db41abc-586c-4d6d-b231-639e07256b3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="f800233f-ec4b-4d3f-a7bf-00f2ae301cd5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="bca5a498-3ba3-4ebf-b782-3817b4323f89">
+      <statement statement-id="au-12_stmt.b" uuid="e53a6c7a-39a7-4a40-af2e-f7898cf0fbc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="0c52ec59-07d8-4525-8bf6-618438a1247e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9231971d-f684-48ee-bd1b-16fe73e2d621">
+      <statement statement-id="au-12_stmt.c" uuid="3baa0952-d9bf-4d8b-be5a-72ee07bf17e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55836c43-5730-4b53-9581-1ca60fa9ced5" control-id="ca-1">
+    <implemented-requirement uuid="971e9508-426c-4403-a87f-f0ffbb29a222" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="5c79818b-3504-49df-9e63-d19ea3cb0fd5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="66d00a67-4b3f-44bb-a6a7-536ef325a121">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="446c70e8-c5ca-43f3-a3d4-a99baccd5db3" control-id="ca-2">
+    <implemented-requirement uuid="5261b627-d858-4901-934a-e370806710e6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="72a5b563-8c3a-4e6a-a29e-073ea7ef242e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="fe165688-0105-4b04-bddf-7bbde97207e1">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62b8f726-40a8-49d8-a9d2-98dc7ff5a4e8" control-id="ca-2.1">
+    <implemented-requirement uuid="feb6cf0d-d8ae-4f12-8a00-eb9cd47740b8" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="8bc7a816-fbf9-498d-8b63-139a17ca9e85">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d58745cb-7f6a-4add-88f3-8c1c88e10a2e">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="511597d0-ba46-4178-b0cb-59c66d7505c7" control-id="ca-3">
+    <implemented-requirement uuid="af5a6093-d245-4da5-ad1f-d99f2d2df6ef" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="b5619ef4-7892-4f5d-a300-c3a146327ac5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c0120207-7cae-4419-8408-1cb7b1285af2">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ebf90be-f650-4413-a859-c58ae41b3d9e" control-id="ca-5">
+    <implemented-requirement uuid="1b914e6e-95e4-467f-aded-d23dd5e9d7bf" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="6ffb6841-052d-43cf-be51-dd11766e4499">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7c2368cd-582c-41f8-add9-d5aa14d76225">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e0800d-43cc-42f4-8c8c-4795fc6a6869" control-id="ca-6">
+    <implemented-requirement uuid="bb0b9ff7-b5d0-448b-9dd0-4dcd974b1738" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="f0139f77-56d8-4cf8-9302-fb29f4e0747d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="241f3c58-21e2-4ec3-8adc-13a7357ea981">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="280b2de5-9efc-4b51-b4c8-280ee3223ca2" control-id="ca-7">
+    <implemented-requirement uuid="567d50d9-72bb-4086-8068-58e1b8e9c1d5" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="bc8a4618-0a37-42c9-a55c-f8c5345fc17f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="15de6707-46c1-4441-bb7d-b9aedec7cff2">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3899cd39-2e7b-4cc6-aa84-9a72ed7853bc" control-id="ca-9">
+    <implemented-requirement uuid="64db1d9d-4002-4019-bc0e-7d5edd01ea32" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="902330c5-6bf1-46a1-8393-0364c735469e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f7e2fc5c-9787-4e14-b116-20bb525072b2">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96815dff-945c-444d-a0cd-9ee0e05014dc" control-id="cm-1">
+    <implemented-requirement uuid="380e7a14-e061-4121-a8bf-79d0005964ac" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="4f836a69-3d5f-4377-8b59-142d87c40514">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c7e5a185-b27c-4e1a-ab98-37710ae46e65">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff5e4ca3-f13f-4f57-ae64-7c23a575301d" control-id="cm-2">
+    <implemented-requirement uuid="722eab9b-ec8c-4e05-b741-b75eb4b0784f" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="9fd06887-4796-46f6-b67a-ed093eb4dc3e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c2a44e4f-a3dd-458f-927f-1039b54df175">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="402f42b6-a17f-47d8-b770-d4554240eff0" control-id="cm-4">
+    <implemented-requirement uuid="f9d4934e-52e6-471a-9b01-b234b2bfe396" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="bdd70238-87cf-4fbb-99a3-0702086067ee">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d0b8b1ab-707e-43a5-9478-2d7aa390efae">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7459ace9-4867-4f1a-80ba-fb4d91c5b860" control-id="cm-6">
+    <implemented-requirement uuid="d52b144a-784f-45bb-902c-8c75d7c29f61" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="3882ff0f-9e6b-424c-b350-408bae30efb4">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="a7a68279-680a-4a02-9795-e22bb00d8952">
+      <statement statement-id="cm-6_stmt.a" uuid="df3d7a5e-5965-40bb-9507-2c7d8e25635a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="74798352-aa20-4f31-beeb-61a97c2bc153">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="633bfbff-1887-479c-b43b-ebb98e1f5356">
+      <statement statement-id="cm-6_stmt.b" uuid="50e28883-5f66-44ad-a4d0-58f966e9fcb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="fac9cb6d-7736-4bec-8046-7227a8b609e4">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="20c330cc-754d-488d-8d7b-c7f2eea342f0">
+      <statement statement-id="cm-6_stmt.c" uuid="4967c4ad-f6bd-46e8-8be3-a82ffb6df199">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="f61e8f90-9fd3-4797-8aad-09f9505b6420">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3142060e-ada9-4b10-b6bd-a484b6d2739b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="111981a0-24b2-493e-babb-41736719e010" control-id="cm-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="83d09b4b-3f1e-48f9-b1e2-504903c10443">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="a8674fa0-6713-48bf-aaae-5302518661d0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="f6d2d238-6373-4af5-9881-fdbc328a53b5" control-id="cm-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="3b26e2f4-489c-44ea-a4f2-fa5ec063c8fd">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d43789d6-d1ce-4b98-af6c-a1ec9c89253a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="014707a8-f677-4033-a9f9-ad2727d3306f" control-id="cm-10">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="f8b0efd8-f31b-47a8-bcba-e2041f9a19c2">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="b4825def-c2c2-42e3-ade6-f72f795f11f8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1a7d06a3-ef12-4b1c-8969-09b4948c0dd7" control-id="cm-11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="e41771f1-ed66-4e9a-840b-fbbf2cdb57b2">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="003a3ebc-139a-496d-980e-a9a401513a72">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5109859c-77cf-4f1b-a544-04db3359015f" control-id="cp-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="2b39b53c-c868-4178-91c1-883d28c6d18f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="2e020fab-d72e-40a8-b2c2-60d449ff082f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="b1bbd35f-62be-46bb-9af6-00cc2aafe37e" control-id="cp-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="95134309-198a-4bbe-95c9-28ae832a22e5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f134fd25-c7c0-4162-ada0-054631ac8bdf">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="708e3473-e4c0-4bd4-be99-0fe5117961b7" control-id="cp-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="a547af35-aea3-4276-9d37-4e06fe259244">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="01bcfe89-ac71-4d2e-8b6a-32efc13f55f7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ef18028c-b5ab-4b0f-9b46-e93b4f332ae2" control-id="cp-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="d94649fd-486f-4b04-951b-e5886b439dba">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d2cd9a87-3168-4913-a024-46d02c4741de">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="08065258-1b5f-45c8-b803-3c9aee24c94c" control-id="cp-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="ffec72f3-3774-4e9b-afd2-54dfa9af49d6">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="51eae86d-843f-4502-8df2-d1085c0ac25c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="5f09cab5-0fec-4d63-aec4-bede14d9faec">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3bfa2451-689e-4a5a-ac55-391f0a50010d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="da9f4189-b11b-4e44-8513-4f2bfe05cba9">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="671d754a-178c-42a3-bb13-9a0d33f92c3a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="9a10222e-7f31-4f50-ba5a-4b596b00cccb">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c620cf66-eff4-48d1-9cf7-aa42da8c6895">
+      <statement statement-id="cm-6_stmt.d" uuid="8bac2c7a-dc9c-4a45-b5f0-6b01f311534a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2058accd-971f-433c-bdae-868879ea83f4" control-id="cp-10">
+    <implemented-requirement uuid="eeb4a8f0-0297-4da6-b654-c419632fef88" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="76bd4578-0a3d-487d-8d65-5a68f86e3028">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="15ae4327-ec15-4ca5-b8fa-869021c354d2">
+      <statement statement-id="cm-7_stmt" uuid="3dce3505-f872-402c-9895-140c2bf099b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b8e9fdf-7301-43b0-8bab-6cc193961ee6" control-id="ia-1">
+    <implemented-requirement uuid="16693daa-98d2-43b7-baff-aa83a4ad25db" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="73552a13-f3d4-48aa-ba7e-3449d9bed414">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3e8cf429-1d9d-421a-9eef-f7fb2745885d">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56533784-2ba1-43de-b528-a07662cd8052" control-id="ia-2">
+    <implemented-requirement uuid="f19518a1-afae-4380-bcd9-24be30a53938" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="6cd61e24-573e-4a34-b5fe-e8dffb825476">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6b283e37-00af-4916-8451-9d26fe52f348">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1de96096-9740-4f13-b2d9-498ecbba1024" control-id="ia-2.1">
+    <implemented-requirement uuid="a65ca1a5-22db-4288-8611-563896620700" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="78d2ac18-1a61-4970-8c25-eb2dd4a6c841">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3aed227c-cd28-4799-813d-e130b9234e82">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1e72c4f-ab9c-4c79-a69e-f29b6e169b27" control-id="ia-2.12">
+    <implemented-requirement uuid="ea6dee5d-c9c3-4065-b507-1c156b3a9faa" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="756e5706-f0db-4eb9-b98d-3a02e57d6a98">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="88922249-2c2a-4eba-a71a-8b7eaa15a5c5">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f603d85-8339-45ff-85d8-d06c25f47b77" control-id="ia-4">
+    <implemented-requirement uuid="723a02e4-1c79-4718-bc38-ee38752343b1" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="244364fb-12c1-4066-9d17-ff3bb1a161aa">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="17204393-0104-4522-9a89-b4acb6c4f949">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="51f5e702-aaa5-41ee-bdfd-f4393f038f4d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f919738b-ec24-42e9-b591-1094d8b0418f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="4762558b-71bd-40f2-a15e-1e1d9db21b7d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e101be04-0d2f-4e70-8c95-5c87e8c2ae64">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="11293660-4065-4423-8cfc-25ee2239352a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c6a5e28d-4506-456b-b8cb-5908cbe44843">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="1bbe869f-1671-4853-ab59-f45aea6d3496">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="00b0ed21-6bdc-4e97-add8-714e9394e1fa">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="16420aa7-a064-4549-9a84-bb521a451c8c" control-id="ia-5">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="a26ff4ea-9abf-4708-8841-c36fe0f66f6b">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8fe9a388-2290-47ff-b499-7138bc5f8c66">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="bfb4ccc6-4dbf-4f64-811f-0d181e45c253">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7f4d34e2-d4a3-4ee6-8a9c-9b52b7aa6936">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="a60e776f-4691-470e-957c-9a143b3d4de8">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8fb8da4e-04d4-4733-bb93-a34864f0579f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="551a1c64-98f7-4f39-ab76-ff215558b82f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="17a4c15c-d6dc-4289-8ee7-273b361ad36b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="1a5e3ea9-df02-4658-bfcf-68554a5c9d59">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="b272884d-8745-47ad-9cc3-90d43f0bb256">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="12ed6f4e-673a-43a8-9ca9-4d16d3c852d0">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="00af69aa-be40-47d6-9976-c7b3230dfd54">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="29dbb7e9-e8fd-4fd6-bff3-2709c7a41842">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8f5ca54c-c0fa-44e0-a981-f399b7d673c4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="4dba3412-7319-4325-9d55-ab949ac61960">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="686419cd-13ad-4a6b-85e7-adf7e0ef22b1">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="3a2057a8-1e68-4173-9445-59d764e75dcc">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7ed7c117-38a6-4a54-9d11-2fc448ca1678">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="e17e427c-a935-419b-aaa1-c48a034bb73e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="4e500f21-2682-46f5-9699-95a4e5e8c6b4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5ee86f70-dae5-4947-b95f-7bee49d8cf65" control-id="ia-5.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="c7a87910-83b8-4eb2-8f69-d8e560f9b80b">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="be165c01-6ce8-446a-93ab-13f103e102af">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="9db566e2-5e59-4f45-b6f2-651a3b38fe01">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="5732ae2e-6ceb-4bb4-90c2-32755304317e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="f9f99685-66fd-4652-9c67-46cab57a7489">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3cd5e8e3-ae20-4ad0-82b6-d3817ddd426c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="573e4e89-ab1d-465a-a0f0-ef9df0bd32fd">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="04b1fe79-7247-45f6-b524-cfb0a4d11344">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="548f502b-7800-44c5-af5f-8a9ef99d8326">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="98df177f-7b4b-4fca-b0cc-8270fa4d02fe">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="9e7eafa8-15c3-4544-ab9e-995142433a4c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="d1ae2f32-0daf-4840-b6d4-c7db79d802c3">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="467151d7-3723-49a2-af2e-ab942e42de9c" control-id="ia-5.11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="880b6baf-7b66-41af-a6a1-fb922f79f256">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f7121050-ad46-47fe-8b40-d9a2f7a8d9e6">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf35a996-648c-43f6-aefa-82decbd3d702" control-id="ia-6">
+    <implemented-requirement uuid="8d4ca3f2-090a-4ba7-b7c7-7ebcf314ed38" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="d482ed86-855a-44d2-a391-0f6651ef8f09">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="df5c8a8a-43bf-484d-b6f1-2a49c0d49a53">
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e92a4f6e-93f2-49b9-b493-1c2e6fd2f54a" control-id="ia-7">
+    <implemented-requirement uuid="fb214c5b-30b7-4b32-bb7e-06cff0651262" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="0a2a44a7-5473-40d3-9c07-3083a92ba9d1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="997ff152-d756-4b78-b2ea-3cb0df69d276">
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dec976d9-1f1d-4460-ac17-f48770afdb2a" control-id="ia-8">
+    <implemented-requirement uuid="fefe0445-0e64-41c9-b480-338a4c5bd9ba" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="a39c1661-6fed-4e65-b257-e4ac3347744d">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c765ae93-2147-4a21-b2e2-0a9abf211261">
+      <statement statement-id="cp-9_stmt.a" uuid="57ff7385-77cc-4cfc-a336-272d1beb7567">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
+          <remarks><p>''
+</p></remarks>
         </by-component>
       </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fcf270f4-a3f0-4d1f-8c8e-aa29b4f66050" control-id="ia-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="d18b803f-e809-4fc1-a25d-df99e86d63a2">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7bd7342a-2073-40c9-9aa2-d6032e7b5fd1">
+      <statement statement-id="cp-9_stmt.b" uuid="60b825b4-2b2a-4a27-b9bc-e4bd83daa5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
+          <remarks><p>''
+</p></remarks>
         </by-component>
       </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="c59b7dd3-4821-452e-bbff-e4584bf51571" control-id="ia-8.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="cb07ee13-17f8-4979-8ddc-421c2352c8e3">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="11c27fd1-42da-4879-83ab-9e1a737916a6">
+      <statement statement-id="cp-9_stmt.c" uuid="69f94737-48c2-4b8d-9802-0e9e5e8aa97e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
+          <remarks><p>''
+</p></remarks>
         </by-component>
       </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ec4ff867-1b07-4fa5-aa0e-d567e30e5226" control-id="ia-8.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="5aeda215-bea9-4194-ae20-a94e56357d0a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="5955c8df-a214-447b-929b-32c94256e6e3">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="009932b7-dd5e-460f-a025-769dfcf12b1d" control-id="ia-8.4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="481929c4-7def-400f-96de-447d0968633c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="29486ceb-0bb6-4ade-8d2f-dac5dac54478">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9ca089b5-d888-4cad-b1b9-1d5472cc2b08" control-id="ir-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="e3560e08-c335-49eb-98ea-0bdac26bf9c5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="59c9b244-e53e-4493-b54c-8cd23c0e14df">
+      <statement statement-id="cp-9_stmt.d" uuid="69738b01-a603-4de2-a97f-b09db026e408">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b3bfae7-f64b-43fa-8d4a-2351f8bf4cbe" control-id="ir-2">
+    <implemented-requirement uuid="492337f8-10a6-4327-a66a-ea1bdd457586" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="958d11e4-5cd8-4c39-8065-075d28c03a48">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="551c547b-9b25-4a8c-8e6d-c0963c085ac5">
+      <statement statement-id="cp-10_stmt" uuid="d1cdfa3b-767b-42ea-9551-29a60119e39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="3d758108-acb6-4eac-9b0d-915d022c8d76" control-id="ia-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="82903ec3-33bb-4857-8cb5-f56d44ec0560" control-id="ia-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2_stmt" uuid="188213c0-2886-4654-94a7-d3d29f60238f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="4541b2e4-a651-4dae-bc37-0c55789025e5" control-id="ia-2.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.1_stmt" uuid="0ce9f0a7-76db-445c-9400-e6ff2b4fc7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17ceb079-816b-4d76-b5d7-e9ff38e520be" control-id="ia-2.12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.12_stmt" uuid="42bb9f64-b1eb-4b59-ae75-8bce8d6cea87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c4ce1586-af7c-4486-99a4-a2135d320661" control-id="ia-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-4_stmt.a" uuid="cfaa44d0-6476-4a3f-b1aa-bb081ff43f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.b" uuid="758139f6-3cd5-40b9-91c4-38775ebc6fdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.c" uuid="79b1819c-ff07-4803-b426-7994dfd3734e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.d" uuid="b3a202e3-f292-4ba2-b5d8-bae09f051787">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.e" uuid="5a3ed097-5611-49d3-a1ea-5f3ed83758d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c471f10-6ae5-4cf5-ad0d-18870d85111c" control-id="ir-4">
+    <implemented-requirement uuid="3fb902e3-a4df-40ad-8c86-9e5b88d9e17b" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="25185c3c-5261-40bd-ac0f-774ef0c1d0c4">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c22e5c6d-d291-45ad-bec0-fcab77c1e05e">
+      <statement statement-id="ia-5_stmt.a" uuid="e45f25ba-f806-4e4c-a2df-f23d1aa3f319">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.b" uuid="42462fae-3f29-46c9-a22c-8c9f2a276623">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.c" uuid="34bee8e8-b77b-483f-8c75-546a85ee209f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.d" uuid="d63b5685-fcd0-4f75-a3b3-1ad69b91d414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.e" uuid="e45c697b-8dfd-472d-9f9c-ecacbfda96f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.f" uuid="77011543-3370-4773-90e9-b1b265ce0d76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.g" uuid="acf4cd95-c065-40d7-8fc5-baeee3682049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.h" uuid="c2a4d63d-209d-4a49-92f8-b5d10f50dc4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.i" uuid="de33cfef-2076-4db2-92af-a4ea950a13f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.j" uuid="ed0b7320-a255-426e-ba0f-1b271d718687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71826f34-3bae-46b7-b23e-ec964a35f613" control-id="ir-5">
+    <implemented-requirement uuid="aacd4c81-3fbe-41ef-a1ae-375c10e04ddd" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="22d8e392-a0b5-4142-a6d0-879be188e72a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="01fc449d-7522-4366-808e-4644df6c603a">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba6d6897-8997-4bb4-9530-1b5b548dddb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.b" uuid="5dcfe43e-28ac-4e71-9b64-c0c94455dd73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.c" uuid="1b44b970-a455-4465-a491-9a439d16a0f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.d" uuid="fd847861-5041-443e-b446-9a29dc75fe26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.e" uuid="a8d49da3-e616-4399-854d-5976bf4642e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.f" uuid="86e222e6-8aee-4d6a-87fe-50a30a57e002">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ec1409c-c67b-4316-84e4-1d970104c93b" control-id="ir-6">
+    <implemented-requirement uuid="2eb13d36-5514-496b-b454-31c775a1fc70" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="6bafc802-f3ad-412c-819f-dff3aafa78be">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="2fcde5f5-afaf-4248-a006-4d4398aff339">
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c6b95d74-8648-4b21-9c78-39550972de14" control-id="ia-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-6_stmt" uuid="ffd86149-b84a-40f5-9fcf-adde40f974d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="cd0b8d25-c145-4d15-be94-07bacf532824" control-id="ia-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-7_stmt" uuid="5354e6b0-a65e-4aca-8e86-a9a289c7f61b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2888bfcc-e194-422a-8825-4f53bdb20d89" control-id="ia-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8_stmt" uuid="3cb73140-4585-4e6e-8417-c1ec9ff7b55b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66f0b14b-5d6f-4ae9-b8bd-a9c2164a8aa2" control-id="ia-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.1_stmt" uuid="06757d86-2146-46c7-bdce-dad895acad87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="316b86bf-44d2-4fa6-a4f5-7833eb8452c2" control-id="ia-8.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.2_stmt" uuid="4b9c3d26-d95c-4161-b3de-5b333fbdf6c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66acb44b-508c-4e55-88c6-6db3bbc366f3" control-id="ia-8.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.3_stmt" uuid="593b1940-e12f-4507-9d3d-acb1bc340259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8eec4d41-4452-4ec2-8a6c-540cbf19cd0e" control-id="ia-8.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.4_stmt" uuid="992d4863-d8ca-4ed9-a82b-59fdccc1b1eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="28ff4a5c-d327-40e3-99aa-bedf8fb5203c" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-1_stmt" uuid="07381d25-127d-465e-9c8c-b64f43fd04f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b3699a1-efc1-41b5-b0df-5858ee274550" control-id="ir-7">
+    <implemented-requirement uuid="3d26ebe3-7f91-44d0-a3e4-f44192791ec8" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="ce132248-0b98-4a19-b755-2f5747f87d8e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f98c204d-962d-4d07-bbf8-76b0f93e85ff">
+      <statement statement-id="ir-2_stmt" uuid="34942c74-95ac-4599-b551-7397d0d08f99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="334c5aaf-1c79-4320-a7e5-5e6b96d03deb" control-id="ir-8">
+    <implemented-requirement uuid="632ff990-7955-40a0-83e6-81ba280c93a4" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="0497db8e-9d90-41a3-aed4-3e3e13ad1fcc">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f92f8c1f-80d3-4dc4-884f-ed68b9812e1d">
+      <statement statement-id="ir-4_stmt" uuid="4eedad3d-d67c-408e-b55b-44b72a18ea2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41a8bef3-b806-48a1-ab96-b2e7651b51d2" control-id="ma-1">
+    <implemented-requirement uuid="4780a3da-36e9-45ac-9448-246d9de52d4d" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="ca73269e-5055-4af3-a2cd-2e00c81818c4">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="297fee92-2a85-4898-a53c-eb9b48719ac0">
+      <statement statement-id="ir-5_stmt" uuid="934c7912-3aa8-4b48-ae97-b62c5a5dfda1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="90dbe198-eaa1-424d-bbbc-aa898e2f8910" control-id="ir-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-6_stmt" uuid="63df69cd-4851-45f6-81eb-006fbd9b0ddd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="65889916-6ebc-478a-9e11-9eac2f138f8b" control-id="ir-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-7_stmt" uuid="8fd6efff-d8f2-4c7b-9fc9-2593323d8bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="81dc3c73-edd1-4c6d-bb2e-95e9ddecdad2" control-id="ir-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-8_stmt" uuid="ad980c89-acc1-468b-b401-1263a56b1090">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="624adb57-c624-407f-8775-cdcc75abe075" control-id="ma-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd899dee-6319-4688-974a-ce248a6404a1" control-id="ma-2">
+    <implemented-requirement uuid="ddcb61f4-5048-4ab9-973b-490a5db3c808" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="1e5be307-ec79-44c3-a5a3-7d6a7b9bf104">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="bda757f7-48ea-48b8-bf2e-e7e60f708d35">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2107e8a8-6bd1-4f2b-8202-8971ef58cdba" control-id="ma-4">
+    <implemented-requirement uuid="59b21f81-8979-4404-a720-f32cf697b4c1" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="44f0aa12-338f-46b5-b1f1-c5824476b10c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="bb4dcd6c-1571-4191-9e83-a660fe686fe0">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13254e8e-e139-48a7-bbe6-c2ba0c84825c" control-id="ma-5">
+    <implemented-requirement uuid="46e83d36-ea11-439b-bd56-a355174a7d12" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="e42b4ba7-c48f-41b4-8b80-e2227d89f564">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="18c22b79-840f-4ab5-96a3-a41193a63814">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c23e315-6a9e-4c2d-b222-315d9f0b2ce5" control-id="mp-1">
+    <implemented-requirement uuid="cce0658a-b46e-425e-a359-ccbbdadad9e4" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="8408d372-50d0-4d20-ab0d-72682e0c5dca">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="13efad3c-e006-4811-85d1-2791d8a78127">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e3e75fa-4298-4851-9af0-a0d369fc216c" control-id="mp-2">
+    <implemented-requirement uuid="f9b2e3ea-90a8-4e2f-9dd2-c8bfd1883265" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="90a8ddc5-8f29-477a-be3e-605152f36149">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="17de2ee2-6df6-4024-ab40-817cd4cd8660">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ab2a330-4365-4cb4-8774-2cf52b8db41c" control-id="mp-6">
+    <implemented-requirement uuid="c4c70fa8-e2de-418c-af96-5aa873793015" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="3d320182-57e0-47d8-831f-54a2fce9b5e9">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e2ebdc9d-727c-42e4-a343-63d34249508b">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f858e182-7c21-4727-b91e-b9b84eac77c6" control-id="mp-7">
+    <implemented-requirement uuid="e85261f5-5f7a-4602-bfcc-c91fc07fad67" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="8c21f58e-a03d-42d7-b8ca-d8665e64fe34">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8b4f6b12-e8ff-469d-8725-ba741d21e960">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99a70c7a-a8df-4594-8c20-935d4c18aebb" control-id="pe-1">
+    <implemented-requirement uuid="a936699e-188b-4365-b8c8-ac27c7c551ef" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="fa9fd194-c023-4f49-a0be-a92390290e98">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="dd035aa1-2a67-4346-953b-7a5933d22b79">
+      <statement statement-id="pe-1_stmt" uuid="9eeaf67c-b116-4010-bf82-2cedced92bff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="635e39b2-31b8-4559-8baf-bbac88e50381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked
 via:
@@ -1509,10 +1509,10 @@ via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d1d04ba-7d52-46fc-8dff-e51cdf2174c9" control-id="pe-2">
+    <implemented-requirement uuid="357f50ff-894c-415a-8eeb-f49f3d068779" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="a46118b0-9580-4d1d-8022-ef50a4217872">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="30cb1027-9d23-4399-ba01-72e485c71ca4">
+      <statement statement-id="pe-2_stmt.a" uuid="b57fbab6-6e7c-4331-88d8-b80a3510b436">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1521,8 +1521,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="43ef23ab-c974-4867-a34b-b20522d20e18">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="50ca4571-9dd8-4c78-b2ff-7bafef40ae51">
+      <statement statement-id="pe-2_stmt.b" uuid="aef52af3-fe2b-4d6c-8571-7f9fbc647e97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -1531,8 +1531,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="a16f4ff7-7a10-4cd4-8e33-ba8210f61078">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="2c674016-6c76-47f7-8201-30fce6b0889f">
+      <statement statement-id="pe-2_stmt.c" uuid="ef527317-5209-4c89-926c-78c14b1fa41a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -1541,8 +1541,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="6846e192-d3b4-4df3-aac6-ef973bd79dda">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e1704321-b092-48d0-bd39-c96297c97cf8">
+      <statement statement-id="pe-2_stmt.d" uuid="10afcd59-4906-427b-9948-baabd570648a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -1552,10 +1552,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3700dfb3-059f-44ad-a5e8-84f0ded45f73" control-id="pe-3">
+    <implemented-requirement uuid="8c21f041-ad73-49a3-9294-c789ab513d8f" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="d678aba8-484c-47c8-b1e4-dc3e484984ef">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="783e0007-c9df-40c2-b011-735c532bf9c5">
+      <statement statement-id="pe-3_stmt.a" uuid="666d7036-90a5-40a9-854a-0a1ee6a21363">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1564,8 +1564,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="96dc3064-6c55-467e-a8c8-f4c0e582e517">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e459a5b4-7697-4a92-b065-fcd33d8973fe">
+      <statement statement-id="pe-3_stmt.b" uuid="fd166ad5-7fca-497e-8e51-4c8a4cdc28d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1574,8 +1574,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="dc748e19-dd39-4eb3-b20c-75d5a5beb5bb">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="4d5493db-ac31-46d0-b70c-c13d66996563">
+      <statement statement-id="pe-3_stmt.c" uuid="25ed7e5f-2cdc-45f6-af02-9a0c77db04e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1584,8 +1584,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="aea59e91-c213-489f-a97d-54aa36956872">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="b9093e7e-52a1-4822-b167-cc21fb34aba9">
+      <statement statement-id="pe-3_stmt.d" uuid="9960adac-3249-426c-9d36-6586f4ceadf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1594,8 +1594,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="4a4cf320-3b08-4a77-9bbc-7edab79ba05c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="2dbb0b09-d552-4ca8-a669-789ab6d2542a">
+      <statement statement-id="pe-3_stmt.e" uuid="58a40390-8a4e-459f-9e58-368a83aebeab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1604,8 +1604,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="af30e945-17b8-4247-845d-155ffa0a596f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="059e5159-bfc3-426b-af53-eed472e6ba9a">
+      <statement statement-id="pe-3_stmt.f" uuid="cd0ce203-100c-4430-87d4-3b5c3387f9df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1614,8 +1614,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="d25d2655-f945-4e26-81a8-1cc0adb6efde">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3f779c6b-8de1-40ae-8fef-b5638c0e4881">
+      <statement statement-id="pe-3_stmt.g" uuid="07f74625-38ac-4ca8-bc8f-4434d856d129">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1625,10 +1625,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26b0cf30-fbac-460f-bc87-017c257d3fb3" control-id="pe-6">
+    <implemented-requirement uuid="ea3b1ae8-ca6f-4178-a120-def72eb0edb4" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="0680ea5e-ce79-4167-ade3-281e3052d7af">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c086263c-5a77-49ff-a788-1cf9ff36c7cc">
+      <statement statement-id="pe-6_stmt.a" uuid="adc055a6-c4df-48b1-8df5-e825566ed731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1637,8 +1637,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="9856b0d9-a696-4f5c-9077-1b0768678da8">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7bfb0a60-dc68-4d4d-8223-c3e3d600fe28">
+      <statement statement-id="pe-6_stmt.b" uuid="7bdf5f6f-2836-4984-b5db-b5ffd79be70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1647,8 +1647,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="9baba1e4-1758-4bfd-a17c-d3da4bdf2cf6">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="cdb69d45-0cb2-463a-8d73-2675fd6cc6cb">
+      <statement statement-id="pe-6_stmt.c" uuid="61e0973f-7994-43ba-9bb8-62a5fa0f0b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -1658,10 +1658,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bd1ff17-c71b-43b0-8388-c0b8dababff6" control-id="pe-8">
+    <implemented-requirement uuid="e4f2790e-8cdf-402e-b3b6-7805c45878ef" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="0d1ddece-fcf4-486f-9558-51e5570f1f63">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="7275ffd1-8a94-40b2-86a6-32d200f70a65">
+      <statement statement-id="pe-8_stmt.a" uuid="e3512a72-92e7-4983-8945-ee9a467eabc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1669,20 +1669,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="48e4301e-d807-4cb9-bd90-4cf7b8b51940">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="60761ee1-ecfd-4f8f-9b48-06a2b41a216b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is inherited from Amazon Web Services, who own
-and operate the facility where the information system
-resides.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5975fa84-9935-467a-a9a2-a511e31422d1" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="ce2860eb-f1c3-4274-8910-359286f6fff1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="129bfce2-c5a5-4297-81a6-ea9e1012aa4f">
+      <statement statement-id="pe-8_stmt.b" uuid="dc35409c-4dcd-43a3-9bd3-53ec208e4f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1691,10 +1679,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a25a6a94-4371-44ef-ba79-70922bd0ea16" control-id="pe-13">
+    <implemented-requirement uuid="3156bcaf-1fdb-4e58-9c33-41b74c964038" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d4493604-c985-481f-9ed1-7ae10573d7dc">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="3acf2f1c-1422-49b5-bbcb-4644ca763382">
+      <statement statement-id="pe-12_stmt" uuid="162e05ce-172b-4055-9a53-5a5a466e62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1703,19 +1691,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfafb5b2-e2ed-48cf-885d-a7b4369fdd7a" control-id="pe-14">
+    <implemented-requirement uuid="2b8e5e39-05a4-42d3-879b-6c2d85fb6698" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="ad220986-1b19-42cb-afcf-abeaf827942a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f9c40fed-d3d7-4cfe-b253-d5700e7008ae">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is inherited from Amazon Web Services, who own
-and operate the facility where the information system
-resides.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="08277123-fca8-4b1f-b1b6-a0443774adf7">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="8a4bec1e-7675-4411-a59f-5684fb541faf">
+      <statement statement-id="pe-13_stmt" uuid="e539b4af-1f30-4b7e-b7c0-a5a2e754eaa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1724,10 +1703,19 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1412f5e-a9f2-4a9c-8dd9-ae7890c9e4c4" control-id="pe-15">
+    <implemented-requirement uuid="95ec2fce-564f-4fd8-b858-b89af62566d3" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="8684e910-bc48-47db-a487-b6d9401b9169">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="262bb0de-2805-4617-be8d-720ee5cd037c">
+      <statement statement-id="pe-14_stmt.a" uuid="63ad4abf-3740-4e72-94f7-393c8625edd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is inherited from Amazon Web Services, who own
+and operate the facility where the information system
+resides.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="bec858c3-3512-418c-9c3d-902ceec3def3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1736,10 +1724,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34a6eabf-948a-474f-901e-d7c2212b471c" control-id="pe-16">
+    <implemented-requirement uuid="b8c2ad37-9714-411a-ad3c-ea5800b64aa1" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="c7e43ce5-45d8-428e-a288-de08cb63fedb">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f6eb7b93-b973-455c-b2e2-8926b9a87aca">
+      <statement statement-id="pe-15_stmt" uuid="2d10e6f1-78e0-424d-a58b-4a2e01a3fb43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -1748,368 +1736,380 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54c02816-bd66-485c-864b-982133b16220" control-id="pl-1">
+    <implemented-requirement uuid="62b24ebb-350f-463b-b9dd-d0a9f76644a9" control-id="pe-16">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pe-16_stmt" uuid="b71c7cb8-6d89-48bb-b6bb-5957ab08ce34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is inherited from Amazon Web Services, who own
+and operate the facility where the information system
+resides.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="1a5e4178-9df9-45e0-b04e-c88228dc5fd3" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="10093e19-d818-4ed9-a119-06cea759652a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0235286f-5945-411f-860b-c175d4ceaf79">
+      <statement statement-id="pl-1_stmt" uuid="4f330b5a-3729-4854-bb38-91c48434723c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b0b7a43-2402-4bfe-84e8-aeecdb916aff" control-id="pl-2">
+    <implemented-requirement uuid="0ba70246-52c9-4cd4-902a-b406fd162505" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="5d762f1b-6133-4fcc-a9d7-95f5e3f00760">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="23bcc180-db9f-4e44-89af-683394fc0a4a">
+      <statement statement-id="pl-2_stmt" uuid="09a9c7b1-dfc1-4884-8a4e-f76340d26b5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0020dd48-de31-4412-ae87-c8f3f1ce458d" control-id="pl-4">
+    <implemented-requirement uuid="7a0f5f95-640e-4569-ab2a-41be6b94bb58" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="8016703e-e8b0-4a91-87f0-a62987fdfb01">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="ef5b85cf-4fc5-4ccc-ae94-9624bb202277">
+      <statement statement-id="pl-4_stmt" uuid="12d94f45-18cd-4a10-b195-11cc6f6de5a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="328d4c1b-fbc0-401a-8622-957a8c5e8796" control-id="ps-1">
+    <implemented-requirement uuid="eb3dd41a-bbab-4d9b-ae5d-4b219bef17c1" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="c813af4f-6658-44d6-989b-6da7afc9c8f9">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="dc9bf842-598b-4f61-8dbe-040f51802cec">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caa352fe-f760-46ab-904a-ad4badd21a28" control-id="ps-2">
+    <implemented-requirement uuid="daa68232-f074-4b9f-a109-865771304d0e" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="f2a7a4ad-e7ef-4839-80b5-cf931f5073ac">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="1e8983aa-f96f-43db-ad4a-72c1814d20dd">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfc65db2-8d11-4b77-8b9c-de41af212559" control-id="ps-3">
+    <implemented-requirement uuid="49180b21-da3a-4e0f-9a97-011c62ae8e06" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="89c64fc3-b8d8-4c87-9cbd-dc5deceb4924">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f5b2fb39-540a-4e0d-8943-c95f42fe0532">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12401659-0fb1-4d7d-9c1d-e1a9cf74052d" control-id="ps-4">
+    <implemented-requirement uuid="e2c40744-e377-439f-ac7b-2278f730964b" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="ed20bd6c-6297-467a-97ae-b99adc2945a1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="cf36f112-c4ca-4c92-bde1-d6776c31981c">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d54743f1-e441-4daa-baf8-037291209c5b" control-id="ps-5">
+    <implemented-requirement uuid="7909e627-5796-4305-89ba-5f66c9918ce7" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="dfdea59b-2d96-48ac-970f-a3fce41ee027">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="81e19219-3dbe-4a96-893e-61c2ad947ad4">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c99af2a-e862-4807-b6bd-30ceef03f915" control-id="ps-6">
+    <implemented-requirement uuid="ac05a0ba-c487-4d5c-a072-9e746a101b00" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="24d698be-4c6c-4381-8594-49a446d08b9c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e57fd49f-445e-4254-a6bf-4b5b1512fa39">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ab5bf4b-e5da-44d9-ad85-9f4aac47103b" control-id="ps-7">
+    <implemented-requirement uuid="d0f887d5-2b2e-4de8-aa3f-c5490c35bab7" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="434158fc-cbdb-4b84-a76d-b272f165cc87">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="297c37fe-c4af-4168-becf-c65b71e93f50">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23447901-fef8-40db-8f60-70a3df8f9929" control-id="ps-8">
+    <implemented-requirement uuid="6da54514-da22-41d5-9c37-ed629645a10b" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="d6d1d412-83cc-47e2-93b7-9434b1749eee">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="266d44e7-24ae-4183-9f82-fcbccd02e265">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bea068c4-ecef-4b01-97e5-04bae0f96f97" control-id="ra-1">
+    <implemented-requirement uuid="ff695294-861f-41d7-b470-178d71912b8f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="d79e6179-1eed-4cc1-b095-396e9601f706">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="72663ad4-c637-48aa-9d67-eabacd1d9061">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68d662cf-a0db-459e-9409-2f78a4068838" control-id="ra-2">
+    <implemented-requirement uuid="136a72f7-d72d-4a7d-9dc0-499becbc392a" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="db5f8143-47b9-4a91-bd2f-2105a3045536">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="479e6a55-f168-477b-b382-d924cd0f4fbd">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6eb676e-75d7-4119-a3af-985fe4e30070" control-id="ra-3">
+    <implemented-requirement uuid="7dbe0353-27aa-47ed-afa2-2a6823696698" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="e6df4ca2-3c5f-4fd9-b693-8b950673a35c">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="ae14d84f-603f-4455-9297-b1d7aedf6e56">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efa4e9a4-930a-4bcb-9515-b109ebc85333" control-id="ra-5">
+    <implemented-requirement uuid="9dfd0d25-bc22-41b9-b13e-08a0ed87cb85" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="96cf03b8-0835-4957-a9e9-87887249beea">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0ef4645d-fb4c-4986-a87d-e4c83aecf8e3">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5bc4664-732a-4b95-81b1-199dc93b5db2" control-id="sa-1">
+    <implemented-requirement uuid="cb54c9b7-9d11-4572-80c3-784ec67da4f3" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="ec07001c-aa58-4b00-809d-c5c49f71a128">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9e31743f-2c57-4365-8b00-4018b5c4dde8">
+      <statement statement-id="sa-1_stmt" uuid="b7625cb2-66d5-4892-bbb0-a9d7d5faf003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f7909bd-3380-47ae-9dde-366fade9b3ac" control-id="sa-2">
+    <implemented-requirement uuid="c575a17c-62a9-4567-aa0f-9f26b4745496" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="917bafc4-516e-404f-8b9a-da033660c586">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="86b02928-2167-4978-bc11-2bd3d0f54b71">
+      <statement statement-id="sa-2_stmt" uuid="bdc6558d-3570-4907-b9e0-64ef3e1e00f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad1cf46b-0b63-42b1-b845-01ba0c053e2b" control-id="sa-3">
+    <implemented-requirement uuid="740568db-cbb0-4ca6-a4ab-3f606104c86c" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="d60c09d5-de90-42e2-aad2-11154f29fe0b">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="4b4e9de0-f2fc-4860-b435-04dd01f02ca0">
+      <statement statement-id="sa-3_stmt" uuid="8c037ef8-ea13-4df1-8f57-0d8131701f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98794c7f-15a0-4b9c-b7d7-b42c296e231a" control-id="sa-4">
+    <implemented-requirement uuid="fba35c40-c7d7-4c2b-9b9d-8f38770f4343" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="79d41483-1ff4-48ec-ab1e-91dc579e3bc8">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6021e4b1-1f08-4d1a-91fd-f0860208615d">
+      <statement statement-id="sa-4_stmt" uuid="cc86ae33-c11a-47f1-b346-5fcc89190585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62364c9c-7a9b-4563-a251-77f2a0a62cb5" control-id="sa-5">
+    <implemented-requirement uuid="26cae64d-898f-4832-b702-1b228d6a7ce0" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="0d07dfca-8b12-4993-a718-400407e9c649">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0f53f2e3-7134-4199-ace7-981d42382086">
+      <statement statement-id="sa-5_stmt" uuid="6304df28-0587-4607-991c-972dade816e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b7c2217-ed39-4098-a52e-ca784d1c0d46" control-id="sa-9">
+    <implemented-requirement uuid="3dba2dd7-5806-463f-a2a5-f927c9f17197" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="06059f21-3be7-4002-91c1-2807e6cb7298">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f0ab558b-e838-43e5-b5b0-785360491676">
+      <statement statement-id="sa-9_stmt" uuid="5ce7182c-ceca-4e58-b733-ece84ff92504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbd419fb-cfaa-4e7a-b51d-5beb22c9aae1" control-id="sc-1">
+    <implemented-requirement uuid="b885d23c-98bc-4694-b3df-ad5e2d79b193" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="4530d71d-0ea7-468c-9f39-8adf711f39cd">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e9ec0ae8-c188-4caf-aa1c-4418fbadb7bf">
+      <statement statement-id="sc-1_stmt" uuid="31a28689-d22a-4281-9396-3e39aaf00400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1da90145-a6d5-4099-9b0b-af60e8ec9417" control-id="sc-5">
+    <implemented-requirement uuid="36d6ee6d-75a4-479a-99b4-18617dcb82b5" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="a1373b98-0329-437a-80e9-7a0ce04b071b">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="84a6f0da-1ada-417d-a4da-7daa05a71749">
+      <statement statement-id="sc-5_stmt" uuid="04f915f3-359b-4ed2-867c-c0d4ded64687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a469ea69-7818-4d3b-b6b2-bdbb666e9c14" control-id="sc-7">
+    <implemented-requirement uuid="c79f28d7-1ee0-4de9-ac9f-b038234e264d" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="dc802304-b360-4aeb-986e-dec28dd55536">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6c0bbe51-fa62-431b-a17f-2455f00fbd04">
+      <statement statement-id="sc-7_stmt" uuid="7bd816be-8571-4716-90fb-770dff3d90bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bc094ae-5e88-4b56-9854-d9c47a873482" control-id="sc-12">
+    <implemented-requirement uuid="fd9ed307-9307-48a0-b4df-23137355735d" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="2ff37406-89cd-4388-aea1-e3bf4d38936a">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="0f768817-a265-4341-bb1b-e520c853da56">
+      <statement statement-id="sc-12_stmt" uuid="1265e32b-2e01-4b72-9fd3-82ce6a990176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c88b2c7-0b09-478c-a1df-95d2c531b9e7" control-id="sc-13">
+    <implemented-requirement uuid="375718e1-a987-475b-b769-b532677acbc6" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="00a17010-202e-4b40-baad-5298d963b831">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="e138f09c-d4d9-4ec5-9062-560d5c3f07d0">
+      <statement statement-id="sc-13_stmt" uuid="5ca69218-91fb-48ca-ba66-733c6b941a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e47f7ae3-97c3-411c-a7d5-0485defe9ac2" control-id="sc-15">
+    <implemented-requirement uuid="9f623733-ea80-4bb0-aae3-e74004c03fdc" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="98e88ce8-a9d7-4eb7-8679-e859f1821895">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="94500679-77bf-4bef-b832-5527d93bf16a">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="230a95b4-b996-44ac-a381-ff32faa17661" control-id="sc-20">
+    <implemented-requirement uuid="8c87c369-bc5e-4588-97ae-ab413040e28e" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="d7759a7b-a01e-4e8c-8216-fd14fdb111d5">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="1ceae4dc-e3da-45c9-bd58-4ba04be3d435">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86c458dd-fe26-482a-acdf-182bab6d92a2" control-id="sc-21">
+    <implemented-requirement uuid="8aa2a844-5c53-4ad0-96de-8b84998ddb1d" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="72a0e784-cad7-438a-b3ba-abe5f6df25a1">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="49a4b425-e0ac-4b2b-a4c4-18332085417a">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af289995-4470-48ab-88b5-2ea7b6e961c8" control-id="sc-22">
+    <implemented-requirement uuid="6aa8d7c2-44cf-4e9e-a7d4-2993d6428e16" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="478eda7f-5b52-4814-a48e-5f4feeceac16">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="4051706e-25c8-41db-adf9-cbab3370d9c7">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef6962c0-debf-4533-82cb-52a65d660260" control-id="sc-39">
+    <implemented-requirement uuid="758e3f6c-4438-46ea-994f-e3b47147705e" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="6450585d-19bc-4564-a123-4aae40e583bf">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="1aefa49c-4b24-47b8-b420-176481f86d2b">
+      <statement statement-id="sc-39_stmt" uuid="925ad4ee-2f66-4648-9a31-11916aaa7e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbff7404-a76c-4066-8a3e-91b477c247bf" control-id="si-1">
+    <implemented-requirement uuid="fad37c51-3b6c-49ff-a563-6dd95baaadbf" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-1_stmt" uuid="04d27496-1a82-470a-82e8-da3f29c53d70">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9e9b0670-a6a9-4518-a385-b2a74b2ccd08">
+      <statement statement-id="si-1_stmt" uuid="378180e0-e560-4d05-b874-93c566727297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd316b4c-22f9-4405-a0ea-ad2f72de6e6a" control-id="si-2">
+    <implemented-requirement uuid="d145ad6a-a7ee-4fef-b361-19e0901849ed" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-2_stmt" uuid="25e74f8b-c9c6-496c-868f-7219d7855702">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="f8cd2550-22cd-494b-88a5-c42c68a62b3e">
+      <statement statement-id="si-2_stmt" uuid="fbd48d0e-3698-476b-b60b-cfd9e17d053f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55b918bb-cd8e-45b9-9e69-05935cc94b4f" control-id="si-3">
+    <implemented-requirement uuid="12a9295d-25c1-4afe-bbb2-bc3176a0e6b8" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3_stmt" uuid="28a573de-f8aa-41d5-802f-32d3dca39ec2">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="b848e827-c3fb-4de2-ab72-0d6481aba090">
+      <statement statement-id="si-3_stmt" uuid="4206e8f0-b3a8-4c9d-b5c6-3d40e0ae6634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b27ec7e-6a60-480c-b2d7-66c19e6145b6" control-id="si-4">
+    <implemented-requirement uuid="f808f76a-7dd5-40bd-b73a-0eacadd447a0" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4_stmt" uuid="1b63bd50-bf40-40b6-a25c-ca984cb3af2f">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="9c5845a3-8f1a-40cf-b85b-b591b7e0c8ec">
+      <statement statement-id="si-4_stmt" uuid="901968f4-a0f8-416c-8212-dbeead97b485">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1d7412b-5071-48ad-b9e5-e859147bc672" control-id="si-5">
+    <implemented-requirement uuid="d246d1db-451c-42db-8834-5b50d8a831d0" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-5_stmt" uuid="39e0e3a7-9de1-4e0a-af1e-502c0ea0fc72">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="6e2b3622-6066-4970-9ae5-a959442d8de4">
+      <statement statement-id="si-5_stmt" uuid="dc50f1f5-8925-4856-999c-7bc1960b9580">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea848ca8-5dad-44e6-9d5b-9ac4a3cd066e" control-id="si-12">
+    <implemented-requirement uuid="d8df9871-e1d2-4feb-a760-893e044d0552" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-12_stmt" uuid="a4dbbb18-f46a-41e9-a99e-51d014a42799">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="97359bf7-a422-4921-baaa-4b60ea7b4100">
+      <statement statement-id="si-12_stmt" uuid="71503f08-ca5f-4e1b-9cd6-3dbdb0f72c6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb1e2fd6-79b7-480e-9e60-2316766cdb52" control-id="si-16">
+    <implemented-requirement uuid="b82a5b17-3cd2-4fd3-b74c-aa929adfe913" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-16_stmt" uuid="50065490-272f-42ac-8879-3708c8b8f99e">
-        <by-component component-uuid="50c04255-c2ac-4e62-8c62-09dfc42db5fa" uuid="c930f058-a5d9-4681-9f9b-0f4520bd2868">
+      <statement statement-id="si-16_stmt" uuid="2695eee3-10b5-42be-b8f8-ca027016329b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d9d2d85-73e6-4152-82d5-cdfcee4ba9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''</p></remarks>
         </by-component>

--- a/xml/openshift-dedicated-fedramp-Moderate.xml
+++ b/xml/openshift-dedicated-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="bcd2042a-f4d8-481d-95f5-56b642cabfe8">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="95b22b25-1bca-4b40-8357-c50fe6a693ee">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.01+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.70+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="89a535b1-23f1-4e12-a092-7a906e11e054">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,1745 +484,1745 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="1075124a-a145-430b-af57-bf9c1c4963d7" control-id="ac-1">
+    <implemented-requirement uuid="39a1b693-1d3d-42df-a7d4-f62ed63b754c" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="1ff854bd-32ac-4d23-9556-42f08470df7b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="65e086c9-3c49-41c0-915b-3ce57e5b0c0a">
+      <statement statement-id="ac-1_stmt.a" uuid="324dcda4-4f96-4ff5-8427-f924b21a8d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5309070-b957-4a26-8a72-9142200914d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="60913e1e-c44c-44cc-8575-d1374f1c7ac8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="64df64e5-2a1b-4fc1-a658-5cdfb553bd85">
+      <statement statement-id="ac-1_stmt.b" uuid="887641c8-6db9-493c-8ead-40bc3f2279d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="da0449ac-a99c-4e11-a5d3-aefae5063f81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-1(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73da236b-570e-40af-a188-57f7ddf0eb8d" control-id="ac-2">
+    <implemented-requirement uuid="308f2ab9-f2fb-4ebd-bd22-6f26a99c54a3" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="cad3c107-2d06-4e5f-8fba-2c1c41e36977">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7f657bf1-bd8a-4f15-8ade-c5abf4277ad9">
+      <statement statement-id="ac-2_stmt.a" uuid="18e57d62-e667-46fe-858e-91af9c9f0477">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ead5e410-8afd-480c-bade-088a12eef60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(a) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="8ec6c3c6-0119-48b3-9eb3-fca596d3bbb4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bb125cec-1adc-486c-bfb4-69e1e8656c26">
+      <statement statement-id="ac-2_stmt.b" uuid="b7e2816e-2be0-4f16-95a4-394a2fd00758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="048adc9f-d720-4d87-bfcb-643ff1c62695">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(b) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="c5b7ca7c-06e7-4c29-91d2-afc72d739801">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9dde9f93-7d19-4e2d-bdd3-78cb089e7021">
+      <statement statement-id="ac-2_stmt.c" uuid="b4009d35-0f2c-4fa2-ac5b-348f424d348f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18af0d86-53be-49b8-a66e-a54267998f90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(c) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="5740557b-0653-4276-b294-8029c38e9152">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b59c8c7c-ff2c-478e-b182-c9663460b81d">
+      <statement statement-id="ac-2_stmt.d" uuid="0c23a834-cae8-4a5b-9db7-00b2ddc807b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22a7c136-117c-448b-a504-ac996979de3c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(d) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="49626770-4160-4bdc-b8cc-ce2a67b81aef">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0550cf14-e3af-49f3-bc0e-2dbaa4f5def2">
+      <statement statement-id="ac-2_stmt.e" uuid="58c0cb86-c145-435f-a0d8-757dc7ac9fff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9eeeb20-47db-4e6d-9154-fc86fc11fe10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(e) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="68781ab3-9645-4fda-956f-5a5a8366fb0f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9a8745e1-e5b1-47e4-b220-ce450380b375">
+      <statement statement-id="ac-2_stmt.f" uuid="1a1d724e-24dc-46d7-8c21-2f08da427696">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f5fbaa5-af8c-4109-a130-4d5c42713c9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(f) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="6251bda2-1db1-432c-acdf-38c75f2bd4ca">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2138777c-d95b-4bf7-a732-822f6d8796cc">
+      <statement statement-id="ac-2_stmt.g" uuid="461e9ffa-c9ff-4936-ba8b-71d1ad995fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94bc620f-e15d-4880-a056-abb577b18005">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(g) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="b15c7923-58ac-402a-9664-abdf1f96c4fb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="69154ddc-22cd-47d3-af2f-a98343ab854b">
+      <statement statement-id="ac-2_stmt.h" uuid="63220789-6f43-4e94-b50b-33138a10b46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a3f1c4f-8287-401a-a2d5-d383ecbf12a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(h) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="30171882-0e03-4e44-8c3e-52aea99365c2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="23054928-7554-4a78-9423-bb301e11c186">
+      <statement statement-id="ac-2_stmt.i" uuid="43b7976d-f5d1-4355-b32e-6bde93f63664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1155986e-c445-4ba6-9173-ec12fb48c8d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(i) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="f82ae43b-f7e4-49fa-a931-0a3f14ebe6f6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="28a425fa-7e13-4f32-bb98-03c586e140b3">
+      <statement statement-id="ac-2_stmt.j" uuid="e637623e-534f-46c5-a039-1f0931b14fa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff4fa720-c1b9-4840-8240-99543669ed40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(j) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="2b216697-e685-4f23-872a-5f1b90ffe806">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="722c83fc-a7a4-425f-96e6-87cabceb92d0">
+      <statement statement-id="ac-2_stmt.k" uuid="f26cf7a0-d40b-4cad-8582-76bdfa8ca372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23d24c07-dfad-4e80-8794-c11b3b1b2707">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2(k) is an organizational control outside the scope of component-level configuration.'
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="759d6f37-318c-4835-8566-a5cfaf68c7c3" control-id="ac-2.1">
+    <implemented-requirement uuid="e8c03b47-302e-4dfa-acc7-aa39624182ac" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="75c4ff2a-da0f-4f8c-baf0-74ca8d2d35fa">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="808f0b8d-4023-4b08-b6d0-fdb2a8a979cc">
+      <statement statement-id="ac-2.1_stmt" uuid="3da628a2-3db1-4308-b090-6b78a447b0d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b58356f2-f2e2-4ac5-845e-cb223fc3b368" control-id="ac-2.2">
+    <implemented-requirement uuid="47e6f61a-b1d2-49a4-a122-fa99f51ba7e3" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="36e78b89-ac76-40c3-a06d-16c9b2284613">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2ab73f19-5c00-4614-9b27-d6f599202f5e">
+      <statement statement-id="ac-2.2_stmt" uuid="ea1fc28b-24bc-49b0-b5f2-1367977532e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a0393d5-2cb5-45cc-a857-1c7a2c0cf521" control-id="ac-2.3">
+    <implemented-requirement uuid="1edba262-35e5-44a0-96ea-bc090abb6764" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="4b04a67d-0383-4235-8d31-4805494c9e55">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="876044cb-f37a-4575-92b7-bfd915217439">
+      <statement statement-id="ac-2.3_stmt" uuid="a1e9ab12-2a19-4e37-9b75-8f361c825231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="202e67a2-5c19-4eca-80db-a299a4181092" control-id="ac-2.4">
+    <implemented-requirement uuid="d73283b6-7199-4143-914f-6a337202f4ea" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="d0ff5c45-5fb8-4c95-a4a7-5e2d0dfe42db">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4ea13988-b730-47f7-b4a9-fa3d04ff5f32">
+      <statement statement-id="ac-2.4_stmt" uuid="aecad161-6461-40f8-9506-6b3727207d68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10360f24-e9b2-4d75-9820-aec2fce03ba4" control-id="ac-3">
+    <implemented-requirement uuid="e69b7912-dc17-439c-9d84-b50501ec5536" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="8afe30fe-a528-452a-9304-59b40a08c643">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c319a938-5323-43fe-8ea0-cb966c1dd3b2">
+      <statement statement-id="ac-3_stmt" uuid="7bb7f069-70e1-426a-82ce-a6e8d2dd3fe3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2462366-04f1-48b7-8d8d-94ae73315678" control-id="ac-4">
+    <implemented-requirement uuid="71e43e55-ded3-408d-a47f-8389825c94fd" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="9a3f3618-917c-4cc4-8163-cf7eabd7fc36">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="3abcedee-b251-4aa2-8150-d9bfb24f6cfa">
+      <statement statement-id="ac-4_stmt" uuid="316dd639-50ca-4348-8750-8079ffbfe80f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f8dba23-1ba1-4e61-9e09-4f25add7da9e" control-id="ac-5">
+    <implemented-requirement uuid="bac6dfb9-5b2d-482c-99d1-eac9b5b2b99c" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-5_stmt" uuid="7539a9cd-bdd5-48b3-bb7c-044f89def988">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="abdeb304-b87d-47c0-aa69-58870c5854f6">
+      <statement statement-id="ac-5_stmt" uuid="a9d2b65a-c0a2-44f4-ba68-32d11fb2ae5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="165466e5-5b11-4a7a-b7f9-1416cd87f578" control-id="ac-6">
+    <implemented-requirement uuid="c8a8f396-46b5-46d1-bd5b-37e3d2f5cf77" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="6a95e182-dfa6-4776-a657-b2bc94d93328">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c17b4ef8-11ff-4a98-921e-d947154a15b1">
+      <statement statement-id="ac-6_stmt" uuid="f8551c48-88be-4c5a-bc02-8439040acb73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eca5b513-6e7e-452b-8c41-60f42d34d442" control-id="ac-6.1">
+    <implemented-requirement uuid="d944e809-82f3-460c-a16d-ac248cb87766" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="57e944d0-8db2-4daa-a43e-16b9d98410d0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="185c995f-da3a-444f-9e84-fb0c4d56cd33">
+      <statement statement-id="ac-6.1_stmt" uuid="32c35c84-6287-4b62-b2e9-e1620227904d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0924a4f-51a4-4925-a3d4-232b73ec1a6c" control-id="ac-6.2">
+    <implemented-requirement uuid="2d4b876d-0dc1-4ad1-914f-f37de5e17ed3" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="b21eafb2-304d-4930-ab0a-ff6325ef204d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5850ae64-d148-4fcd-83b2-fac050ca67e6">
+      <statement statement-id="ac-6.2_stmt" uuid="fb6f13a9-6670-400b-a131-8019e78e14f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08a35ab1-c357-4dd7-80c7-3e072b6904df" control-id="ac-6.5">
+    <implemented-requirement uuid="09e12c67-8c64-4c69-ae5d-435871af86a6" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="72118df0-e214-4a9b-a007-07571930bcc1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="38b62289-8d75-4525-a02a-043d8e303a63">
+      <statement statement-id="ac-6.5_stmt" uuid="63c65ff0-b2c8-4527-a4d7-f2db05b9a98d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e7d214e-9e85-4aa4-8614-445ae90aa585" control-id="ac-6.9">
+    <implemented-requirement uuid="a68b7c48-097c-4aa4-98df-b0b8ebc764b8" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="b1ed0cbb-3823-428e-bfd6-43d409380941">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f4189cc6-bca8-42a6-8075-969fc025f436">
+      <statement statement-id="ac-6.9_stmt" uuid="3ef10200-8642-41bc-9170-3f13044d5f42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79e23320-bf27-4eae-8203-bfab369c0058" control-id="ac-6.10">
+    <implemented-requirement uuid="99e6695a-3847-4432-82a0-c1dcce9c8e31" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="e7f753ac-cfd7-4ac4-aa70-c879b539561b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bbd6deb2-13f1-4a06-bb15-64e070ecfb1b">
+      <statement statement-id="ac-6.10_stmt" uuid="1afdc7e7-716a-48ea-bc84-0ea931f485f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bff388f6-7061-419c-a6d6-926e7f150297" control-id="ac-7">
+    <implemented-requirement uuid="34c744db-4973-418c-94fe-d132d3582c89" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="b7045cfb-5c84-43a2-9eca-2c4625adc598">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="830ebdad-3719-4901-83f2-c03a702ef9e1">
+      <statement statement-id="ac-7_stmt.a" uuid="0ce553e4-fe3a-4e37-9835-fef4fa7649d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="368759c2-a3d9-489e-84ee-8ece87c9bc6a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7c7df962-942d-44ca-9260-1170fa65c2eb">
+      <statement statement-id="ac-7_stmt.b" uuid="4fa082e8-6eb4-4e3a-b627-5f0658b016ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="158c508f-edd9-430f-889a-dbcb0c418e50" control-id="ac-8">
+    <implemented-requirement uuid="acbcd64b-c787-4c14-bd1e-3adf9ad25d14" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="1e58e16e-890c-4b2a-ba4d-093ef8366cb9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="293da102-302e-46e8-843e-250e3ed20c85">
+      <statement statement-id="ac-8_stmt.a" uuid="f891ef64-ff0d-46d4-b5e8-27410f1b96d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="3d8adfd5-0d7b-4338-9096-855aebd001fb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ad1d28f6-4285-4918-91aa-cedbee561a56">
+      <statement statement-id="ac-8_stmt.b" uuid="f2446ca4-cf6f-4158-b73a-dcbd92583a5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="47305d48-1aa4-49b5-9f1c-ee489fcb4c07">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5a6cdfb7-e671-4ae3-94fd-d5e6f994991a">
+      <statement statement-id="ac-8_stmt.c" uuid="8537cf10-713a-4183-8ff8-6ae3ea21364c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="398adbcf-b409-4df2-930b-e78f2ef5e84c" control-id="ac-11">
+    <implemented-requirement uuid="ebfa466c-6513-48e0-b16c-8e4664d3acae" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-11_stmt" uuid="4dc28840-0a35-4073-b616-9396dc12c8d3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="daaa5916-4336-4442-a59f-c78418e1f84e">
+      <statement statement-id="ac-11_stmt" uuid="fdd54146-084d-4907-8ae0-cab0e39e2da4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39fbca32-d3af-4ca7-a49e-a0a0cb672d6b" control-id="ac-11.1">
+    <implemented-requirement uuid="d111fe5f-30c9-4c34-b812-1adaa9808a74" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="39cef9cf-a57c-41a0-af54-f7f90bc5b765">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9e39e796-3921-45c1-bc45-174f4cd82f68">
+      <statement statement-id="ac-11.1_stmt" uuid="dc4ec50f-df76-4cc4-911f-b4ac0ca8a14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afa1da69-3c80-46c3-b2b4-7244c25fddad" control-id="ac-12">
+    <implemented-requirement uuid="3e86bc55-b3d0-430d-a558-da100e16e440" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="7e083e38-96b6-4e6c-87f6-478b254827b6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1b817c0b-61ec-4141-9229-2bcc369b15c2">
+      <statement statement-id="ac-12_stmt" uuid="5a6c3a55-11cb-45c9-9bf9-2add957d87eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e559b524-6b8f-4399-a236-6b739aa2aca1" control-id="ac-14">
+    <implemented-requirement uuid="2f0f0ead-5fa5-4682-a174-7800552dedce" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="ac0a3ef0-2835-434b-80a1-2d3b03f92248">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4c9eb48f-ce6d-4793-a7f5-001008f44367">
+      <statement statement-id="ac-14_stmt" uuid="17e1ab2a-d00e-469e-8692-6b38e0f65a14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96984d9d-2545-41b0-9cef-be83c46230fc" control-id="ac-17">
+    <implemented-requirement uuid="320c1d9b-b2b2-48bb-9c34-17fae95a4dcc" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="b400e7df-9b9e-4da4-89eb-49587f771cbd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bcefcc4a-cee5-4ff3-94ea-68029b554d90">
+      <statement statement-id="ac-17_stmt" uuid="5d90a3e4-7361-4273-a8bc-db4c696d838a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="894940d0-f7bb-4bbf-abf4-c49f9fe03a02" control-id="ac-17.1">
+    <implemented-requirement uuid="626329d3-c0f6-4dbe-b213-a539d1a2dd6a" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="f0a959fb-6248-4fb3-b2bf-ce2fcf31f54b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7cdad36e-47b8-4d01-8ae6-127113aec44f">
+      <statement statement-id="ac-17.1_stmt" uuid="b422b35c-cfbb-4c39-901a-4b1b13c64ca2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69267497-cb9d-4682-b7b5-82d641405e57" control-id="ac-17.2">
+    <implemented-requirement uuid="c832e5c9-3edb-458a-8137-1b42ab16c13e" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="a2c0eca7-ca04-4db1-94bc-f2c36e9b71b1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="faaa6197-5ef6-4f94-ac9c-0f9033a85161">
+      <statement statement-id="ac-17.2_stmt" uuid="7194261c-7f01-4acc-a845-200978219a9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e792255-f84f-446c-b60c-dad3951537e0" control-id="ac-17.3">
+    <implemented-requirement uuid="49cc8838-2e3f-4732-83e8-6a5fe3b7756e" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="f5f52dd6-c22c-4a6d-9a72-15913255951d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="efd6ee24-cfb6-4803-acf4-2b6fa1cd2235">
+      <statement statement-id="ac-17.3_stmt" uuid="899e2598-6344-4130-84cf-0a80cd57e5c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e810eee-6a63-4a27-a8a4-99a231a1262f" control-id="ac-17.4">
+    <implemented-requirement uuid="d45c7a34-3c7f-434f-8e3a-8a9871913b1c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-17.4_stmt" uuid="869dd9af-2f4d-42b7-9418-2a855e76f48d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="20d444d3-c447-4ce8-95e7-6e9cbb81503d">
+      <statement statement-id="ac-17.4_stmt" uuid="caa76b51-69e2-4b05-8c48-1aeccc2f7702">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17e69fea-bd2c-40de-a9e0-c81c749807f9" control-id="ac-18">
+    <implemented-requirement uuid="cf4f32c5-c564-4155-bb9c-f9503665fcba" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="320e46dd-a198-4651-9c0c-f2e3355704bd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5569cba5-8ec3-4ee1-9aa0-653b91eda86f">
+      <statement statement-id="ac-18_stmt" uuid="679a2eca-7bdc-4f86-9fbe-308e6f9cf989">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="351ae5c3-0d5e-4e26-ab2c-267869ed5344" control-id="ac-18.1">
+    <implemented-requirement uuid="264faace-8c8b-4a88-9d5e-77b44a5ff92f" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="cfc5c28d-ee4d-46fb-b4ae-543dc203f124">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f8f9c8da-6cc4-4761-90d2-4a17b03f4e3b">
+      <statement statement-id="ac-18.1_stmt" uuid="8dfd26f1-7e77-43f7-81ba-b2daf416b4dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="896fb501-2ebc-4a04-a757-753066ef7020" control-id="ac-19">
+    <implemented-requirement uuid="1f782fa7-e28e-47fb-ab66-2a3924b4e768" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="03491d1a-44d5-4d3b-a261-d710592ff90b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f17034a3-85db-4005-a6b2-396353500776">
+      <statement statement-id="ac-19_stmt" uuid="eda79b65-5b50-4781-a955-9e11b3cd8d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0386fd8f-b723-4f39-b610-6f89cc0a48cd" control-id="ac-19.5">
+    <implemented-requirement uuid="bc7e60a7-b03a-4d11-bb24-cd0bf4d7697b" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="8adb1847-ebe0-466d-9465-731402fd82f0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="be9536c8-5f1a-4aa8-906a-e903e0a26529">
+      <statement statement-id="ac-19.5_stmt" uuid="9fdfee96-2ee4-4eae-8fc9-6c8ad51cff13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d97c7d79-7552-4d16-b486-c6d6a4990599" control-id="ac-20">
+    <implemented-requirement uuid="c3be2813-ce58-4647-8d38-acd11c0b09fa" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="5adf8bf3-649e-485c-be02-1e46aa8e9fbb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e37ec312-3690-4aab-8fce-77ced25263a7">
+      <statement statement-id="ac-20_stmt" uuid="88248406-b936-4edd-8091-a2f86e3ba4b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b400acd5-b430-4315-aef6-8f2c23c56058" control-id="ac-20.1">
+    <implemented-requirement uuid="6349eedb-335e-4949-a6bc-0cf3807c9998" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20.1_stmt" uuid="b976e3e1-1982-4596-812c-7293c51dc5a8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0d2695c3-8137-4402-aa1b-b6bf20a0fba0">
+      <statement statement-id="ac-20.1_stmt" uuid="f7a3c913-3a12-4cc3-aa0f-05f43f886597">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5cfe032-4170-4439-9958-70e8bb94c24c" control-id="ac-20.2">
+    <implemented-requirement uuid="b41ebb26-af1f-4e54-a6a7-0fb4f4b4df73" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="5fefdf09-c596-40e1-89f1-5f7c8ed77c06">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c28f174f-f9e0-4bac-b0c1-16f6bc721131">
+      <statement statement-id="ac-20.2_stmt" uuid="1defb44e-3bf3-4b2f-8ace-c6632f9ca07d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09f3c6eb-9a3e-4911-be18-25673f74cd5c" control-id="ac-21">
+    <implemented-requirement uuid="b26be87c-63c8-4b79-97bc-072aad71cda3" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ac-21_stmt" uuid="7d1c89b0-97db-431f-9f32-3d1feeb8a4e0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="eb9e8842-aab2-4f91-8d7e-85ec1dd16752">
+      <statement statement-id="ac-21_stmt" uuid="99eeb87f-3920-404a-b9af-e8426878e46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8442786-585d-4cba-b860-02a1eff97ea8" control-id="ac-22">
+    <implemented-requirement uuid="9e74d09e-7b3f-4fa2-ba78-c9bcadb577a6" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="46299491-7eb1-460b-b934-09012f236786">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7a5d22af-af2b-45a3-a90a-80f25cff843f">
+      <statement statement-id="ac-22_stmt" uuid="73127c56-bd15-4e9f-bf78-77d76f7f9929">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df4d934f-c63b-4b62-afab-172b49a0cae9" control-id="at-1">
+    <implemented-requirement uuid="7f5357fb-e9ff-4372-8dfe-30971d1d15a4" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-1_stmt" uuid="b6787c4d-1529-4175-8f05-21a24f54cebf">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="468e48e2-2da9-460f-89e3-1dd1a05181fe">
+      <statement statement-id="at-1_stmt" uuid="25f73115-0474-4dd4-9bdd-401954c96b87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00a8bb32-120e-404d-8941-ed629b3fe19f" control-id="at-2">
+    <implemented-requirement uuid="9165e48c-47b2-45c6-9ef9-1be15d4bee34" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-2_stmt" uuid="3c2de85b-480c-49d2-af62-21d3906f8dd9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ac353192-0dbd-4e93-a7c4-ae8fe3071407">
+      <statement statement-id="at-2_stmt" uuid="777b75c3-3c9e-4be7-ae9b-83d323694887">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2047a33c-5aab-4a7f-b122-a0627cdb3012" control-id="at-2.2">
+    <implemented-requirement uuid="8c583409-381f-4a7e-8e7c-7f1e4a75c8c5" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="ef324a73-bbaf-405b-8daf-4bdb32f4872a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b5b4441e-ef0d-4ac7-8057-988046241fab">
+      <statement statement-id="at-2.2_stmt" uuid="ddbcb366-d536-4ac3-a7e3-0ccb970101f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="003b0dc9-3fbf-470f-98eb-551d097c70f8" control-id="at-3">
+    <implemented-requirement uuid="70995a7e-a4d6-4c67-bdd1-ca7e9e0213d5" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-3_stmt" uuid="bb245051-8318-410e-9d46-ff006ba3a7f5">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c53916f6-96f0-4398-9798-3c4731f20185">
+      <statement statement-id="at-3_stmt" uuid="21d83bc7-fb3b-4876-a7d0-683325d30d77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52670394-0f0d-4cbf-8d70-8165663d3403" control-id="at-4">
+    <implemented-requirement uuid="9f744156-db76-4f8c-a95b-c73ad5c5a9e1" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="at-4_stmt" uuid="39f1f06d-aca9-4002-b96c-256c9c7dea56">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="78244e59-56b0-472f-a7ca-672db18b0616">
+      <statement statement-id="at-4_stmt" uuid="2d36c3d1-c630-494b-ad2b-3dc40d0b15bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24e8a235-904d-435c-9cf1-ca5793f0fb84" control-id="au-1">
+    <implemented-requirement uuid="1e2c00bb-257e-4c9a-8976-4ce731867b45" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-1_stmt" uuid="a590b34d-8441-4fac-b057-f6ea0ed9d1f5">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="615c4c08-728d-4c3a-a27f-be722a343126">
+      <statement statement-id="au-1_stmt" uuid="48b0f4ff-0104-4ba3-95b2-b32c29d9d4d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0614bc17-26f4-4821-937b-dd14ff439771" control-id="au-2">
+    <implemented-requirement uuid="4c08c196-0de3-477f-9170-57f638549f6a" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-2_stmt" uuid="88ed8dae-4dc0-4961-a9eb-3c42a3307ff3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bddfc83a-23c4-4efb-a798-219221a28e30">
+      <statement statement-id="au-2_stmt" uuid="6efe2f9c-19dd-421a-9707-3c71129487c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="931db3fc-5c7d-4fbb-9649-4b44be25294e" control-id="au-2.3">
+    <implemented-requirement uuid="3bc17cbf-609a-456f-ba2f-2aa175ec2829" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="63610e23-97a2-4b70-9e1e-4757b35fcf2d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4b920592-b99d-4960-a520-c153196b4ef3">
+      <statement statement-id="au-2.3_stmt" uuid="c4ae0ea3-7e03-42d6-8cfd-ceb4281bd941">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7535df1b-cdc2-453f-b151-f7c1190f2636" control-id="au-3">
+    <implemented-requirement uuid="af56a0ad-445f-4a57-97a1-6f48aff745d3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-3_stmt" uuid="74313036-5ba0-4658-af21-688bdc276828">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="628a7bf3-106c-4159-9ff9-f3442001e74e">
+      <statement statement-id="au-3_stmt" uuid="20ff5cbc-f1db-45fc-ae63-36db96309b77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ddec0c9-245a-4943-9145-1eb3af8adf8d" control-id="au-3.1">
+    <implemented-requirement uuid="7f2849b7-9dc0-487b-a7ac-a87636504674" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="58f60a56-0e27-4c0d-a0a8-1733112b12cd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="68beff06-b5ac-433b-9965-ff24369ee3fd">
+      <statement statement-id="au-3.1_stmt" uuid="5bfcd2c1-e90e-4993-9d4d-6db4fc6129a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5ecf394-a085-44c0-91dd-d055fdfec417" control-id="au-4">
+    <implemented-requirement uuid="0ea0d8e8-ffa5-4ecf-979f-c63a5f0da105" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-4_stmt" uuid="66b262eb-29f5-4a41-8a5f-314cb69258e0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="711f858d-ca87-461c-887e-39ec5ae3f986">
+      <statement statement-id="au-4_stmt" uuid="2226f5be-fa26-43c2-ade6-dfd11dfb4951">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a2afb7d-3427-4b71-b2cc-eff23604d475" control-id="au-5">
+    <implemented-requirement uuid="5a3691b1-30a2-427a-abc5-fe83986ca715" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="81600cd8-b07e-4e31-8bd4-5cbd88513d24">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="cd57510a-c82b-4e2e-81a4-d888ff2d0647">
+      <statement statement-id="au-5_stmt.a" uuid="7889bdac-bfb0-4861-aac0-cc136c1c2b4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="d485c19e-363e-4cbe-b94f-6c457e682b6c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a58c1008-e156-44b5-9f85-95195b2cb314">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="594c5eaa-e0ad-4550-b080-9496082f5b84" control-id="au-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6_stmt" uuid="7a840eeb-8c1d-4024-a531-c123700647f2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bfdcb030-4d25-41eb-9386-3b6a7c25b7ba">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="454a9ed6-a9da-4553-ab4a-441214e67c9e" control-id="au-6.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="69ca62ac-a8b4-4c8f-8481-c4e1dd5126bc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="adefc378-1c35-4e44-8abc-3d05d80617b2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d90b3793-f1b0-4437-8e2d-e1c4c11c178f" control-id="au-6.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="98ad7006-e527-407e-af5d-15845b13597f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="455d788b-a6d0-4f1e-a6c2-9bab52e80453">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d39b7e0d-c862-4951-8d63-44e0851b1a45" control-id="au-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-7_stmt" uuid="7bee9fd6-8206-49cf-81a8-080367505fa1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="44576b98-cfaf-471c-b1b9-7e36daa9e082">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9bb98049-d792-4b8a-bd72-1ad5a753d99c" control-id="au-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="3455a789-8023-4369-a111-fe8d2dd419e3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1fe3d366-412a-4d8f-a901-91f97f106372">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="765349d4-d20e-4a48-9d05-6808b2da87c0" control-id="au-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="f9a512ce-9b74-46a6-b27a-bf334a6e4bf7">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="589aa3ea-4ce6-4da4-927a-3fc454bf1bc3">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="au-8_stmt.b" uuid="20f92f06-d694-455d-9112-45c115cb6334">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d4758286-ef1b-4387-b184-60747dfc8547">
+      <statement statement-id="au-5_stmt.b" uuid="252cd8e0-2732-497e-bbb6-7b5062eca13e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ec7563a-e125-4f5b-bd53-db227751ddee" control-id="au-8.1">
+    <implemented-requirement uuid="1f6efc7f-06cf-40b6-a0a9-650c53e0f178" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-8.1_stmt" uuid="f5382c34-6563-4389-9064-00c85b9e1b5b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="02f450b5-f7fb-404f-82e6-d96bb45e8a5b">
+      <statement statement-id="au-6_stmt" uuid="c4fb2454-d02e-4154-b5f1-f1821fd421c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce8635fe-6c2b-4598-9efa-e44d0d2b6386" control-id="au-9">
+    <implemented-requirement uuid="86c8a666-b7cb-4108-853b-567eb8bf4238" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-9_stmt" uuid="4e109772-1b28-4180-a055-41c330cdf684">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="91b88b40-6fe0-42f3-8b3a-90cd9a4830e9">
+      <statement statement-id="au-6.1_stmt" uuid="278d0664-63de-4e5a-ab0f-c9ca5bfb276e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="699f103f-4110-457b-9799-8d2dc150163f" control-id="au-9.4">
+    <implemented-requirement uuid="5a95c446-2b3e-46f5-a57f-14a058b7f57a" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="e445443c-beed-47e5-995f-8f390f8113ce">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d7631c13-f160-48df-b8a6-31f15a97d985">
+      <statement statement-id="au-6.3_stmt" uuid="7ea83329-7711-4dd3-a35f-ec8e5e422fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="975be9e9-256c-4d22-8e9d-cb0be5c88b7a" control-id="au-11">
+    <implemented-requirement uuid="9f8dc33e-8cb7-4eaf-9357-3baf7c120cb1" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-11_stmt" uuid="e1e3a5c0-8a4d-4872-8163-8b50a2900dcc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7036db36-59d0-4fb7-97e5-ba67a1ff4700">
+      <statement statement-id="au-7_stmt" uuid="b1bc0029-2fde-4d40-840f-9c818566f414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef22bae2-b3ea-4fb5-b178-29d222a75d09" control-id="au-12">
+    <implemented-requirement uuid="1ac38bc6-2270-4b2c-a40f-b5f2c888e646" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="bb76867d-f28a-43ea-b7d8-3510e57be298">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0c94ea90-50ce-433b-8eb5-8783fefecaf2">
+      <statement statement-id="au-7.1_stmt" uuid="9098cc15-34b5-455e-94cc-1309592fcbcc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="86503bc5-38e0-4f6d-bf8d-331ea3d1a2b8" control-id="au-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-8_stmt.a" uuid="51d7e171-b44e-4ba9-bf07-0dae8326dac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="4e22e121-f7c4-4220-952d-fd369f9969a3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="3c35445f-6c01-47d8-8e33-396ee55b55e5">
+      <statement statement-id="au-8_stmt.b" uuid="3ddb5ae8-d5ea-4655-87d3-058e32962850">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="176034f6-7e0c-4c28-be40-0cc8c93d758e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="31ae191d-5e51-45e3-b7f0-fdc75ca0247a">
+    </implemented-requirement>
+    <implemented-requirement uuid="d597c550-7f60-4e79-9713-7c8d24b29fa5" control-id="au-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-8.1_stmt" uuid="5c59fe74-8d55-42c6-a1ca-111c169a49fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9e7467a4-dad1-4276-bf08-d8d34380831e" control-id="au-9">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-9_stmt" uuid="399a2a67-60c7-4f14-8a6a-b073089ead3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8877d82d-0b9d-4232-8f63-15a7ce719c30" control-id="au-9.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-9.4_stmt" uuid="7916cc4f-c84a-41fc-b4d9-8d5ff5b68845">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="325e4141-ff18-4912-8ca2-fac8295c5172" control-id="au-11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-11_stmt" uuid="ae2204bf-c4d7-49c8-859a-829d982f7803">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17a6e0b9-18e4-44c4-b7a8-a80b7c808622" control-id="au-12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="au-12_stmt.a" uuid="6db41abc-586c-4d6d-b231-639e07256b3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="au-12_stmt.b" uuid="e53a6c7a-39a7-4a40-af2e-f7898cf0fbc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="au-12_stmt.c" uuid="3baa0952-d9bf-4d8b-be5a-72ee07bf17e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2a14420-a610-4397-bca0-464151065981" control-id="ca-1">
+    <implemented-requirement uuid="971e9508-426c-4403-a87f-f0ffbb29a222" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="64e628cc-565a-43a4-ba9e-71e4b65b19ac">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="da38b2a9-2566-4bff-a770-edb053f223e1">
+      <statement statement-id="ca-1_stmt" uuid="46b8a74a-9f80-4ba6-8138-ceb05880ef58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f42a5c28-a7b5-49d6-8e7c-4aa0c50df168" control-id="ca-2">
+    <implemented-requirement uuid="5261b627-d858-4901-934a-e370806710e6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="613c00b7-0a52-4cac-98e5-ab91ae63f43a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="6255fb3e-bb97-4fbc-b484-646ca83ccd13">
+      <statement statement-id="ca-2_stmt" uuid="a6b03178-7b7f-4c3e-8fb8-17aa47256d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8eb821dd-6b5a-4ba3-be5a-58b5913ec821" control-id="ca-2.1">
+    <implemented-requirement uuid="feb6cf0d-d8ae-4f12-8a00-eb9cd47740b8" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="26c2950d-b945-432c-af7b-f12b83fa0b24">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e7a5d15b-bad0-4a18-a8c3-6159a09de6fd">
+      <statement statement-id="ca-2.1_stmt" uuid="9509e517-0390-4c95-b918-3e221cd113b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7944e76-ac9b-4b59-a4a2-42d48461305a" control-id="ca-3">
+    <implemented-requirement uuid="af5a6093-d245-4da5-ad1f-d99f2d2df6ef" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="fbbf807f-0c86-4d57-8996-968e8f9fffcc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e61b3e32-8b85-468a-9046-4bb9333bd8f2">
+      <statement statement-id="ca-3_stmt" uuid="6d35641b-efbd-4d18-a403-37baf1180bb9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f3478a-5e48-481f-993d-c0646bcdfb07" control-id="ca-3.5">
+    <implemented-requirement uuid="f92ee641-231a-4bb7-a4bd-316f7d190cdf" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="8e3fd574-e01e-4ddb-86e0-6536edb796c2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="764c6cec-39a1-46fd-a86f-354b7501b7c7">
+      <statement statement-id="ca-3.5_stmt" uuid="4c9c3596-df43-469c-b5b1-fcf54739b744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5167431f-b86d-4698-8207-e1f6b7372dce" control-id="ca-5">
+    <implemented-requirement uuid="1b914e6e-95e4-467f-aded-d23dd5e9d7bf" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="6a0a6886-57f7-462c-b0ae-f64546f31f95">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="baa2593e-0214-4196-b0bd-1d86cd77760b">
+      <statement statement-id="ca-5_stmt" uuid="9edeef89-9962-4daa-842b-cbc201b87e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a90c5ef-3808-4027-bacb-0e96e39e3d02" control-id="ca-6">
+    <implemented-requirement uuid="bb0b9ff7-b5d0-448b-9dd0-4dcd974b1738" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="5819c104-3ff7-4fa3-8233-40b631f7fa66">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ec26d312-328f-44aa-b90e-15d90ec3a014">
+      <statement statement-id="ca-6_stmt" uuid="867ae207-54b9-4e90-8ac3-f1fd300e72ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04bd3cea-8467-4a04-a2a0-e7389d098969" control-id="ca-7">
+    <implemented-requirement uuid="567d50d9-72bb-4086-8068-58e1b8e9c1d5" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="1f368b91-e990-4398-9bda-28f6ca27c0a1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="86371755-5e84-4cb8-a33b-382ebbc2e171">
+      <statement statement-id="ca-7_stmt" uuid="7a8a866e-b7a1-4d18-9493-01a1a6acfa64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e5699de-f915-4f80-8ff8-e8c13621da5f" control-id="ca-7.1">
+    <implemented-requirement uuid="ab50e11c-6cd2-48df-97d4-cbb119d1c6f6" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="1857ef19-dce3-4f9a-984d-5f596e8186a6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b7064127-28f0-4c9b-acf0-3a1ecd57aea5">
+      <statement statement-id="ca-7.1_stmt" uuid="9375a78c-bf7d-419b-8bf4-b2e91b5da8f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e951a570-3dc0-4121-b5ad-0f527f73b706" control-id="ca-9">
+    <implemented-requirement uuid="64db1d9d-4002-4019-bc0e-7d5edd01ea32" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="4607f561-3af1-456e-a9af-b274a07fb387">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="95f54ddc-810b-47eb-8bbf-cafd776e571e">
+      <statement statement-id="ca-9_stmt" uuid="affdd47a-c192-4094-8874-d3f6b3b88f20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21e8493c-ab65-4249-8f47-ad59921e12f4" control-id="cm-1">
+    <implemented-requirement uuid="380e7a14-e061-4121-a8bf-79d0005964ac" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="387a6e89-cdf1-48fc-b98f-af4a12cdc8e0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="019e5c95-63e1-41d2-adcc-0adf409dd5f9">
+      <statement statement-id="cm-1_stmt" uuid="51f63c2e-b95d-4f67-91f2-9c0d7d81e733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79bde2ba-038b-444f-9e28-8c8389e2aa66" control-id="cm-2">
+    <implemented-requirement uuid="722eab9b-ec8c-4e05-b741-b75eb4b0784f" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="49c5cb7c-5670-4d33-bf24-5a4ca17dbc9a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5584686d-6d81-4954-939b-8698c4a07bcd">
+      <statement statement-id="cm-2_stmt" uuid="6041d2ce-ce86-4ae5-b4ec-32db39eb19cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34f5959b-2416-4fe7-a123-ba22416834ab" control-id="cm-2.1">
+    <implemented-requirement uuid="4ecfbc5b-4bf9-48fb-b59f-fdbd0b9f1be4" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="097747bb-2f4d-47b5-bf5d-438cc1b6772a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9f6fd2ac-6e58-4af3-8a9a-21abb9f931a7">
+      <statement statement-id="cm-2.1_stmt" uuid="e551e386-023b-4d62-8437-6955d2400e1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="feb7bffe-4aa4-4763-bc32-f5d4fd626fe7" control-id="cm-2.3">
+    <implemented-requirement uuid="633cd543-b971-44e5-bc81-fdfd8c2a3221" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="e80cca5e-60fc-4c5b-ad52-fb6d9fd1f975">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1a1b71f4-add5-4728-9153-25ed2e839915">
+      <statement statement-id="cm-2.3_stmt" uuid="1095cbcc-c7c8-41aa-a8af-cf0e92f116a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ca3e1a4-23f6-4483-815a-8f466a75160a" control-id="cm-2.7">
+    <implemented-requirement uuid="6829d65f-ab65-4e03-a5d1-abd0f9fbee6d" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-2.7_stmt" uuid="23ec62c1-c1d1-4955-8113-8227f80dde3f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c96c5ae0-26e6-4f8b-bdef-e60bff5ee58a">
+      <statement statement-id="cm-2.7_stmt" uuid="d5f826cd-0ece-4d0d-b103-d3a2edc624c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c23caa0-607e-4b5a-9b3f-38df56da09e9" control-id="cm-3">
+    <implemented-requirement uuid="6a3bf7bd-328b-4941-8256-b5b93419ce18" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="4c08f058-802c-4c94-9d90-3e5a32c674a3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="180ed476-aac3-47fe-a433-abc47b54c9a0">
+      <statement statement-id="cm-3_stmt" uuid="9796b833-efa4-4000-9687-e129cb2cdf05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4c2a22b-ad6f-444d-995c-9e3f0da4e224" control-id="cm-4">
+    <implemented-requirement uuid="f9d4934e-52e6-471a-9b01-b234b2bfe396" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="76374147-0f72-4411-ad9b-5433808ee37e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="83e8ecb1-f719-4996-b0e9-918aec83edfd">
+      <statement statement-id="cm-4_stmt" uuid="6dc0ba14-3590-498b-b656-23c90f02b6f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f01b440-ccb1-4387-ab71-649bd80086a9" control-id="cm-5">
+    <implemented-requirement uuid="c7e1a67a-1209-457d-8b72-e79f9b00c7f6" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="7534d517-7de7-4f70-9bfa-9bf2136efa01">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c319cf2e-9109-4d4a-8c49-63d2a7642d4f">
+      <statement statement-id="cm-5_stmt" uuid="f44ee25b-cf19-497f-8ce8-101924d33c3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bed7157-ea6f-46da-a640-8f9ada8d3b4e" control-id="cm-6">
+    <implemented-requirement uuid="d52b144a-784f-45bb-902c-8c75d7c29f61" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="bc7bc397-9393-4f38-b7c4-570d745b635b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="133c5f2e-9f2c-481c-a7c6-a933c006264a">
+      <statement statement-id="cm-6_stmt.a" uuid="df3d7a5e-5965-40bb-9507-2c7d8e25635a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="8a4b6934-9abf-4815-8620-07660f11200d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7de71a9d-d96f-428e-8a4c-f9e147377564">
+      <statement statement-id="cm-6_stmt.b" uuid="50e28883-5f66-44ad-a4d0-58f966e9fcb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="7dbf9b3f-aad7-4cf8-90e4-303900de320e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d99709f1-fa33-46ea-ae69-b4ccf7384501">
+      <statement statement-id="cm-6_stmt.c" uuid="4967c4ad-f6bd-46e8-8be3-a82ffb6df199">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="f17be45d-0542-4e7f-9cf3-d4a7ae61936c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9760e9ae-88df-4d0d-9f3f-f6a81f71e507">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="ef280831-e852-4a15-b610-d0a4aeeedb07" control-id="cm-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="2b8267d9-26f7-4bf5-8f28-7a4888a5e58a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="00d1b094-c2a3-495e-bbb9-cb87293b5244">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="95ba37d9-fd4b-4776-be00-e98a17c6e9c7" control-id="cm-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7.1_stmt" uuid="20ff57c6-2eb1-4e44-9752-403433c78dcf">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="66a79e7f-ef46-4a29-ba70-9a83ab87131c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="c96af3c3-edca-42de-903f-5dc627ae3a30" control-id="cm-7.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="d1dd3bd4-bbf3-4d36-b3b0-bfb0453fdf6a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="aa11da9f-5616-4e9e-8835-2e0138e4242b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="65ced1ef-25c2-4c05-9b42-aeab1aeb1db9" control-id="cm-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="031b038c-09be-44d3-975a-76748a31ef3e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8e011656-f016-488d-a280-565290e5ad42">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="cb7d727b-6590-412d-8809-667bcb212590" control-id="cm-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="9f1a3d9b-eab9-4ee0-bcc8-e811607f829d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0486f2f8-ed24-4424-b513-ccc9a2fc777e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="4a584eaf-5a3f-4f5b-afa3-1d7c55532dc7" control-id="cm-8.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.3_stmt" uuid="f9499f98-6936-4c9b-bd8b-f87067e664b4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ec11baaf-305a-4599-be05-428f8a90ead9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="20f4295e-1b5b-409e-8640-5bde1bc065d0" control-id="cm-8.5">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="b5a5c5d1-03e6-4270-8f23-2727026ad1f4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f83e53f9-fb03-47f7-8724-081bcf39eeb5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="762ac642-41f9-44a7-9c7a-8ce3af301e9c" control-id="cm-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-9_stmt" uuid="8b873eb8-696c-493d-baf0-4458724a877c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1b94e2c6-b27f-4979-b0ce-936964952de8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="aedf40b9-a616-4f22-a455-43b3277411a0" control-id="cm-10">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="88a26097-8193-4d6f-9fbc-b7b84a23ebd2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="dc9a8583-23a4-408d-94e2-b42a74024616">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="146439a2-41be-4066-ab1c-26c56fc9c8b9" control-id="cm-11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="4c757ae8-742c-4b2d-b45f-07a9eb05ac55">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e269d3c9-c816-4293-a97a-351d4c592bef">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="494d4ef2-a801-44d4-8d0d-331aecac37aa" control-id="cp-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="3e006b4a-2747-4cb4-ad65-9d2c93210831">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f79d2dda-ff1f-4b9a-b1e3-ad2a383d0200">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="18e2dfba-1860-470d-9cac-df68bb926aa4" control-id="cp-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="1d2a2c65-7a80-4445-9aed-3c623fa2f4c5">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="3ed1eda3-b4b9-4fb4-9201-6a7ca5299b9f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="08b71005-e870-444f-acf4-97986333456b" control-id="cp-2.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="ff35e927-abfa-4adf-999b-12a2746d4eb3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7f7bcfaa-8cae-4b0b-87bd-fd8cf1097016">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1f427fb4-cc7c-4211-b95f-b4d1d62bfcb6" control-id="cp-2.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="052b371c-0405-445a-9a80-b327a895db8f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8aaeab4a-d68b-448b-9c2f-24bbb397488b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="83b25a73-277d-4f67-ba6a-9b9887015d97" control-id="cp-2.8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="fd916dd3-8d25-48e4-b77a-6da58976aeab">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="61f07873-65d3-4003-a854-6d9f8a23df9e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="64effbd5-480a-401f-9007-25fefeddd3b1" control-id="cp-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="8352fcf3-21f3-4437-a223-b69527fb06b9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="96d34df2-051d-4cf2-a0bf-031e460dd604">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="65a7dfac-6ad8-44a9-b3fc-d7d31cb7e058" control-id="cp-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="28e15fc3-1f38-4bb3-ac40-c7893a3d7fcc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="798f5cdd-1440-4603-b7bb-d3507d7f631c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fcd727ef-1926-4489-92c8-3c1d311b3351" control-id="cp-4.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="499d4053-6008-41ad-89b4-f62b31ec794d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2bf4b4da-77fc-4c5f-83cc-284dc5c1e2ce">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="03cc6d83-1627-413b-905a-49ab1da4ee35" control-id="cp-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="ad8604d1-9410-4cd8-9443-b9ca004fbbdb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1f69a402-c1c2-4e00-b2fc-172e64ca95a0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="430096e4-e659-43dd-9ae7-4412cee2f2e7" control-id="cp-6.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="e90176d5-be96-4c8e-994e-6a87402b010e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="87d71466-3f99-4d14-8d60-aa048e0a6adc">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="144d6541-d5cb-498a-bbba-666b793c05a9" control-id="cp-6.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="53bde6eb-c5ce-4102-9c53-1657487c1ae3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8c56eff7-ee09-40d8-849e-55c31a37da3c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="bf83575e-ccf0-4fd6-bbe1-b11326a5aa49" control-id="cp-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="360a98a7-899f-4847-9498-f7f49a8218e8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b6da9288-e40d-4cf3-8c50-c3b4d2af37c2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1d2d68f4-19ef-401f-948c-d3035cf4b62b" control-id="cp-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="cf287d2b-317f-4af0-87bb-beefa8b92aa6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="dd300248-1d81-4166-8541-7d55f605be94">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="b8b8f05e-d6db-4d73-abbf-f9edac969ac4" control-id="cp-7.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="89295016-2d0d-4f16-b904-39da540ef90b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2b1f6fdf-1bef-438b-b803-f7d6f05a9ba5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2321844d-de15-4bcb-9895-57ea218fdb4e" control-id="cp-7.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="992fbbe3-eaf4-4806-9e81-99766abaef44">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="6e866df6-5986-4c2d-a6a3-9ed7e0ff8919">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="dca28615-2db1-4664-b6ef-f92c247925c5" control-id="cp-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="9fdc95a4-cbb4-4a0e-b21f-03596cb7a460">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="724972d2-9533-4c8d-a9c4-5fe2a9f48490">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="754b0646-bd2a-4f93-b19e-2e8d47bb4dbc" control-id="cp-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="f97e3c5b-ff3f-4251-a267-d747e9ba48bc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f03d4bb0-ef97-43d8-92f8-47bf9913a214">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="db82d939-1a67-49c2-ace3-7ba96a0952f4" control-id="cp-8.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="cb0384d7-d94c-469c-a9f8-b1323449ce86">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7bab5a66-a5e9-4984-8bfc-cc4e4e22b333">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1e148b61-355f-4b47-b64a-824e2d80086d" control-id="cp-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="a0664ea2-35bd-4774-b110-05e1553fc723">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d8c84a22-ac92-40ab-8ff4-624a516eee22">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="d39c55a1-46fb-4955-ab54-0754f1811d37">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d9db8d48-49a0-4822-ab6d-ce8af68391f7">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="1b0a9300-4461-42f4-bc7b-a00f124f5a9b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="90f92efa-e894-4878-bd8b-cf95fde8877e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="df3d4c8c-d179-47b0-adc6-d7703478c8de">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7f9e1f8c-b717-4228-9c75-72e855cf5b2c">
+      <statement statement-id="cm-6_stmt.d" uuid="8bac2c7a-dc9c-4a45-b5f0-6b01f311534a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eac67ef8-120f-495e-a5b6-02a35c8f7583" control-id="cp-9.1">
+    <implemented-requirement uuid="eeb4a8f0-0297-4da6-b654-c419632fef88" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="1bdfc08c-ceed-4fcf-8c1d-af638d028d1e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ec8254c5-9ef5-4f17-91a9-9a32bbb5ab4a">
+      <statement statement-id="cm-7_stmt" uuid="3dce3505-f872-402c-9895-140c2bf099b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19512c81-74b3-46fe-accd-6e4ff67dc393" control-id="cp-10">
+    <implemented-requirement uuid="200a629e-6011-422f-9772-f4f1aa4307f7" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="acd6f40e-5af7-42ca-8c4a-de3661654839">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e70b51a8-0f65-4fa8-9ce9-8ec126445783">
+      <statement statement-id="cm-7.1_stmt" uuid="20f53a62-43ef-4dee-96db-2a8fbf44d057">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="873aca9e-75b6-481f-a24c-a251511c6b2d" control-id="cp-10.2">
+    <implemented-requirement uuid="83263317-803a-4663-9c39-412771b42a4a" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="7be45c28-aea2-42ac-9e01-5f67b227da2b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e0bd3297-cbdb-4dd1-a9ef-a94a51290d3f">
+      <statement statement-id="cm-7.2_stmt" uuid="d00ff979-6dcd-4de8-bb64-df12ef40a9eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d85485a3-e963-4f2c-9e84-8a38d1eec105" control-id="ia-1">
+    <implemented-requirement uuid="16693daa-98d2-43b7-baff-aa83a4ad25db" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="9e93c49b-d2bb-4d80-9f7f-ec1735ccc630">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a80d045f-411b-4b2b-92fb-81ddf6dc7c41">
+      <statement statement-id="cm-8_stmt" uuid="655b46ac-0faf-4e0e-816f-638e3b03ca9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92491863-9f57-4185-9a9c-157ed4eb083c" control-id="ia-2">
+    <implemented-requirement uuid="8855e841-3cea-4f02-90b6-f51f7d2f0368" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="ae88bc9d-3f53-4ebc-8d79-d430ec3a69b8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="378f8c77-4750-4d6e-81a9-ed6dcd7b4918">
+      <statement statement-id="cm-8.1_stmt" uuid="8fcc881a-5b37-4d7e-a813-71d4a3521582">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53ca9065-7ff2-4935-980f-585815c5d182" control-id="ia-2.1">
+    <implemented-requirement uuid="4ab2215c-384c-4dbe-bdac-256daed01585" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="1182a2ca-4374-4f1e-9fff-a89eb24d68e6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9713e18f-cee4-430d-9ae1-1a5c4da92c91">
+      <statement statement-id="cm-8.3_stmt" uuid="a9a10e8e-e0f5-44e6-a44c-7fb1b2b0d53f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="059c92bd-27b9-46cc-af9e-9553d4e64c0d" control-id="ia-2.2">
+    <implemented-requirement uuid="5b44f2f8-094b-4ec6-9a75-df1dfc66f323" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="99f00e15-4dff-4b25-aa75-5b89f5e4b900">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="152785cb-6f57-41b9-9288-df19f8f977cf">
+      <statement statement-id="cm-8.5_stmt" uuid="cec41ce7-379a-4422-a578-98ef0f0a9c36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc944c90-0f57-49a3-aa7b-189804c3ae82" control-id="ia-2.3">
+    <implemented-requirement uuid="e258cf48-9f04-4638-9794-380abd4e9731" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="bbd26a68-dc3c-41e4-8daa-bda1e28e04ce">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d5418012-b5eb-47c5-a98d-0d7bae356412">
+      <statement statement-id="cm-9_stmt" uuid="c54a38a3-8371-4695-9666-a12a4e2420b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6b29ce4-6173-49de-9dda-ca5be9fc7348" control-id="ia-2.8">
+    <implemented-requirement uuid="f19518a1-afae-4380-bcd9-24be30a53938" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="c9104607-e314-487a-ac94-69d386be9e7b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="eb539e1f-4107-48ef-8e8e-29711f71ca2e">
+      <statement statement-id="cm-10_stmt" uuid="9d174f2c-091a-46e9-a0ff-71fef70b108c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a308807b-914d-4aa8-9486-61ea1ca38c83" control-id="ia-2.11">
+    <implemented-requirement uuid="a65ca1a5-22db-4288-8611-563896620700" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="47d702c8-643f-43c7-b85f-6a5a8c7264d4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a90c67d2-9fae-4d41-8cd6-75230e8fb265">
+      <statement statement-id="cm-11_stmt" uuid="5c1bb060-3965-423a-a1c2-448f24514220">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b38a615-14ab-4acc-b3e2-f57d24036483" control-id="ia-2.12">
+    <implemented-requirement uuid="ea6dee5d-c9c3-4065-b507-1c156b3a9faa" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="a8d5a898-e79d-4183-bbaf-419820a05cbe">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="deda1c15-ca87-4903-89a3-eab55f2e30a5">
+      <statement statement-id="cp-1_stmt" uuid="16ba263b-5cab-4d3f-a54d-0519747f22b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="047cb391-d825-44aa-b304-88c501d01cea" control-id="ia-3">
+    <implemented-requirement uuid="723a02e4-1c79-4718-bc38-ee38752343b1" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="008a56cc-64ae-4e51-b924-0ccb7531088f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5bfb36c8-8693-4603-b05b-85ae0e867547">
+      <statement statement-id="cp-2_stmt" uuid="7d5a1fc2-4c1f-4feb-8373-f483d661a581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67ebd9b4-9bbf-49ae-a668-17ce80cd6468" control-id="ia-4">
+    <implemented-requirement uuid="c6aca99f-1f55-429c-bcb2-80ddd7966792" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="f03c77a2-edf0-4382-b726-7b688e7cd18f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c41ba348-71d0-48ee-a92e-0081902655c1">
+      <statement statement-id="cp-2.1_stmt" uuid="3fbf6d5d-7dd3-4f36-a24f-dc24e4cf4750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="00d3044b-80ff-4c14-973e-ac8cfc422f27" control-id="cp-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-2.3_stmt" uuid="7616f896-3052-4311-b55f-1abd450d081e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c3e82ba4-9c71-4e11-84c2-b0aac7638a46" control-id="cp-2.8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-2.8_stmt" uuid="d9ff945b-acf7-4268-afc3-517e7db25dde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8d4ca3f2-090a-4ba7-b7c7-7ebcf314ed38" control-id="cp-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-3_stmt" uuid="e11b1f35-dc2a-4b14-8479-05601c3def0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="fb214c5b-30b7-4b32-bb7e-06cff0651262" control-id="cp-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-4_stmt" uuid="ce9be4ad-3a63-4f99-bcfe-b6ffa581e414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9719f1ed-f7ff-4fc1-aa93-99beca590cb1" control-id="cp-4.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-4.1_stmt" uuid="c8aea2e1-2176-487d-8c8d-6c57a6854319">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b49fe7f5-1f08-4c87-8c47-36e4e4b03a7b" control-id="cp-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6_stmt" uuid="01ea60dd-11b4-40ca-b7c4-7f6ddf79ee17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="5642bd90-d270-4c41-9ba4-5bba6cacdd05" control-id="cp-6.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6.1_stmt" uuid="4462fe05-f95a-413e-9507-96e07d5e3041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="dc23d0bf-7977-4e62-b615-6b549582cc01" control-id="cp-6.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-6.3_stmt" uuid="44757adc-738a-4fe9-82f9-fdabaeef1444">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ce458fc4-77ae-4e4b-9e1a-f362a6186a90" control-id="cp-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7_stmt" uuid="97e24600-21be-46a1-bb11-46bf2e3f16be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ff101a61-1a8d-4eba-ac71-c18aefff863d" control-id="cp-7.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.1_stmt" uuid="d2b8d434-4fda-41a5-b1dd-814b1b7abe45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9007a1f3-919a-4273-b329-05e492af1c4b" control-id="cp-7.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.2_stmt" uuid="0051a470-c75a-4f6c-9960-f30576e7567c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9f0f9c2d-14dc-4580-82cc-f2abb6983c4c" control-id="cp-7.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-7.3_stmt" uuid="d0e0685a-549a-47b9-b22b-d3ef5ec2124a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="538b675b-5f1c-4062-9c79-364688fc8847" control-id="cp-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8_stmt" uuid="594c4d1c-c4bd-4bd9-a559-83fd9a90d4ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="6c4c0d80-7252-4b6b-b971-f1b2a32a1422" control-id="cp-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8.1_stmt" uuid="39f1588b-498d-471d-b58e-22807f1b6514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="34bd1dd3-d7b7-448f-a673-6c856f2b4df7" control-id="cp-8.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-8.2_stmt" uuid="20f298fb-3706-460c-8f3b-fc2fc477f1c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="fefe0445-0e64-41c9-b480-338a4c5bd9ba" control-id="cp-9">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-9_stmt.a" uuid="57ff7385-77cc-4cfc-a336-272d1beb7567">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="d45e8f53-9eff-4151-b711-462ed0635279">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1ccf173a-71db-4bcc-a34e-368dff0f4d63">
+      <statement statement-id="cp-9_stmt.b" uuid="60b825b4-2b2a-4a27-b9bc-e4bd83daa5ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="b94f3612-6954-4629-a5f3-f72df83e3293">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d6691cd0-c2cc-4704-b484-2df01bf137fa">
+      <statement statement-id="cp-9_stmt.c" uuid="69f94737-48c2-4b8d-9802-0e9e5e8aa97e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="c3800974-4ae2-4014-b1f0-c6a454185026">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8d0011ea-e7ac-46fa-b09c-ec1fb331f3a1">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="67c8270c-c41c-47c7-ae83-2ddeeeb0d26e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="29128480-5be8-41af-9d27-52e8eb1deaed">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="add33a52-773d-49fe-96a2-3cac80688589" control-id="ia-5">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="ff6f536f-a60e-4a68-acb4-288f030c35ec">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="3ff870cd-6c6d-47f0-a4ce-fcb2a52f3af5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="6a082f5c-f145-4ecb-b166-bb45a3f1a3b0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9fd43f40-5599-421b-a32f-20d45adfdd1c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="bac52310-603f-4a87-a958-44873c9285eb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="951fe262-ada0-44f7-8b97-6126fecf73a9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="831e27fd-df3f-4f56-b827-287e4db373c4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ea32090d-71cb-4475-a60e-b2c04171e53a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="94186bf5-9116-4d4c-9c9e-6f6409469488">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4214e9f0-2db4-4156-a66e-199ff7f11c31">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="02325a89-8beb-4611-8f1b-35b1a4c4ae06">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="942d37af-87ad-4159-8804-bc2e2d538b5f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="1457bebd-31fc-4f59-a09e-6804b743217e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e419fa84-5899-44ac-bd30-b918840b5cdf">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="0a07d649-f287-4709-a3f4-534c57015c44">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="540350c2-a775-4db6-b463-abf891fac96b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="aac07350-0277-4845-a585-22ee95cb7f82">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c1d3711e-1105-448f-a60e-b56c80a4b93b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="c6a10ca8-a4ab-4b3e-bf10-34dda4a50acd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c7d0b9ce-dd56-4232-aa4b-1225f7b12f7d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d4da8c9b-c905-4608-bc52-cd067c388b0e" control-id="ia-5.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="c6a1186f-da99-4018-8a92-45ed7449e64c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="12cc52b2-1936-417c-a542-4af400b4c3cd">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="82898ea4-305a-4582-9a82-f118c8ab0898">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d8bb0bbf-2229-4b34-a964-7355bbe35cbe">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="2d043150-ba78-49f6-8fad-e325e01d3a2a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2460cbfb-9649-4541-927b-5dc612d1eb7e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="8a3ca6cd-30e4-4afb-ba56-a86009230603">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2275ae54-3bec-412b-a372-acd004d74249">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="1a3cea61-811f-406e-a594-ad35b11dc5b3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="78776d2e-9100-42ad-a24b-8fe671f0dd76">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="029b8c5a-d7d8-41e2-bc6b-4aa777d431a2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ebb6f53f-5b2b-4385-945d-4f0deeda4088">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>''
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="6eea5cf5-d822-4f40-b5e4-6fa847677cf6" control-id="ia-5.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.2_stmt" uuid="47483d4c-6b93-44b5-8809-22f44ef99ba2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="36638e6d-834a-4d56-83a0-0b8e1af650e8">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3487f6ef-f5e5-4453-83e3-117ef9259a81" control-id="ia-5.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="9121bd83-ea66-4590-88e3-518cc3d251b3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2d4972fa-4f60-4100-9b2d-48282d0ad57b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="18f3fdf1-45c2-46a6-a01b-2d6b39742213" control-id="ia-5.11">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="0876ef7e-1dce-4934-b44d-4d45896f3f02">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1f4e88c7-7953-47bb-9d82-78cd837272fa">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="a0c474ee-759f-4a9a-9cdd-b4c1594214a9" control-id="ia-6">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="78336fee-09ed-4c91-95b0-97a4d4eac9f8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="eb24beb4-d3ed-4a1b-b467-bd63de188ebd">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="4c44cf76-4229-421b-9892-d831c1aa9f13" control-id="ia-7">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="5b6b0d51-022c-4c68-b846-4f423343f8a0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5edad949-c660-4c54-9e50-6825ca90e12d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d24e8e3f-158f-4e1d-8594-79c6c9e3192c" control-id="ia-8">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="b139bb98-b6e3-4000-a971-cfdf7f64644b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8bd0c0c1-3f9f-441d-a2aa-75d2d43fbd6d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9884163c-59a3-4e7b-88a6-d7b847d49401" control-id="ia-8.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="e5324d24-9787-4c2b-9ea3-42e7abb638e2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a85e689c-a54f-422c-b99e-dd14535dbcea">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8b3d666b-89d4-48c0-b2a5-7c39406c7b4a" control-id="ia-8.2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="2bb3bef2-fb55-4071-8af1-9b25de9d39ba">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="034e613b-7c9e-4f8a-a230-e55f6fb71269">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="e6852a63-2715-4982-b372-6b267827cf3f" control-id="ia-8.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="f96baf86-cde1-42e0-b6a8-1ccb81d5c9be">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="370d2ccd-c371-4cce-a5a1-6241fe98bffc">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="d44f3319-6a25-4420-8ae1-b2440a88ae36" control-id="ia-8.4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="f8178ae1-b772-47f0-94fd-c1de25173071">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="80237915-b776-4099-9acc-77a7ae2ddd48">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p></p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="72f11d9c-c498-472b-96cb-b47918cc5780" control-id="ir-1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="7bd30005-06ad-484c-afa0-365f8aa5c755">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="fcdaaa35-4c22-4d41-9a83-f0b0868e43dd">
+      <statement statement-id="cp-9_stmt.d" uuid="69738b01-a603-4de2-a97f-b09db026e408">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96d0c568-75e2-4ac9-9e2b-95def27a2160" control-id="ir-2">
+    <implemented-requirement uuid="6990152d-2af8-40c1-8df6-63f2b1819ae7" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="3c119684-f912-4d1e-9d4b-7804f5013100">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b3f7d297-7848-4323-9a1e-5e031dbfe9dc">
+      <statement statement-id="cp-9.1_stmt" uuid="8dee39ec-4d1f-4e79-9506-61cd32be6d30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="492337f8-10a6-4327-a66a-ea1bdd457586" control-id="cp-10">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-10_stmt" uuid="d1cdfa3b-767b-42ea-9551-29a60119e39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="f26994cc-add2-4188-acc0-d4de3134c43a" control-id="cp-10.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="cp-10.2_stmt" uuid="4211b0f6-8bb1-4cde-89d4-fe88e1957a4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="3d758108-acb6-4eac-9b0d-915d022c8d76" control-id="ia-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-1_stmt" uuid="b217d162-433e-40a5-92e1-af29d849fa80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="82903ec3-33bb-4857-8cb5-f56d44ec0560" control-id="ia-2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2_stmt" uuid="188213c0-2886-4654-94a7-d3d29f60238f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="4541b2e4-a651-4dae-bc37-0c55789025e5" control-id="ia-2.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.1_stmt" uuid="0ce9f0a7-76db-445c-9400-e6ff2b4fc7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="05cb299e-6620-4365-9ed3-f6a996230932" control-id="ia-2.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.2_stmt" uuid="37704307-6f19-49cc-ad8a-4754438002f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c863808d-8249-411b-9791-dd188f771fbb" control-id="ia-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.3_stmt" uuid="36985d66-8ddc-4203-b3ec-7cf9e7f39c2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="957230d8-6844-4a3e-a948-47d81f94eb60" control-id="ia-2.8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.8_stmt" uuid="4201bd75-9e51-40e2-aa08-099d8ed4a9b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="0a955489-b3e4-47f9-a4e8-b4fb4ea22003" control-id="ia-2.11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.11_stmt" uuid="d43bb82d-7878-47e8-a97e-ee90ab2b748e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="17ceb079-816b-4d76-b5d7-e9ff38e520be" control-id="ia-2.12">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-2.12_stmt" uuid="42bb9f64-b1eb-4b59-ae75-8bce8d6cea87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9a473d99-6efa-4156-8488-83fb851b8aab" control-id="ia-3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-3_stmt" uuid="9a42056b-e053-4832-b9f0-0555d69b9d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c4ce1586-af7c-4486-99a4-a2135d320661" control-id="ia-4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-4_stmt.a" uuid="cfaa44d0-6476-4a3f-b1aa-bb081ff43f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.b" uuid="758139f6-3cd5-40b9-91c4-38775ebc6fdf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.c" uuid="79b1819c-ff07-4803-b426-7994dfd3734e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.d" uuid="b3a202e3-f292-4ba2-b5d8-bae09f051787">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-4_stmt.e" uuid="5a3ed097-5611-49d3-a1ea-5f3ed83758d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b82b492-d552-424d-bfd1-3dd7b30f6b64" control-id="ir-4">
+    <implemented-requirement uuid="3fb902e3-a4df-40ad-8c86-9e5b88d9e17b" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="e7102784-fca8-4a60-9756-56dc365bb160">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5b4a0b85-9ea5-4589-834e-49b148d1773c">
+      <statement statement-id="ia-5_stmt.a" uuid="e45f25ba-f806-4e4c-a2df-f23d1aa3f319">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.b" uuid="42462fae-3f29-46c9-a22c-8c9f2a276623">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.c" uuid="34bee8e8-b77b-483f-8c75-546a85ee209f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.d" uuid="d63b5685-fcd0-4f75-a3b3-1ad69b91d414">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.e" uuid="e45c697b-8dfd-472d-9f9c-ecacbfda96f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.f" uuid="77011543-3370-4773-90e9-b1b265ce0d76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.g" uuid="acf4cd95-c065-40d7-8fc5-baeee3682049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.h" uuid="c2a4d63d-209d-4a49-92f8-b5d10f50dc4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.i" uuid="de33cfef-2076-4db2-92af-a4ea950a13f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5_stmt.j" uuid="ed0b7320-a255-426e-ba0f-1b271d718687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3a68878-5916-4c29-9f8b-19926fceb49a" control-id="ir-5">
+    <implemented-requirement uuid="aacd4c81-3fbe-41ef-a1ae-375c10e04ddd" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="85a49dff-4222-4eb3-ae19-3a64c964c008">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9173d034-f6b8-4cb2-9b69-9c210490f1d0">
+      <statement statement-id="ia-5.1_stmt.a" uuid="ba6d6897-8997-4bb4-9530-1b5b548dddb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.b" uuid="5dcfe43e-28ac-4e71-9b64-c0c94455dd73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.c" uuid="1b44b970-a455-4465-a491-9a439d16a0f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.d" uuid="fd847861-5041-443e-b446-9a29dc75fe26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.e" uuid="a8d49da3-e616-4399-854d-5976bf4642e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="ia-5.1_stmt.f" uuid="86e222e6-8aee-4d6a-87fe-50a30a57e002">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e502e25b-5178-45d9-9b15-c72dec60795e" control-id="ir-6">
+    <implemented-requirement uuid="401d1a24-c155-4c7f-9983-d6fbc97a85c2" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="be9c58e0-48c2-4f84-8928-a04f397524c9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9654a2cc-cfbc-4a0f-89ea-f7009d04aa1b">
+      <statement statement-id="ia-5.2_stmt" uuid="d27f42c1-8b69-462f-8c0f-efb29c5fbecf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="99b8a2ee-d23f-4675-8451-7fbb0f8504c2" control-id="ia-5.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-5.3_stmt" uuid="2373f55f-4fba-4086-89e6-6a12eedaeb52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2eb13d36-5514-496b-b454-31c775a1fc70" control-id="ia-5.11">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-5.11_stmt" uuid="13326533-06ef-43eb-920c-87b9a8f47737">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="c6b95d74-8648-4b21-9c78-39550972de14" control-id="ia-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-6_stmt" uuid="ffd86149-b84a-40f5-9fcf-adde40f974d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="cd0b8d25-c145-4d15-be94-07bacf532824" control-id="ia-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-7_stmt" uuid="5354e6b0-a65e-4aca-8e86-a9a289c7f61b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="2888bfcc-e194-422a-8825-4f53bdb20d89" control-id="ia-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8_stmt" uuid="3cb73140-4585-4e6e-8417-c1ec9ff7b55b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66f0b14b-5d6f-4ae9-b8bd-a9c2164a8aa2" control-id="ia-8.1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.1_stmt" uuid="06757d86-2146-46c7-bdce-dad895acad87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="316b86bf-44d2-4fa6-a4f5-7833eb8452c2" control-id="ia-8.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.2_stmt" uuid="4b9c3d26-d95c-4161-b3de-5b333fbdf6c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="66acb44b-508c-4e55-88c6-6db3bbc366f3" control-id="ia-8.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.3_stmt" uuid="593b1940-e12f-4507-9d3d-acb1bc340259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="8eec4d41-4452-4ec2-8a6c-540cbf19cd0e" control-id="ia-8.4">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ia-8.4_stmt" uuid="992d4863-d8ca-4ed9-a82b-59fdccc1b1eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p></p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="28ff4a5c-d327-40e3-99aa-bedf8fb5203c" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-1_stmt" uuid="07381d25-127d-465e-9c8c-b64f43fd04f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a92d8d5d-5764-4ecf-b8b4-6440497e5af9" control-id="ir-7">
+    <implemented-requirement uuid="3d26ebe3-7f91-44d0-a3e4-f44192791ec8" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="905d6977-ef5b-4d99-88db-f4578b99256c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a071da3e-e839-4cb2-8d63-d7725374edbd">
+      <statement statement-id="ir-2_stmt" uuid="34942c74-95ac-4599-b551-7397d0d08f99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56c9924e-5537-4811-98ab-277c4c83dcd0" control-id="ir-8">
+    <implemented-requirement uuid="632ff990-7955-40a0-83e6-81ba280c93a4" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="29edf6fd-ff6a-4456-8e31-f97d34ff2467">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="736ef4e3-825b-4ca5-9690-30f2ff916c4b">
+      <statement statement-id="ir-4_stmt" uuid="4eedad3d-d67c-408e-b55b-44b72a18ea2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b7d52dd-3615-48e2-a531-c073e647f73d" control-id="ma-1">
+    <implemented-requirement uuid="4780a3da-36e9-45ac-9448-246d9de52d4d" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="32f96f80-a43e-4e27-8659-d1475bf67bc7">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a7d39b89-e009-45c9-b1e0-5499430872e2">
+      <statement statement-id="ir-5_stmt" uuid="934c7912-3aa8-4b48-ae97-b62c5a5dfda1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="90dbe198-eaa1-424d-bbbc-aa898e2f8910" control-id="ir-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-6_stmt" uuid="63df69cd-4851-45f6-81eb-006fbd9b0ddd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="65889916-6ebc-478a-9e11-9eac2f138f8b" control-id="ir-7">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-7_stmt" uuid="8fd6efff-d8f2-4c7b-9fc9-2593323d8bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="81dc3c73-edd1-4c6d-bb2e-95e9ddecdad2" control-id="ir-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ir-8_stmt" uuid="ad980c89-acc1-468b-b401-1263a56b1090">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>''
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="624adb57-c624-407f-8775-cdcc75abe075" control-id="ma-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
+      <statement statement-id="ma-1_stmt" uuid="10102b0e-c4a9-456c-b5ec-06acfe0dac75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6902a554-7236-414b-b0fc-2fd653104e7b" control-id="ma-2">
+    <implemented-requirement uuid="ddcb61f4-5048-4ab9-973b-490a5db3c808" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="4155cb6a-e773-408d-8906-c0de00891e0c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d645e23f-9259-4926-a23d-08dfbcb48b60">
+      <statement statement-id="ma-2_stmt" uuid="077d4499-e419-410b-aa07-2ec6aec2a54b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b8dc131-5609-40ad-a7a8-e9c258e51524" control-id="ma-3">
+    <implemented-requirement uuid="8d4df011-385b-46c4-a9c3-1dcc81a39c87" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="3d845f6c-3a3f-4528-81fa-fca6d030490c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="eb49a6c8-f765-4983-837a-f14474477325">
+      <statement statement-id="ma-3_stmt" uuid="1a8a743a-f6fb-4783-94c8-96f103d8dc08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8c9fe04-1808-4dd9-a6a3-85bf68388f1c" control-id="ma-3.1">
+    <implemented-requirement uuid="2687c70f-75ba-482b-9dc1-84b6954ce4e6" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="ea24a4b9-fa9b-469f-941d-f638ec7b5771">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="961397a9-cbbf-4b9f-9b57-ab11737dcf91">
+      <statement statement-id="ma-3.1_stmt" uuid="c286a8ac-629c-4de6-9128-4ab059ae6b3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7da4db0-2435-4d02-932f-13ff01455fc3" control-id="ma-3.2">
+    <implemented-requirement uuid="c89c8c5e-69bb-4d8c-856e-58169fc2cfb5" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="844d6b65-33f1-4f2d-86b1-05ac946b4b03">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="366f56eb-d8ee-475e-8af9-3a5f55ec7dce">
+      <statement statement-id="ma-3.2_stmt" uuid="9f3c30fc-4943-4742-bcfd-031db91bc94e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d52d45a-280d-41dc-aee8-c3a71dd2c781" control-id="ma-4">
+    <implemented-requirement uuid="59b21f81-8979-4404-a720-f32cf697b4c1" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-4_stmt" uuid="60fad39d-b9f8-47d0-9982-ab0d786c65df">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="07d5f105-805c-41b8-b05c-ca88c11939bd">
+      <statement statement-id="ma-4_stmt" uuid="caf41cab-c02d-4d3f-b898-b3ea874cd3c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="028c93f8-5e9d-4aaf-8d78-0cdbe44c936d" control-id="ma-4.2">
+    <implemented-requirement uuid="daf0e985-dcd3-4523-af89-fd37e966ecce" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="c6269e1f-e1bb-43c5-bf56-ab508bad14b1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b1a962b7-65be-4f0b-96cf-0101637edf80">
+      <statement statement-id="ma-4.2_stmt" uuid="4052ef6c-7601-4f55-84eb-b9d7dc40781c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc3ecdbd-5290-434c-9c63-f5b4ed7f1e31" control-id="ma-5">
+    <implemented-requirement uuid="46e83d36-ea11-439b-bd56-a355174a7d12" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="b9bb5af3-81ac-4570-acc1-11be0884fbaf">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ca759c2b-9d69-4a15-9d26-d40db9df3305">
+      <statement statement-id="ma-5_stmt" uuid="3672de4d-6646-4a8f-b442-add1db7eaf72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6827e86e-93c1-4838-b2ac-845f62cc0b99" control-id="ma-6">
+    <implemented-requirement uuid="a74f38c2-d5ea-4ef9-ac48-a76b0ff1dc63" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="64bc62eb-76d7-44ea-b1d4-4d6dd7f4eb90">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="db4c7fe5-3c1c-48f0-abfb-1ea047963d8a">
+      <statement statement-id="ma-6_stmt" uuid="b26d2ae7-8b2c-4e3f-b94a-46de28fc5c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26c1f805-0cc1-457e-9b10-bedeefe570f9" control-id="mp-1">
+    <implemented-requirement uuid="cce0658a-b46e-425e-a359-ccbbdadad9e4" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="d1e503fe-1e74-440b-bb37-d84411b7e410">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8a27fa2c-6065-4097-8173-e6eb1111f880">
+      <statement statement-id="mp-1_stmt" uuid="c28b2e96-7d13-4320-b93c-31d1ba35dcb3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23a887fc-7592-49a6-9ed0-d0bc8cbd56a4" control-id="mp-2">
+    <implemented-requirement uuid="f9b2e3ea-90a8-4e2f-9dd2-c8bfd1883265" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="3c5d9239-2d5c-4365-88d3-ce6cb3aabff9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9ae46778-2bbc-428e-a3d7-a78278b9d8b4">
+      <statement statement-id="mp-2_stmt" uuid="5d1bd24a-257a-46ae-82d2-54e634995271">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37d8de40-a34a-4f51-8cfe-6ad5793525f7" control-id="mp-3">
+    <implemented-requirement uuid="f17ea9d0-451a-43ad-9800-ae4eb4f9b321" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-3_stmt" uuid="70f02fac-173b-4227-a855-0ffe536b0ef0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0151ab07-5c3c-440f-91a9-e4946eb37078">
+      <statement statement-id="mp-3_stmt" uuid="47fd6b98-fe60-457e-a54f-64bd3e19341f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d04e012-d066-4403-9e79-bc5726511af7" control-id="mp-4">
+    <implemented-requirement uuid="c401e303-8756-47a3-a636-a6c8c4f91678" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-4_stmt" uuid="db36abbc-9b60-4799-be01-4c8543df9867">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="adba8839-a69e-428d-89d1-4f7f595a5f9a">
+      <statement statement-id="mp-4_stmt" uuid="17ff3f7f-a367-458a-857b-9da507e60341">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75077b4e-51a3-4cb0-9d2d-b2f2276141c5" control-id="mp-5">
+    <implemented-requirement uuid="4d7cb2e1-e250-439a-8d9a-28775bdb8bed" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-5_stmt" uuid="bcc80010-c5ae-4a26-b645-9fc09d33f1aa">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1059aed7-2ad3-4d66-9502-60460f2187c9">
+      <statement statement-id="mp-5_stmt" uuid="2d3c86bc-25c2-4ea7-b3ad-0c11a4315b13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcffe43f-5211-45a2-be55-a9a21dbdd975" control-id="mp-5.4">
+    <implemented-requirement uuid="f052427a-7c13-41c2-b1fd-8aa70947c65b" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="c8ff7d20-1f1e-47de-8edf-c96cbee96394">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="6f80f62e-16b9-48c2-af3d-4cfba3eb931f">
+      <statement statement-id="mp-5.4_stmt" uuid="1ea3e9a2-1134-41a3-bfff-0bfb734f129c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ce85e7a-2436-4ae4-9887-6c10d6d628f1" control-id="mp-6">
+    <implemented-requirement uuid="c4c70fa8-e2de-418c-af96-5aa873793015" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="4c303d9b-7204-4c7b-a4d7-eb1c93c759b1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0cbdc6a7-9ee5-488f-ae54-a514a6a5e9eb">
+      <statement statement-id="mp-6_stmt" uuid="8efd2033-dd8d-40c2-abfa-ccd253e17f8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89562559-f2f8-4833-8a78-061a1d93f606" control-id="mp-7">
+    <implemented-requirement uuid="e85261f5-5f7a-4602-bfcc-c91fc07fad67" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="d2a5b874-b0cc-48db-a153-9fd5a66dc263">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="08371180-8ff8-42f9-b751-1562296fa7bd">
+      <statement statement-id="mp-7_stmt" uuid="3c0ff776-5261-4f11-b7f8-3720d55f6758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab339528-88f5-43fd-a807-4cf8825a2840" control-id="mp-7.1">
+    <implemented-requirement uuid="275bf8d8-d80a-4025-8992-b2c664737bd7" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="e1fd40b1-08f0-4ad6-9a85-e1dc2a4e6edf">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f6e352f7-74b4-4888-9417-fb141c41f081">
+      <statement statement-id="mp-7.1_stmt" uuid="ac6d868a-b18f-471d-98ad-6b9bd12ca221">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c68e2467-ade2-4fed-8241-4261dc0d1cc5" control-id="pe-1">
+    <implemented-requirement uuid="a936699e-188b-4365-b8c8-ac27c7c551ef" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="7f6f7395-3915-4683-b45e-52244ddace7a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8eb106aa-18eb-42e3-afa5-d4d6eaa3a8b4">
+      <statement statement-id="pe-1_stmt" uuid="9eeaf67c-b116-4010-bf82-2cedced92bff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="635e39b2-31b8-4559-8baf-bbac88e50381">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked
 via:
@@ -2232,10 +2232,10 @@ via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd3caffb-d48b-4498-8175-514ea6f8438f" control-id="pe-2">
+    <implemented-requirement uuid="357f50ff-894c-415a-8eeb-f49f3d068779" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="9db3353e-20e4-4cfe-9b44-0fc63d86173c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ef60749f-f800-424f-b443-97e111d48b00">
+      <statement statement-id="pe-2_stmt.a" uuid="b57fbab6-6e7c-4331-88d8-b80a3510b436">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2244,8 +2244,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="3dbb5855-5830-46b9-8c3b-26774f7bb12f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2500a7fc-2ab2-4a81-bf05-8ab2460e5e91">
+      <statement statement-id="pe-2_stmt.b" uuid="aef52af3-fe2b-4d6c-8571-7f9fbc647e97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2254,8 +2254,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="c9afdf5f-4ac0-43d1-aa75-26c1b9f0ad87">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f13ea110-0425-4960-be3c-36b953a9e427">
+      <statement statement-id="pe-2_stmt.c" uuid="ef527317-5209-4c89-926c-78c14b1fa41a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2264,8 +2264,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="a73d2ae0-4bfa-43f0-b122-3b4568cfe84d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7e1ec8f2-5082-4aed-9545-bc990d27c37e">
+      <statement statement-id="pe-2_stmt.d" uuid="10afcd59-4906-427b-9948-baabd570648a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8e71ab2-3ab0-45ee-834b-9b9fb2b38177">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access
 to the facility where the information system resides.
@@ -2275,10 +2275,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8bec873-2190-4d70-a51e-154e2a90e989" control-id="pe-3">
+    <implemented-requirement uuid="8c21f041-ad73-49a3-9294-c789ab513d8f" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="76feac93-2df5-481a-9466-a92c0aa18d83">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="cf420c85-cb5c-47b3-85eb-f4c38f2580aa">
+      <statement statement-id="pe-3_stmt.a" uuid="666d7036-90a5-40a9-854a-0a1ee6a21363">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2287,8 +2287,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="06f0e3d5-7fec-4cb4-b0d9-10a41ed09db1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1033938c-55c3-4a33-bf83-07e486ecd670">
+      <statement statement-id="pe-3_stmt.b" uuid="fd166ad5-7fca-497e-8e51-4c8a4cdc28d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2297,8 +2297,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="c7a1fd88-8fa4-4a66-8fc6-433509f46414">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ae64469e-f725-4b9a-939a-dded4c5ee2ef">
+      <statement statement-id="pe-3_stmt.c" uuid="25ed7e5f-2cdc-45f6-af02-9a0c77db04e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2307,8 +2307,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="381c5184-6ecd-4ba2-b59f-8f9d076f1607">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="42ef56d4-0f7e-4f68-a20a-d073ee99507b">
+      <statement statement-id="pe-3_stmt.d" uuid="9960adac-3249-426c-9d36-6586f4ceadf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2317,8 +2317,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="e89d39e5-0656-4ed9-9806-98f9cc5acdcc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a6678466-96aa-48b0-b6cd-482bd6dc4ba6">
+      <statement statement-id="pe-3_stmt.e" uuid="58a40390-8a4e-459f-9e58-368a83aebeab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2327,8 +2327,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="ffb96ecc-f7ab-4f7e-b80e-3ebedcf69204">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="079d7ccb-2061-4baa-923c-a24812e9ab89">
+      <statement statement-id="pe-3_stmt.f" uuid="cd0ce203-100c-4430-87d4-3b5c3387f9df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2337,8 +2337,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="e2b734d1-40fa-4501-a18a-f5b54f366ade">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="226658e5-f25d-447d-b442-cf4e4192a7f4">
+      <statement statement-id="pe-3_stmt.g" uuid="07f74625-38ac-4ca8-bc8f-4434d856d129">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2348,10 +2348,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d39e7064-3711-405e-87ce-c2ac477e9c89" control-id="pe-4">
+    <implemented-requirement uuid="d3462df0-aee0-4239-a596-a9f078af13a7" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="e410fd9c-0608-4910-8811-19d3df87f2af">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bcc4bf2b-c172-44d5-b510-0826ed58046f">
+      <statement statement-id="pe-4_stmt" uuid="36ec06b7-9a42-43be-b7b1-a7595dec2dcf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4806905a-5a17-4e91-8527-d57c46c4d5ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the information system distribution and transmission lines.
@@ -2361,10 +2361,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="145deeb7-9789-4fb0-bdbe-6b98e62eb18e" control-id="pe-5">
+    <implemented-requirement uuid="15955cd5-0a86-4916-93d5-00f3d6df5156" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="d409eb20-eba0-4ac0-81b1-fab9e3e6e557">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2b203484-50a5-4346-b53c-0e2e810989cd">
+      <statement statement-id="pe-5_stmt" uuid="577e2491-1086-4f53-a7e6-b95f1c21e6b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dbc7f1e-df28-4da7-8e27-2aee9ede6c31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 information system output devices.
@@ -2374,10 +2374,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fd266bc-8bd1-4219-9d44-064d91f51c02" control-id="pe-6">
+    <implemented-requirement uuid="ea3b1ae8-ca6f-4178-a120-def72eb0edb4" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="a83a3a38-c235-488b-a7e4-cfef6d6114db">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b1b30bd8-f169-4a3a-8162-edea25388e66">
+      <statement statement-id="pe-6_stmt.a" uuid="adc055a6-c4df-48b1-8df5-e825566ed731">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2386,8 +2386,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="79608a6c-f40f-4089-8990-f262b126ca50">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="414f92ee-0c03-4338-9f73-866826a9cff4">
+      <statement statement-id="pe-6_stmt.b" uuid="7bdf5f6f-2836-4984-b5db-b5ffd79be70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2396,8 +2396,8 @@ This control is inherited from Amazon Web Services.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="b4b6a5b6-6823-41ec-9220-79bdc1fb94eb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="103f4a01-e1e8-4c81-98d7-173c52998361">
+      <statement statement-id="pe-6_stmt.c" uuid="61e0973f-7994-43ba-9bb8-62a5fa0f0b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c866bacc-21ad-4981-95fa-df3525a603d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not have physical access to
 the facility where the information system resides.
@@ -2407,10 +2407,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f0e70ea-8496-4343-b2e2-239c3b16fc6b" control-id="pe-6.1">
+    <implemented-requirement uuid="1f9da45e-a2c8-4327-86ce-d911cdee70f4" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="4cf990f8-3679-404c-a885-de6956102c8f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b2a67909-b0d9-4f4d-923c-042c75dbc823">
+      <statement statement-id="pe-6.1_stmt" uuid="447cdf5c-1a84-4105-8c63-d2eaef6c741a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7485b727-b740-42e7-b9a4-508a375eaddd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>OpenShift Dedicated staff do not monitor physical
 intrusion alarms and surveillance equipment.
@@ -2420,10 +2420,10 @@ This control is inherited from Amazon Web Services.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d3e7e7c-1c26-4629-922b-1e77648c6fd2" control-id="pe-8">
+    <implemented-requirement uuid="e4f2790e-8cdf-402e-b3b6-7805c45878ef" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="c593fb7f-cf52-4337-b44e-b136305a152a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9591a319-b221-46b0-8825-8dd857a500e1">
+      <statement statement-id="pe-8_stmt.a" uuid="e3512a72-92e7-4983-8945-ee9a467eabc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2431,8 +2431,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="8a46f5f2-689e-4855-a9a2-2ea82664dc35">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="15a0fc4a-5c93-4664-9a5d-6e75edb4531b">
+      <statement statement-id="pe-8_stmt.b" uuid="dc35409c-4dcd-43a3-9bd3-53ec208e4f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2441,10 +2441,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8436075-e6ee-47e9-992d-6eca43b386aa" control-id="pe-9">
+    <implemented-requirement uuid="01032f1a-2173-4a7c-89a4-781e2c9ef03a" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="7e598d3b-f09f-45b9-83a9-32137a90440a">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9c54764e-0fbd-49fa-801f-e6106e3c64ea">
+      <statement statement-id="pe-9_stmt" uuid="78f70808-7b68-431b-8ea0-373718038124">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2453,10 +2453,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca419a0b-55a7-4df5-be72-03f1bc8fa777" control-id="pe-10">
+    <implemented-requirement uuid="4ed859e5-774d-41c8-895f-baddf7735d34" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="93c54b73-04ae-4173-b35a-edcc4d6ff599">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7cdf5430-2d27-4252-a24c-e9352b57e72a">
+      <statement statement-id="pe-10_stmt.a" uuid="4864cb7e-cb90-4a8a-acbc-d7299f9cdcc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2464,8 +2464,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="7739cd7e-ddd4-46f7-810b-793e40fffa96">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="757369de-a2ff-403a-a493-d3bcb11f3170">
+      <statement statement-id="pe-10_stmt.b" uuid="ff468a23-5814-4390-944b-08fa357c8f58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2473,8 +2473,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="955495a1-5a2e-4b59-ad4d-cfebae6a8a8e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1c5afbb4-79b5-4ac6-80f4-8e519cde4dfb">
+      <statement statement-id="pe-10_stmt.c" uuid="ce90be40-54a8-4084-ad21-a1a768fc1cf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2483,10 +2483,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dde71c71-b705-4de0-af7f-2b534dc11b03" control-id="pe-11">
+    <implemented-requirement uuid="ba6fd9bf-e51c-4950-addd-2113dc5c191a" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="d3eaf87a-b699-424c-8566-0d1c557aad4c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b95978ec-0f31-46f0-923d-3676a8bc5795">
+      <statement statement-id="pe-11_stmt" uuid="5fd00de1-e820-4ec9-9a74-d571014e494a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2495,10 +2495,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61155273-259e-4bc6-a48a-e4a53c1a3e3d" control-id="pe-12">
+    <implemented-requirement uuid="3156bcaf-1fdb-4e58-9c33-41b74c964038" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="49e935d9-cfd8-4c9f-a5a3-d789caaaeec1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d8341b5c-1fa2-4834-9267-26f42d074079">
+      <statement statement-id="pe-12_stmt" uuid="162e05ce-172b-4055-9a53-5a5a466e62e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2507,10 +2507,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04919801-b7d1-4199-9bb1-a821a6e4becd" control-id="pe-13">
+    <implemented-requirement uuid="2b8e5e39-05a4-42d3-879b-6c2d85fb6698" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="fe1e8238-b20b-4ee9-b700-0e5abccc05c4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c4ecca28-be59-42d0-9723-00794660e908">
+      <statement statement-id="pe-13_stmt" uuid="e539b4af-1f30-4b7e-b7c0-a5a2e754eaa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2519,10 +2519,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0eab013-229f-453b-a889-b250a1cd652c" control-id="pe-13.2">
+    <implemented-requirement uuid="c388758f-8a6b-4809-95e9-652ccb5eece2" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="09323044-7427-4b88-8d71-6bccce551d40">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="db5e105a-21c4-4320-b798-9ad0716494ad">
+      <statement statement-id="pe-13.2_stmt" uuid="db283059-ed26-4dd4-9f86-fe7f82d40324">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2531,10 +2531,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f67ddb4-1177-4f3b-b2b7-f844b99b61fa" control-id="pe-13.3">
+    <implemented-requirement uuid="c8a56da2-768d-4994-8a7d-8119d8b0c04e" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="7ee37dc7-90d1-453f-ba0d-581a26d69a76">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ad075d0f-b5ba-4acb-8d2a-aa873bdefc6f">
+      <statement statement-id="pe-13.3_stmt" uuid="859977d3-2f03-4b90-b293-f092f74bdfd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2543,10 +2543,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c7341c5-6ecf-461f-9145-639c6fa7400a" control-id="pe-14">
+    <implemented-requirement uuid="95ec2fce-564f-4fd8-b858-b89af62566d3" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="7b70f016-0958-41ae-9a9e-b8c8681b1648">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="3191180a-df61-4ccd-ab8a-44f991c67cf9">
+      <statement statement-id="pe-14_stmt.a" uuid="63ad4abf-3740-4e72-94f7-393c8625edd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2554,8 +2554,8 @@ resides.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="f4c3347c-5fc8-42c0-9efb-862104a7b17f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1dd2d93a-7d4c-42a3-976e-b9f3787e2ad9">
+      <statement statement-id="pe-14_stmt.b" uuid="bec858c3-3512-418c-9c3d-902ceec3def3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2564,10 +2564,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dad6d28a-283c-4559-b308-7847b1db8d73" control-id="pe-14.2">
+    <implemented-requirement uuid="d8f37391-2361-49bc-bef5-954d32a40da5" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="90b80737-4266-4abd-97a6-2a68825f8787">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="dff8938a-f39c-48f7-9027-7d3aa21789b0">
+      <statement statement-id="pe-14.2_stmt" uuid="5c21b98e-0119-48e3-99fd-d942c0665010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2576,10 +2576,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3af13f9d-fbd2-4d6f-a888-ce02872a077e" control-id="pe-15">
+    <implemented-requirement uuid="b8c2ad37-9714-411a-ad3c-ea5800b64aa1" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="841176e0-c849-4e62-a689-cb0bf35e5684">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b39b71eb-90fd-4f47-b73e-fa7cbe9b84ad">
+      <statement statement-id="pe-15_stmt" uuid="2d10e6f1-78e0-424d-a58b-4a2e01a3fb43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2588,10 +2588,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c6b5919-f361-4d14-be65-1c644db3f123" control-id="pe-16">
+    <implemented-requirement uuid="62b24ebb-350f-463b-b9dd-d0a9f76644a9" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="a9d4bd04-de8c-4625-a28c-e43b6495ab84">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="51dcd7ab-4875-4a9e-b959-56e8741c63f3">
+      <statement statement-id="pe-16_stmt" uuid="b71c7cb8-6d89-48bb-b6bb-5957ab08ce34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2600,10 +2600,10 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b69ef390-2761-4d2e-9598-a93c4b4783d1" control-id="pe-17">
+    <implemented-requirement uuid="daaf181a-d178-4a0a-bedf-2cbd147ccc1f" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="846da6bc-16bd-41b3-8cb9-84233d686286">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4eea81d7-0304-4467-9abd-227251d5f506">
+      <statement statement-id="pe-17_stmt" uuid="87fc8de3-dcb4-48d3-bb1a-e84802eeb821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff31200e-51e7-4541-a244-748f0f9d4d0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is inherited from Amazon Web Services, who own
 and operate the facility where the information system
@@ -2612,765 +2612,765 @@ resides.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08447e16-76ed-44d2-b056-d5ad2b17c5d8" control-id="pl-1">
+    <implemented-requirement uuid="1a5e4178-9df9-45e0-b04e-c88228dc5fd3" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="be01f971-ef50-4bf2-b55d-dcf1572d5ead">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="dfc4c2fc-7e02-4bb4-9a41-d2d774b57c93">
+      <statement statement-id="pl-1_stmt" uuid="4f330b5a-3729-4854-bb38-91c48434723c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a98351ae-7821-45b4-8303-df1f19ec515d" control-id="pl-2">
+    <implemented-requirement uuid="0ba70246-52c9-4cd4-902a-b406fd162505" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="a7cd999a-3420-4f7d-b623-4600dcbc454b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a6b3377d-30b4-4582-8cea-f6e146095d68">
+      <statement statement-id="pl-2_stmt" uuid="09a9c7b1-dfc1-4884-8a4e-f76340d26b5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ceeffcb-c6f5-4de5-bcf1-b35c9a3ab141" control-id="pl-2.3">
+    <implemented-requirement uuid="1905e193-35b7-4aa1-b7ec-b941a3ba6e5d" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="2b555bd6-7404-4831-a121-cbcc0dcab55f">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7f220f92-5b22-4171-8616-f8f4521444c9">
+      <statement statement-id="pl-2.3_stmt" uuid="e4741e90-691a-4b42-8e41-a7574f7a0c8a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2c02d02-4ca1-4064-808c-9ae717f38e33" control-id="pl-4">
+    <implemented-requirement uuid="7a0f5f95-640e-4569-ab2a-41be6b94bb58" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="885fb4f5-182a-4816-a215-95b03b9c0b55">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="132cc14b-5319-4330-bb45-8a90fec81c04">
+      <statement statement-id="pl-4_stmt" uuid="12d94f45-18cd-4a10-b195-11cc6f6de5a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b180d5dc-d5b2-40d7-acc5-4eb5407139c9" control-id="pl-4.1">
+    <implemented-requirement uuid="3337e63b-f8a9-46c3-8495-c49059959114" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="49fba768-4859-401d-8e2d-3074493abe7e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4b3380a1-ddeb-4f5b-8671-cc32e6d3a7c2">
+      <statement statement-id="pl-4.1_stmt" uuid="6695f9dd-25e6-45a6-8012-c39ac2d125bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1922a72-8b79-46fd-8e41-dd4f487f7ae5" control-id="pl-8">
+    <implemented-requirement uuid="37d3fb7b-b734-4596-9738-05ddac23e28c" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="02ee40f9-4614-433e-80cc-6036b526ee98">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="16892c93-7f47-42d9-a41c-fde8a456a430">
+      <statement statement-id="pl-8_stmt" uuid="557cfa5b-b6c9-4bb7-9333-6a34fac04827">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29a97071-8909-47bb-ac53-cd294db0d16a" control-id="ps-1">
+    <implemented-requirement uuid="eb3dd41a-bbab-4d9b-ae5d-4b219bef17c1" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="2295e5a1-edd1-44c9-baef-da1b14c2e484">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="38df095d-6ce6-4d29-9442-8f0255ee8997">
+      <statement statement-id="ps-1_stmt" uuid="d801ba76-cb38-48aa-a78e-a48d3fcf57a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5784104-9a91-44d2-a2cd-254c35a311e9" control-id="ps-2">
+    <implemented-requirement uuid="daa68232-f074-4b9f-a109-865771304d0e" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="51ff5caf-efb3-468d-8760-a0be73504457">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="97bc5bae-5082-4409-87ef-7fd405c94a5b">
+      <statement statement-id="ps-2_stmt" uuid="c497b71b-2ea0-4163-be92-978db18b837d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86057dfc-1926-4f5e-b7e2-95cd3cba0153" control-id="ps-3">
+    <implemented-requirement uuid="49180b21-da3a-4e0f-9a97-011c62ae8e06" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="eeabedad-1aab-46ea-ba58-522e84a1b296">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9e0b95dd-8db6-4133-ae41-653c5f9f6147">
+      <statement statement-id="ps-3_stmt" uuid="edeca7d9-cefd-4692-a1e0-9c873371f24b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7aaa07e7-dff2-4b11-b6c6-2abd32020428" control-id="ps-4">
+    <implemented-requirement uuid="e2c40744-e377-439f-ac7b-2278f730964b" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="66683664-05cd-4ea2-b466-810b97baa0e6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b6554688-1245-4be0-98f4-7285b9ccb55f">
+      <statement statement-id="ps-4_stmt" uuid="a9b66737-1c42-416b-906a-b91dcfad8c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="023aaaa5-077a-4e71-bd44-6128556e1425" control-id="ps-5">
+    <implemented-requirement uuid="7909e627-5796-4305-89ba-5f66c9918ce7" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="82972f8b-e7cb-40c5-80cc-e4f643ab4572">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2fed4435-fb6c-48d8-949c-eff406b8fa7c">
+      <statement statement-id="ps-5_stmt" uuid="a82c2d3f-223f-4197-81f8-5137d548c165">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7a656d0-629d-4607-9b67-23ed1a05695a" control-id="ps-6">
+    <implemented-requirement uuid="ac05a0ba-c487-4d5c-a072-9e746a101b00" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="85c397d0-360c-4505-9a05-a4c06b7f517d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="60b97335-47be-41c7-bba6-90640e2203c7">
+      <statement statement-id="ps-6_stmt" uuid="a4163a29-637c-4323-864a-182f50a43a4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2816b7bf-2fa6-4227-8952-8d8c9c83affb" control-id="ps-7">
+    <implemented-requirement uuid="d0f887d5-2b2e-4de8-aa3f-c5490c35bab7" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="e9ce4696-a40c-43ff-94a8-58ff9f1e04a5">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2483d99a-950f-4b4e-839b-d0ed7e983899">
+      <statement statement-id="ps-7_stmt" uuid="69322f64-642f-4a53-93e4-509bb25bc954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99449cd1-8dbe-487e-8f63-7cf2e3e40296" control-id="ps-8">
+    <implemented-requirement uuid="6da54514-da22-41d5-9c37-ed629645a10b" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="7f18a547-cb77-4724-a210-78b135eb8314">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e06fcfa5-6371-4e44-8617-4d930c0a69d8">
+      <statement statement-id="ps-8_stmt" uuid="96587a7a-8d35-4131-b1d6-ebe60b30eb9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b58b1d8-b174-4d8a-b608-811a72920e51" control-id="ra-1">
+    <implemented-requirement uuid="ff695294-861f-41d7-b470-178d71912b8f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="3656a216-d606-4cb0-8514-4c7de39fadcb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="de7e1b4b-6d1b-4e35-bcaa-fa9cc993c29a">
+      <statement statement-id="ra-1_stmt" uuid="7b9b9499-4ab4-4779-aade-339ac837c535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ffcfbd1-df5c-4109-957b-7512a9a0384a" control-id="ra-2">
+    <implemented-requirement uuid="136a72f7-d72d-4a7d-9dc0-499becbc392a" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="58381ac6-13fb-4ffd-9e39-d46008346769">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="34665091-95ce-4aab-bfb7-f2659d998216">
+      <statement statement-id="ra-2_stmt" uuid="5931e57b-c4b6-431a-8234-1cab5c8f7610">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdfd6468-8a4a-49e3-8a70-e539c29bbd67" control-id="ra-3">
+    <implemented-requirement uuid="7dbe0353-27aa-47ed-afa2-2a6823696698" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="4465d068-2956-4a0a-b0b0-a194713f43be">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f40a03b0-3e7e-4139-8729-ded730d08db3">
+      <statement statement-id="ra-3_stmt" uuid="470d9f68-7c8c-420a-9d01-cc03a101210e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91edfd74-fcad-4025-8c42-258842fdb376" control-id="ra-5">
+    <implemented-requirement uuid="9dfd0d25-bc22-41b9-b13e-08a0ed87cb85" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="2acb6310-5415-4d78-877e-fdd42606e860">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c2f7494f-fede-4a90-a53e-5e18e73505b0">
+      <statement statement-id="ra-5_stmt" uuid="9322da0a-5fc8-4850-bab1-c53964899e39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cfcf100-b960-48ca-b3b4-1fe3a8fdcbf3" control-id="ra-5.1">
+    <implemented-requirement uuid="967171a0-ef3d-40c6-a254-dadb6a822dfe" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="10c9e67f-2713-46ed-8143-11bc78cedfc9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b59027f1-870e-41af-bc70-0907fdde3fac">
+      <statement statement-id="ra-5.1_stmt" uuid="fa771de0-c72f-447e-b3ec-bccf04b6a21f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94ce6b91-a494-432e-971f-3e3ad01eb250" control-id="ra-5.2">
+    <implemented-requirement uuid="afbfe19c-3cf7-43da-b599-71673d84e1ab" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="55106379-300c-4a5e-ae4a-f3db2d13fcd3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c6bb3fef-dd77-49e1-b3e6-6463178ba6fe">
+      <statement statement-id="ra-5.2_stmt" uuid="9f514565-fdb5-4642-b4da-027eab07959d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e18763d6-52ee-4159-b837-87cc08a9a158" control-id="ra-5.5">
+    <implemented-requirement uuid="3a5a530c-804b-4092-9dca-15cd27f501b2" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="f2be433b-385d-4770-a0d3-e94572ef29fd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="51f17f24-9142-4e2e-84e6-2a689733d6a7">
+      <statement statement-id="ra-5.5_stmt" uuid="2bff8d5e-210f-411b-8261-f536ea5f25be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd5d70c1-5aba-49e4-b59e-66ee2af59d03" control-id="sa-1">
+    <implemented-requirement uuid="cb54c9b7-9d11-4572-80c3-784ec67da4f3" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="dbe0e73f-d8fd-45eb-8799-1101b12ef1d0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8f3561c1-22a8-4191-b4f5-ce722f1f830b">
+      <statement statement-id="sa-1_stmt" uuid="b7625cb2-66d5-4892-bbb0-a9d7d5faf003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4923b912-9b65-4437-8c5c-663ff581f210" control-id="sa-2">
+    <implemented-requirement uuid="c575a17c-62a9-4567-aa0f-9f26b4745496" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="f350321b-469f-4e6f-a2d0-5b45e251d69e">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="480ca400-0d33-4ddb-851d-7ed01dfbf050">
+      <statement statement-id="sa-2_stmt" uuid="bdc6558d-3570-4907-b9e0-64ef3e1e00f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="431ffd76-72d5-4c6c-a181-607685eba860" control-id="sa-3">
+    <implemented-requirement uuid="740568db-cbb0-4ca6-a4ab-3f606104c86c" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="21c83e31-3c0a-4d22-9844-e8046e9c90e2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2e937849-6536-40a7-beb0-8a935676ec0d">
+      <statement statement-id="sa-3_stmt" uuid="8c037ef8-ea13-4df1-8f57-0d8131701f7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2a327bd-c660-4507-bf10-d3f8908810d7" control-id="sa-4">
+    <implemented-requirement uuid="fba35c40-c7d7-4c2b-9b9d-8f38770f4343" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="f5b1dc7d-0300-4369-a891-00bb6536a032">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="61e7c0c8-3ef6-42af-925e-d2a340825c3e">
+      <statement statement-id="sa-4_stmt" uuid="cc86ae33-c11a-47f1-b346-5fcc89190585">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6bbd837-1c36-4183-894d-c2e2cf3059cc" control-id="sa-4.1">
+    <implemented-requirement uuid="4a9c6706-2e7c-4409-9ba9-bb31cd708ea7" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="c1887c2b-3aab-4a88-8712-a5448755efa5">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="babd2dd9-e912-471f-8755-8916e7592d18">
+      <statement statement-id="sa-4.1_stmt" uuid="6098953a-b156-4498-b200-01fd6df340b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cbe83c0-7df1-4b4c-9d23-64d88ce16e4f" control-id="sa-4.2">
+    <implemented-requirement uuid="fd02b4c6-c9df-4490-ae08-9b73903022e3" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="67fcfcec-6e46-4b72-ac9a-cc33a2d5db53">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="639fac36-8829-4db0-bd15-dbc2f0151d83">
+      <statement statement-id="sa-4.2_stmt" uuid="012d0527-e9cd-4913-b788-0b4fbba641b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99eb476b-a564-4f34-acdf-bb22f974ae22" control-id="sa-4.9">
+    <implemented-requirement uuid="0bc0a158-ae92-40f4-8204-1edd757ed4f8" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="002c0984-830e-47da-8544-661ba5556d43">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="01aba58a-82f7-41b1-af62-18ff5a794588">
+      <statement statement-id="sa-4.9_stmt" uuid="403f6f56-bd04-41f3-b065-f1d2368d715e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42a2a7f1-49ea-4952-ad59-e3b72bcc40fe" control-id="sa-4.10">
+    <implemented-requirement uuid="d3ca4c93-0635-407b-8599-5097ac00f4fd" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="17d4d2ea-3e6b-4329-a4b6-717ef76e4a93">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="58e147fa-3456-4242-8e38-5392b520fc2c">
+      <statement statement-id="sa-4.10_stmt" uuid="4180f765-02df-4f94-8c3b-dfd75684f316">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee646d16-43b5-4e9a-96e8-2856f202c434" control-id="sa-5">
+    <implemented-requirement uuid="26cae64d-898f-4832-b702-1b228d6a7ce0" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="bc8875d1-edd0-4db7-b17e-324d42d82d88">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1922f148-d609-48c7-8a28-e901fd2370fe">
+      <statement statement-id="sa-5_stmt" uuid="6304df28-0587-4607-991c-972dade816e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c2ee385-a844-44f0-9522-420e33da82e1" control-id="sa-9">
+    <implemented-requirement uuid="3dba2dd7-5806-463f-a2a5-f927c9f17197" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="fce8244c-586d-4964-b80f-b0d9bb20d6f9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a2cc5af4-ac33-405f-83ce-717a8067082e">
+      <statement statement-id="sa-9_stmt" uuid="5ce7182c-ceca-4e58-b733-ece84ff92504">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b1cbf13-e5b7-458f-a756-8d4959f65fc1" control-id="sa-9.2">
+    <implemented-requirement uuid="c55b5e98-a606-42be-827a-7932c2e60fd2" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="6a472c40-7191-4459-b89f-91dee3973162">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8be38c37-c2d0-467f-babd-bb258a25583f">
+      <statement statement-id="sa-9.2_stmt" uuid="ca1e3a5c-5b5e-470a-9b95-457e13ff0672">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3db9cece-2426-419a-852d-8c50909804f3" control-id="sa-10">
+    <implemented-requirement uuid="51bc3e94-1e98-4a22-ada7-bb6dfc661955" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-10_stmt" uuid="ed79e9c5-340d-42d8-9bb0-544eb4df6ba2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="465e9a4c-d4cd-4840-8725-3f79bcc74b92">
+      <statement statement-id="sa-10_stmt" uuid="00033cf2-4ea1-4f05-bbf0-a98439127663">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19bdb51d-5ceb-48d1-b01f-ba561fc1ebea" control-id="sa-11">
+    <implemented-requirement uuid="02ea9daa-6c9c-4762-88d4-635f2689d70c" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sa-11_stmt" uuid="83823074-7929-4dda-9dd5-fb339438f9f1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c38459d2-8dc7-4c3d-92d3-2fb6da293b19">
+      <statement statement-id="sa-11_stmt" uuid="66a9ba4a-b1e8-43da-be89-e5159018dc10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2285a955-61ca-405f-aabd-419adc4aa42b" control-id="sc-1">
+    <implemented-requirement uuid="b885d23c-98bc-4694-b3df-ad5e2d79b193" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="e102ccd5-e1f3-4f6b-bd6d-3797851696aa">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0cb68484-ff40-4585-a05f-c8c24bcff398">
+      <statement statement-id="sc-1_stmt" uuid="31a28689-d22a-4281-9396-3e39aaf00400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53dcbaa3-3cbb-4965-a836-7d1f5478d65c" control-id="sc-2">
+    <implemented-requirement uuid="bd828fb0-01e6-42c9-9737-7f0b6c7cc415" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="dcd1558a-4c65-4a8e-bf93-729417d834c9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a365d4db-f39d-460e-986a-fef4d7407faa">
+      <statement statement-id="sc-2_stmt" uuid="92dad8a8-645f-4b6a-b37b-24973bbcbdd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85b10623-383f-4827-9c1d-9c97d28435fc" control-id="sc-4">
+    <implemented-requirement uuid="f07499ae-3448-4736-866f-d3eaf2fbf4c6" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="83879b3f-acdb-47e0-816c-978dec4880e2">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="25d2d2ea-5fc8-43a9-9ca5-4bb25b0ec19b">
+      <statement statement-id="sc-4_stmt" uuid="b3bef6f8-ed25-480c-ae1a-aa2dc2205eae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fef335b-4326-4614-9698-dfc79b010824" control-id="sc-5">
+    <implemented-requirement uuid="36d6ee6d-75a4-479a-99b4-18617dcb82b5" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="2ef985bc-8256-4fb2-ac17-a39b8ce13fe3">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="721f8eb5-371e-479d-9292-becf8cd5bbfa">
+      <statement statement-id="sc-5_stmt" uuid="04f915f3-359b-4ed2-867c-c0d4ded64687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95daef72-1981-49b9-b635-206cda05c094" control-id="sc-7">
+    <implemented-requirement uuid="c79f28d7-1ee0-4de9-ac9f-b038234e264d" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7_stmt" uuid="ac614862-b09f-4246-b879-5c7c6c11c5a0">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f4898ff1-3fa0-4fc4-8fc9-e238a437a758">
+      <statement statement-id="sc-7_stmt" uuid="7bd816be-8571-4716-90fb-770dff3d90bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9447b0d-1d32-47eb-a234-b7a47c40e20e" control-id="sc-7.3">
+    <implemented-requirement uuid="a04d087b-3243-4998-b877-9b060f1a7668" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="b91bec6b-8be9-4741-9af0-edfbeaa24665">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d3bae301-a65b-4b73-ba61-4f59c0be5783">
+      <statement statement-id="sc-7.3_stmt" uuid="912fa1bf-7e93-4dd4-9f68-127badf64e79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f6ca11c-277f-42b7-a386-bd9a06c024e8" control-id="sc-7.4">
+    <implemented-requirement uuid="c78e796e-1fa2-4462-8f71-db2dc29d7ede" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.4_stmt" uuid="137b17a5-9842-44b0-878b-c03ee3060505">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="bf2995dc-f57a-4ac7-8c26-403a839125ba">
+      <statement statement-id="sc-7.4_stmt" uuid="e1dfd666-78b2-4ade-bbab-5628fc72512b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4f3376e-8834-4b38-8dbf-961f9f8bd163" control-id="sc-7.5">
+    <implemented-requirement uuid="4431f779-a58e-4fb7-845d-ea28b859d488" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="20cb2b79-e731-45d0-9f2f-32b1f8ba42df">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4cb58f72-efba-4c91-b65b-ea54ccd0fdbe">
+      <statement statement-id="sc-7.5_stmt" uuid="efa9dd88-8fb5-42cb-95fe-83ba78ed5c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abeaaab3-a1f7-469b-a8fa-8c8bd5a95b66" control-id="sc-7.7">
+    <implemented-requirement uuid="cb7bf0cd-de6e-4a32-a3ba-ebcd26d36348" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="b670d39d-c297-4203-9b5a-d2a930e2fff8">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="dde64217-96ed-47ae-8dc9-9f509e34b90f">
+      <statement statement-id="sc-7.7_stmt" uuid="89cfbcd0-57a0-40d8-a266-ef14383eca62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a844713-596a-4261-9d92-e7328c79f508" control-id="sc-8">
+    <implemented-requirement uuid="e77d8915-773e-4021-af5b-d309f271e0a5" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="9c7088fa-4fb4-4e11-bbca-5520824fdca4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="72636ab3-7b31-4a89-99a6-403849c62aaf">
+      <statement statement-id="sc-8_stmt" uuid="8c21e59d-12b5-4c6f-93c9-26ffe32aa31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ef9e657-3017-4fd6-8111-409dd41c9159" control-id="sc-8.1">
+    <implemented-requirement uuid="cbf32005-5ab3-423d-b3ce-959705a54b13" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="74c45996-08c7-4afd-935d-e05d03e93f91">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8cb57522-0b12-402d-9f4b-ab1ae76074e5">
+      <statement statement-id="sc-8.1_stmt" uuid="e95b70fa-5d45-4af3-9e64-60407fa7d4ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f828569b-d687-452e-80ec-c38b68e46eb3" control-id="sc-10">
+    <implemented-requirement uuid="fb8f824b-ce7f-4acc-98dd-5793a79de505" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="7ea70a60-e9d0-47b7-9f77-e0d5e3d159ec">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="876b0515-8e18-4da4-b203-169238095f73">
+      <statement statement-id="sc-10_stmt" uuid="eda80d21-77b7-4de6-9c4e-b43cb8bd8884">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9087f1a-1cbd-447f-aabb-fc4a1ad9f2a8" control-id="sc-12">
+    <implemented-requirement uuid="fd9ed307-9307-48a0-b4df-23137355735d" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="9bfe9ae0-039e-4741-933f-286e4970f869">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8cad3cc7-3b2e-4220-bdf3-a08fa3259a00">
+      <statement statement-id="sc-12_stmt" uuid="1265e32b-2e01-4b72-9fd3-82ce6a990176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f15c350-da89-441b-93d3-99c9582f8280" control-id="sc-13">
+    <implemented-requirement uuid="375718e1-a987-475b-b769-b532677acbc6" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="0f1f061e-d395-4bcc-b17a-8996ca4eef58">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1e85505e-180c-424b-a7cc-f85567b030d1">
+      <statement statement-id="sc-13_stmt" uuid="5ca69218-91fb-48ca-ba66-733c6b941a33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="beac7cf3-ee79-44ee-b81e-ffc498a68366" control-id="sc-15">
+    <implemented-requirement uuid="9f623733-ea80-4bb0-aae3-e74004c03fdc" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-15_stmt" uuid="26af1983-ab46-4591-8d38-efed4e419565">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2e4f48ad-5734-4fec-8846-69fcf7d5743d">
+      <statement statement-id="sc-15_stmt" uuid="65341d7a-5048-4aeb-9868-4aed33d3e642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c83d9c8f-cc08-44dc-b3dd-4e4f6638b0c0" control-id="sc-17">
+    <implemented-requirement uuid="6fefe615-4b9f-4ea1-84e1-c932ad0b3e58" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="93b5d610-6aed-46e7-8e21-95dbe0dc8c67">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="c338b4f7-574e-4748-aed3-ae12f7e2d245">
+      <statement statement-id="sc-17_stmt" uuid="a9b6e346-aecb-4b51-b1eb-53d0a697d27c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45b82548-e809-44d4-8e9f-bc535f5e2e73" control-id="sc-18">
+    <implemented-requirement uuid="fa7d30ae-c3c3-414e-a1a4-543c74462573" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="43118e1a-8dc8-4768-ba10-3142391f76f1">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0256674d-9180-4c04-9d91-c0859c08598a">
+      <statement statement-id="sc-18_stmt" uuid="f4128e89-150e-42dc-9d02-ad6322f2f8dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fb75d48-cad0-4d28-a873-2997c04bf636" control-id="sc-19">
+    <implemented-requirement uuid="81e53007-3c0b-4848-9315-b86300e4678f" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="a5c3bea8-9070-48a2-8f33-4f16edf91e5c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="2a0d95fa-9734-44c2-baa8-59cbb8b65d16">
+      <statement statement-id="sc-19_stmt" uuid="946691b9-efc4-4b9e-8f56-9699097030e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3694706-a9af-4bb3-b32d-00b1202e7438" control-id="sc-20">
+    <implemented-requirement uuid="8c87c369-bc5e-4588-97ae-ab413040e28e" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-20_stmt" uuid="9cd20d35-3dac-4a1c-a58f-3effc936e061">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0a059d53-7207-4029-85ab-d0687bf2605d">
+      <statement statement-id="sc-20_stmt" uuid="e6d43ee2-e134-4615-a6a5-96abffdf0d8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="116729e1-4d4f-4fcd-835c-efc819fc653d" control-id="sc-21">
+    <implemented-requirement uuid="8aa2a844-5c53-4ad0-96de-8b84998ddb1d" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="954333e3-7775-4f5a-afb1-1d367cd07eb4">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="16b90e27-5061-4a44-8818-54c72f30376f">
+      <statement statement-id="sc-21_stmt" uuid="94068221-ee66-41e6-ae49-c1347298014b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e76e774c-9a5f-4243-9c2b-ed9f409d1d1c" control-id="sc-22">
+    <implemented-requirement uuid="6aa8d7c2-44cf-4e9e-a7d4-2993d6428e16" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="9fbfc7d4-f4e4-41d8-8cf6-fb591c0ebc48">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="0cc540e4-9c78-4fb0-a344-3752f2eb1cab">
+      <statement statement-id="sc-22_stmt" uuid="2d9e7064-f178-40b2-92d9-28a08ec6de4c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dde3e092-3094-4a5b-9b0d-bfcb11637a47" control-id="sc-23">
+    <implemented-requirement uuid="c64e20e6-1320-4518-a825-825d9ad82726" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="039b98bc-28c5-4f2c-8d6a-8214f25ec8c6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8b88847f-6edf-48f1-af37-be7b873acaa6">
+      <statement statement-id="sc-23_stmt" uuid="3bc85eed-3358-4c65-9e70-461ac3982bc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="651ad10d-4341-4726-b3a9-b6df9c691c2b" control-id="sc-39">
+    <implemented-requirement uuid="758e3f6c-4438-46ea-994f-e3b47147705e" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="5b7c698b-312f-4533-8732-387e426a0e4d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="91c6fe27-4b7b-49cc-b158-ae7300212e0d">
+      <statement statement-id="sc-39_stmt" uuid="925ad4ee-2f66-4648-9a31-11916aaa7e33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76d29dbb-fc35-4487-a578-42658a664580">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''##
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30849d02-c291-4b10-8de5-6273460a2818" control-id="si-1">
+    <implemented-requirement uuid="fad37c51-3b6c-49ff-a563-6dd95baaadbf" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-1_stmt" uuid="90a43a72-9362-4940-900b-5c8a6e589760">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="af324859-71ca-4c3f-9141-a13d49a46341">
+      <statement statement-id="si-1_stmt" uuid="378180e0-e560-4d05-b874-93c566727297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a560a0f-9bba-4ab4-a5c9-e48a09020bc3" control-id="si-2">
+    <implemented-requirement uuid="d145ad6a-a7ee-4fef-b361-19e0901849ed" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-2_stmt" uuid="aac6ce8b-144f-477f-aa96-bc916c147366">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ce3b7ca2-2cac-4b8a-bcb7-7cc20be62ec2">
+      <statement statement-id="si-2_stmt" uuid="fbd48d0e-3698-476b-b60b-cfd9e17d053f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26009598-b917-4ef8-8557-9032fab5a80e" control-id="si-2.2">
+    <implemented-requirement uuid="a997c594-359a-43b9-bbe4-1c655d9a4e09" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="ad63bcf0-03ff-4a34-8ccf-7f7b2b024b98">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e2ddf87c-bafe-4fc1-8ed9-1f6607c204b0">
+      <statement statement-id="si-2.2_stmt" uuid="e44363f6-d1ef-4b2e-b9be-27dd06271e80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8a73dc4-284e-4440-abb8-66f7826edff8" control-id="si-3">
+    <implemented-requirement uuid="12a9295d-25c1-4afe-bbb2-bc3176a0e6b8" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3_stmt" uuid="98330846-a4cb-4bba-9655-ff97012ef3a7">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="7e353e33-d00e-4009-8aec-87713fba15ea">
+      <statement statement-id="si-3_stmt" uuid="4206e8f0-b3a8-4c9d-b5c6-3d40e0ae6634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6daf93d4-9081-4e27-9154-44c9937e0862" control-id="si-3.1">
+    <implemented-requirement uuid="73958e84-b8c9-4a39-b4f5-34baf9d41605" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="b275d3c8-e612-442b-bc1a-66809b1ac2ce">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="658580a2-0aee-4931-9667-eddb709597f7">
+      <statement statement-id="si-3.1_stmt" uuid="67a90945-cc85-4044-b050-a54c4a082155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f5e931e-c6ed-4b10-8680-ffec608cff50" control-id="si-3.2">
+    <implemented-requirement uuid="3aa0dede-bdea-44c6-8873-de70f01af37c" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="8140f2b0-ca0b-4fa5-b25f-8c68895794bc">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="540a9f9a-c31b-4071-ae84-c85b818086bf">
+      <statement statement-id="si-3.2_stmt" uuid="0f21275f-6e20-43ee-bf0a-6bb9b356236e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e3531b1-9966-4b82-bdbf-8df9a999831b" control-id="si-4">
+    <implemented-requirement uuid="f808f76a-7dd5-40bd-b73a-0eacadd447a0" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4_stmt" uuid="d7df0563-4712-49a2-b375-9b8a023c14d9">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9d27e06f-5e2c-4b84-9fb0-14091cfbf4f6">
+      <statement statement-id="si-4_stmt" uuid="901968f4-a0f8-416c-8212-dbeead97b485">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a76e00e1-ba56-4c45-a029-a4e3f656c320" control-id="si-4.2">
+    <implemented-requirement uuid="0f1f29e9-027b-4aa4-9207-57078514c289" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="2aada8f3-d626-491c-a6da-f992ea521945">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="f8f6d5c9-2d50-4b5a-8d33-e7a7aba2f2f9">
+      <statement statement-id="si-4.2_stmt" uuid="7f7cec13-2728-45f3-a8bb-8b79365ddc80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b575d142-9847-4cba-b573-d46edc90b4ad" control-id="si-4.4">
+    <implemented-requirement uuid="f4f7a3ea-5d74-4e3c-958e-2d0c5413832e" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="022614dc-f381-4a3f-a873-02d93f5e5cdb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="d37caa1e-6d1f-489d-907a-288edf243095">
+      <statement statement-id="si-4.4_stmt" uuid="de5d635d-a38c-4947-ae93-43fe08613ebf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82437895-165e-4ec1-88fd-6b268c24ae53" control-id="si-4.5">
+    <implemented-requirement uuid="2e87d164-534a-427c-a25c-28aec0cf0ff6" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="5918e8bd-6e61-407c-b781-d0fd01e0f418">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="e4972bb6-299e-4403-b312-28c166e56520">
+      <statement statement-id="si-4.5_stmt" uuid="485fb0b4-dc8b-4b6c-bdcf-930727364793">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ef91dc8-3d43-4f7d-863e-dad54cd4efee" control-id="si-5">
+    <implemented-requirement uuid="d246d1db-451c-42db-8834-5b50d8a831d0" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-5_stmt" uuid="11fe186a-1610-4016-837f-d6876accdacb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="00c4dcaa-7f80-429f-a5b2-5b11b8fd48f5">
+      <statement statement-id="si-5_stmt" uuid="dc50f1f5-8925-4856-999c-7bc1960b9580">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c065d2d1-7b33-49c9-85c9-b17f5cb3364f" control-id="si-7">
+    <implemented-requirement uuid="8f3feaa2-716a-4719-a4a3-e52d4942554b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7_stmt" uuid="cacebc14-ac16-4cb3-a756-867e708bd34b">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="4f8e9e6b-428d-44aa-8189-182984a07f79">
+      <statement statement-id="si-7_stmt" uuid="edff0796-06c5-4387-bebf-791731cadcde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecc9cc6f-a98f-42da-be90-2f62a4227b9f" control-id="si-7.1">
+    <implemented-requirement uuid="75e014e4-4322-47d6-ad1b-b66ef2366402" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="c993672a-ef4b-4c0a-837a-f2d0152f64e6">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="1a648c91-ab43-49a9-846e-5294528d80d6">
+      <statement statement-id="si-7.1_stmt" uuid="de28409b-4d14-4a0b-91b0-ca32495d424b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe35e867-2b46-44c2-9c08-e48dc0ebd1eb" control-id="si-7.7">
+    <implemented-requirement uuid="95597edf-2078-4477-b30d-c4c949062c68" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="b7cf11e2-bd49-421b-9b84-ac444a1dc831">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="a3a3fbe9-dbf3-4215-87f0-16e94e5c0bf1">
+      <statement statement-id="si-7.7_stmt" uuid="4c2458fe-26ce-4079-8348-5b17dfe69c14">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3fd1ea0-b9c7-478b-a096-ea5236220a26" control-id="si-8">
+    <implemented-requirement uuid="6f743189-5265-4f1e-9999-88d7bfd910f1" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8_stmt" uuid="42b3c124-1336-47f8-a469-6c17a4ddd8bd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ca4a996c-36a3-4504-8153-2abf81d1317a">
+      <statement statement-id="si-8_stmt" uuid="6b1ab2ba-f547-4820-b3dd-7a84fa66916b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f83e391-c1d0-4aaa-ab1d-20aad1481d49" control-id="si-8.1">
+    <implemented-requirement uuid="d2a0eadb-9acb-4422-b41c-e045abe62458" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="0b1dc122-b7ec-4b49-bfe2-3cce1a953c73">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="9b98beea-e01b-4201-9a1e-5943b7dc4a2b">
+      <statement statement-id="si-8.1_stmt" uuid="d1b9660a-5d9b-47ad-88f5-f8301ecf55b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbf67db8-6037-4b73-8b89-d0a4e25aa883" control-id="si-8.2">
+    <implemented-requirement uuid="c9b4e825-808e-40ec-8410-4a2b9a7e4064" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="50894421-0df5-4bd4-a5d1-ac2fa056dc2c">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="8ed21ce8-34d1-44a3-ba85-047c338c40ed">
+      <statement statement-id="si-8.2_stmt" uuid="cf23cdf1-0af4-4c9d-a7fc-385734490740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fae6ec6b-2e52-44f3-a2a0-02dfb03f0582" control-id="si-10">
+    <implemented-requirement uuid="75b016ca-0db4-4e1f-88a7-832a6337baa9" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-10_stmt" uuid="ee5e8c2f-1efc-4191-8690-ce40223de6fb">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="5a4a0a15-6ab7-4e1e-a632-2f74451b8f34">
+      <statement statement-id="si-10_stmt" uuid="0ecbd19f-a738-4d78-8d58-933e526286d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4de0cdc-c7ae-49ee-9551-b2d15e9397de" control-id="si-11">
+    <implemented-requirement uuid="25f86faf-aab2-46fd-acd6-3ef7dd989191" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-11_stmt" uuid="3eb3158a-27db-4980-b026-573c8c678d64">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="ea4f0d4b-1efe-4c26-afb3-6b23924d9299">
+      <statement statement-id="si-11_stmt" uuid="833af296-bd19-40aa-af3a-3a08aae4af7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3eaa6159-8b32-4e94-bb5b-d4b02a189e28" control-id="si-12">
+    <implemented-requirement uuid="d8df9871-e1d2-4feb-a760-893e044d0552" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-12_stmt" uuid="8bc97a6f-0819-420a-ae6f-35dc8815b55d">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="b9d5ff72-f638-4cca-b107-78a46d78790b">
+      <statement statement-id="si-12_stmt" uuid="71503f08-ca5f-4e1b-9cd6-3dbdb0f72c6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0822dfcd-65eb-4ffa-8380-45fedf445030">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c44e8fbf-0196-4ed6-9ca2-43168f73b90b" control-id="si-16">
+    <implemented-requirement uuid="b82a5b17-3cd2-4fd3-b74c-aa929adfe913" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="unknown"></annotation>
-      <statement statement-id="si-16_stmt" uuid="1ad47fca-d2cd-488f-a5ec-53e37cf59cfd">
-        <by-component component-uuid="9c578319-e4cf-4556-88e2-1430d9a8c163" uuid="41f362f3-3c2c-4d2c-b26e-09000ee25443">
+      <statement statement-id="si-16_stmt" uuid="2695eee3-10b5-42be-b8f8-ca027016329b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d9d2d85-73e6-4152-82d5-cdfcee4ba9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>''</p></remarks>
         </by-component>

--- a/xml/openstack-platform-13-fedramp-High.xml
+++ b/xml/openstack-platform-13-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="1b0ddf74-68eb-4187-a6ea-017cd84c843e">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="a4cf5145-732f-4bfc-9871-91dca13429c1">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.19+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.98+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="21ccc226-f75a-4fbd-b43b-90edc099a50e">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="8602cc88-0d2f-4933-8214-c182043ae15a" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="f036ea2f-3c59-4ed5-a147-17c1f0db3554">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="228b24d3-0be2-4710-bf51-855fe02d4766">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95493bf9-2ad8-4c0c-89fd-babba7675629" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="d8998e36-9ae2-4e6a-b6be-78594299ca66">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b57e9767-1122-4b83-918d-08895b1fbbd7">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16f41b4d-a7ee-4955-99a5-9c5f82d3de48" control-id="ac-2.1">
+    <implemented-requirement uuid="07848e9f-19d5-45b4-b443-e08f500bd595" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="8da1b51d-f869-455b-929b-dae20ca53ca0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="53884dbe-71df-47aa-a4b6-f158c6abbf48">
+      <statement statement-id="ac-2.1_stmt" uuid="1298ec9f-c861-4b6b-a616-1053749c932c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b34c1845-4cae-4578-a741-80f3dcbe2368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Usage of an external identity management system, such as Red Hat IdM,
 is recommended. A successful control response will document if an
@@ -515,28 +515,28 @@ OpenStack is configured for its use.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9139690b-ee1f-4205-b9de-4360bf771df2" control-id="ac-2.2">
+    <implemented-requirement uuid="2b859479-3f51-4790-b100-a8540237870e" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="7f944bbb-6270-401a-a3a7-bdb80b7b88d0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="23e68b71-a219-4de0-b928-eaee8a1d9f6b">
+      <statement statement-id="ac-2.2_stmt" uuid="ea1fc28b-24bc-49b0-b5f2-1367977532e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d266c7e-8f69-4786-886d-f5e7671aa227" control-id="ac-2.3">
+    <implemented-requirement uuid="b731de9f-ecbb-4c4f-9c4c-2d8bef96bea0" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="a9f2499f-ffb8-481d-bbfe-e9bdf16d604c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="14d4f713-56b1-4cd3-850a-3840414c43b2">
+      <statement statement-id="ac-2.3_stmt" uuid="a1e9ab12-2a19-4e37-9b75-8f361c825231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="692da59f-d743-46a6-af06-fe479af8d181" control-id="ac-2.4">
+    <implemented-requirement uuid="d960c57d-23d0-464d-9caa-86051d74c135" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="4512d651-e50e-489b-af23-4efe1eb39f15">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="61b37345-b174-43a1-b82f-400897a55b72">
+      <statement statement-id="ac-2.4_stmt" uuid="55d2b336-8e53-419f-a6b2-54a639df4315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="679e2c1d-555b-4510-8ba4-4947616b8edd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked in
 GitHub:
@@ -546,10 +546,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/159'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f031f7ee-6984-4e63-97dc-6dc6c2b88598" control-id="ac-2.5">
+    <implemented-requirement uuid="8f0f4ef6-7b3e-41b6-8f6c-f49a4646651d" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="5ae3e724-ec70-48ca-b222-5bfcd9046167">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="327fc6e2-9774-4570-9bc9-f89b2bd47934">
+      <statement statement-id="ac-2.5_stmt" uuid="762b4739-a18b-41ec-a576-797447578643">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98ecc7ca-7e19-4ca1-9b47-1e5273e52952">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked on
 GitHub:
@@ -559,10 +559,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/160'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ec0e204-e7c2-47d9-80f5-d429505f0d84" control-id="ac-2.7">
+    <implemented-requirement uuid="95429a97-42d9-4170-bd5b-0cc7ffb00b9f" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt" uuid="e0c40cdf-ad2f-49c5-80fc-ddd9f08e4b04">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="43b297f8-e39e-4d3d-a660-cf1ebec01fe9">
+      <statement statement-id="ac-2.7_stmt" uuid="6611ba37-306d-4571-907b-6268b329a7b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="478dab26-e94a-40f3-a866-d4d89a006611">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked on
 GitHub:
@@ -572,10 +572,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/161'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="814a89e7-bfcd-4fa7-8e22-b9614eb1106e" control-id="ac-2.9">
+    <implemented-requirement uuid="eef60bfd-bfe6-484d-a3aa-5e897b7bb082" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="ca7aeb22-ede9-457c-b1df-999621a65fec">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0a3fc1ae-045b-4b7a-ba8c-ad75c30bae54">
+      <statement statement-id="ac-2.9_stmt" uuid="6f28be9b-63cd-434d-b7f6-b2423778b4cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c9e3ac2-45f0-44f6-a23a-2ef244ee79f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (9) is an organizational control outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -583,10 +583,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17b55672-bf71-48c5-9c46-e5de182d9bfc" control-id="ac-2.10">
+    <implemented-requirement uuid="6e54a7ba-c5f9-46e9-a067-112a3d7c3f54" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="3b90dd21-93aa-4c4c-8db0-4462ebb9fc19">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5d17672c-2aa0-4278-83ec-bd1c8726bf2a">
+      <statement statement-id="ac-2.10_stmt" uuid="7774106a-ae0a-4750-8cf3-4ab273b7d81b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a885466-bf19-4117-b700-b36d2174c796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (10) is applicable to external identity management components,
 and is outside the scope of Red Hat OpenStack Platform configuration.'
@@ -594,10 +594,10 @@ and is outside the scope of Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4fad2d6-4d9e-4aea-a68e-79c33a857de5" control-id="ac-2.11">
+    <implemented-requirement uuid="82b4e206-ec01-4af5-a07a-981adc560d67" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="5664085c-027e-4302-950f-4ce6842f5436">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="33eed702-e599-4042-b591-cb27304b946f">
+      <statement statement-id="ac-2.11_stmt" uuid="2c25c803-9c6b-43a1-ab54-dfad62656702">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa3627e7-a1c8-46c1-aa4d-fa3ea6e7e0a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (11) is technical control that applies to centralized
 identity management tools/capabilities, and is outside the scope of
@@ -606,10 +606,10 @@ Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11eaa1c8-c831-4a00-99c9-bddb66c0e196" control-id="ac-2.12">
+    <implemented-requirement uuid="e741cd30-ae0c-406e-acf9-37a26c891b17" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt" uuid="37de59d8-88b7-494a-9cd0-b22dc4b5b40b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6fd17b5d-c22c-43e2-b71d-17f88a733669">
+      <statement statement-id="ac-2.12_stmt" uuid="4d53d1e1-c3a4-44f3-86bb-e1f65176282e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07303c50-704b-4341-815d-3b8b39155940">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (12) is an organizational control that applies to centralized
 audit reduction tools/capabilities, and is outside the scope of
@@ -618,10 +618,10 @@ Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4eff4a9f-94ef-4a4f-8af9-e0759aeea98a" control-id="ac-2.13">
+    <implemented-requirement uuid="52fe3d76-01e6-46e7-ab6a-a0c11e43ecb0" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="a9b71cd4-0a87-46be-9150-1d0dc1e0e038">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8b3624a2-6e48-49b5-86f4-7477d0cf2550">
+      <statement statement-id="ac-2.13_stmt" uuid="95aeff9b-8c6c-4bd8-8ef3-20d6e8ed1ca6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fac740db-6714-4a02-a385-b0df9c7ebea4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (13) is an organizational control outside the scope of
 Red Hat OpenStack Platform configuration.'
@@ -629,10 +629,10 @@ Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a13f67b8-43cc-44be-8347-8d159a50c8cc" control-id="ac-3">
+    <implemented-requirement uuid="37a855d0-90d2-4883-8052-2b76137d3ba7" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="c926a3dd-3cc7-4d94-b027-5ea897df2883">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="57b8cf04-f769-474e-87fe-140f6039239a">
+      <statement statement-id="ac-3_stmt" uuid="2da5110a-ab42-4c47-b656-d66a42f3ffba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfc41980-03f9-4cff-a609-6f46c86e694d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The OpenStack Identity service supports the notion of groups and roles.
 Users belong to groups while a group has a list of roles. OpenStack
@@ -644,10 +644,10 @@ and association to determine if access is allowed to the requested resource.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a02cacc5-45a2-4d1e-babc-d9f1f13ebd49" control-id="ac-4">
+    <implemented-requirement uuid="52b5c69b-8164-4ca2-a7dc-6d63a9788900" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="15a205ba-1dc9-4580-8d46-d2352f60d28b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a44f8428-9472-419c-b28c-1a0f63a11413">
+      <statement statement-id="ac-4_stmt" uuid="bb5fa4f3-14cd-4e58-82be-becb36bdc52f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc04d97f-de87-4185-8ab8-04a6686fe95e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance relating to information flow enforcement is
 being tracked on GitHub:
@@ -657,10 +657,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/166'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2ec15a6-0d00-403a-b5b8-6ebfdd8684fb" control-id="ac-4.8">
+    <implemented-requirement uuid="98e215f2-09d3-461f-b7a3-3fe3be1871ee" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="ce969870-3601-44f0-8f82-3fa0dc725fd8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="59c404aa-93a7-4a23-a907-a9495100ec68">
+      <statement statement-id="ac-4.8_stmt" uuid="47277d99-d000-4564-84ea-1c97c4ccd656">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d48b712-9f99-4a2f-ad10-0bcba3896fe8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance information flow control
 is being tracked on GitHub:
@@ -670,10 +670,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/374'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ce993c5-4367-44b9-a30a-e22089e38c3f" control-id="ac-4.21">
+    <implemented-requirement uuid="d3f19230-48a6-4382-8ea8-edd3a87bb7db" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="898ed6ff-2f10-45ba-b39b-b69b0d0e5859">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bfe5e101-d865-4471-8057-345faea68bfb">
+      <statement statement-id="ac-4.21_stmt" uuid="2b4dce12-a702-4709-8c29-22485c9a200b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a75e2d9-f7dd-4df1-b0a1-1e9e14f71c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on logical separation of information flows
 is being tracked on GitHub:
@@ -683,10 +683,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/167'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3d9a317-0bd7-4223-bea8-9db6cd497c9c" control-id="ac-5">
+    <implemented-requirement uuid="e441e4c5-e2c9-4388-92e9-b18105ea3ac4" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-5_stmt" uuid="3e901b65-a858-41c7-a381-aa6895c87da8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7954d29b-2176-46c8-805c-520df37ac677">
+      <statement statement-id="ac-5_stmt" uuid="ef4fa400-e84a-463f-b529-cec225ea787d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4beec2e6-51ea-4b4b-8ce4-f8c0e1d3c527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance of role/duty enforcement is being tracked
 on GitHub:
@@ -696,10 +696,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/168'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19ff898c-07f4-46d5-b244-c91e9b9625f5" control-id="ac-6">
+    <implemented-requirement uuid="dd0056e7-e775-4913-9609-a69f6c40b224" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="996aa56e-802a-4938-8164-29f39052a43c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="12150a7c-2c8c-4589-84c8-8ccee201bb8f">
+      <statement statement-id="ac-6_stmt" uuid="160d5a7e-da64-4a68-991c-0ed8b4a8ffff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73ddf83b-136f-46ec-84ef-0cea4a711319">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how Red Hat OpenStack Platform follows and
 enforces the concept of least privilege is being tracked on GitHub:
@@ -709,10 +709,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/169'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f785379e-f92c-44c5-a856-5042f31a9cb3" control-id="ac-6.1">
+    <implemented-requirement uuid="1eb234da-ca27-4db9-84f6-3c54bdc1060f" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="e553130e-bfce-4766-83da-f6737dc65355">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3a9a48ec-7d6f-4652-a158-d979b4f29165">
+      <statement statement-id="ac-6.1_stmt" uuid="b2b2277e-5717-477a-aa10-341c7b5786e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9a4880d-bd6e-490b-8f1d-c1ebe085554e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how RHOSP requires explicit authorization
 for elevated privileges is being tracked on GitHub:
@@ -722,10 +722,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/170'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57c8a6de-2fc0-4805-8ac8-06ee17f51621" control-id="ac-6.2">
+    <implemented-requirement uuid="708b2f0c-4724-4f04-a480-07e6586cd928" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="c3b44fda-3afa-4695-9599-15ed02d34bcc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="603ecbd9-4720-4925-a9a2-46218f98d06f">
+      <statement statement-id="ac-6.2_stmt" uuid="09a21427-da3d-43ad-b647-403eda9cdc5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b38197d-3bf2-4c92-ae57-6c9263b7dff3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked in GitHub:
 
@@ -734,10 +734,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/171'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4681a7e-73b8-4f5f-977d-3c8acca1551a" control-id="ac-6.3">
+    <implemented-requirement uuid="8d2fbd38-987c-42e1-b742-4fe80d25802a" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="5c54ba04-dadd-4650-9547-8ef79a67e412">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a1215ab7-ac3f-47fe-b98d-71a3c22402b8">
+      <statement statement-id="ac-6.3_stmt" uuid="a2e6bfe8-747e-400b-866c-ff2b7ff1a00b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cd5f46f-1383-4722-a5a4-70b83180a627">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked in GitHub:
 
@@ -746,10 +746,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/375'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0020d70-6eef-47eb-a023-991cd576a588" control-id="ac-6.5">
+    <implemented-requirement uuid="bf126577-dc18-4815-bd31-07729084ac85" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="7c90b1ce-15c5-48f4-985c-8d436b3ee475">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="cbedff3d-cd15-4f6b-84f7-4a1b1acdc879">
+      <statement statement-id="ac-6.5_stmt" uuid="8d0fe372-e1ea-43fe-aa9a-cb8182c447c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f63cbc-85b2-48e1-9c0e-b9f50b9b0dd5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-6 (5) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -757,10 +757,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af5dfe63-ef88-4778-8dad-7e941ca85c0a" control-id="ac-6.7">
+    <implemented-requirement uuid="f839136d-f50e-426a-a465-593f76bbc50c" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.7_stmt" uuid="4c14c076-fb2e-43bf-b4a8-5542b89b6e68">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="18c4f085-4373-4150-933e-3596606b1acf">
+      <statement statement-id="ac-6.7_stmt" uuid="0eec013c-8ef3-44ca-9b07-3eee08d92e25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf809db0-5cfb-46f0-97fe-c07482d8929b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-6 (7) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -768,10 +768,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1e309f8-ea4b-4628-b96d-29507da29201" control-id="ac-6.8">
+    <implemented-requirement uuid="036d356a-c5ef-4586-a030-abcccdf07c5a" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="b9fbff0f-6f8e-4ebf-a3d0-939cfb021276">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4e28aff0-76ec-4ab8-a0d9-a7cd3aa8ce61">
+      <statement statement-id="ac-6.8_stmt" uuid="846711ca-46db-457d-b3e4-cd85384bd244">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80d0a189-8bdd-487f-b718-4af604139231">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -780,10 +780,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/376'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27b1293f-d833-47b9-99af-1332a466aba0" control-id="ac-6.9">
+    <implemented-requirement uuid="f50ade8d-7a8c-4de9-b73a-2564df17a82a" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="0ec5d629-7334-47a6-8570-7a37cda2039a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b20b80b1-bbb3-46c4-aca9-9ed21567cab8">
+      <statement statement-id="ac-6.9_stmt" uuid="ffde3865-039f-40b2-a74a-1f68e136b1f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2fc24a5c-d8f8-40dc-a35e-4a7e79b6a3fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -792,10 +792,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/173'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95bb1c4f-512d-45e3-a3b7-2bc86e899bd6" control-id="ac-6.10">
+    <implemented-requirement uuid="89f45c9f-a394-4530-8e45-04680613806f" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="50469dd4-d364-46d2-922a-4bd27e9b1115">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5c3be8c2-36cb-4d25-a612-ce2a15f8e72f">
+      <statement statement-id="ac-6.10_stmt" uuid="fceed92c-d62d-4a0a-a529-a7d0c9a0694a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0091b60a-a998-438e-970f-c40425e34b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -804,10 +804,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/174'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6dc5ac02-750c-4341-8b1f-971ffb36ec45" control-id="ac-7">
+    <implemented-requirement uuid="190b26d2-10b1-47e5-88f6-450145e92ed2" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="93fd4d78-359e-4c8d-8803-0197147be0fd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ded4b4a4-842e-45db-a42a-90cb1fcef75c">
+      <statement statement-id="ac-7_stmt.a" uuid="1bef3d71-d9b0-4cb8-879e-600174407f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -816,8 +816,8 @@ to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="879329a8-9991-4e49-8395-c941ea1d8b2c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c994bbdf-8eae-48dc-bbd8-f05a6264b9d7">
+      <statement statement-id="ac-7_stmt.b" uuid="be2edb42-6f1f-4727-b9d5-0bfc96898c49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -827,10 +827,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3740498c-48f0-4c40-9a5e-57fc75996f31" control-id="ac-7.2">
+    <implemented-requirement uuid="99acff9c-0aef-4883-883c-7a935eb8e7cc" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="3737ac90-e6ff-49a9-8cca-91767542d381">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1670fac4-aae3-465b-8a35-8ff4c59a4bfa">
+      <statement statement-id="ac-7.2_stmt" uuid="9e0a690f-edd3-41cc-91ce-fa1557cc99df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6af1ffb-2b91-402d-98a9-930d8ffbe691">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-7 (2) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -838,10 +838,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef6a9e96-1e10-4542-b98b-e12e8540667b" control-id="ac-8">
+    <implemented-requirement uuid="3c7dcd8a-8a1c-4720-a1bf-425a9b810f7c" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="79edc3cc-17a8-42e6-a82a-4c30c99a903f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="de0bd160-066d-434b-8c6c-f573760c31ff">
+      <statement statement-id="ac-8_stmt.a" uuid="4e30b817-eda8-41ee-9a23-2f19799b50d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1018d6-5f53-474b-9d19-092699fce6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -860,8 +860,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="f31df25c-39e3-41ea-a2be-504f3db44328">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8d23aee5-4e0c-4fda-a069-2c268ca5f218">
+      <statement statement-id="ac-8_stmt.b" uuid="8cac1383-8b47-47dc-b910-b8abe32cd73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c110a8-4332-4751-8dd3-d5e9c088377f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -875,8 +875,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="58f1dd41-4628-478f-8c53-8e98745ede17">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="08a2f0a5-57b6-4880-ab6e-c2cf7fd20e1e">
+      <statement statement-id="ac-8_stmt.c" uuid="1959d416-63d4-4558-9ff3-02e1060844b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bad8105c-14af-47b5-a477-194b9d3efd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -892,10 +892,10 @@ It is recommended the same banner be displayed as configured in AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b838cec-5dbc-43a0-a3c5-39bd9f363b6a" control-id="ac-10">
+    <implemented-requirement uuid="b5c501dc-2d33-43ee-a740-c738c6967713" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="a085f346-7154-4950-bf30-5e1d08719526">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="249d4ebf-7964-4b79-846d-1ee396a16c99">
+      <statement statement-id="ac-10_stmt" uuid="f2ec3f3b-a703-430f-99f5-1b941bba3c19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9101acb9-2324-41e4-8d88-3a58c3c1ff39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -904,10 +904,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/175'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1aeb69cb-5bcf-4410-a57e-43f578006a74" control-id="ac-11">
+    <implemented-requirement uuid="0c8021ef-996f-45ac-9c86-e84bdf27c7bb" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt" uuid="7985a52a-df47-4b48-bee5-796db7280114">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b2312f8b-8388-4115-ac99-18b94374360b">
+      <statement statement-id="ac-11_stmt" uuid="2d6dfadc-2986-4d13-9125-35c4edf87846">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f660c858-925e-4e13-82dd-1f4c1995e15a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 behavior of Red Hat OpenStack Platform is to disconnect the idle user
@@ -916,10 +916,10 @@ from the user interface.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa310e0e-18c0-48b3-b14c-4d3c8f3512a4" control-id="ac-11.1">
+    <implemented-requirement uuid="79f3136c-e316-4f56-9ddc-7d86218b44ad" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="1e31f494-1118-45ab-a0ce-81fd89cab554">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="eaf104af-1b6e-4fd4-b365-7351fea55da0">
+      <statement statement-id="ac-11.1_stmt" uuid="7ad56d48-1943-4978-a4c5-debc5fc63bea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f660c858-925e-4e13-82dd-1f4c1995e15a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 behavior of Red Hat OpenStack Platform is to disconnect the idle user
@@ -928,10 +928,10 @@ from the user interface.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b9125c9-faf6-4f38-9f13-494746d724b7" control-id="ac-12">
+    <implemented-requirement uuid="9d2b376a-4ca6-4370-ad29-487832ee0337" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="f1be124d-6418-49ab-b441-9efacaf6ea13">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f4c38d33-c492-458a-bdc5-da0fbccf1c5a">
+      <statement statement-id="ac-12_stmt" uuid="5a6399aa-82da-44d8-a878-61b4b7f6a99d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19f5f9c0-c90a-4a34-8106-2d55b0fc7805">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being tracked on GitHub:
 
@@ -940,10 +940,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/177'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c0ec306-7031-4ef6-8548-d30d161c7c1e" control-id="ac-14">
+    <implemented-requirement uuid="a0c92060-22e2-4929-8d06-ec1468232753" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="b0a30c97-93e9-4c71-9043-424f2af9b2e9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="21041bd4-9e6f-4a1c-93d1-6e7e86492d84">
+      <statement statement-id="ac-14_stmt" uuid="1ffeb67d-0d45-487c-ba49-416acbcfa90b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="116c1ecf-7617-4874-8eee-3900fc91dadd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat OpenStack Platform Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -956,10 +956,10 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b9ddb5a-a91a-48f3-b9d9-04de58d01a05" control-id="ac-17">
+    <implemented-requirement uuid="a28a91c2-7adc-4a36-9e89-fc7a048894cd" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="12b1c57a-c685-4af2-8a23-ab60d518d2c0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fc10b4b3-349d-448e-8508-45e47c950ac3">
+      <statement statement-id="ac-17_stmt" uuid="1c3ac4b9-ae12-4073-8905-ec981d0f9d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -967,10 +967,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d5a1785-017f-448d-bb01-a20f4100d70e" control-id="ac-17.1">
+    <implemented-requirement uuid="c8c9ecb8-9cfb-48c8-a912-6ec66f8ba20b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="1231638a-f3ee-4cb6-8e7a-0858b5e8b108">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7ce50b72-0c66-4e6f-9fe1-cf99cb1ac854">
+      <statement statement-id="ac-17.1_stmt" uuid="a9cc62a3-9b32-41e9-b53d-989ae960e5ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a55eea32-503a-4f72-a32a-f8c81f703b37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'As a network accessible service, all connections to Red Hat OpenStack
 Platform are treated as remote access. No additional configuration is
@@ -980,10 +980,10 @@ non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2162c93c-feb7-4854-ae7d-d4565c01778e" control-id="ac-17.2">
+    <implemented-requirement uuid="3321fd05-4ccd-4d57-b78b-80a9451924b1" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="9bcbf559-ac5b-4548-811f-ad0920a38470">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3a198ae6-5f4b-4209-aa22-95a96bcf8053">
+      <statement statement-id="ac-17.2_stmt" uuid="d8056d08-02d8-468d-9074-747e33c783be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3727dca-2c9a-4379-9985-60a962b0f92d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -992,10 +992,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/179'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc7bd67c-7f30-415e-8153-5766b95cc343" control-id="ac-17.3">
+    <implemented-requirement uuid="e1557dfc-c802-4b95-bd3e-8bda4aad4d24" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="8f540c93-fe5d-4026-9ae5-03befc31fa83">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="971dc347-c82c-48ac-a491-91a496ee8a05">
+      <statement statement-id="ac-17.3_stmt" uuid="16ece187-9ea3-47a7-a964-b780a0c961b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7dd9924-e1e6-4bcb-b643-93c98091670b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1004,10 +1004,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/180'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85826cd1-1a40-4126-81af-5dd43b5cf3d1" control-id="ac-17.4">
+    <implemented-requirement uuid="6399c737-d4e2-484b-86bb-a81ed044be10" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt" uuid="2fbdf2a3-8ca8-407d-97fc-f879247f649b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1bd655c7-8796-450a-93b6-4315b95d6334">
+      <statement statement-id="ac-17.4_stmt" uuid="c4b067f8-0f70-4d23-817f-1e136a9044f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3538a779-2e89-4b5b-8973-163eb68c55a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable. Due to the native of cloud
 computing, authorizing activities over remote access is
@@ -1017,10 +1017,10 @@ procedures) are provided in AC-2.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8e4dc4a-fb8c-4b43-8da1-0d6f01c988f0" control-id="ac-17.9">
+    <implemented-requirement uuid="931abcc4-6424-4b1b-93bf-2686fabc7573" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="20d373a1-94a3-41d0-b9bb-e0ff836a0d61">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d73e0de4-7b5e-44e0-b38b-2481985aebaf">
+      <statement statement-id="ac-17.9_stmt" uuid="a054f60f-9388-4160-84e7-2201b57b7bb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60862f-8ec8-4267-b5a8-4aed2dd6abd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1029,10 +1029,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/182'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db0dd3b1-22a4-4a7f-8acf-72aa1a664ab6" control-id="ac-18">
+    <implemented-requirement uuid="542db06a-3132-4641-b932-b44a95c3b37b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="e462744b-170f-4d5b-8b10-24f61860166a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="78503e92-0610-439d-88a1-2c5d62b32545">
+      <statement statement-id="ac-18_stmt" uuid="bc5a066c-bcca-4690-b7da-88aa4df0ee25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1040,10 +1040,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1eb1752a-ebfd-4016-a798-f78721558781" control-id="ac-18.1">
+    <implemented-requirement uuid="02e0f4c1-4de2-4bdd-a531-0d0f4a6b3e7d" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="2ebf9e81-eabc-4fea-bb7f-b2d3105f5d4f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="82d7ee5f-4899-4ee6-bea5-d72c78f24b72">
+      <statement statement-id="ac-18.1_stmt" uuid="567a40a8-8f12-4386-9fff-618e4670dfef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a16a28f-3ed2-4ba6-a22a-2c872c22f0dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies
 at the network access layer, and is not
@@ -1052,10 +1052,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc0123a1-13b9-418a-9b47-3a98e996cdcd" control-id="ac-18.3">
+    <implemented-requirement uuid="59f0d385-73f4-4d6f-ac47-2960df76d922" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="81166796-fb73-4523-b223-34c534ed1eb8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b95005f4-44bb-42e7-9cf4-310d505ea7a2">
+      <statement statement-id="ac-18.3_stmt" uuid="922004fb-355e-4269-b2cc-21cf8981afb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c998f247-5c9f-4d99-ad2c-99c33dc53e9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-18 (3) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -1063,10 +1063,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="facb6c00-861b-484c-986b-992d53cbc5b5" control-id="ac-18.4">
+    <implemented-requirement uuid="8f731941-1fdd-42e9-9318-b1a760755d8b" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="b41a3160-cae7-4200-be47-63b8e91ff92c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d9c8caf8-aec4-4824-9903-8c3f25fac57d">
+      <statement statement-id="ac-18.4_stmt" uuid="880d6635-92dd-4029-93d9-4fc6a6e8cba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73985d1c-288e-4aa0-bef8-da4d6b96f6d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-18 (4) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -1074,10 +1074,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="459215b9-5c76-4343-b91e-0d1b56cdfa4d" control-id="ac-18.5">
+    <implemented-requirement uuid="4d4adf3c-99ee-4597-a959-e454a16b4c3a" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="c7c9f8b5-69fd-4e93-8ba4-40dd2fc418cc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d8e64db9-303e-46f3-a0b7-e7e934d85f8a">
+      <statement statement-id="ac-18.5_stmt" uuid="9092ae7d-06a0-44ed-a94f-07618e25edbc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57e560d2-9f60-47c3-845a-119dc3888980">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-18 (5) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -1085,10 +1085,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a94d7601-93ef-4819-810d-aefea34fc3f0" control-id="ac-19">
+    <implemented-requirement uuid="dc10d2b7-c173-4f90-8d04-19b3de77a1d2" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="93e01b12-aac8-49a2-8088-99d63e98fbb8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="98821c5c-0dd1-4a12-9a87-5638eb2abad1">
+      <statement statement-id="ac-19_stmt" uuid="b7e8d38a-57c8-4abb-9006-60327755e2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1096,10 +1096,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6736d38a-f708-44c2-befb-cb5769861230" control-id="ac-19.5">
+    <implemented-requirement uuid="32e8c3b8-9583-42e3-b494-c015d4f940f9" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="0d7c2f25-ba1d-432b-a541-18069555dccd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="51582e95-d7eb-41ba-b858-8f0e8c140e45">
+      <statement statement-id="ac-19.5_stmt" uuid="0d19cdba-cb75-4c89-843a-3499d88a0984">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d875880-2b77-477f-9f42-83b997dab5f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to mobile devices, and is not applicable
 to the configuration of Red Hat OpenStack Platform.'
@@ -1107,10 +1107,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a506373-cf74-4f9b-9b73-a242fecec70a" control-id="ac-20">
+    <implemented-requirement uuid="f7a0ceec-9299-4a0a-af63-ec3782f76704" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="9ceef69c-df9c-4d77-90ba-0590c2aae107">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="da37f2e8-dcd1-477c-9f7e-e2efb6ee544f">
+      <statement statement-id="ac-20_stmt" uuid="2bedb697-599f-4296-8f4c-07a074100182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1118,10 +1118,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="accf9b79-da18-4786-9457-b6aea08d3c92" control-id="ac-20.1">
+    <implemented-requirement uuid="1bc859f5-ee47-4a7d-948f-42c93837e228" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt" uuid="5cc6895b-fea8-4d9b-bd9e-e5bd6eb53fe0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="268d3cb9-39cc-4edb-adfd-502cd3a95a7c">
+      <statement statement-id="ac-20.1_stmt" uuid="fa04c320-5921-4eb6-bdc8-54a1f7e8d571">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a44d7b8-b146-4b2e-9c19-e1489de600a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies for
 external information systems accessing the Red Hat OpenStack
@@ -1131,10 +1131,10 @@ configuration of Red Hat OpenStack Platform itself.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c0e33ce-b7b8-41e6-999f-bf94db02edcb" control-id="ac-20.2">
+    <implemented-requirement uuid="44420817-8343-4af0-9873-0e72aa3c38f5" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="142549a1-5ded-4be5-b882-f3563ccc5b80">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="339c1827-0797-4bf1-8571-bee1e545d78a">
+      <statement statement-id="ac-20.2_stmt" uuid="fe0c6d1f-5353-4844-a99e-33220430613c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd672133-4435-4dc4-9567-3e57628a7eab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies outside
 the scope of configuring Red Hat OpenStack Platform. This control
@@ -1143,10 +1143,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8247817d-5e57-4e06-9e2c-3e475e3864aa" control-id="ac-21">
+    <implemented-requirement uuid="40e95b8f-9bf4-46cd-93ed-f29e7d0fa5f9" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt" uuid="a73ac37d-8985-40bb-aab6-cc99c777a6fd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a90c7317-5c4d-4219-b9f3-f311b4ea98b7">
+      <statement statement-id="ac-21_stmt" uuid="acbfe654-15b8-4274-bc7a-769dc9b9310b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd672133-4435-4dc4-9567-3e57628a7eab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies outside
 the scope of configuring Red Hat OpenStack Platform. This control
@@ -1155,10 +1155,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b4d219b-1b72-40fd-9ea7-b62afaca5016" control-id="ac-22">
+    <implemented-requirement uuid="9dfce701-b6ba-4df5-a330-1fb7562f33cb" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="5288d8ac-792a-4a7c-95b4-51ec7f890a3e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a23ce195-6477-4f2c-a656-1d0a01b9c731">
+      <statement statement-id="ac-22_stmt" uuid="2b36af0f-a585-4fe7-9ffc-093a778a9e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1166,18 +1166,18 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3ec20bc-39a6-4b54-9453-dc4a01127303" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="92bc9951-e728-4d57-bad0-b1f7e10a1c53">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c48d5bd1-56ad-40f3-9199-e98d6c900d88">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="26f5457f-5c37-452d-a664-89507699f4f3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2857e48b-1dde-479f-9baf-bb2963f3f5e2">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1185,26 +1185,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df2aadaf-68a9-435e-a45b-4c80185858fa" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="447a01ce-dafb-4554-9044-32733144a6f9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0d850fc5-b487-4987-a155-c248b736b4d1">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="8b9083d9-5f9e-4b8f-844d-f6ecb358f68e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c9b51a81-59b9-4649-84a2-9bcc2a492b20">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="d7611cfd-f4e5-42e4-94e8-d16d255bb4fa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="62fdae56-c246-4ef3-a3ec-04e1ecd69a1f">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1212,10 +1212,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="183ea74b-a37e-4346-8735-9aa7d1851799" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="7ca902ca-1935-4a73-9e22-7e5e9c054b86">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b9363640-c799-4ee4-b791-97bcdeae66ad">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1223,26 +1223,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ebe2d2-cba4-4255-bfdd-6450abada9b4" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="2618557f-e300-46d2-a33a-150b610ff64a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4b7f1547-b302-4360-ad9d-ab4b4ef1625d">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="b4b1c6e0-eb65-4457-bf5c-8778d13bbd44">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c1103f0d-52c3-4806-8714-f57f144b759c">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="a2b4d198-f27b-4236-88b6-40f1c15ffefb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8fc4a306-ae9a-4fed-97e1-5d9c4e66d519">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1250,10 +1250,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e92979b-05be-4b33-914b-747ec263ed8e" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="c4f2ac51-0126-45b4-bf3e-11b93a07e728">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d98062e9-0224-4fa0-aa7a-46f38f37241b">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1261,10 +1261,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d06497c-ed57-4617-b9e7-a4d87368b2ba" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="ff595156-af31-4869-a14c-788d50a48525">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fdf9fd78-b1c8-408c-8959-ace0fca2c0c6">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1272,18 +1272,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bd53e4b-7245-410f-b4a8-0627e3aa984a" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="02a57529-8c63-4a5d-abe3-f8bcd0486ee2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4b74a23f-c45b-4c2b-a521-69274a0040c4">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="190f1cb6-8dd7-4468-ba02-6f19f1104951">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5dd5d8c3-f4e4-4386-a409-787000e69e55">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1291,10 +1291,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc275eb9-f19a-477a-bb3d-8a2267c23f5a" control-id="au-1">
+    <implemented-requirement uuid="9bf02c5e-bac7-426a-99ee-612029fb4422" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="459d114c-6b70-4232-90fd-27f45fa9b085">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e3fb3bc0-5038-48d0-97bc-8be508b0a673">
+      <statement statement-id="au-1_stmt" uuid="022814e1-5123-48e3-9bb2-414d326089f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1302,10 +1302,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bdff4b9-6e03-4f61-bfb2-0c0c6759e9a2" control-id="au-2">
+    <implemented-requirement uuid="70ebfe3a-dd07-44bb-934a-1f049c3df081" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="5cef836d-2078-4456-810b-e724b8476524">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="46967041-f0c1-419a-86a9-8f8406886536">
+      <statement statement-id="au-2_stmt" uuid="c740b0e8-7529-4771-86c7-7abaee9d8e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ec78773-f971-4af8-a715-99a4cfcc3d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.
@@ -1316,10 +1316,10 @@ Red Hat OpenStack Platform through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72555c40-6a93-4624-adeb-213422ee3fca" control-id="au-2.3">
+    <implemented-requirement uuid="dd80b246-db52-45ae-a248-b309e468f7f8" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="aa425322-a0de-4bc7-b1b5-7234d7a1a501">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="96d3aca6-4685-4964-93c7-863cf382a1ed">
+      <statement statement-id="au-2.3_stmt" uuid="6acaa086-c812-4ef4-af83-9aeff07f5229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1327,10 +1327,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb5b8003-9d53-41f3-9251-946aab11362c" control-id="au-3">
+    <implemented-requirement uuid="fddce8ff-c1d3-4b41-ada0-b62b24cfb2b6" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="ad9f249f-f785-4666-b696-9dce120889b7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8e1e3958-07e3-4bb0-a526-d2c006f570bf">
+      <statement statement-id="au-3_stmt" uuid="a3c40616-3e41-45e1-a8b9-63205765ed89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6cd09a8-08a4-4f88-9f72-1429acae092a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform audit records contain this information by default. No
 additional configuration is required.'
@@ -1338,10 +1338,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2dd95156-c637-4b3e-a42f-470e4d405a0a" control-id="au-3.1">
+    <implemented-requirement uuid="f3d92c70-33c5-492e-ac77-5c5def090b58" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="f237ae07-99df-4a8b-8f0d-321b41c6a16b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="63321e36-f850-48ba-b422-69205302e351">
+      <statement statement-id="au-3.1_stmt" uuid="5a15922f-d663-4724-8e07-8b412792a2e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1349,10 +1349,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bbfd373-896a-4dd7-b96d-44ca32a3365c" control-id="au-3.2">
+    <implemented-requirement uuid="ceaed06c-a40f-4673-96c9-f5ea0da11784" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="90a2a5ba-f060-42f7-b1e6-c6a6b6e2e4ce">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ad14fa04-f502-478f-857e-2d85465e8ed0">
+      <statement statement-id="au-3.2_stmt" uuid="4bcace80-df19-4dca-ba7d-47631ee63b56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3951b-f1fb-46bc-bd81-40c943d35eab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked
 on GitHub:
@@ -1362,10 +1362,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/387'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="728b2271-7132-4a45-b921-c72d24b1fa80" control-id="au-4">
+    <implemented-requirement uuid="3c3a6218-edb3-4574-9991-1c281a4af6db" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="ffad338e-7fdd-4ff9-bc90-97ae04a16280">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ef240db7-7e2c-44d9-ba96-e8aab4186b99">
+      <statement statement-id="au-4_stmt" uuid="c897c7e2-3bf6-4ea2-9c5d-0971f6de0e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b11dbe7-4a7e-4827-b1dd-da2cfd809e31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform. This control is reflected
@@ -1374,10 +1374,10 @@ in proper disk partitioning of the underlying Operating System.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3aa7f99-77a4-4b72-8f0a-09e1a7c65f84" control-id="au-5">
+    <implemented-requirement uuid="d867a1bc-cbd0-4edb-b26e-9b1b0ed32513" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="dd4cf6b9-da52-4d80-929c-1dad4f1b50b4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="82a5518c-4c9e-4fa2-9f46-5b961aa612c2">
+      <statement statement-id="au-5_stmt.a" uuid="681d6b0c-120f-4476-863f-0a8b4bf8f3a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fc991c-c801-45c8-baa4-ba3b169595d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -1391,8 +1391,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="564cc610-4453-453d-8b64-950eab0e0aa9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ca84cd92-3f68-4e6d-afc6-ab41f14cbc44">
+      <statement statement-id="au-5_stmt.b" uuid="ef5f7d6b-80d0-4295-9ea2-505668e025e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3dd40bb0-312a-4bed-abed-0be2db2606ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat OpenStack Platform Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -1403,10 +1403,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6fd48f9-71c4-454f-90ed-5640909ea0e1" control-id="au-5.1">
+    <implemented-requirement uuid="267207ec-66e6-4375-a607-2fb9a9c0e30f" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="73cc57ce-a339-4701-8076-9e49de2cb6e9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="182e67c4-f34c-45cf-bd31-ddc1397a1cb5">
+      <statement statement-id="au-5.1_stmt" uuid="7e3533d2-4705-4a0b-88ac-6323c641dcc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84b3ef0c-57b3-41d7-9630-743edccce2d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1416,10 +1416,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/388'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44f51e9c-219a-4d9f-85b7-7e283ea099bd" control-id="au-5.2">
+    <implemented-requirement uuid="a95dac86-73ac-4178-bf65-99db8d2b391a" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="eb3e0728-0fbd-4ea2-a12a-0ca88b69d43f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="26d7459c-6fdf-4fb6-8020-6f40929c0778">
+      <statement statement-id="au-5.2_stmt" uuid="9bed33db-657d-482b-bd78-bcf9c76e49ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0047d0e-037b-43a8-abdd-1c5ef590575a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1429,10 +1429,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/389'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d5e8a18-faca-4937-b637-f1be772b8ebb" control-id="au-6">
+    <implemented-requirement uuid="3c5d91fa-2336-4a39-9f4a-38b9178be864" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="4a61bb4b-ccb3-40dc-883c-734944a871cf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="116643cc-b165-47f2-9f41-42752281f8dc">
+      <statement statement-id="au-6_stmt" uuid="382fddb1-91a1-4a1a-bb6d-169861ccd7ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1440,10 +1440,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c23420a4-3cdb-4443-8422-afd555e2f8ae" control-id="au-6.1">
+    <implemented-requirement uuid="c27f6618-4d69-4d1a-a512-ffb85b8b222c" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="c526d9af-887c-4b12-8a71-9b97f56a1283">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="96b8dc7b-ec3e-4075-bd91-13ed68550bec">
+      <statement statement-id="au-6.1_stmt" uuid="c600f133-736b-4549-8757-aa96f7fe1c70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1451,10 +1451,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b60552e-6534-449a-b976-6060af22c8e3" control-id="au-6.3">
+    <implemented-requirement uuid="dad2591f-3b7e-4daf-b55f-b0311685704d" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="bc707dbb-08b1-40e3-b268-44eccd57aebe">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f297bf5b-7c44-4fbd-8707-7cd99a8ea270">
+      <statement statement-id="au-6.3_stmt" uuid="d1a97bba-193e-48e2-b9d4-7dd0e063ad4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1462,10 +1462,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="419fa83e-3994-4d8b-b92b-7c4174d10c4d" control-id="au-6.4">
+    <implemented-requirement uuid="c358dfee-0f43-4c0d-a526-71f3e82406b9" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="2b82c1fa-58ce-4bea-99c3-3b0a6a4844fa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f7e5f33d-f2cc-4152-9b70-861ed7355df4">
+      <statement statement-id="au-6.4_stmt" uuid="a8ff899b-07d6-4590-a5fa-2b2b66df366e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73372395-641c-46d6-abaa-9b26e440f69d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1475,10 +1475,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/390'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f5b6db9-a6f3-4978-af61-b792a20cc4fb" control-id="au-6.5">
+    <implemented-requirement uuid="f510fc73-41e3-4311-82d2-6c2bacad450f" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="dd9f6c54-5087-43de-887b-d6b58d5f25c9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b2a25358-89f0-4119-8fbc-ddbc3da9df7d">
+      <statement statement-id="au-6.5_stmt" uuid="76093438-d230-4ed7-8ee6-ed316264d065">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4ebee3b-01b0-4921-884c-6b7e3fd87976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1488,10 +1488,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/391'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8835e57e-e5e2-4778-bf55-fcff6500df27" control-id="au-6.6">
+    <implemented-requirement uuid="db454269-519f-44d4-b34a-10f32e0c6ba7" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="56845541-d123-4745-8320-fd6b3c646493">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="25129340-a0cc-4af4-bf26-d6fb9127afd7">
+      <statement statement-id="au-6.6_stmt" uuid="ff81e997-0607-49f8-97f7-9a3bd8dfc395">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6480e55-7271-4423-8bdb-211dd18353d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1501,10 +1501,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/392'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bb6e991-70b5-4e9a-b5e7-0117447ce011" control-id="au-6.7">
+    <implemented-requirement uuid="a2b72a32-3a6f-4340-809a-51fd68234eb6" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="1e0a8289-0fb3-43cb-bc24-c0ed34f321fd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="be10ae11-7119-4160-89ff-65092d97bdaf">
+      <statement statement-id="au-6.7_stmt" uuid="8b039a73-4188-4914-b727-2e44b627e573">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9894326e-0595-4441-ab1b-6c224a2e6b7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for satisfying this control is
 being tracked on GitHub:
@@ -1514,10 +1514,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/393'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c307bf5d-1a9b-4a82-b3fb-31484165fe38" control-id="au-6.10">
+    <implemented-requirement uuid="4a651495-82e4-414b-a7cf-c234eb7bade4" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="3e47a263-e775-4f28-b9fe-aec90d7dc19d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5472610f-df34-4974-b646-06cc7880e5e2">
+      <statement statement-id="au-6.10_stmt" uuid="6ec3210b-1f80-4ed8-8201-0c5a7964ed3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1525,10 +1525,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f9ee8b2-2056-4976-b0fa-8f0034fe231b" control-id="au-7">
+    <implemented-requirement uuid="ac3f3fb8-cacb-47ba-988b-84e28ef73483" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt" uuid="24cb43bf-d7d1-485d-9536-79050361aed7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2a946f4b-b727-4ab2-8ee7-f94b3e156ec9">
+      <statement statement-id="au-7_stmt" uuid="30027b2a-b6b7-4718-9455-bf662140182a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18aff937-f527-4130-9c1e-fb9dba74b466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on GitHub:
 
@@ -1537,10 +1537,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/196'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0feb40a1-49ca-4ab0-9401-e8854a343474" control-id="au-7.1">
+    <implemented-requirement uuid="7a28db6c-28a7-4dde-abd4-3582910a0b68" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="583bf59e-20fe-4537-831d-ca2fa8a6d16d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bc932597-284b-4b00-9684-b59fd7417ae9">
+      <statement statement-id="au-7.1_stmt" uuid="99c25fcf-8a36-4dff-a460-97fbc61e1beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28f6789b-879b-4f0f-b557-8ff0bc201133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on GitHub:
 
@@ -1549,10 +1549,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/197'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a63eb809-afce-43dc-bfdc-992d3eec9410" control-id="au-8">
+    <implemented-requirement uuid="d4452df8-ab68-4376-94f8-4849a8bfb851" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="4007990f-f90e-481f-a261-8b7840def777">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1903281f-79b3-41d4-a866-404c218e12b1">
+      <statement statement-id="au-8_stmt.a" uuid="ebf16490-e892-4926-8e04-5f05a2d4e1cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -1560,8 +1560,8 @@ of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="d8223b78-b8d3-4d00-ad0d-a021932c2f71">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3970354e-6026-4bfd-ad69-55b6c89a4c72">
+      <statement statement-id="au-8_stmt.b" uuid="9d59163b-c469-4dfb-a1f6-7425f23f0381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -1570,10 +1570,10 @@ of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be1b73d2-456d-4e12-a190-eeb9727a4426" control-id="au-8.1">
+    <implemented-requirement uuid="b1a55688-ef6b-4dd4-8d0a-762d8369ff70" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt" uuid="d9e59fef-bbce-48f0-8412-01560f36b6d2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9f0358ca-1a1e-46d1-9d11-2265ab92eaae">
+      <statement statement-id="au-8.1_stmt" uuid="ea929555-934d-4492-b753-52e6555e936d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3353df5e-a8a7-4611-aa8d-96739561a1d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform utilizes the time services of the
 underlying operating system. This control is not applicable
@@ -1582,10 +1582,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be75785b-5eac-411f-9ce9-492f3250fcc9" control-id="au-9">
+    <implemented-requirement uuid="146245dc-fac0-4451-80ed-bf2dec829320" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="2d40f6bf-8fbb-4783-a8ca-22ad45ce21ea">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1014eafc-922d-4c93-bf88-ed1dc27567bd">
+      <statement statement-id="au-9_stmt" uuid="3733f6ae-83ff-4751-9dbe-8c2ad28014b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6dfb370-517c-4b4b-9d2f-bac24716a925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -1601,10 +1601,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33954a03-ac4a-4be0-b7b9-a484cc0e2083" control-id="au-9.2">
+    <implemented-requirement uuid="eb803f8c-a05e-4905-8b4e-244c896317df" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="250d98b4-4b1d-430e-bec6-5d702dfe5992">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4b752f1d-222b-410d-a195-797d418fec21">
+      <statement statement-id="au-9.2_stmt" uuid="e15236f0-7845-479a-a742-0342b07464d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ebc2640-0c1a-4e83-a0fb-569cfed6f0dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring OpenStack to perform
 centralized audit logging to a central facility is being
@@ -1615,10 +1615,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/199'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="863fb8d0-1363-470b-8794-5512d798e190" control-id="au-9.3">
+    <implemented-requirement uuid="704df49c-3d49-4936-9dfd-1294c73ffed2" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="ea48e1b3-31db-40e9-a231-b2ca7af978aa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="397ef1f2-bbfb-40f5-8971-8250e4201789">
+      <statement statement-id="au-9.3_stmt" uuid="be4ef506-affc-46ea-ab5a-31c3feacbaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66c50e3d-7903-4410-9569-35eea13a149a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -1628,10 +1628,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/394'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ab0d82b-31d7-4f84-b3b9-f884047711e8" control-id="au-9.4">
+    <implemented-requirement uuid="0efafc69-ef1b-4196-8a68-aed6d114b8bb" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="abafefbf-0e2c-45bd-a585-c4da52c9aa0a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8ea0064b-137d-4eae-b9f8-2da2b4c45dbe">
+      <statement statement-id="au-9.4_stmt" uuid="d143d0da-572d-424b-b97d-01e8c2c8ce3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e38b8b6-6e83-4434-a440-47a364f74a1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring Red Hat OpenStack Platform
 logs to only be accessible by a subset of privileged users
@@ -1642,10 +1642,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/200'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a5adc82-d55d-4a98-9a81-0fce37b6978a" control-id="au-11">
+    <implemented-requirement uuid="5c7ff55f-ec1c-4d4a-87d2-82ac5696a9d0" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="a382c2f1-7d4b-4081-9288-a260a85e8b6a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="505a4334-efb3-4f24-bf03-dda0458f17da">
+      <statement statement-id="au-11_stmt" uuid="aaeb8b45-0e00-40a4-84f0-bd5cf83dbcd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c10fb204-7d24-42e8-9c63-567b6cfb25c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -1655,10 +1655,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d12fb92-eabd-40bf-87b8-f683bf50faf6" control-id="au-12">
+    <implemented-requirement uuid="1967f2dc-1435-4eda-8ccf-ba5ba151624e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="47f20814-4703-42d4-aabf-b6d5f4955c4f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="64d86a54-c176-4b5d-b9a2-d66a51c181e8">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -1670,8 +1670,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="f8a3b6eb-0aa2-4a61-a747-7e0ea8fe2cdf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9ad07f51-9c4f-4102-943a-755a4801979d">
+      <statement statement-id="au-12_stmt.b" uuid="731aa217-5c07-46bb-ad2d-632e3255dd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f61858fc-aa00-42fc-ae4d-a24a7acf2895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -1689,8 +1689,8 @@ is recommended that Red Hat OpenStack Platform specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="0c8851ee-2885-45ae-939a-9430bfb7264c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="51a71774-1604-470d-a050-b3af73ed7267">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -1702,10 +1702,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b4d0777-4f07-47c3-aebb-0aa9ffae2dea" control-id="au-12.1">
+    <implemented-requirement uuid="195d82ad-2380-4f75-8e8a-f9772400731f" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="afb3c432-90e9-47ee-8564-a98675c0b8ae">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e30f4be2-a2a9-4898-b155-34247f622cf3">
+      <statement statement-id="au-12.1_stmt" uuid="8c49fc92-704a-436d-b13f-281a072ac5fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="83f72a4e-38da-4984-90c8-121740829a17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -1715,10 +1715,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/395'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2f6fdee-6af7-4def-89f2-8566cef2f9f1" control-id="au-12.3">
+    <implemented-requirement uuid="8356ed61-1b54-4bf3-9db5-7ae5a915ad5e" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="5be8f6bd-7d9d-46c4-9c30-2731eba3d98d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f07188a7-7b7a-4e14-be7c-4ea790e17d4f">
+      <statement statement-id="au-12.3_stmt" uuid="8cc493de-8fc6-4afc-9a04-6605f83dedd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d363e955-8eaa-4feb-b387-463f232dfca7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -1728,10 +1728,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/396'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00870bda-7cc7-4207-8556-095e8a186d33" control-id="ca-1">
+    <implemented-requirement uuid="d87cdbc6-4547-433b-b751-62499a9ce52a" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="e3801b28-d9d9-4ffa-a908-9c2d647b8339">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="875fe0c7-7070-44dd-b910-c1a10b93827c">
+      <statement statement-id="ca-1_stmt" uuid="0f646fc8-76a1-46f5-93a8-c55da7cc75af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1739,10 +1739,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b730585f-99a1-4a7d-8451-e186f598bb43" control-id="ca-2">
+    <implemented-requirement uuid="5b50db58-75fa-4448-85a1-a24cad98b5b7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="fbb8dc7e-608a-4aee-9799-65d84c094906">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="80a3ba3c-6a00-44ea-abdb-27ad28c14e6d">
+      <statement statement-id="ca-2_stmt" uuid="85d565ff-b15e-45b5-aa32-a26453e7426b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1750,10 +1750,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcf315b6-0f89-4143-a7df-42edcc22852a" control-id="ca-2.1">
+    <implemented-requirement uuid="35ae93da-4d51-44f2-bd19-c36afeaeb949" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="e3ff719b-797e-4f0c-aa6b-3335dc0a502d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="cb77a823-ea50-44c6-ab3c-21b5e7264a45">
+      <statement statement-id="ca-2.1_stmt" uuid="11c7a1b7-45a9-4f01-b0fa-79c893a8f95f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1761,10 +1761,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f9f6341-f780-4bd6-88f5-09387d5d7a99" control-id="ca-2.2">
+    <implemented-requirement uuid="c3e8546d-85a3-4155-b0ad-6f293fd47519" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="b0906f72-e461-4c0f-8451-b874134eed0f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6736aee5-7619-43f4-b77b-3d7538528d92">
+      <statement statement-id="ca-2.2_stmt" uuid="b965a20d-28fe-44a1-9e78-8889797ddf84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1772,10 +1772,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b23c0701-d2b5-40cf-a51b-5cecfb9db53a" control-id="ca-2.3">
+    <implemented-requirement uuid="80259878-8ffb-4ab0-a7ae-9e3ef2f9600c" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="76214af3-a76f-4dca-ae84-843dd1ae2222">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7b0377d1-9d47-40cb-afb9-521aeca9714e">
+      <statement statement-id="ca-2.3_stmt" uuid="42143f0e-7af5-4e6d-bf35-eb5cc958c307">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1783,10 +1783,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e104b1f0-69b2-4da4-867e-49092aa8f4d2" control-id="ca-3">
+    <implemented-requirement uuid="a5c5b25d-a826-4eff-affb-e56ef4c37941" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="97791584-6d35-42d7-ba02-368612966457">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2173fe90-a99a-4347-b30f-79e2973f1cdd">
+      <statement statement-id="ca-3_stmt" uuid="1e74400d-8cf8-4cf1-828b-fc8eb630326d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1794,10 +1794,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f851dc1a-abb0-4869-b4bc-04e4faa9c853" control-id="ca-3.3">
+    <implemented-requirement uuid="3dcb907d-a220-471e-87d4-31157dff1d4f" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="e3028d7c-9044-4e78-9bc3-989fa5dced05">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d6e77650-2a0c-4d3d-9ebb-2b57af02e720">
+      <statement statement-id="ca-3.3_stmt" uuid="191fcc8e-fef9-4594-bea7-6233eb59c71c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1805,10 +1805,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29e4f1cf-277b-46f7-8156-568389fe3373" control-id="ca-3.5">
+    <implemented-requirement uuid="eeabf62a-5c1a-46cf-8a13-718e38a78dc4" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="a0461bc3-4fb8-492d-bad8-081441c3e9d8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e24efc64-1624-4098-8941-11d483f3f22f">
+      <statement statement-id="ca-3.5_stmt" uuid="8eef30a2-434e-40b4-815a-afb50caacd79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7b50cf8-2f8c-48eb-8949-4305e6b821ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to implement traffic flow policies is
 being tracked on GitHub:
@@ -1818,10 +1818,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/204'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b68335aa-662e-4662-a164-deaa7818a788" control-id="ca-5">
+    <implemented-requirement uuid="75bc3a7c-5883-44fe-b857-2ec0779b6f2d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="84060e07-06e7-4d0c-a8db-a41c4ac94bd3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d1e34c5b-16d4-4453-9144-01f081b4f9d8">
+      <statement statement-id="ca-5_stmt" uuid="c898adea-56b2-496b-a95b-aead7a416a39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1829,10 +1829,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2713f54-f683-4b77-aff7-731c99445a3e" control-id="ca-6">
+    <implemented-requirement uuid="c27d2686-16bc-455e-a5c3-2f90509df2a1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="2142031b-35ba-454e-a5bd-b1d1b6eddaf3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="db1f01d2-2f7a-4441-b557-3cdac9f11ae1">
+      <statement statement-id="ca-6_stmt" uuid="66d1077a-8d5f-42f0-9078-bde3910bfabe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1840,10 +1840,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11c8c687-01c0-4431-901a-2c495802da25" control-id="ca-7">
+    <implemented-requirement uuid="b39d3be7-d4b4-4834-987a-b997656af1ab" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="ab75eb13-f062-435b-a7f1-fc90f5ebe013">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="60824a08-009a-466c-a6f9-7accf2cffb1d">
+      <statement statement-id="ca-7_stmt" uuid="5da17598-9a18-4a3b-ba63-f89d9e00730c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1851,10 +1851,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6d0a1dc-5439-40c0-a476-a1d80c8c5ba2" control-id="ca-7.1">
+    <implemented-requirement uuid="48fd5e62-c030-48d0-bbc6-c766f385e887" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="ed75f045-c9f1-49bf-a0a6-14958953c4a4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a5962b68-69c3-4565-bb47-361a2efa4235">
+      <statement statement-id="ca-7.1_stmt" uuid="4a8d334b-6dbd-4da7-ab95-afd467d1c4de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1862,10 +1862,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb7e1bab-a41b-48f3-b830-1a7603b56e75" control-id="ca-7.3">
+    <implemented-requirement uuid="24bcee65-2d43-4b0f-915d-d488c4f18c2f" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="83a6617f-ec5b-46ba-afa7-bddf062abaed">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="124d0a44-ffed-4abd-9c40-866b4b83f0f2">
+      <statement statement-id="ca-7.3_stmt" uuid="d5f9dc07-e004-4b6c-ae97-4b7f4cf0b462">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1873,10 +1873,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1bc2cc6-e634-4cfa-b762-3e7853ce388d" control-id="ca-8">
+    <implemented-requirement uuid="026aa160-ea10-40a9-be7b-d300ccfc9d3a" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="be4db93b-db72-48ca-91ec-94b2d4925d5b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7be992b4-2ed3-40b3-bc73-ab428880f951">
+      <statement statement-id="ca-8_stmt" uuid="2ae2c566-e4ad-44dd-92df-3baf7027983c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1884,10 +1884,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f3288b1-1d86-4066-b3f2-85ca56b15dc6" control-id="ca-8.1">
+    <implemented-requirement uuid="051d1fb3-685a-4a11-af63-dfbc60007600" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="5af70a64-eec5-45af-a7f8-9fc40a5898f5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9327fca5-ac2c-4b65-937b-eabaf90d6451">
+      <statement statement-id="ca-8.1_stmt" uuid="90eb101d-5581-48dc-a61b-f378f1ae31f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1895,10 +1895,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db94938d-0fa6-416e-afd1-6a0524b61e9e" control-id="ca-9">
+    <implemented-requirement uuid="c11fdde0-925d-4e13-8c59-e9cada8a0451" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="3bc600ba-baac-4db2-a55f-1e114b7a5432">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="66b8d640-d3d9-491e-86ca-61c00316701b">
+      <statement statement-id="ca-9_stmt" uuid="2d0f71e2-f35c-4da1-92fe-da865c00ea17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -1906,10 +1906,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17b708d0-dc53-4a29-878c-bf1fea2350a4" control-id="cm-1">
+    <implemented-requirement uuid="7f9721c8-ebae-4ae2-9022-673f7b917ff0" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="c8d97039-d48f-4eb6-b806-00d6ca04000a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d866a651-3942-481c-86f9-4fb4585c24eb">
+      <statement statement-id="cm-1_stmt" uuid="b5b2da40-ce44-4950-bcac-eabaf42efdb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1917,10 +1917,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aeea32d5-902b-49cd-b211-d224ece64515" control-id="cm-2">
+    <implemented-requirement uuid="08fc4016-155c-4080-a938-333e75955e05" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="0855d515-bcc6-40a2-8114-4305bd935778">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ef7aa801-04ab-42bc-8081-17a46fe06568">
+      <statement statement-id="cm-2_stmt" uuid="288a0964-e247-4769-bf2f-c173a3820b6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1928,10 +1928,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c4960f5-fdf5-4ff8-b4b1-7e89279d6315" control-id="cm-2.1">
+    <implemented-requirement uuid="8f20847a-f87c-4199-a4e6-f0a5602df0bf" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="17694988-d7fa-4c09-b303-ef5a034e62e9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="964ad75f-315f-44d1-802c-bc8d6a738d22">
+      <statement statement-id="cm-2.1_stmt" uuid="a6e5379c-f3b4-4d4c-81c3-dd8e4acfa71f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1939,10 +1939,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6745757c-e6ce-4c7d-9636-977eb5c5d2aa" control-id="cm-2.2">
+    <implemented-requirement uuid="676fc1d4-5625-4d09-9a13-6a649a5f9b4e" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="d6c59403-99c8-427e-86bc-24551cc298ac">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f0baca7a-59e3-405c-9128-a53bc3ff412d">
+      <statement statement-id="cm-2.2_stmt" uuid="5f74a076-498d-4e5a-b1d7-5e1776c25d07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b0548c2-79dd-4735-92e8-d9aaf0f05cbb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on lifecycle management of Red Hat OpenStack
 Platform is being tracked in GitHub:
@@ -1952,10 +1952,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/210'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5c7961f-63a5-4c96-84ff-acb3bb1b9253" control-id="cm-2.3">
+    <implemented-requirement uuid="968542a1-3000-4341-a4d4-556b263056d8" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="a41b9f05-6ce8-402c-b4c7-f32672bd89a6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="cf19cb72-9fe1-42b8-84cc-2979fdabd97b">
+      <statement statement-id="cm-2.3_stmt" uuid="21b3950f-812b-45c7-9759-ca6a7bdf8103">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58ad83df-ca9c-436e-bee4-c5dbccad5901">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on retaining previous baseline configurations
 of Red Hat OpenStack platform is being tracked on GitHub:
@@ -1965,10 +1965,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/211'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b2241c9-ad82-42f3-9e45-fc3d92de18fb" control-id="cm-2.7">
+    <implemented-requirement uuid="332d45f8-8ab8-4efc-b98e-544515224e7a" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt" uuid="89217c69-bb7c-4b2a-abaf-c89ff3d6a9f7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a3cefbdb-9da5-48a1-a410-0a22422fec29">
+      <statement statement-id="cm-2.7_stmt" uuid="de106cf1-5f32-4e96-96e5-5dd28b9d85dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1976,10 +1976,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2f8691d-9729-4310-9fa0-cdf9e67382a9" control-id="cm-3">
+    <implemented-requirement uuid="0f12eae9-54f8-4d1a-9263-461694950c5d" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="85010749-d044-4563-8b3b-ad95693915b7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c07aed25-269a-46ce-8a19-e9c448e67492">
+      <statement statement-id="cm-3_stmt" uuid="833fb41c-f11d-4e39-94a9-8739654b4e7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ba9415d-fc25-476b-b362-c4cebba10e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on establishing configuration change control
 for Red Hat OpenStack Platform is being tracked in GitHub:
@@ -1989,10 +1989,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/213'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79aeffcc-2593-4eb7-93f2-48b2b257f4a8" control-id="cm-3.1">
+    <implemented-requirement uuid="ece25177-9fff-4874-843a-888c60df0bde" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt" uuid="3fc8cf0e-bc8c-4641-a0a4-a4651fbcbfff">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="507123c2-32ff-48e8-852b-eeb4fb3340a7">
+      <statement statement-id="cm-3.1_stmt" uuid="5be96d8a-183f-4905-89b9-e7a636fa276d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2000,10 +2000,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd6857ac-09d4-4509-86c1-3bbaf5c258c8" control-id="cm-3.2">
+    <implemented-requirement uuid="1974695d-e480-478d-a347-933ed5a83e31" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="ac9c81f6-a539-42a5-ba4b-4bca932b840f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c15ff4b9-ebb6-4a70-9d3d-50ac19f63706">
+      <statement statement-id="cm-3.2_stmt" uuid="6febd6e8-3309-44ba-9d29-073a192b97cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2011,10 +2011,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44d77e86-86ff-4067-ae86-30fae9af0727" control-id="cm-3.4">
+    <implemented-requirement uuid="d2288106-9356-4332-a49d-0906a9c71f4f" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="cbde2aeb-152f-4e5c-b4c5-f0c1c63468e1">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6a3444fe-da6d-4226-991b-0abe7c39b376">
+      <statement statement-id="cm-3.4_stmt" uuid="5c1f36ae-535a-4fb2-a792-7967d5e5db6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2022,10 +2022,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52201e55-e787-4482-ae75-f65751804d28" control-id="cm-3.6">
+    <implemented-requirement uuid="8ae236bf-19e1-40c3-91f1-01fd4cdf94c0" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="22695692-d01e-41e2-8a3d-17f2c689300f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="aa2f7ad8-2d8e-43b1-836f-fba44ca40460">
+      <statement statement-id="cm-3.6_stmt" uuid="b383f986-90a7-49c2-843f-d0174e448930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c92e9e7-8a8d-4132-93b8-ff332aaa9979">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -2035,10 +2035,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/399'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="227ceb23-1a9d-491b-aba3-39c66efe049e" control-id="cm-4">
+    <implemented-requirement uuid="ca463470-1923-4e11-b2a5-04195c0cc655" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="91c8fa49-cdaf-47f3-adec-b87beba15b7f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="33e55320-885e-4e9c-b1a8-99e273eaa5fb">
+      <statement statement-id="cm-4_stmt" uuid="89ab5096-0c14-4df8-8b0a-69e84ae06703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2046,10 +2046,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f5f2a60-03e1-4507-8474-dcfc6e11f0be" control-id="cm-4.1">
+    <implemented-requirement uuid="cd07e707-d1c5-4c81-85c4-7352bead212a" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="9a3aea7f-da76-4aec-8333-a362424bcf17">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9cc61794-2592-4528-82e9-8910f34b0744">
+      <statement statement-id="cm-4.1_stmt" uuid="90fc80ff-8226-4c11-b165-0758e35462ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2057,10 +2057,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8aa77d2a-3934-422b-9637-d3a4b6488b84" control-id="cm-5">
+    <implemented-requirement uuid="b2e6927d-4be9-46d3-8642-31cad06633a7" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="bb5deebe-1f28-403b-b1f3-626829790a3a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fe6a1006-3066-4f86-99a0-242f61056fa2">
+      <statement statement-id="cm-5_stmt" uuid="17547a3d-b8c0-4ebb-9725-805cf5c7f8d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cc2b60-d387-43a9-9c68-95cbfe76c421">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing access restrictions associated with
 changes to Red Hat OpenStack Platform is being tracked on GitHub:
@@ -2070,10 +2070,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/214'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25759ea8-ab70-4459-82b2-e4d81ccc2b10" control-id="cm-5.1">
+    <implemented-requirement uuid="c8652b8e-6f79-40f0-b8de-e79e50692782" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="3889a19a-96f3-44e5-80cd-7736c66e8a4c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0aebfe90-16a3-4692-a7e9-48e0a13db04d">
+      <statement statement-id="cm-5.1_stmt" uuid="ce75ef50-f920-4147-8a29-3da51b115577">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d88ebd57-15b0-4f52-afb4-599e6b3aba04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on ensuring Red Hat OpenStack Platform enforces
 access restrictions and supports auditing of the enforcement actions
@@ -2084,10 +2084,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/215'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c36735f-80fc-4e37-a688-c42f4c5aadc7" control-id="cm-5.2">
+    <implemented-requirement uuid="d312407a-6bfd-4a89-9f24-9d8f0572dd47" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="bfdc63af-e6fe-44e7-9c80-63cd5e381128">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="56b662d5-e394-41e4-a7d6-b94dd4be3951">
+      <statement statement-id="cm-5.2_stmt" uuid="2caf669e-e73a-4bef-b914-8f3efc65dedd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2095,10 +2095,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06154b16-c0ee-4baa-a86e-05f23e8aae54" control-id="cm-5.3">
+    <implemented-requirement uuid="ea627fe1-e001-44c2-90d8-e8652ff7a238" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="f77b66e0-f59e-45b9-9e28-16752ff93f54">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b1040aed-6d81-441c-bd86-08aa6fd69d79">
+      <statement statement-id="cm-5.3_stmt" uuid="0f52e976-5dc8-4455-86df-302541eb12bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="324bdbd3-f6bb-48ca-8720-cdf33cefb0b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform binaries are installed through the package
 management tooling of the underlying operating system. The
@@ -2109,10 +2109,10 @@ configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d444404-fdb8-4dda-9ddd-7bdef126e127" control-id="cm-5.5">
+    <implemented-requirement uuid="cb627402-f188-4afd-97fb-8ebc8b2c2f81" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.5_stmt" uuid="4a4286b9-7a71-43a2-9c23-7177ac4818ce">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d92ff305-4a89-4077-a995-445d55d1d9c4">
+      <statement statement-id="cm-5.5_stmt" uuid="3ab52e26-97f5-4f26-94c1-38c78a58bbc3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2120,10 +2120,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94b116bb-1be2-4d3b-8224-e77c63368a12" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="b75ddca3-24ba-49b1-bafc-253df0750a64">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a723eb99-d7d5-45c3-a732-b4cf3529e6a7">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -2132,8 +2132,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="317819c5-66b3-4466-a30c-b6473f282097">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2cc9a54e-1308-4620-abc9-ea2042768ff6">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -2145,10 +2145,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="448893dc-9058-40f6-8b02-26c86f493171" control-id="cm-6.1">
+    <implemented-requirement uuid="8bfb6bea-093d-48d9-99ca-47c09e70c82d" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="49d3a725-3cf9-4a57-9ae0-4673d25795d8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4de7e706-796d-410b-b96e-374f40906f24">
+      <statement statement-id="cm-6.1_stmt" uuid="9abd6936-7599-4fbc-8602-daa325275f7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="657b97a6-63dd-41cc-8752-4ea0f944b412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -2157,10 +2157,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/218'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47946cf3-e0ab-439d-a89f-92f3673fa287" control-id="cm-6.2">
+    <implemented-requirement uuid="827de642-9830-482b-988a-e4d57d0b23d6" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="fa6104f2-b568-48bf-b775-21ab034668d9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="421a5424-773e-41e0-86fc-173502072b26">
+      <statement statement-id="cm-6.2_stmt" uuid="2f25be7d-4774-4091-871d-b5663a6cee99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2168,10 +2168,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5317ab0-67b1-4c15-aeb7-8b3f56822e7d" control-id="cm-7">
+    <implemented-requirement uuid="4d976505-3f36-45be-833c-0a408af8a66e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="425abee2-6191-40c6-91c4-549dfe35ef87">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="98b74ef5-80a4-4b82-95ee-070217f3b290">
+      <statement statement-id="cm-7_stmt" uuid="bb4c0a1d-74c8-4548-a2ce-4453ade8ae70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea975add-2b4c-49e9-b422-e8ad807ced37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenStack provides many capabilities, ranging from elastic compute,
 software defined networking, and storage subsystems. A successful
@@ -2181,10 +2181,10 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2730e567-ab92-497c-a09a-59efddff0c16" control-id="cm-7.1">
+    <implemented-requirement uuid="48a39b77-4ce0-447c-a02b-439e04d1896a" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.1_stmt" uuid="d268b92b-b864-43b7-9862-2f00b3f58c17">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1aa27f5a-aca7-46d8-a1c2-aa0f459a12e3">
+      <statement statement-id="cm-7.1_stmt" uuid="275a8df8-1ec0-4caf-863b-7267ccbe63df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2192,10 +2192,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79393d76-4de7-4b1d-9422-a1d2a077b746" control-id="cm-7.2">
+    <implemented-requirement uuid="9684a7fc-19d9-4a8a-9c62-0a153b3115e3" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="fec0baf5-c3eb-4050-abd9-debcc0af5c0a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="22782151-7dbe-4ea3-b2c7-e0aec68c4c9b">
+      <statement statement-id="cm-7.2_stmt" uuid="0c19c364-3e04-4e7b-ae38-3a7c379356f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7184f2a5-5a9e-4626-a714-ef464b1ed472">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Software execution is a function of an operating system, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2203,10 +2203,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa1ff18c-0b53-4e17-a5b7-a01d270df7b0" control-id="cm-7.5">
+    <implemented-requirement uuid="17db50eb-feff-451d-b0d4-c6f591de4534" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.5_stmt" uuid="e5470a2e-f8a4-44d0-9f0e-13b2b6981a8d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ca64ac4b-4163-49a7-bb8c-8983a716b78d">
+      <statement statement-id="cm-7.5_stmt" uuid="f5bef52a-d45f-4233-8a67-fe750f264bcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="851e61f7-7033-4872-abb0-27cd97151bd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Software whitelisting is a function of an operating system, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2214,10 +2214,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32fb016a-341c-4eec-b4fd-b4b62b623e57" control-id="cm-8">
+    <implemented-requirement uuid="09ffc592-4a4a-4d6b-b111-0cd51b377e19" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="9a128976-0341-49bc-b880-ffe506593e46">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2a6a564b-82ff-4702-983c-4bee505e5d81">
+      <statement statement-id="cm-8_stmt" uuid="047a6256-e6c8-43f8-8e82-be0b4595340c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2225,10 +2225,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37278ebf-24d1-47b0-9abc-29f59096cf67" control-id="cm-8.1">
+    <implemented-requirement uuid="6df1e099-d7aa-4750-9689-da94f5e2d388" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="a060a804-ed28-4b3a-8148-bcea916be232">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="80c6b229-d7ff-4fdd-80bf-60cf63a0f46c">
+      <statement statement-id="cm-8.1_stmt" uuid="75d9d43f-f1d4-4925-9fb5-b75dee187096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e9c23f0-11b7-4899-929a-9b1e9bf3cee5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -2237,10 +2237,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/222'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="534857e1-f5c7-4303-bfdf-129c4f2223e5" control-id="cm-8.2">
+    <implemented-requirement uuid="9d18ca01-5388-4088-954d-8ab2a78b5521" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="5386aab3-9e9b-494f-9493-f5c109d55c62">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d5e586c9-f610-42cd-85c3-571c1e04b2f8">
+      <statement statement-id="cm-8.2_stmt" uuid="bcf94940-be2f-4db8-85c0-8e87ea61626d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b10cb10-2ebc-442e-850d-baf498620d1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -2249,10 +2249,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/400'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7254107d-dd7b-447d-b68b-79c91c235d80" control-id="cm-8.3">
+    <implemented-requirement uuid="7fc2f137-9721-46ec-92de-2cff911a2eda" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt" uuid="b08bf9b0-abc3-4ce1-960d-31c239a3d728">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2749ab50-82f6-4103-a8a6-45ff8cdf8ae9">
+      <statement statement-id="cm-8.3_stmt" uuid="6e32a8c4-ef08-4fb6-910b-c6f2c98d819f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b00de6a-54bb-4ace-8a6d-ed5f7503ab01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -2261,10 +2261,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/223'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="134f070a-6bf9-47ec-8b59-b872b68b43d9" control-id="cm-8.4">
+    <implemented-requirement uuid="4114529b-9a77-4358-a99f-93aff9e235f7" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="5224dbf6-de8c-4449-84d0-cfafb54fe0aa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ab8b7f52-bd8c-4aee-8ea6-97779385b2a9">
+      <statement statement-id="cm-8.4_stmt" uuid="ab38375b-ed57-49fa-b17d-d9b915389fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2272,10 +2272,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f85a5129-64db-4c59-b2a7-6ae4085e101e" control-id="cm-8.5">
+    <implemented-requirement uuid="b44fcc73-2920-4d16-8c02-78729ecf74e7" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="de928fd7-6042-4b69-86cf-c7e9f64c7bca">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="650ba4ce-7eca-4086-961a-d7720acf7d09">
+      <statement statement-id="cm-8.5_stmt" uuid="4ef62b9c-cc5a-49f3-832e-d2d0f24e0508">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2283,10 +2283,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1169ff1a-87cb-4a76-a69a-169d93bafb64" control-id="cm-9">
+    <implemented-requirement uuid="91d8ed99-c23f-4c85-b263-3c8ee46eb80d" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt" uuid="99ef0f84-66de-43ec-85b4-ffd3d28b16e7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="01bab63f-6dae-4e6e-9e53-3d48c566045c">
+      <statement statement-id="cm-9_stmt" uuid="992168c7-e4f9-49db-b02e-7a8155706981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2294,10 +2294,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d965ceb-60e6-4b86-999f-534913740132" control-id="cm-10">
+    <implemented-requirement uuid="7c2f6f17-e66f-4bd9-bbe6-20acc81cd359" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="3eec093b-d22c-4823-9491-d2301ae1b77c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3f32a359-2664-45cd-8e27-031e05bf33dc">
+      <statement statement-id="cm-10_stmt" uuid="ae00dd5d-ce1a-4477-a834-6dc28807dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2305,10 +2305,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61249ce5-ceca-41f1-9761-f2d4c664d620" control-id="cm-10.1">
+    <implemented-requirement uuid="8ee32b4c-de62-4e65-82c0-cd54eacf4837" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="d94a6ece-8dc9-404b-b163-1c7d0ec6b51e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6f1aab96-90c2-4aa6-9788-5aeff47f4f22">
+      <statement statement-id="cm-10.1_stmt" uuid="4e0e3594-e2f0-4bb0-aaad-6f72f67eb56c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cee3bfa9-3e86-4195-83de-e3deb6cf111f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.
@@ -2320,10 +2320,10 @@ of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e04c92e-b717-435f-998d-5b945d3fd7f9" control-id="cm-11">
+    <implemented-requirement uuid="ee70a68a-e5fd-4583-bf65-e8129a8cd9e5" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="1de00c7a-2116-4a80-9dbb-720912a77f01">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8dec3360-df09-47c9-a8e7-31a35a89af21">
+      <statement statement-id="cm-11_stmt" uuid="1cd21848-59e4-4f9f-9bd8-480b0008abca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2331,10 +2331,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2e264c7-58b7-4674-bd4b-f6f780daa5ba" control-id="cm-11.1">
+    <implemented-requirement uuid="f808da61-9c38-43c2-a270-832944fec584" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="1fc05ac7-7c39-429b-b326-df20f8e3e707">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3a5d77c1-9516-4d57-a3b7-db89008e3a7f">
+      <statement statement-id="cm-11.1_stmt" uuid="37477689-1bfd-4c42-8eb2-a42514c29c8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2342,10 +2342,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24935390-848e-49c2-ab39-5c980ce656af" control-id="cp-1">
+    <implemented-requirement uuid="d54fb627-a20c-4241-9723-7a843bffaa6d" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="f2f7b76b-25c8-48b0-b864-7b8db5274c70">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e545bcd6-f5ab-4ff8-b433-a10ca1745f1f">
+      <statement statement-id="cp-1_stmt" uuid="dd2cb0b8-7e3e-4b6c-8bfe-e8cd60dc6e43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2353,10 +2353,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e64d92e-fc3a-41f5-a84c-1494c7d016f3" control-id="cp-2">
+    <implemented-requirement uuid="bffbcf7f-ed96-405c-8bc5-b2f37b429ded" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="8f248247-677a-4709-8ace-3cedc849d576">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9d3f3de0-e340-4882-8547-4063e6bc4119">
+      <statement statement-id="cp-2_stmt" uuid="8a30e876-f811-40ae-bffe-a9032187b2cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2364,10 +2364,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23d2bbdb-4c27-4a51-9a1c-cd9819ce2131" control-id="cp-2.1">
+    <implemented-requirement uuid="e67dc6e9-2798-4812-925d-fcf3a1fa0802" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="e2fc1364-f3b2-4d03-a607-09556e3e1597">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="209be16e-aaf9-4bee-bca9-89f0f5f0a314">
+      <statement statement-id="cp-2.1_stmt" uuid="8499a58b-9df8-4509-b8ce-5c6db5f489c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2375,10 +2375,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d88174d6-c886-4391-9c6f-e91eb75d6392" control-id="cp-2.2">
+    <implemented-requirement uuid="bbe2c8fc-bbe8-4646-a86b-a84d3b728ac1" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="630c31cd-1c3b-4e63-b995-47c572bca726">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="06581b3f-8de9-4faf-8edf-f30e1e71a44d">
+      <statement statement-id="cp-2.2_stmt" uuid="78f846c0-632c-4afa-8429-17bb48b65ecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="186bc4ea-e2b3-4ced-99f7-8d979860e4bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on capacity planning for Red Hat OpenStack
 Platform is being tracked on GitHub:
@@ -2388,10 +2388,10 @@ http://ssptool.securitycentral.io/certifications/FedRAMP-med/NIST-800-53/CP-2%20
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9b48a5f-e77e-4dc5-b153-09a2758816d3" control-id="cp-2.3">
+    <implemented-requirement uuid="17ee05db-7b84-48e1-9f3c-0908b49a8ab5" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="80ee7fb7-d61e-44f2-82ee-612ad4d8bd1d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0a7f85f0-eef2-4dcb-9da6-b71c3fd6101d">
+      <statement statement-id="cp-2.3_stmt" uuid="b0b876cf-0de2-4670-985c-bdb68b690981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2399,10 +2399,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7f35dc0-67ed-4d7d-9aab-ec6b4bfb4b3e" control-id="cp-2.4">
+    <implemented-requirement uuid="95f3ae7f-0e73-4628-892e-d1ee822c1033" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="47af9328-a4b2-4c3b-a3cb-2db9c97323de">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d589848f-5333-404a-8520-e499dc9992dd">
+      <statement statement-id="cp-2.4_stmt" uuid="50fc6e5b-0e9f-4b93-9f79-ff4861890e81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2410,10 +2410,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d868e9c9-7abd-4fd9-8cc8-96c81a0a38b5" control-id="cp-2.5">
+    <implemented-requirement uuid="c9a04805-62f6-4d5b-a04e-4fde11018ee8" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="ab136fe5-5a66-49af-aff2-8adff631d548">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="edfd7054-8137-462a-88fc-02196c66d061">
+      <statement statement-id="cp-2.5_stmt" uuid="8dbbe98a-be38-4f19-a7f0-c376028f15e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2421,10 +2421,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8e3a5bf-b361-48e8-8721-6fdffc138957" control-id="cp-2.8">
+    <implemented-requirement uuid="6b2b7657-05a3-41d8-bd2c-2ddfcc0b157e" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="04f658ae-f993-4cef-942c-692e16989b9c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="433a61c4-c665-44c8-a2f8-2cc3addaf9c1">
+      <statement statement-id="cp-2.8_stmt" uuid="009dec9e-9053-4c37-be5e-24807813daac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2432,10 +2432,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b0d5611-ad02-4be3-9feb-59cfeb9dbf24" control-id="cp-3">
+    <implemented-requirement uuid="49c028d6-b83e-4f62-8980-606ce9a02364" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="47a2e9bb-8bde-4c63-b902-392323483eca">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="47614c79-fcb5-4b52-84ff-f02ed91fc4cd">
+      <statement statement-id="cp-3_stmt" uuid="0a69f546-afc0-425e-afd5-7e4d042ed2b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2443,10 +2443,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11115e13-1487-4e5a-89cd-c9ee3dbfef32" control-id="cp-3.1">
+    <implemented-requirement uuid="08851760-916f-49d6-bcab-0206bc1ba2eb" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="ab09bf96-3836-43c4-a515-506cc1319cfd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="931687dc-33e5-43b0-be62-36f6621121ca">
+      <statement statement-id="cp-3.1_stmt" uuid="d0914b91-9ad6-419f-9251-702a26d29c52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2454,10 +2454,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e89bf032-79f0-4db5-8796-d5284c6f39ab" control-id="cp-4">
+    <implemented-requirement uuid="a414e1c8-9ea0-4fd3-87d3-5d2bb0c871bc" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="bd8beb0d-f80a-4b69-9db5-e78ad8542c8c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ce4fa342-f262-473e-838e-3e6da434d462">
+      <statement statement-id="cp-4_stmt" uuid="b07bb60f-5bc0-4bed-b706-7bd175dd221c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2465,10 +2465,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85c9b143-2a38-4bde-9a02-e0e3b5527282" control-id="cp-4.1">
+    <implemented-requirement uuid="4005220b-cbf7-401e-b498-35684f3ee065" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="ff192bb2-8b99-42d5-8e20-46cce205091c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="64a2dd2e-f948-495a-a7e0-b031afc85a78">
+      <statement statement-id="cp-4.1_stmt" uuid="332c0b19-73a5-4aa5-839e-aa2016142f16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2476,10 +2476,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b99ae6fd-8071-408e-b3ed-d25ae8c4758e" control-id="cp-4.2">
+    <implemented-requirement uuid="79ba7bda-abd2-4d04-bb09-a42ef58a35ee" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt" uuid="f2ebdee4-1c91-48a4-bbac-3e538ba62e93">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fb3516ec-ca5f-48a3-8860-45ed6b35ecac">
+      <statement statement-id="cp-4.2_stmt" uuid="c388a84c-9596-4726-8b67-8f2835d9b166">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2487,10 +2487,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="953e742f-33f8-469a-b74e-ee8b50708f8c" control-id="cp-6">
+    <implemented-requirement uuid="f51835c3-5fb3-4920-b1ad-d05e6b731161" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="ecdf11cf-fe57-4e5b-b52b-a2648c3ed03b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d2790e00-a793-4013-a41c-3ca32f363a64">
+      <statement statement-id="cp-6_stmt" uuid="19eaebb5-c1c2-47cb-be27-0cc5b96953a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2498,10 +2498,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ff792c3-f6cc-4320-9801-a1c0185235de" control-id="cp-6.1">
+    <implemented-requirement uuid="ca4d5841-9e0a-4f6e-8c46-f6181413caca" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="5c5e1a3b-fc6f-40d9-b602-499c29bbeb08">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="694f04f4-c1c2-463b-adb0-8b12b6f6659c">
+      <statement statement-id="cp-6.1_stmt" uuid="fa235989-6811-4523-8e76-8f4474402575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2509,10 +2509,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb63bbaa-365a-4c02-916f-4140fc35d3c3" control-id="cp-6.2">
+    <implemented-requirement uuid="57817db4-48c4-4104-9ae9-95db621e7ec1" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="0b8ac915-b790-42dc-a3bc-d717f449d220">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d2c3617a-effd-4c9b-90b4-2bf9a7d47b11">
+      <statement statement-id="cp-6.2_stmt" uuid="733b5f01-3899-4d30-99ca-ea4e5e29c095">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2520,10 +2520,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78d86909-81f2-48c4-be2f-1465da4df20c" control-id="cp-6.3">
+    <implemented-requirement uuid="ba6f6dd5-86cc-4556-8db6-a87b0f0b3ef0" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="a5609403-f394-4b3d-9de7-555641554cc5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="03d8e9ce-a310-4a4b-96d6-e431dee56c46">
+      <statement statement-id="cp-6.3_stmt" uuid="67b89cc6-e5c5-41a4-a2e0-49358bdee8fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2531,10 +2531,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfa449cd-529a-48dd-8de4-6991c2165a8e" control-id="cp-7">
+    <implemented-requirement uuid="82944e30-f1aa-45f4-87f9-7ecfab123441" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="189116b7-c272-449b-803c-625da9d610b3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8e199f5c-3703-4fdf-9c59-5b33515666f8">
+      <statement statement-id="cp-7_stmt" uuid="21fa537e-5626-437e-aa43-b08f869b2fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2542,10 +2542,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d71d1b39-045f-40cc-a191-06389e2c665a" control-id="cp-7.1">
+    <implemented-requirement uuid="6c768450-20cc-4fed-a167-540582a13452" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="80a2133b-e67d-4f69-8bfe-f04b5e288113">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="81cb2774-8af0-4ce9-b56c-2931d69ae022">
+      <statement statement-id="cp-7.1_stmt" uuid="f79ca17f-984a-4530-8b46-367d3a855299">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2553,10 +2553,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8828aa9-77bf-4cfc-940b-ec46a4bfd3ac" control-id="cp-7.2">
+    <implemented-requirement uuid="819495f6-490a-41a1-baf2-a216bdd61a4f" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="6c819f76-37b7-4798-82f7-6adccd906460">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0abbf745-c8ea-42b2-99d9-938510481606">
+      <statement statement-id="cp-7.2_stmt" uuid="a8dd17f7-2700-4539-9d47-943699077096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2564,10 +2564,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a2e53d0-2d22-48e4-ba85-6e6e7567532f" control-id="cp-7.3">
+    <implemented-requirement uuid="e26964e2-4165-41c6-9056-b69af2491d6d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="c4a87808-0f20-4e9a-a3c2-14666f89c84f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ea760c4a-5b7f-41ce-9ecb-1730266d5643">
+      <statement statement-id="cp-7.3_stmt" uuid="ab5fe666-2f92-4436-96cc-dfcc191dc63f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2575,10 +2575,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02e58996-236c-40fc-9547-f9a08055d919" control-id="cp-7.4">
+    <implemented-requirement uuid="88a15637-33b1-4c6a-a47e-a1a1cc0dfef6" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="4656b411-5452-45c9-90fe-9d315c802f66">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="67da4bbc-e2ba-414d-83f2-9650fad9384d">
+      <statement statement-id="cp-7.4_stmt" uuid="b3da8c11-13f5-4842-908c-11401c6986be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2586,10 +2586,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a8812ca-57fa-4be7-9739-8f6bc16202e0" control-id="cp-8">
+    <implemented-requirement uuid="5b70ed26-e4c1-464b-8d06-f70ce228c952" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="ae0c1934-f140-404a-9b33-0d0265e50b9b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c607b152-1809-4ddc-a728-0deae819b2e7">
+      <statement statement-id="cp-8_stmt" uuid="b1219b90-3eb8-4de8-8ea8-825a17184254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2597,10 +2597,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c809794-7eac-4997-bbf5-9fb3c2996c4d" control-id="cp-8.1">
+    <implemented-requirement uuid="2532a38b-74a8-4e8c-861d-45394b047115" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="a42f753f-0a9a-4d9e-8631-10960806c797">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="405cc51d-e718-4984-8456-f3f34dee4989">
+      <statement statement-id="cp-8.1_stmt" uuid="5d1a8e04-db4f-4019-8ce2-1108d327738e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2608,10 +2608,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="521e1fa4-1b49-4e9e-89c1-e58ca9ff1499" control-id="cp-8.2">
+    <implemented-requirement uuid="337bdd77-2d01-40d7-b364-63ee9922c51f" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="c4df07b9-53b8-4f84-9adb-3b3dd5a55321">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="90354fa5-b728-4bff-b293-e859aebb9d50">
+      <statement statement-id="cp-8.2_stmt" uuid="de065898-ab89-4342-bd60-e7cfe611e249">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2619,10 +2619,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccc9c622-04af-44b1-b93f-2a664f23104c" control-id="cp-8.3">
+    <implemented-requirement uuid="24c0c29a-8131-40a2-984f-3cec2d4f6b56" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="e23ea728-9904-4f4b-b8e8-4d213763652b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="57833866-9e6b-4a80-9365-ac60efff3a81">
+      <statement statement-id="cp-8.3_stmt" uuid="b12e5a4b-49ba-4c3d-a4d2-6f76b345f340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2630,10 +2630,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a748ca57-b2b3-40f2-9ffe-b844d6b5b4a2" control-id="cp-8.4">
+    <implemented-requirement uuid="1d59c785-3f57-424f-8f9a-c8fa8b367962" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt" uuid="0b5b0951-5814-4d80-a0d5-75755ee304f2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a56d6239-f310-4f15-a627-7d9f7192126f">
+      <statement statement-id="cp-8.4_stmt" uuid="d031978b-f3e3-472b-8fcc-5c3e9e3a7616">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2641,10 +2641,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93d0ff0a-1c31-426f-9648-3a4cb834502d" control-id="cp-9">
+    <implemented-requirement uuid="84eb20b4-b361-492b-a117-9d8ae2d2f503" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="6e21d7f1-5136-4438-a3c0-3cad15f88495">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="823dcc8d-4343-4b64-8685-c275d8722491">
+      <statement statement-id="cp-9_stmt.a" uuid="030db880-9f30-404a-963d-8118b1a36560">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="121e2947-005b-4006-b881-37d6b73e101a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -2661,8 +2661,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="e3d63338-c040-48a2-99e1-11ea0c578938">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fbe7ff44-0026-46b0-805b-18fa35506eeb">
+      <statement statement-id="cp-9_stmt.b" uuid="bc7daf13-d4b3-4962-9ab9-97db290db49c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f481be8e-f668-45fe-8178-d3b5b7117361">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -2679,8 +2679,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="29262af2-0eac-4901-8671-9f30ff8fe14d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="863fe804-0e2d-4e6d-950e-b00a929adab7">
+      <statement statement-id="cp-9_stmt.c" uuid="12c214d6-9769-414b-b027-1775cd63996b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="139f3266-94bc-413f-9339-5325ac829eef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -2696,8 +2696,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="6194317b-7706-4c09-8208-6cf28a4c9ac6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="78b9e881-ce9e-404d-81dd-194ec7032e3c">
+      <statement statement-id="cp-9_stmt.d" uuid="af663e8a-4d5b-4da8-acea-2ada0ee4469e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d27cf6a1-258a-4b79-8c9b-15d3ebae71a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2713,10 +2713,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b12e32b-1c0c-4b59-964b-dc0f2e19fc37" control-id="cp-9.1">
+    <implemented-requirement uuid="1aa069f3-92cf-4f5a-89dd-5396244aed23" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="2b8510aa-f9d0-4e37-bbb3-fe90a40bb81d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="90782906-f60c-4cc1-b7df-0dee4db16c64">
+      <statement statement-id="cp-9.1_stmt" uuid="2d84aee9-cd36-4c32-b495-0f1fb3b25d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2724,10 +2724,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf095353-5bd6-4126-bf56-5a246489df2e" control-id="cp-9.2">
+    <implemented-requirement uuid="5d2d680e-c646-4a32-827b-cd8385c06122" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="bb9d9b1e-8a27-4ce0-999a-b60666026f97">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="599d1a21-8e5a-4027-9b55-f6d49c3ed710">
+      <statement statement-id="cp-9.2_stmt" uuid="0e38a9e4-281e-45e0-9074-a59bc900abf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2735,10 +2735,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e300e50-742f-433c-a87f-15eaf1494975" control-id="cp-9.3">
+    <implemented-requirement uuid="d4bf350c-c08e-44ee-afcc-b6524197ac75" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="c56729dc-0aa5-473b-b6ec-32bd03f757a7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="945ce551-054f-4fb3-b00f-d870709a5ffb">
+      <statement statement-id="cp-9.3_stmt" uuid="18d7b007-91a2-421e-ad2c-b9f441f60b94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2746,10 +2746,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba33404c-026b-481c-8e5d-d9fd5c58e5a6" control-id="cp-9.5">
+    <implemented-requirement uuid="b7b66d29-0316-4dbc-a971-bce7071b9a4f" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="65d564a7-266c-4bb6-b13b-b33de26528dc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="de5dd971-e22e-4383-bd78-09f2413e6625">
+      <statement statement-id="cp-9.5_stmt" uuid="80e95732-c5ee-4228-b2f7-67ad1c669d38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2757,10 +2757,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7df45b89-5e02-4d6d-9749-805090232fac" control-id="cp-10">
+    <implemented-requirement uuid="c862ea26-e36f-4fbd-95c1-b86e39715c34" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="a1f7adf1-a02b-4ee7-8c52-4ebf9eafad4c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b0ffa0b0-0026-4a6e-ab3e-d76866c667d6">
+      <statement statement-id="cp-10_stmt" uuid="1eca2502-2937-4113-bee4-487ad831df0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca57dba3-2f22-4e61-857c-3d7dbee1e16a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their Red Hat OpenStack Platform environment. A successful control response will detail
@@ -2769,10 +2769,10 @@ processes used to fully recover/restore the Red Hat OpenStack Platform environme
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d990e447-1e21-471b-a82b-cc8098f594de" control-id="cp-10.2">
+    <implemented-requirement uuid="0b0f85ec-3b8e-4bcf-8bdb-730fb07fd966" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="d6d57cc4-955a-4972-bce2-d3d6c72d41ae">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6890bc9a-2102-45e9-8e42-a460e610a19d">
+      <statement statement-id="cp-10.2_stmt" uuid="cf295bf3-9f25-4f2f-893f-f56574bcfaf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e0331bb-538b-4b0e-bcee-03869df85a49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this requirement is being tracked on GitHub:
 
@@ -2781,10 +2781,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/232'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b0caa84-7ddb-4e1f-906a-2d858315d130" control-id="cp-10.4">
+    <implemented-requirement uuid="1568b5b8-6026-472a-964d-df98743e1edb" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="adaaa613-a880-4c12-85ae-4fe36a6468b0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a5d4f88f-0881-45cb-9dd1-03182630ebfb">
+      <statement statement-id="cp-10.4_stmt" uuid="58b4546e-211e-4a19-8e1d-8ae525fca1f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2792,10 +2792,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fb9f0be-34df-46ec-a93c-971803a02d20" control-id="ia-1">
+    <implemented-requirement uuid="c208fa13-b331-4bb3-a906-a11d825dc54f" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="fe08c11f-b2f1-41ac-8264-8a290aebe99f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a7b52df9-7499-496e-9bb4-04bb4aa4b608">
+      <statement statement-id="ia-1_stmt" uuid="ab66bff7-66a3-4f54-bdd0-426477d879b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2803,10 +2803,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1138b8b5-558d-41d2-acbe-13b10f8f90d7" control-id="ia-2">
+    <implemented-requirement uuid="c59161f4-7aa0-4f74-8e7a-d70e2d287475" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="6cd7efca-4f59-49b3-a2e5-0e614de68928">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f8a3177e-063e-4c83-bbbe-fb80e20bd427">
+      <statement statement-id="ia-2_stmt" uuid="1673fedd-fd2a-427a-939a-8df8b41f3969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30c63e3f-c480-4d92-a1d2-aeed0b3491a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -2814,10 +2814,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb0c201b-b04a-42fb-8709-b80a496db260" control-id="ia-2.1">
+    <implemented-requirement uuid="289fe0db-1b27-4024-ade0-c9f37575aa9b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="63d5af5c-efb3-48e0-b5ea-2a2b4760567e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a6ae6118-af61-4c2a-a819-877e830376a4">
+      <statement statement-id="ia-2.1_stmt" uuid="f9bc119b-3db3-4372-9611-7ae8c72f14b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9db1564a-325b-44ac-8611-3dbf6252b163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2840,10 +2840,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a232ed8-dc5f-4a33-96cb-73710adca098" control-id="ia-2.2">
+    <implemented-requirement uuid="b2020e8d-9b88-4cff-a546-9048c19a474f" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="43d26639-14ca-45d6-a50d-98cfd22fd19e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4911de2f-bc23-4c30-ae52-48e2937fd595">
+      <statement statement-id="ia-2.2_stmt" uuid="6e97b211-dce0-4d4e-96cf-f31a88105d6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="feca902d-8065-4184-8b96-573f763dbff1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to non-privileged accounts.
@@ -2866,10 +2866,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="787c1798-2a62-4e4b-8806-3552bf26a55c" control-id="ia-2.3">
+    <implemented-requirement uuid="74d7b087-d10c-4660-be79-f045941dad6e" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="fb68a013-0ab7-4625-8fca-3ae61c19c7f7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f1b9d636-d7df-4168-bacd-26007b030927">
+      <statement statement-id="ia-2.3_stmt" uuid="93081a9f-90a4-4f85-8cae-9bdb5d2e02c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cc3e2d6-ed15-4747-a244-ade6730b7438">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for local access to non-privileged accounts.
@@ -2892,10 +2892,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e04b23ff-7447-4768-8718-ccc83a838ad0" control-id="ia-2.4">
+    <implemented-requirement uuid="c7ef0607-d158-439b-a38b-7d0c701ae84b" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="b26236da-781a-4261-97b2-aa431235e5f9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="070e228c-2edc-420a-b530-b902e66efacc">
+      <statement statement-id="ia-2.4_stmt" uuid="33b3d811-82ba-4d06-a803-1b69931d886d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2f770a8-3ccd-4c2d-986c-61477abc7e2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for local access to non-privileged accounts.
@@ -2910,10 +2910,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/421'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73daed9a-c036-4e69-a5c0-3d0dd9ae2915" control-id="ia-2.5">
+    <implemented-requirement uuid="e02c19c1-b78e-471e-a847-506eee7ebaeb" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="80663002-82c4-4963-a098-93324d37e7ea">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0c67b3ed-6e06-4acb-9385-50f830d316bc">
+      <statement statement-id="ia-2.5_stmt" uuid="b413065f-9686-44cc-9338-45943bcb2a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65aec7e0-8b96-4feb-92cc-282025ae3453">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform requires all users to have a unique
 identifier, of which each user first authenticates against prior
@@ -2924,10 +2924,10 @@ configured to be out of compliance with this control.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7439fcc8-10dd-4700-836c-7fa1dfee468b" control-id="ia-2.8">
+    <implemented-requirement uuid="9018d6a5-e8e0-4e74-a756-90c8d7ed021e" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="b47cd805-4624-4528-8afd-ccca390f2eaa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1fcb04bb-9c01-4549-b9d4-20441dc965ef">
+      <statement statement-id="ia-2.8_stmt" uuid="cc23fe32-e1bc-4719-bb59-0623309932d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="433aadb1-c80f-44d0-857b-40734780a125">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enabling replay-resistant authentication
 is being tracked on GitHub:
@@ -2937,10 +2937,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/249'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21b319f5-3928-4d00-a2e6-e66941f35dcd" control-id="ia-2.9">
+    <implemented-requirement uuid="90c2af82-2f25-4421-90ee-33050f313c67" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="9f149d03-0ce7-4877-8e4e-186c92eb6ffc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5ecfac14-06b0-412b-9853-abf864dfd81c">
+      <statement statement-id="ia-2.9_stmt" uuid="6c18deaa-cca2-453b-94d5-9d5557573a1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbbb49a5-67db-42f9-90f1-8a559315d625">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enabling replay-resistant authentication
 for network access to non-privileged accounts is being
@@ -2951,10 +2951,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/422'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f5bc2ac-e14e-4d63-921e-d20cf63405af" control-id="ia-2.11">
+    <implemented-requirement uuid="7b8c8787-a825-4f4a-8411-cd1b2f954302" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="70f765e7-da1c-4011-b8a7-7f374e1815a9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c3d1c52d-1619-4df4-9abb-9542bd9cd47b">
+      <statement statement-id="ia-2.11_stmt" uuid="42d6c994-f63e-4f82-801e-b0c355aaa8bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffffa5b6-49a7-4e8b-a24c-0453d9cc45d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on
 GitHub:
@@ -2964,10 +2964,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/250'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54030e6b-8ba7-473c-8e85-e2850ba95aa3" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="7434e468-5801-4591-a5d3-63596db08f8d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d6ccb8d9-b622-4089-9e23-bfdc6951a7b2">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2980,10 +2980,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb6d2d3c-73ca-4c4e-82f4-add5676a4f7c" control-id="ia-3">
+    <implemented-requirement uuid="ffe89caf-865b-4d27-92d9-2588245a16b2" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="996cf3f8-ae11-4f28-8f8b-1d4dd76925f4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c98ac0b7-903f-4e69-b005-2713cf69c6d2">
+      <statement statement-id="ia-3_stmt" uuid="35de0580-a5b5-4c1e-a4b7-5a14f7d582fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb2ba80c-0967-4b98-ad92-87881ef6f476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -2993,10 +2993,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/251'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e30a1c9-0e9c-4075-80d3-70ae77ed62be" control-id="ia-4">
+    <implemented-requirement uuid="baf076ff-0ddc-48dc-baf1-69303b069ded" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="5c44c5f1-9557-446b-b2d3-9030be2c970a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e6c8c243-ecf2-4942-a25e-82f4af275908">
+      <statement statement-id="ia-4_stmt" uuid="e1e9cd09-58e4-490c-a082-7e1ef882b3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -3006,10 +3006,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dda408e-5de2-4ab9-a79d-0745ba112b3d" control-id="ia-4.4">
+    <implemented-requirement uuid="e6aba87c-5c25-441a-841f-3172722c0809" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="3d657ad0-31f0-4f48-a462-3fec91c0fa80">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2e907d2c-5958-4e5e-9478-35212c016e14">
+      <statement statement-id="ia-4.4_stmt" uuid="95bd075f-12c2-4604-ab58-113542a4213f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a30b3352-fb58-466d-b91e-d7a05ce1fecb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -3019,10 +3019,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/252'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0890de81-943a-4613-b3b4-f21fd414e092" control-id="ia-5">
+    <implemented-requirement uuid="8a61c669-9aa3-469d-830b-458a18eba93a" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="fdd7c416-566a-4c5d-a20d-ad2fcafaf976">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5f553352-4877-4502-8444-c30d783ed621">
+      <statement statement-id="ia-5_stmt" uuid="9f79c036-9e57-4781-83a9-ae1da8d838d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -3032,10 +3032,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce3fff56-9c69-418e-b466-05c59157dd08" control-id="ia-5.1">
+    <implemented-requirement uuid="2f2060ee-3124-4509-b1b6-024ec5ed28b7" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="83765f00-9a91-4314-a5d0-13f266ee8b61">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="83f8c00c-7577-4e77-b754-ac72883d4c74">
+      <statement statement-id="ia-5.1_stmt" uuid="22c3e411-946c-4b61-a5a2-df5b89b2a412">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -3045,10 +3045,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e278120-9706-46c0-86e7-ab52da9b3921" control-id="ia-5.2">
+    <implemented-requirement uuid="7972f4df-c218-411b-bde3-d4e1f3a1517a" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="df07347f-16db-40ff-8e3d-067854cc713d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4dbfd4dc-0c8b-4818-b918-a7bc53535720">
+      <statement statement-id="ia-5.2_stmt.a" uuid="289932dc-c12f-4a3b-816c-b178b261346f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4208ad47-2a7d-4003-ab7f-8a4894cb8df1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on establishing certificate validation and
 trust anchors is being tracked on GitHub:
@@ -3057,8 +3057,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/253'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="32d9b2de-b8e0-4a35-8473-f5deecd43b53">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0de12fa3-9d5b-49f9-bd4a-4bac0eeebb79">
+      <statement statement-id="ia-5.2_stmt.b" uuid="3e5ba83f-d533-4a80-b6fe-8d0be413b5c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffc6d2e5-74b9-46da-aea3-125a25f93f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance regarding enforcement fo authorized
 access to private keys is being tracked on GitHub:
@@ -3067,8 +3067,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/254'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="12dcf09f-1e58-4b01-bae2-2727400de5ac">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a4bfbc5c-44ad-483d-855f-2afc1a986b8a">
+      <statement statement-id="ia-5.2_stmt.c" uuid="654adb6a-7c4b-4d05-ba90-93e2fad8c5a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e002d79-7595-4caf-a4d2-ee042f656219">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance regarding mapping identities to individual accounts
 is being tracked on GitHub:
@@ -3077,8 +3077,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/255'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="0ce6290a-58f9-44e3-9fa4-cce53d602a1f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a1ac0fc2-6027-40ff-8e5b-e69ee4c5551c">
+      <statement statement-id="ia-5.2_stmt.d" uuid="2db89e81-061e-42c8-9d42-3ad6a07963e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c818bc3f-5cf7-451a-bcd4-ceec2861c05b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing a local cache of revocation
 data is being tracked on GitHub:
@@ -3088,10 +3088,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/256'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1e252c0-4598-4264-89a7-29c36da2f4a5" control-id="ia-5.3">
+    <implemented-requirement uuid="fc5d4018-650b-40de-b766-c1206411ae90" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="c5012895-3adf-4623-9af6-cedada4d63a5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="afcfe2e9-e6e9-4508-b7f7-079f3100932b">
+      <statement statement-id="ia-5.3_stmt" uuid="6830c1e5-8a8c-4cd0-a092-79708f1b5b97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3099,10 +3099,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c41bc5e-4f62-4a07-82a8-f04e39777bdd" control-id="ia-5.4">
+    <implemented-requirement uuid="d4fc2f08-ae06-4c52-9dec-4c8c476da653" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="8b137ece-4b39-4447-b1ad-0e21f20e4d51">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="958f0340-4dd9-4a96-8b20-82b18b99aba2">
+      <statement statement-id="ia-5.4_stmt" uuid="64f95f88-8b72-4344-95b7-4cce904ceb5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2cd99c54-0871-4211-8217-1ab84e99779f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet FISMA Moderate and/or FedRAMP Moderate controls, Red Hat
 OpenStack Platform should be configured to use an external identity
@@ -3113,10 +3113,10 @@ is not applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5921b03d-956d-425f-8961-7e63065f0e0a" control-id="ia-5.6">
+    <implemented-requirement uuid="af95e832-1c2c-45dc-86a0-6d9ea75f2e41" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="c66ca9bd-bca0-441c-a5cf-9923ad7ec1ad">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="41094e41-20c0-4543-b101-f8ba7ca98db6">
+      <statement statement-id="ia-5.6_stmt" uuid="258b8145-49b5-4660-8712-b4ec8d46b05e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93c2a02-4467-4f37-aa99-40e8ce5c9178">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how Red Hat OpenStack Platform protecs
 authenticators is being tracked on GitHub:
@@ -3126,10 +3126,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/257'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="952a95d7-633c-42e3-b0a2-9286a315d99a" control-id="ia-5.7">
+    <implemented-requirement uuid="d81eb0c3-1e37-4a79-a43e-c0c21ac70b14" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="97c64ea9-744f-42b6-ad5b-dfdf7a7eff24">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2fb0909e-7653-4e64-bc9f-a3f0dcb17422">
+      <statement statement-id="ia-5.7_stmt" uuid="aeb99828-fe08-4592-b7ac-30b2eea4be65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="961f12fa-b2d0-4848-b4ed-32cb7317beba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to ensure unencrypted static authenticators
 are not being embedded in applications or access scripts or function keys
@@ -3140,10 +3140,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/258'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6112e02b-041c-4df6-b73d-23eea6ed0413" control-id="ia-5.11">
+    <implemented-requirement uuid="20d94349-ac22-43e5-858b-0743396f0631" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="e9fbf972-42ce-4cc3-aafa-bde864a9c02c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8f8ff2c4-6bcc-4f12-b203-91e3efd6e59e">
+      <statement statement-id="ia-5.11_stmt" uuid="190217c8-24cf-4786-91be-1b461696d954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -3153,10 +3153,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9954230-7f43-426a-92c1-bcc25440a3c7" control-id="ia-5.13">
+    <implemented-requirement uuid="8eed47e9-33d3-4223-a9dd-4b67fc18bbf2" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="70d59eed-2b9e-4256-9544-f0e9d224b859">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ad369882-447f-45c4-8f3c-cda5f535412c">
+      <statement statement-id="ia-5.13_stmt" uuid="c48f6451-b60e-4049-98bc-0a1d1ee2626d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ba3eade-3d73-4f34-89b2-6ab598d4f2c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to prohibit the use of cached
 authenticators after an organizationally-defined time period
@@ -3167,10 +3167,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/423'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a38f070a-dc22-44b0-9e30-496c4b6d5faf" control-id="ia-6">
+    <implemented-requirement uuid="05005a74-21e3-4100-92b7-ca71ff828a98" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="4537cc61-e642-4092-b0d6-ad37046d929d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4d4a04b9-66f9-460d-b5e1-55d23ecf4784">
+      <statement statement-id="ia-6_stmt" uuid="0c0685b8-0c35-4f53-a730-6ad9020ef2a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecabbad6-1b16-49fd-9b7f-cd712dcf01d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform natively obscures such information. Red Hat OpenStack Platform cannot be
 configured to be out of compliance with this requirement.'
@@ -3178,10 +3178,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a024db4-b01f-4f19-8040-bb29d80071fc" control-id="ia-7">
+    <implemented-requirement uuid="a2b87a9d-d758-4b0d-8396-3d77001d2d9b" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="6b3b4f6e-a3ad-411c-be7d-68813743ea64">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="32b9074d-c4ca-4eaa-bdff-acc631340039">
+      <statement statement-id="ia-7_stmt" uuid="892b15aa-bc59-4bae-9ad7-0f86f9ffff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="526f4b91-8447-47d1-96a5-1090fb4e10dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to Red Hat OpenStack Platform nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -3203,10 +3203,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b912e2f-601f-4158-9903-38fd9278d367" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="bc646b5a-5d19-4082-a337-a3a80cbd35a0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="15913127-48b0-4cf7-8fea-6f1c18afc310">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -3218,10 +3218,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bab8addf-296b-4bf4-ab01-f2101e0373aa" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="6113801c-e4a9-4c52-a54c-1c27a7328062">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="505e794c-d33f-4a1c-9f40-3ef91cd98581">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -3234,10 +3234,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ceabbd19-0354-41dd-87b6-52a3a36443f4" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="0224cede-c547-49c2-8f30-f0683df037a5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c356dbf2-60d3-4ed0-b42f-f51580948023">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -3251,10 +3251,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22b8eb5d-1c22-41f7-947a-bba3f4e2cfce" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="c92e42d7-6c70-41cf-8827-05413e535fa3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="30e02441-b589-4c32-80d4-0f9c86896b06">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -3268,10 +3268,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09e97eda-4d23-4f56-9c66-b94e4cdba0a9" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="b68f578c-ab88-457f-a05f-f9492e00c687">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1da6a3a1-a721-44e7-a1c2-32761f160da7">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -3285,10 +3285,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c913cef-6458-45b8-9281-8dc0e8b732fe" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="dd7f56e3-6ead-4cb7-be64-dd6f0236f92e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="94b0b849-e74c-493f-9c6d-d55fd9c3c917">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3296,10 +3296,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b987394-0b8d-4400-9c0b-b91e1b7b1af4" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="ba1ace26-9d2a-4efe-82a6-85b5c1a83d90">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="011648b7-32c1-4587-bd99-57d17df93628">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3307,10 +3307,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0b6f682-3b4c-4904-bd3e-e981aec08197" control-id="ir-2.1">
+    <implemented-requirement uuid="78d7845f-de00-4c63-bd97-4e0839f3f0a2" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="5250ab87-7cf8-4c7b-a90e-68d6787b129f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5fe3bf37-9b31-41b4-973e-c04f91c2a2d3">
+      <statement statement-id="ir-2.1_stmt" uuid="2a2123c8-220a-4661-8f26-18515e8eb566">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3318,10 +3318,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91101c0c-5d5f-4590-ad5a-32f60616827f" control-id="ir-2.2">
+    <implemented-requirement uuid="246aa74d-9372-4467-ac4e-954bae434f90" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="ef109380-634f-495a-bb56-8b362a073692">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bdb7153e-2fae-48de-a1e6-005d56bf1566">
+      <statement statement-id="ir-2.2_stmt" uuid="f3b8f0bb-f626-43e6-9afa-be7e82b405e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3329,10 +3329,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a932464f-6354-4981-ba54-58c8731d1bd5" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="9b4280e3-8a93-4692-80f8-266be15d7d15">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2aff41f7-df32-4917-9b5d-cc410d239649">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3340,10 +3340,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0727cc5-08cf-4cc7-8c1f-7e5378397865" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="bad4f6d7-4f43-4dae-97d3-a23c8fed1ade">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4194b55c-0518-47ac-b58e-ed99392b3461">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3351,10 +3351,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cc07542-9dc3-4a98-b62f-f5118569d123" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="057362b2-4fb9-4e46-a1e4-b88dcf1a15ae">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="546a22d5-cb9c-43bb-8806-7f2429876b2b">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3362,10 +3362,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66387696-956f-4b25-a57e-a6f0a49a6828" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="101e3765-742b-4a1e-a1db-1461bdb561b2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bc306334-03f0-455f-bc27-7f4fa2afa047">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3373,10 +3373,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89bab66c-16b8-445f-8d25-f2b5ddc36a95" control-id="ir-4.2">
+    <implemented-requirement uuid="7f0a3982-d079-4924-b580-f0dc1d216e85" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="8bd4bdd6-3bdf-4ae0-a840-8086b53499dd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4ac90419-3c35-4a4d-8376-02d256963f20">
+      <statement statement-id="ir-4.2_stmt" uuid="9c563bcc-5237-449c-a4ab-d3b700a97da2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3384,10 +3384,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fa4ab62-84fd-462f-bd6b-02cdd5e08af2" control-id="ir-4.3">
+    <implemented-requirement uuid="13b97b42-76d6-4061-b638-febe0cd90231" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="6e0f3b6e-b294-4cd2-843c-42337741940e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a9dc0170-a21d-40fa-8663-f226ba208969">
+      <statement statement-id="ir-4.3_stmt" uuid="5e0e6990-1ff8-49bf-be0d-5d2737ce63e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3395,10 +3395,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0998d97-4cbb-46f3-a8d8-219544aaffa1" control-id="ir-4.4">
+    <implemented-requirement uuid="3f7d2d28-2608-42b5-be50-8da2df81d87f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="f3649a9d-a4f2-4855-b871-0ddf77ccf81b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6e003f6d-b39d-4d6a-98a2-9a34564fbbc5">
+      <statement statement-id="ir-4.4_stmt" uuid="ac63043c-31bb-4d93-b0da-40a829860d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3406,10 +3406,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bea18c54-0b96-4c86-a15a-cda71c859ab8" control-id="ir-4.6">
+    <implemented-requirement uuid="37e8a5cc-59e9-4a7c-9bdb-cbeee02214ca" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="ceead80d-c217-4d79-9194-0caf1668c51d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="de65d683-e7bd-419e-8771-7dc11c1021e6">
+      <statement statement-id="ir-4.6_stmt" uuid="7ef8f800-1279-4b68-9615-3565349db7f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3417,10 +3417,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7425203a-20cf-4b49-933e-9f0b9a2e48c6" control-id="ir-4.8">
+    <implemented-requirement uuid="4e72b7dc-4243-419a-8f07-49afa8e6bb71" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="3737fd40-3913-4e30-984d-488b8fe6df80">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e2d3b07e-390b-412c-8b2b-237ea071e535">
+      <statement statement-id="ir-4.8_stmt" uuid="eeea2ede-129f-4055-8e4e-5f5514fae167">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3428,10 +3428,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05545541-1509-44ab-8480-408af619b6c8" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="004221a4-dc46-4679-ba8a-89e21b899e4a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="30ba4863-ac00-460e-95bd-8677064e0aa1">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3439,10 +3439,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e98fec83-12f5-4377-a2f9-8aa43333ba5b" control-id="ir-5.1">
+    <implemented-requirement uuid="6d97e9c2-2cde-4770-915c-0fb3374028bf" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="be13f15f-8b60-4ed2-9625-003be681e3a9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fe13f7bb-d15b-4391-84f8-745e22dde37e">
+      <statement statement-id="ir-5.1_stmt" uuid="555bebe2-f2d2-489a-99b8-98b462646d4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3450,10 +3450,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32f54e55-c208-419e-8f25-33876f3940ee" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="7d269143-e17f-4a07-9b2b-8d32e4b7cd7a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f9463dbd-9a95-4b9f-b383-55dbd1af5c5f">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3461,10 +3461,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="041f3155-b20e-44cf-a797-a9fc585e9a79" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="8f999ce5-21eb-4b7e-80b3-db6fef214f9b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9a5a9743-eaf5-4ca4-a90f-2cf88862adfe">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3472,10 +3472,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53d7b5f6-3245-46e9-8a16-9b133493b45a" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="eaa77f60-4d73-43e8-8344-e103490eea26">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f06561d8-e218-4353-a10c-600606b23595">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3483,10 +3483,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd7b1c26-3e9a-41e3-a6a4-ffcf4b256766" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="d6cf4761-a1fa-43ec-9108-b1ac57942f49">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9c45dff5-f0e4-4bf0-80a4-345acfed3b86">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3494,10 +3494,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08e28361-4a09-4829-8cab-db42773272ae" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="5a5c6a0c-4df6-4d43-af59-b08196aff8aa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3e8f9a9b-15e5-4afa-8680-74ed2257e907">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3505,10 +3505,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78bfea23-49d3-477b-9da9-c76af8fd6253" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="f7baf908-3667-43c3-b348-a25042509371">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="aad393e7-52d2-4f72-8da8-8d87b4e5f1d9">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3516,10 +3516,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63dff634-cd2a-4fef-bd1f-f294fb72fb8a" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="80c44a5d-0488-4fbb-9e2f-ecaa723fa93b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3303f19a-1fa1-4d6d-b966-ecc47770347a">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3527,10 +3527,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccf1b9d8-9af0-4628-82c3-ce56de410a9a" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="ac781458-b022-470c-9f76-1a7789fb1e8f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="97a8b6d5-a961-48d1-956c-d5d0ebced312">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3538,10 +3538,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d7c335d-4277-4f16-9bc9-b4920b799e94" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="9b7a2e4a-87fd-4a53-a5ce-bea358e9e6d1">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a0de7155-b4ee-4294-8bc8-d05c900f276a">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3549,10 +3549,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe068783-0d60-488d-8aa2-5df25285981f" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="4dc51e7a-83d6-4174-92b8-ea6783b99590">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="04f47f2c-ebf3-46c0-aa46-a5c57afdb869">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3560,10 +3560,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d28f1489-0b55-4526-9024-6c9401f67dea" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="79c53c99-b884-4909-b233-4fac1c941308">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b1a2a9c8-4ce9-421c-bee1-f5efc001372e">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3571,10 +3571,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b76fa22-38e9-4556-9533-9321d79301b2" control-id="ma-1">
+    <implemented-requirement uuid="cdcc7eee-82eb-418a-b7cd-f5af7e84446b" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="f3478a4b-381a-437b-9849-d16091e2a7fb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="435a5ea5-5bcf-4758-a196-a8746ee28ebc">
+      <statement statement-id="ma-1_stmt" uuid="51b5eb2e-72f1-4d10-9c29-dc52c48241e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3582,10 +3582,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c527cfb9-ddf2-48d5-8398-04d5e650c0db" control-id="ma-2">
+    <implemented-requirement uuid="2b150918-15e4-4c01-bec2-18f95a448a70" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="3b1e4139-71d0-4d6b-9fcd-2360c7f655b2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3256f27c-06ba-4d6d-92fd-f91e82db861d">
+      <statement statement-id="ma-2_stmt" uuid="3bd08678-77d8-4d13-ab91-d020826517f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3593,10 +3593,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5ae9f70-b75e-475b-8777-05e81e997b06" control-id="ma-2.2">
+    <implemented-requirement uuid="ec0613d3-0662-4899-8e73-06c9b120db29" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="1690f15e-e672-4502-ac12-b92b72e6009a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6c56529f-02f7-4480-a921-9f120201f7c7">
+      <statement statement-id="ma-2.2_stmt.a" uuid="a6ec4490-03b5-4d47-bbb1-c382251f3d66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ee9663a-91ec-44e8-8b75-23d99bf46e96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on performing automated maintenance
 is being tracked on GitHub:
@@ -3605,8 +3605,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/433'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="947049fe-11c6-4384-aec1-18c369aebea0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c4858c6b-ade5-4071-843c-c1a6af48e334">
+      <statement statement-id="ma-2.2_stmt.b" uuid="e7ae14d3-e352-4b86-a063-0523d23e3e2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f06f38a9-644f-4d99-998e-d9894f081b8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on creating complete records of maintenance
 activity is being tracked on GitHub:
@@ -3616,10 +3616,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/434'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="483fb2ca-2a0a-4ca2-9e52-b52e1f70a835" control-id="ma-3">
+    <implemented-requirement uuid="db0ed605-ad59-4c08-a6db-4dc4f7027414" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="613b92f8-223b-4e97-9b1c-57ae07ef46f7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a19a8670-16a5-4b83-9269-ded8a658992e">
+      <statement statement-id="ma-3_stmt" uuid="60216967-46ff-4c09-8861-e83e6610eaf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3627,10 +3627,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afa4867e-11fd-4cd8-84a9-5a5ab21f929d" control-id="ma-3.1">
+    <implemented-requirement uuid="c8fb1723-0b96-4527-a4a4-7335dda6739c" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="dac23dee-0a82-4e0f-b86e-2234015a1742">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="90ffa8ea-999a-4f9a-a067-e7e0fac6ab08">
+      <statement statement-id="ma-3.1_stmt" uuid="0b221eb2-52c2-4232-b148-3c47be0cca9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3638,10 +3638,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5ae478f-1882-4108-9cf3-71321c211adc" control-id="ma-3.2">
+    <implemented-requirement uuid="08161030-d06f-4580-be12-4f0dfedb8c93" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="10593134-8991-4b0a-872a-e6952fc9ee0e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="03989020-51f2-4deb-9db2-470550938813">
+      <statement statement-id="ma-3.2_stmt" uuid="d489394c-0b43-4d58-b164-2c5da5ab7944">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3649,10 +3649,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5258ac57-6b2b-463b-aa3c-0656b8a3c26e" control-id="ma-3.3">
+    <implemented-requirement uuid="cdc121e7-32d8-4970-8593-f3a9a99ca03d" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt" uuid="b30636e5-ca18-4c66-9e33-009bc6fecb4d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5aec14ec-798c-450c-b858-7ceadae8d494">
+      <statement statement-id="ma-3.3_stmt" uuid="25304008-9e2f-4652-a579-fc83eaf49143">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3660,26 +3660,26 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21cfe94c-cf16-45b8-b284-c57675942f1f" control-id="ma-4">
+    <implemented-requirement uuid="35ce3515-cb78-4d93-9fb2-d9a0817d5ed5" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="582b9ab1-585d-4a4e-938c-91861f76a8df">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ff230fcc-4973-4508-9e5c-263f02ced676">
+      <statement statement-id="ma-4_stmt.a" uuid="901b6f87-5fc0-43f7-ba0b-b4368c4aa5c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="30355b66-a679-4e17-8fd2-12c4d36766b6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="15b8d1ec-6ba7-4744-b1a0-26d2be610aaf">
+      <statement statement-id="ma-4_stmt.b" uuid="0dcfc21f-e41b-47cf-8395-67b48f957b89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="f43a8adb-5c15-4349-bca3-8b0915c6d292">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f75aa09c-86b7-4d4e-8037-257b52e4e94a">
+      <statement statement-id="ma-4_stmt.c" uuid="4915cca5-f41f-4273-b32e-41286a07a092">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d59d37fe-e740-46e7-afa6-f8de446e43f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to Red Hat OpenStack Platform.
 
@@ -3691,8 +3691,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="fb9f6201-a6d3-4603-be98-d8a82fbeaa58">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="df9c7330-b53b-4bb3-9efc-d39d1913537b">
+      <statement statement-id="ma-4_stmt.d" uuid="4bb343d0-f3c3-4baa-b052-0334332b2093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08bbbc53-87da-4908-9568-93e814f2683f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -3702,8 +3702,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="0fa88286-22b9-4914-bb34-38fba9593498">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7471da36-6974-4050-9b3e-6753da4063af">
+      <statement statement-id="ma-4_stmt.e" uuid="ef823718-f510-488a-837f-5865ee720ddf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00846073-cfd1-4be2-8bee-7795424cf8b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -3717,10 +3717,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f02bd22-34c6-465b-84a3-5abde5bb3ae3" control-id="ma-4.2">
+    <implemented-requirement uuid="eafea2c1-56a4-489c-baa2-802e2c42e6c3" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="e15496f8-b738-4b35-9628-fc8fddffb408">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="23af5850-7140-4309-8848-9c6ccdb1a1f9">
+      <statement statement-id="ma-4.2_stmt" uuid="a2f330a7-3cab-4230-ba4e-32bdae18d6fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3728,18 +3728,18 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35c2b149-d7c2-474d-9a9a-6afdcecb899b" control-id="ma-4.3">
+    <implemented-requirement uuid="d27043bd-a2fd-479e-a27b-0b0382769f46" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="f68d077f-4553-4d95-9358-983ca0ae3965">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5c246316-44a7-4a9c-9dbf-a5dd70aa980d">
+      <statement statement-id="ma-4.3_stmt.a" uuid="157e9622-1e0e-498b-adba-6f852ed9e804">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="eb081402-b1eb-4524-8668-a6a3c5332398">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7ab3dfac-bfc1-48e4-8905-d6e576a079f3">
+      <statement statement-id="ma-4.3_stmt.b" uuid="b28a047d-cd80-4073-882d-ca4b389d45de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75307558-79f9-4168-a1bf-e7199270700f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on associated maintenance procedures
 is being tracked on GitHub:
@@ -3749,10 +3749,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/435'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adc535fc-a8d8-4e09-ace4-da825efa8f4e" control-id="ma-4.6">
+    <implemented-requirement uuid="188ac133-9742-4f72-a352-3525c18b9a9d" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="29927f68-88cf-46c0-b7a2-20b0295299cc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0c2d8e7c-6e61-42d4-bdc7-6f116bb55e50">
+      <statement statement-id="ma-4.6_stmt" uuid="5447734f-3fc5-47c2-a788-5a10111bd84c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b230802b-b0f5-439f-b00c-31a9de5413ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation/guidance for this control is being
 tracked on GitHub:
@@ -3762,10 +3762,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/436
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="000e9e75-12fa-4e47-bb0b-9abf978d2d82" control-id="ma-5">
+    <implemented-requirement uuid="61ee1429-4ede-45ed-9531-03cb13100ffa" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="a1f4200c-0428-4064-a20a-e6a4af51e85a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ec816567-bbb1-4e4a-9109-4be85fe7180d">
+      <statement statement-id="ma-5_stmt" uuid="b6e18c5e-2ce4-40f6-9151-3c46e6abfbdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3773,10 +3773,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a543844-bf0d-4878-b6d9-a671bc3784d6" control-id="ma-5.1">
+    <implemented-requirement uuid="f7ee8167-7fc7-4a78-a3ee-30f56a3094ea" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt" uuid="4d0d4834-1f46-400a-ae97-6f7a912a4b6f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e5f31ac9-638a-4d8e-8e47-c3ded0a87778">
+      <statement statement-id="ma-5.1_stmt" uuid="362221fb-2477-474f-832a-1bd6f85aaf27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3784,10 +3784,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bbf35ec-dd75-4f0b-b6e9-b617d670a67b" control-id="ma-6">
+    <implemented-requirement uuid="43a3148e-3f6f-4291-9d3f-8a98ab4717d0" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="62cbe8d6-a984-4af6-abd2-f65952192941">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b5c3ec6c-9844-4b50-b642-447579611f79">
+      <statement statement-id="ma-6_stmt" uuid="03201c85-743b-4aa6-8dfd-fa9547f1f0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2246625a-e556-49af-8b07-b9804d0e2a85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -3797,10 +3797,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/275'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2be4340-c2d2-4ea9-9456-64461665d449" control-id="mp-1">
+    <implemented-requirement uuid="c1c191c3-7acb-4b73-a25f-55c23040e87a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="b1390af1-ac82-441c-a968-1c0d51f65a45">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="66425d68-7827-4193-bcc6-84eaae3e254b">
+      <statement statement-id="mp-1_stmt" uuid="28755a59-183a-4e83-a21f-fcebe642f4ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3808,10 +3808,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4fb5088-1369-488c-b45a-b9a8543e2a0a" control-id="mp-2">
+    <implemented-requirement uuid="db07015e-b317-4432-81b9-c61e31c06b1a" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="00f3de1e-98c3-4f98-9da2-d7bb2afbe515">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3e9bd483-89f2-4bbe-b7b9-78d2d7436cc8">
+      <statement statement-id="mp-2_stmt" uuid="bac08d7c-1546-4d50-8e59-d09a70f8f9ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3819,10 +3819,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b689bf9a-7e79-4ccb-841c-0e23c15f3e25" control-id="mp-3">
+    <implemented-requirement uuid="6e41f304-f675-4e35-984a-d3048a61ca64" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt" uuid="2109a366-7a94-475a-b7e1-5b7bd99082db">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0dd66833-2f4b-453f-85d2-a660ca955875">
+      <statement statement-id="mp-3_stmt" uuid="cd8da023-d985-42b8-ba2d-64d4e8dad66e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3830,10 +3830,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97ef82aa-df53-4491-8abd-533d28d7a142" control-id="mp-4">
+    <implemented-requirement uuid="de914eda-7907-4c3b-9e2e-225169a20d0f" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt" uuid="77206999-994f-4893-9279-2645ea855419">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="982c0e56-e935-4187-9980-7175198c0e50">
+      <statement statement-id="mp-4_stmt" uuid="8794e798-1ad0-4892-8e4d-17fb6b0f6fa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3841,10 +3841,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb22c316-5746-43aa-b0f5-ca640d8aab32" control-id="mp-5">
+    <implemented-requirement uuid="fe7174ad-2b39-4efa-9301-b568a3170c36" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt" uuid="25f4e8c1-a2ca-4719-92f6-64050e019cfc">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="13bf1fb0-f065-48b7-ad88-c451cb64dcad">
+      <statement statement-id="mp-5_stmt" uuid="3f368593-316c-4afb-aaa9-a79d8446941e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3852,10 +3852,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa409144-3947-4af6-9374-fd498220bf92" control-id="mp-5.4">
+    <implemented-requirement uuid="f4e10691-6e85-44b1-bd4c-03bbdae7d003" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="29efe699-501b-4966-92b8-b6470947f696">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2ac13950-7fe0-4ce0-b042-6d02fe01de70">
+      <statement statement-id="mp-5.4_stmt" uuid="9205055c-0ad7-473d-9e02-d895bab0d8ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3863,10 +3863,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a8ef6f5c-26ce-4368-8d0e-1831c6d8788d" control-id="mp-6">
+    <implemented-requirement uuid="73dab637-290e-4ed2-8032-79920696e3b3" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="6b27e9e0-92a5-41fe-a334-49531ce0f541">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="56b2eacc-090f-4c85-9c1b-6bb10187c2d6">
+      <statement statement-id="mp-6_stmt" uuid="c609d480-441b-4fb0-b14a-abbfb8e5a6ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3874,10 +3874,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93770dcd-0ac7-4db4-a2fb-4e91001dfd1c" control-id="mp-6.1">
+    <implemented-requirement uuid="8d569356-00c7-480a-9288-63e8023e26f1" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="948f32a1-4d7e-48c6-979c-3c301bb1ccd2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4de47f91-aade-477a-a99b-b24999ffcb36">
+      <statement statement-id="mp-6.1_stmt" uuid="9c2c4733-d98e-487d-825c-763dd372f13d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3885,10 +3885,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1b67751-13fa-40fc-8039-4b9b50a2970a" control-id="mp-6.2">
+    <implemented-requirement uuid="faa86668-0630-4ce5-9345-13af47b14ebe" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="b0ccfaad-c6cb-4a2b-a075-4df7f9f8d998">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ed35be90-3d1d-4b1b-a24f-cfc6b4a8f6bd">
+      <statement statement-id="mp-6.2_stmt" uuid="b5a85ab5-1044-46da-85c9-c8df4f9dfc3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3896,10 +3896,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de0d883e-1931-41f6-a470-29dac897d751" control-id="mp-6.3">
+    <implemented-requirement uuid="6333eb26-0120-4988-a1ee-a1550c87ddc7" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="75b67f5b-08e1-485c-a086-0eaf3de779bd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c2eb990b-f306-4dc9-bc0c-def9c9178a4a">
+      <statement statement-id="mp-6.3_stmt" uuid="443b700e-85c2-4599-ac42-e8b25e498bc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3907,10 +3907,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c367651a-fda2-42c0-bca6-ec7bc2970423" control-id="mp-7">
+    <implemented-requirement uuid="60cf4fb1-3a3d-4f09-85b1-69dca7250ff2" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="ad7354b0-76a6-42af-9a18-92ba78ca16f6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e8c8d42b-4ede-4e2f-a7bd-4beef7a8bb76">
+      <statement statement-id="mp-7_stmt" uuid="d11d55d4-a801-4eba-a4d6-1a042b3edf26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3918,10 +3918,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cda7a2f0-2092-4d45-b653-056e963813c9" control-id="mp-7.1">
+    <implemented-requirement uuid="f447a86e-4d48-47de-a63b-5bcb1cd20407" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="a542850f-adca-4a37-bb0a-cc19d94e4169">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="795e51dd-825a-468f-9db5-10f49a5c9361">
+      <statement statement-id="mp-7.1_stmt" uuid="0b9f6ba6-3937-4b59-9a24-4ace518213c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3929,10 +3929,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="893a2a3c-dce1-46f2-994c-218a9f0b634a" control-id="pe-1">
+    <implemented-requirement uuid="3fe8f97e-0a71-49e5-bab8-4f23b60cdd5e" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="11778af2-0495-4a8f-a488-023d8b939d32">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8bca2fb2-16a0-4d7e-a9cc-68d4828829b6">
+      <statement statement-id="pe-1_stmt" uuid="8a9e2eb1-861d-492e-8d96-e3d580aa8425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3940,10 +3940,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5171730e-4171-4df2-96e8-8ef5cf553f26" control-id="pe-2">
+    <implemented-requirement uuid="66170f39-9cad-4b12-a48c-d0d25d8049db" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="c2d06fcf-51a7-4a63-ad25-9a36d9775af2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="21ec178a-6df7-4d4b-96c9-de93590d9470">
+      <statement statement-id="pe-2_stmt" uuid="047d6949-4e0e-4498-b589-2948f6dffabb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3951,10 +3951,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1349e451-ec27-4c55-8336-f1ffa784f095" control-id="pe-3">
+    <implemented-requirement uuid="c312262c-151d-4867-8039-e80a50115436" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="efb507b8-1251-4a1b-91fd-dfc217ac6b9b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="92434371-516e-422d-8a93-9a2742b8211e">
+      <statement statement-id="pe-3_stmt" uuid="bb36430f-50e8-42cf-9fdb-f097525b2370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3962,10 +3962,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf2c2175-e12e-4e64-a2d5-f20093ad5889" control-id="pe-3.1">
+    <implemented-requirement uuid="d7df2814-96ad-4413-9838-03040e33b2d8" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="e6c8e87f-93f6-4adc-b582-abf665c67c3f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4d6a680d-e3ae-4bd9-b2a6-08e5d98f820c">
+      <statement statement-id="pe-3.1_stmt" uuid="f58c276b-f9d0-46e2-855b-22bd2c9ba2b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3973,10 +3973,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3296c659-6288-4017-85f8-06fd17773fb1" control-id="pe-4">
+    <implemented-requirement uuid="918e3dd9-8676-4153-ae9b-390016e5a17f" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="da5b3772-9d7e-4259-b230-5412cc7e30da">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e96d663b-75f5-4071-b1be-a2b3dd26a9c0">
+      <statement statement-id="pe-4_stmt" uuid="ab53c5d6-71ad-4998-9335-7339dbf2d686">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3984,10 +3984,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="252b56ee-32ce-4fd3-8f01-f65a6e12478b" control-id="pe-5">
+    <implemented-requirement uuid="814592b0-b7db-4ff6-99f8-eca022f97115" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="7ac9b43e-7727-41e8-aa2a-ac63374d1dd8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a6b19ca9-4457-45e8-afb4-7ac16e5639bc">
+      <statement statement-id="pe-5_stmt" uuid="e87429f3-9556-44d9-99e9-077ffe87607b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3995,10 +3995,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eefec74c-f1bc-425b-8c70-86809c5e9f63" control-id="pe-6">
+    <implemented-requirement uuid="ba657188-6d16-43a9-8a37-cd5d85fce9f5" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="93a833da-3fad-472d-a561-18a0fc620a44">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="dc8b213e-45b3-43ac-b17f-30bf97a26c4e">
+      <statement statement-id="pe-6_stmt" uuid="39b29d3a-8830-4285-a9a4-72430aaef0b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4006,10 +4006,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ddcf7ef-c1d6-4fa8-9d1f-15db70d708a3" control-id="pe-6.1">
+    <implemented-requirement uuid="3ebcd570-89aa-4cec-845b-acbf8d943bfd" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="d57f48ed-6297-499e-9bf4-b2af05148f82">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0b96cd4f-cf23-488b-882b-f0259da17b6c">
+      <statement statement-id="pe-6.1_stmt" uuid="d835c343-1ef8-48a1-8f89-2ed9120e9bb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4017,10 +4017,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66ff25e5-f789-4ef3-87d0-955867dc977e" control-id="pe-6.4">
+    <implemented-requirement uuid="fc36cf7b-606b-4a28-a11e-f3231b904d7c" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="514136c5-15f9-43bc-8a0b-7e45c33cebaf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4c2c5fa6-e613-4f32-8ecc-4279746bd020">
+      <statement statement-id="pe-6.4_stmt" uuid="07423fee-f72c-4bfd-8553-c2dce673deed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4028,10 +4028,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8174e2c-262b-436e-99ed-04d1d6334a8c" control-id="pe-8">
+    <implemented-requirement uuid="3dd3cdf9-3129-4ac3-9bc7-bb7c079bc5d8" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="6014b9b7-b262-40aa-afef-f10fca648e8f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="007247b1-6a5c-4b93-a981-fbc2367022f7">
+      <statement statement-id="pe-8_stmt" uuid="601d2879-30a1-47e3-893d-a0d647fa926b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4039,10 +4039,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="080eb12a-1a39-42c7-b105-a5dae568212b" control-id="pe-8.1">
+    <implemented-requirement uuid="04c19eb8-4bf5-4a5a-a63b-b373ef4ffb13" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="7be27bc5-a1e8-4163-93ea-0a44b63f76cb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="29363380-970e-46ef-a9e3-788fe2c87240">
+      <statement statement-id="pe-8.1_stmt" uuid="b36f0bb0-aa31-4a5d-8171-d0cd1054839e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4050,10 +4050,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64b631f8-ccde-44a4-86e7-fc6093577080" control-id="pe-9">
+    <implemented-requirement uuid="5e59f398-8a1a-4d89-97d1-36a4453531ef" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="91180662-3b6b-455d-929d-7b738490a309">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f24da041-3556-4e77-ab01-c477261c7160">
+      <statement statement-id="pe-9_stmt" uuid="d0306de5-ecec-4258-8031-ba37d5ccb8e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4061,10 +4061,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e59b8aae-781e-4d2d-8cbc-0361fb97807c" control-id="pe-10">
+    <implemented-requirement uuid="9c92af63-6a49-4829-b868-2775814b4274" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="841a73ad-b11a-4e0e-b5ec-58eb4a242ed2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a9f16127-9c87-47b2-ac36-c2e209d19328">
+      <statement statement-id="pe-10_stmt" uuid="e8a80447-c1b9-40be-8873-5d02121aeca6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4072,10 +4072,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1cde70f-b09d-4ddc-9bdb-def00964e80d" control-id="pe-11">
+    <implemented-requirement uuid="6b660040-bcd9-4035-9186-db59f90eb67f" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="df5fa841-0f34-4bc5-8262-7b729469f4c0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ed5f168b-3fef-4e79-ab7e-213f47540be6">
+      <statement statement-id="pe-11_stmt" uuid="7ca82d0f-2e2f-4c36-9915-cdf1ad79dfbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4083,10 +4083,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8ea5b95-bb36-4e92-8d84-a1bcf7cebfd4" control-id="pe-11.1">
+    <implemented-requirement uuid="986463e0-bb3e-4ef6-b6a7-ea8a01b82ac2" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="021f5bde-0c9d-4563-a073-fe9ce7958b93">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4d4dbda5-474b-40cf-9947-c4c590748d99">
+      <statement statement-id="pe-11.1_stmt" uuid="548708cd-d538-440b-a95d-25aa1826129b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4094,10 +4094,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f5e4aa0-ddc9-4fc1-8228-3789e81c539d" control-id="pe-12">
+    <implemented-requirement uuid="fcc9b873-07ef-4573-9d21-c5cea7cfdd87" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="1de9fdb1-d9cd-4931-ba0d-97014788b094">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="86dd8685-da81-40b0-bd62-1f66bdad6177">
+      <statement statement-id="pe-12_stmt" uuid="0bf9e3fd-7b32-4587-a078-205a9ced2242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4105,10 +4105,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fde4e5e-b58e-41fb-88df-c18f2bfc838f" control-id="pe-13">
+    <implemented-requirement uuid="158fd9e8-75bc-46e0-a502-294ed9abcc08" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="f6e798b2-91cd-40ce-adfa-6a776dff952f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8b903977-bc73-4e83-bfaf-437903d583af">
+      <statement statement-id="pe-13_stmt" uuid="e2930066-33a3-4127-afbd-337c1d217cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4116,10 +4116,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="633e1f23-4f7e-4b3b-8a85-82f4fc8d7752" control-id="pe-13.1">
+    <implemented-requirement uuid="d3430aaa-721e-4602-8ddf-ffecd948b069" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="e7630932-5964-456c-8d93-30e90ac8b860">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7267e63a-8aa7-4aa0-97c1-3ee7d40eafc7">
+      <statement statement-id="pe-13.1_stmt" uuid="df97bc89-ef3d-4b32-a561-fbd9504baf77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4127,10 +4127,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f300a8b7-27a9-413c-abd3-81d4768d1119" control-id="pe-13.2">
+    <implemented-requirement uuid="aaaa3fd5-682d-4bed-afc7-7dee10fb3ad4" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="f1cf3756-9601-4a52-8244-729828fd71df">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a12b8c85-84dc-404c-9ea9-fda1bd5f7ad2">
+      <statement statement-id="pe-13.2_stmt" uuid="92401cda-a58a-42de-8990-8b269f820e69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4138,10 +4138,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a14eed6d-2a1c-40ef-8d41-ba2d00f3aff0" control-id="pe-13.3">
+    <implemented-requirement uuid="eaa34a90-3ae8-43c5-8b87-5e20b6607b7f" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="9dcf3128-4ae2-4ae1-b2ea-512ca6375d00">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bf7c08da-557d-481d-8e51-d2050f65d107">
+      <statement statement-id="pe-13.3_stmt" uuid="bc8770ac-fcbb-4e0e-bd53-4bd55cd1d60f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4149,10 +4149,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b04e9ec-4874-4a6d-8791-c8d3358da414" control-id="pe-14">
+    <implemented-requirement uuid="a4abc4c0-f5a2-4974-ac4a-8cac7a0b06a0" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="aa871ebe-9509-41c1-846d-9ac7ccb44cdb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="92644d37-c4c0-4a18-845a-8907061ccaec">
+      <statement statement-id="pe-14_stmt" uuid="cffa90e1-f78d-49ba-ac4b-9ab953e61861">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4160,10 +4160,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="878de096-d83e-461f-b65a-c17d6be90627" control-id="pe-14.2">
+    <implemented-requirement uuid="2d49f52d-c35d-4be3-89d6-483f03f08f64" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="d1c1daef-6850-4a87-b652-7c7f9c5f3d0c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b1852fe8-4271-4017-ae22-4548101beda5">
+      <statement statement-id="pe-14.2_stmt" uuid="9270b99c-8d32-4047-ab59-d4842d13f465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4171,10 +4171,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13f05517-d125-427d-a4a3-e5a227adc247" control-id="pe-15">
+    <implemented-requirement uuid="2c8a7cc4-34e7-4bb6-bbaa-1c473d6d0d9c" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="ad5a8dac-2d7e-4083-9869-abd27039e41e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0a4555b8-9c42-4b7e-9fa5-6c1d2bd4c3eb">
+      <statement statement-id="pe-15_stmt" uuid="d1cdef3c-4f86-4c1b-a0df-c2b3746f6315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4182,10 +4182,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="376fde5c-92fe-4ae8-85fe-834ef50527af" control-id="pe-15.1">
+    <implemented-requirement uuid="4795c60f-722c-437f-95ad-cab942cb8a97" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="02eb4d55-b946-4222-a5a7-a7a3591e31b8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fa25e702-822a-4a0a-8475-997aae1ca101">
+      <statement statement-id="pe-15.1_stmt" uuid="04fd6672-c2c4-46b8-9696-ce6f4e53565b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4193,10 +4193,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9dc30ba2-a4c8-4a5c-a0b8-ab3456354b96" control-id="pe-16">
+    <implemented-requirement uuid="66a5c88b-e903-402e-91e2-45e8f970564f" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="4c945632-413f-4801-b84e-1ec626dc98ef">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d29a1fa6-69b9-4b2f-857b-e3ea7c2af9fb">
+      <statement statement-id="pe-16_stmt" uuid="076b1806-98bb-4148-b439-1fa95052ea1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4204,10 +4204,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="524c8e3e-408d-4787-8f6b-b546d8303964" control-id="pe-17">
+    <implemented-requirement uuid="709e1697-d052-4067-93f3-2c4c64edfd6a" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="5458421c-2ea8-47ec-83e5-6887764adccd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="90e1abac-d0d5-464c-9750-a00d5bc20d62">
+      <statement statement-id="pe-17_stmt" uuid="a22aa1e5-e0f3-472e-830c-7a955d1f427d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4215,10 +4215,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3baa1a6-9eb8-4a66-b110-29260c686486" control-id="pe-18">
+    <implemented-requirement uuid="93cc6194-56fe-46e5-90bf-e7bb89d3e621" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="27351481-23a7-4d0a-935b-33327ba0ded6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f23f1180-c0ca-421a-a519-c2a615868755">
+      <statement statement-id="pe-18_stmt" uuid="3b8b6010-48bd-4784-93f5-e62f93e2faff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -4226,10 +4226,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33002992-c226-434c-87be-559db9b0abb6" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="f5c79fcf-8783-443e-86cf-b7771d01d802">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a4f77273-6eb9-44f8-a76a-55cd4f31fbea">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4237,10 +4237,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa1ccab0-aa7d-46af-9a32-ae23562e656b" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="5da73800-e5cc-488a-8198-2d171fc775f3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="cbf31f95-b78f-49aa-81fc-332948450ae7">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4248,10 +4248,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfc84089-3275-45bb-a80f-18fd6485cd4e" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="188aeb2e-337e-4733-a3bf-7dc76adcc5ec">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="65515447-1eb7-435b-a073-d437b3041651">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4259,10 +4259,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="366dc70f-67a2-4688-85ae-43a9ab8d3494" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="257af4a8-2001-4efa-9c32-16dcf2d62f5f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5486cc86-cf04-4226-a6f8-7ea7bd8970fb">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4270,10 +4270,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffd1fa29-ed06-40c7-8455-315f40a4065d" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="b30cf66e-b1db-4eea-a0e4-727c07fee2a4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="17fb31fc-ac40-475c-a959-6f99a8d5a445">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4281,10 +4281,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="853ed9a4-ec26-4ce0-9379-b6449a802d67" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="375a5224-7476-4fb5-a4b3-7947d78df91d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="25358da6-04e8-4af6-98fc-b7d12082893c">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -4292,10 +4292,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9831ed9-b1e9-488d-8b52-a404009720d9" control-id="ps-1">
+    <implemented-requirement uuid="3b48c5a2-3d5a-4a42-aadf-d91bae228196" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="ff8ec4d7-8ac8-49a8-a4b7-dbc8ad2f6235">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a2f58ba8-4222-42ce-96d4-d6af500f69b6">
+      <statement statement-id="ps-1_stmt" uuid="fa75fd4a-bd29-4b42-8b77-05c73da9a9c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4303,10 +4303,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d6c9ac8-288a-45e2-b6db-2dd997f9f275" control-id="ps-2">
+    <implemented-requirement uuid="4dc764f7-9a3e-4226-9a24-f708b609e0a4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="45558792-2991-4fab-a64a-b7c938dee757">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="712cdbfa-49b4-405c-983a-771bc90763aa">
+      <statement statement-id="ps-2_stmt" uuid="bcd6f4f9-3499-4214-a20c-e98f1ea4516e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4314,10 +4314,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8e4e7c1-bdd3-4a62-999f-263d0bf85339" control-id="ps-3">
+    <implemented-requirement uuid="deb274e6-a5bc-4781-91f7-b2d9f37dbb84" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="d56dde03-2ed6-4ab7-9a10-a919a6134aa4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bce83b8b-2e60-4b16-94d6-18c2a1cc8c44">
+      <statement statement-id="ps-3_stmt" uuid="8794e81b-836d-4ded-b9ed-d93238f9eb96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4325,10 +4325,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95b48e9d-6fbc-423d-823f-a5f1f7a3be1d" control-id="ps-3.3">
+    <implemented-requirement uuid="07f1ae4e-e503-441c-9cba-e72fa4af49a6" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt" uuid="c67ead87-27a6-4487-9b83-fb2820cc4f20">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="57471492-bbc3-4799-a89b-9b093d38e56a">
+      <statement statement-id="ps-3.3_stmt" uuid="238c63c9-ecea-429c-9a98-3ee9cb31dde3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4336,10 +4336,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="506fdc6c-7ae6-4cfb-8a74-ed3c6952156e" control-id="ps-4">
+    <implemented-requirement uuid="c35fae4a-f1ac-4c7c-afe8-10ee0db02bd6" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="b605bb09-83d7-4df0-afed-d1d36764d07c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="17d452e5-b401-46e7-8e9b-a8234fbf83ee">
+      <statement statement-id="ps-4_stmt" uuid="d2fabfb5-0acb-45cf-9be8-715b4ebe088c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4347,10 +4347,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9df0fa54-3caf-4481-ac16-b1430d537004" control-id="ps-4.2">
+    <implemented-requirement uuid="a8497712-e27e-4d32-878e-a226dcd0e75d" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="fa641680-f88d-45c2-a568-ed59bf6674ef">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7762a650-50ec-4bd0-b446-ced469305c62">
+      <statement statement-id="ps-4.2_stmt" uuid="073be4b5-d5e7-45f2-9f6f-9e075df0d0ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4358,10 +4358,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="673462fa-94a6-4ca1-8e58-36ca6940ebb6" control-id="ps-5">
+    <implemented-requirement uuid="b145bc21-5681-41c6-b56e-7e483f13904c" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="fc1e172a-ae48-40ef-934a-4e32d32abc1f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b376eefc-9994-4486-a7d4-826f523b4271">
+      <statement statement-id="ps-5_stmt" uuid="d6118325-685a-47de-9b33-6c7f9cfe48a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4369,10 +4369,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56e6378b-b6ce-42a8-8c26-a5500f4a6396" control-id="ps-6">
+    <implemented-requirement uuid="3acff718-a042-4d8a-9361-0041362e69c4" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="d9e37a5d-1238-401c-9cbf-bbebff113952">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bfa7f5a7-7e94-4bbe-abbc-e90c6c73477a">
+      <statement statement-id="ps-6_stmt" uuid="b85963d4-3a51-46f7-9ac8-e2d7488f3344">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4380,10 +4380,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9cf820b3-d9d3-40e7-85dc-bff168cd7794" control-id="ps-7">
+    <implemented-requirement uuid="34569fe7-9406-466d-9dd7-6b5112324877" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="37d31c3e-06d8-4395-8227-c0ebcccec1b1">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9af3f16a-f0f1-44d3-b6fa-3b68dfdaa82f">
+      <statement statement-id="ps-7_stmt" uuid="7f862af0-a6d0-4654-8d86-2dc42f32a896">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4391,10 +4391,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f6833ea-26d6-41b9-b2d3-28acf2edcd3b" control-id="ps-8">
+    <implemented-requirement uuid="d24948c8-041a-4d1e-9b5a-da8664a98f00" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="1dbe7202-4188-45f4-849b-b286561a131d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8292252b-f095-49be-bf9d-69d04daf2daf">
+      <statement statement-id="ps-8_stmt" uuid="bb73d28c-b949-4cf5-9dab-56d3e3fc075c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -4402,10 +4402,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfeda098-36f2-4ec5-a598-318d446acdcd" control-id="ra-1">
+    <implemented-requirement uuid="bb09a5ef-98e5-4052-9683-cdda152142dc" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="c46e7828-ea03-4625-aa97-d97015a5de41">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c9cc9764-e928-4454-95b8-1e00a8425c58">
+      <statement statement-id="ra-1_stmt" uuid="6325f8de-a783-474f-850d-9eb67163626d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4413,10 +4413,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f29e3705-5fd0-42cc-a8ad-abae6c385f57" control-id="ra-2">
+    <implemented-requirement uuid="3db3a332-63e0-40ab-afcf-0f60c0218118" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="65c88c44-457c-456d-8004-db668c6e168d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5e82aaf4-c1c7-4a59-a8ca-1bbe2ed972a0">
+      <statement statement-id="ra-2_stmt" uuid="01c17c2a-e66f-4d3a-aa95-4014747994c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4424,10 +4424,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b325870-46d4-4e2c-ae49-05245fd2df42" control-id="ra-3">
+    <implemented-requirement uuid="79f18335-4d65-4458-96a5-463bdafb81ef" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="4adc8469-a550-4da5-85c5-d6ed496f4e49">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="eef521e6-febe-4067-a93e-7ccf631fe871">
+      <statement statement-id="ra-3_stmt" uuid="a3225534-b562-4304-b849-5b02450ef53d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4435,10 +4435,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84d504f8-07ac-4afc-b0ef-b9bd5a8af694" control-id="ra-5">
+    <implemented-requirement uuid="8306bebd-ff3c-497d-b225-1282a4c9dc0f" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="6542d30d-f7db-4033-ace9-412f1762b957">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="efe43185-2015-418a-8b35-28ff3d15ec55">
+      <statement statement-id="ra-5_stmt" uuid="eb825304-21be-41c6-9966-6a6ad67ce1fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4446,10 +4446,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1af55a6-cb2d-4011-9baf-410e09a7b6a7" control-id="ra-5.1">
+    <implemented-requirement uuid="47ee0ee0-ba05-4161-9633-83ae0a900757" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="683ce01a-3337-403d-a22e-12e9c382aaaa">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="00460e59-9335-4099-aafc-2d948bc4e3f9">
+      <statement statement-id="ra-5.1_stmt" uuid="22f1f7ae-ce80-44a5-8c6b-51e9882d4d21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="637748c8-e910-4b35-bbf0-2bbf61aa9746">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Satellite, the systems management platform provided by Red Hat,
 offers this capability. Managing Red Hat OpenStack Platform baselines
@@ -4460,10 +4460,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/304'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa7d21c7-87e5-44f5-a9c4-1a25dff8010e" control-id="ra-5.2">
+    <implemented-requirement uuid="5a421e40-0c80-4fff-b852-863fcb41b955" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="ad392e3d-6c06-4ac7-a219-e401d75cb7a4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3c8164f0-59e7-40fa-88b2-f845c96e13fd">
+      <statement statement-id="ra-5.2_stmt" uuid="e89c5e34-5b7c-4560-8ca5-6f5ddc53f9d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="088c710d-d866-4515-a72b-13053b2eee15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control relates to the operation of vulnerability management tooling.
 As such, it is not applicable to the configuration of Red Hat OpenStack
@@ -4472,10 +4472,10 @@ platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d31324ff-78fd-4bcf-a583-7767ee4abdab" control-id="ra-5.3">
+    <implemented-requirement uuid="6e87f6f3-3790-485a-9c4c-243614e7138d" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="0c1e3871-37ab-40b5-bbfe-8c3beb4c0f2c">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bf2ed9a3-c14d-419e-aada-99ecdf5ab568">
+      <statement statement-id="ra-5.3_stmt" uuid="a7b4692e-bf4e-405e-9b19-d6fb24f6ace9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4483,10 +4483,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd5614c3-05f7-4f37-9848-ba5c01b8a4ae" control-id="ra-5.5">
+    <implemented-requirement uuid="7a684614-1ec5-41af-9ad6-af02f5dd4157" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="2a56434f-31ba-4741-81ba-9cff5c658b18">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1da232aa-259b-4d88-b6e1-34edcaba0cbd">
+      <statement statement-id="ra-5.5_stmt" uuid="89a1ca8f-3e3a-46f3-a32e-ef247dd92c50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4494,10 +4494,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af1a7080-de12-4e0e-b57b-275d934a6271" control-id="ra-5.6">
+    <implemented-requirement uuid="80c879c0-97ae-4d83-9d85-ef046dc1e1f7" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="6538ce3b-a2e4-4391-a11e-f654c379c5b3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c9cd6e38-abd9-40a8-9940-46339e5026f0">
+      <statement statement-id="ra-5.6_stmt" uuid="54956832-98db-473a-90b4-f9f2d0e7729c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4505,10 +4505,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6119da3a-9a90-4721-9444-d0fd9d949ce9" control-id="ra-5.8">
+    <implemented-requirement uuid="3ab51cd2-45d9-49a5-93ab-4837bbb5cee0" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="b5b0fee6-5aa8-410b-b338-0ec48c0ec1e9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1a40d5bc-9f18-4031-a3fd-4e523d8dbd67">
+      <statement statement-id="ra-5.8_stmt" uuid="c357e6a3-c67d-492b-9c05-f09a324ae8dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4516,10 +4516,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76d68447-8755-4ca9-8220-511d3ef4b896" control-id="ra-5.10">
+    <implemented-requirement uuid="67b9d136-5d4e-4aee-8802-8103b7b84a9b" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="d6515d8e-557d-4d2a-a198-665421badee9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="15d138c7-e127-49d0-a592-2eb07c9f1556">
+      <statement statement-id="ra-5.10_stmt" uuid="ed5f310f-fc55-482d-83a8-e1a17601402e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4527,10 +4527,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1d45269-7b57-4155-9c48-7d618256e1d2" control-id="sa-1">
+    <implemented-requirement uuid="02d0bdc1-480e-4425-8654-0f01d21cece5" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="331ec10c-8dcf-4e4a-8f68-b562dc1a084d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5400407a-ecac-45e5-86b2-09033717c71c">
+      <statement statement-id="sa-1_stmt" uuid="a42234f9-5017-4911-bfca-de2060c205d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4538,10 +4538,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="743c2e53-a68b-42e2-bbc8-f9fc62dba1f0" control-id="sa-2">
+    <implemented-requirement uuid="1366cbb3-170e-49ba-8285-eb7d039de135" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="dd196d4f-ecba-45fb-9963-8e0793e0e567">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="80d8828f-13fd-43e3-bf7d-11f998f3dbc3">
+      <statement statement-id="sa-2_stmt" uuid="ef2b93d8-5bf5-4999-85e0-daa18920d041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4549,10 +4549,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c3509c7-3dbb-4745-820a-0590f8c6b2b9" control-id="sa-3">
+    <implemented-requirement uuid="64776815-7b8f-4794-bb19-baa7eb7161af" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="5e21b141-0402-4a5b-bde3-7109f314ae65">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="20c90e6f-f46b-4deb-8628-09a898e533cd">
+      <statement statement-id="sa-3_stmt" uuid="830adb39-0426-400a-9985-471215d597a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4560,10 +4560,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6935b0a7-9c1e-4a4c-b247-a0493f98c3d6" control-id="sa-4">
+    <implemented-requirement uuid="2acbe488-3ce3-4bdb-a1da-d92a45fd52f8" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="566bea5a-afb9-4022-82b5-1b73be9bdb68">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d00ee1b5-68e9-42ef-9abe-2f3ef6b9ea3c">
+      <statement statement-id="sa-4_stmt" uuid="70ca8eaf-19b0-4537-a2e2-076a70d64257">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4571,10 +4571,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1ba9ad6-f4cc-4c09-aa35-ddc6a6c06430" control-id="sa-4.1">
+    <implemented-requirement uuid="21a880ab-a8ba-4163-904b-bc3dc360934c" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="3a7889d9-6549-40ce-8c3b-3c0cbdf70607">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b1af1971-d575-4666-8864-7b2f990dd003">
+      <statement statement-id="sa-4.1_stmt" uuid="ba0d4ef3-5005-40a2-ac16-ef6b50fab441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="132c9508-eea2-4fac-afae-e39ccb68e92c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on functional properties of Red Hat OpenStack
 Platform is being tracked on GitHub:
@@ -4584,10 +4584,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/305'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="557ba8ed-b728-4a09-ab46-e11f369f9dbd" control-id="sa-4.2">
+    <implemented-requirement uuid="4d50a6e5-8dc9-4ccb-a57b-42603244635d" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="8cec86d8-4437-4797-8eae-adad8c7314ed">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c45593dc-a485-4864-9fbe-64864d4a2a88">
+      <statement statement-id="sa-4.2_stmt" uuid="1f5469d3-3361-4c8a-a3a5-315ca31f0f3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b28339d0-d9ed-43f8-9453-7c0f55331c7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -4596,10 +4596,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/306'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6a22954-21a7-4e7f-baf5-2aa02503c8d5" control-id="sa-4.8">
+    <implemented-requirement uuid="442a5864-d2e1-4d7a-8a0c-ef095b3b66cc" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="f43077bc-7456-41ad-b361-f34f8385c150">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0aea8593-0de7-4c47-a400-cc8619abcfac">
+      <statement statement-id="sa-4.8_stmt" uuid="9c477646-e6b8-42e5-bade-2ecfac2edaaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="55d3d437-0dca-444e-b8d2-ed0c7cc376e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -4608,10 +4608,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/307'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11559888-c856-423f-ad11-eece887ef223" control-id="sa-4.9">
+    <implemented-requirement uuid="87b20b9e-be6b-49e9-aa06-240405b68c3f" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="9158607e-56bf-410d-b042-1973a87cb164">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6bb2bb9e-3a1a-45d7-888e-0c914dc7c970">
+      <statement statement-id="sa-4.9_stmt" uuid="ce5bbc2a-f398-42fa-aefb-a1c7bbde3d1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c547f19-a228-4304-8169-e059ab431d20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -4620,10 +4620,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/308'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0361821d-90cd-4349-b8b1-0cca8eb0c69e" control-id="sa-4.10">
+    <implemented-requirement uuid="e9678b93-f40c-4898-a0ff-b3c31f4ce95b" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="615e9525-f520-4949-a721-35b241b837c4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="69638d36-a242-4cd2-b4e3-409304dc21b1">
+      <statement statement-id="sa-4.10_stmt" uuid="6aa75d79-dde0-4fb3-9f9b-f80614199c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4631,10 +4631,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ff382dc-9d71-40d0-920d-02d698791b5e" control-id="sa-5">
+    <implemented-requirement uuid="49ba8a34-b4ea-4d07-b5a5-ef0a0cee838b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="e7631503-f94d-41a0-9813-65bc98645d9b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d5b99469-cdc5-412f-a56e-e3efd6194ed8">
+      <statement statement-id="sa-5_stmt" uuid="06328e4a-36cd-4e36-b2fd-4098c768433e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4642,10 +4642,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3f4feca-afce-497a-9c31-212df8696327" control-id="sa-8">
+    <implemented-requirement uuid="a72a3bb0-7cdc-4b04-9959-e4a22a4794df" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="810eceb0-27c1-48ac-98ac-9fd918fd08c5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a7e01349-ad9b-454e-a1e2-1f6185cb0853">
+      <statement statement-id="sa-8_stmt" uuid="eb80de8e-fa10-4701-821c-a1cb07df496e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4653,10 +4653,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bfe6cf7-f50d-4bf0-97b8-6e8d5a1a1d71" control-id="sa-9">
+    <implemented-requirement uuid="665bebaf-1273-4d6a-bfec-47c7d9736aef" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="d09d148d-9ac5-4b22-b667-9f25c76ce5ae">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a0783a4c-8e0d-4510-8617-4b2df11d1caf">
+      <statement statement-id="sa-9_stmt" uuid="76e986fb-b47f-41c3-9da2-5bb8b98c5980">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4664,10 +4664,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76fea0ca-043a-42bf-8c92-690ecaae49f7" control-id="sa-9.1">
+    <implemented-requirement uuid="9e77951d-992a-48db-b8e6-05413be8eba6" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="6da26609-0516-4187-9a1c-5184666c6acf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f37e8947-e29d-4394-82d2-d75d0644a63a">
+      <statement statement-id="sa-9.1_stmt" uuid="2381ca69-305e-4415-9744-53ea547211b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4675,10 +4675,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ff583de-be2c-4cf7-8804-e1a8a454b956" control-id="sa-9.2">
+    <implemented-requirement uuid="29b25e38-7c08-4114-9acb-d7961ff7a9e8" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="23c2df3d-1bd1-4af0-837d-7fbb19c516ae">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e025919b-c266-477f-a1e2-a52d82b0cb6e">
+      <statement statement-id="sa-9.2_stmt" uuid="996cb1a8-04d5-4ac5-9bb8-45a2182e3aed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4686,10 +4686,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a6ccffd-92f4-4de5-8a13-e6ef5423f7c8" control-id="sa-9.4">
+    <implemented-requirement uuid="194e12e2-3f59-4f8a-9a4a-16e8dc056f75" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="bfe86f6b-5ffd-4766-a90c-790edd8a1399">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e4610cc0-7a4a-4516-8dfe-87cd3324fbdb">
+      <statement statement-id="sa-9.4_stmt" uuid="95d9ab3c-115b-40e5-b24d-869b15dbaefe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4697,10 +4697,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f103c5b6-f3ef-4513-8676-a177f3d2b23c" control-id="sa-9.5">
+    <implemented-requirement uuid="a920d4f0-c221-4dd1-b192-db73da4ffe1f" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="9e6744b3-8d15-49d7-a8ad-6c9f7f37762d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b45f4606-be94-4f64-93ff-0d7d024df384">
+      <statement statement-id="sa-9.5_stmt" uuid="00e98fe0-e70f-4616-8f68-aeba63c2ad0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4708,10 +4708,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34e0de91-576d-4eb8-aa59-190df1b5292c" control-id="sa-10">
+    <implemented-requirement uuid="8a7e5a26-8532-40b9-ba82-f1ca894f05bf" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt" uuid="5001c095-f6f8-4109-a211-f7e3d09f3827">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="768fbbdb-011e-4815-b37b-23eea4ae2c14">
+      <statement statement-id="sa-10_stmt" uuid="e4117a38-d40e-4bd7-a85f-ba2b97d92c5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="036f33f0-d228-49a9-a330-50fd2652d66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4720,10 +4720,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/310'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df740f01-de30-43e4-9ed2-71460ab1a8e8" control-id="sa-10.1">
+    <implemented-requirement uuid="fe3da24f-31eb-448d-b3c5-a85525c5f632" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="7e082cc1-6afb-4717-a808-09204753b9f9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7d6d93c4-b146-4a7b-902f-10fd7f803f29">
+      <statement statement-id="sa-10.1_stmt" uuid="a4a59990-e902-4179-affe-9400d9d867bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05de491d-0456-4c3c-86d6-986a7b88880b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4732,10 +4732,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/311'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2357242d-fc3c-43c1-a395-097b0f3eef5c" control-id="sa-11">
+    <implemented-requirement uuid="eab33382-35cc-46ab-b7c5-a3cbad82b60d" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt" uuid="50854c71-67a0-48cb-9935-32437e407474">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4bd92a0a-9850-46b1-9607-77a182598ed4">
+      <statement statement-id="sa-11_stmt" uuid="6aa3a962-5972-4b06-a19a-1e4b6d6db27b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36142ae2-76a8-4d0c-bea3-ab3863eddb55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4744,10 +4744,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/312'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1022140-1af5-42f8-87ef-dade4d3e6da3" control-id="sa-11.1">
+    <implemented-requirement uuid="1ea467e5-fc82-4dc7-93cc-b7ca46f80c1b" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="ee655470-ca69-4cb6-a3dc-aa66023f4ce3">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3be23e6b-5e03-491a-8d60-ee068d6126d7">
+      <statement statement-id="sa-11.1_stmt" uuid="a4727343-0e91-436c-ad01-65b94b5bccad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80fd44bd-3be8-428a-8b8c-0a06b51191a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4756,10 +4756,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/313'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="687c4b85-93de-4180-b71b-f7a603be7541" control-id="sa-11.2">
+    <implemented-requirement uuid="80fe8bbd-648f-4925-b6f5-88c9d3f6b3df" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="9b50ee9c-513b-4366-bc9c-22c9de79ef86">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f3f568bc-8901-4ef3-b535-6c216474a3eb">
+      <statement statement-id="sa-11.2_stmt" uuid="574d2e67-3758-41f1-9d9b-05c9e6d0c20e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c7ed2e9-be16-4288-b69c-c13e97e53f94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4768,10 +4768,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/314'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03e0340f-e9eb-47aa-b6e4-8da9de1e8198" control-id="sa-11.8">
+    <implemented-requirement uuid="16d603bb-d9c1-4351-a6d6-f5576ccde5ec" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="05466c30-5548-4113-b8d0-e1cf064e236f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0925cf78-de69-475a-8eb5-cf6052a9e292">
+      <statement statement-id="sa-11.8_stmt" uuid="cb1281e6-e91b-40fb-81fa-9d5a43b1b5e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f42acbe6-caea-40b9-9200-f4666e65505d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -4780,10 +4780,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/315'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a16a65f2-b5b4-48d5-bbe0-ed99e062fd0c" control-id="sa-12">
+    <implemented-requirement uuid="573f36e2-b418-43d5-88e0-6195532506e1" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="cc862b90-41d7-47bc-ab15-e7fd68bf0575">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f2e64269-768a-48f1-8ec3-a01b8fe1b108">
+      <statement statement-id="sa-12_stmt" uuid="56e89e5e-cbbc-4861-9c2b-ead657605d2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4791,10 +4791,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edc1da5e-4efb-48cf-95e0-500fbffd71a8" control-id="sa-15">
+    <implemented-requirement uuid="d6c7eeb7-c65d-402e-8d45-09f28f963ab1" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="18abb1b9-e614-4b8f-b177-abb1176a90cd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9b6a69c7-e1d5-45d2-ae8a-54f4d80ff864">
+      <statement statement-id="sa-15_stmt.a" uuid="d8332050-0d66-4c3f-988d-c40049313fe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1746df4e-dac6-44af-b9e1-946bef6d7ae1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -4803,8 +4803,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/450'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="c3426146-282c-4cc1-bc19-9e9868c03b9b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4c2c16cd-e172-4dea-ae55-56a4905869b7">
+      <statement statement-id="sa-15_stmt.b" uuid="fe11a411-216f-4ffc-8c84-b562cdf3d732">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cf9d8a2-5b80-45be-9d06-71d2b50738a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -4814,10 +4814,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/451'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3de86757-4119-40ef-9f2f-f0d70be1f970" control-id="sa-16">
+    <implemented-requirement uuid="2206cda4-ccc7-452c-a8da-c7e502deaa6b" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="80c15936-93cb-4ece-852f-3ac5cc60ecef">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b66276bd-a2b3-46b3-b8c2-fe0a34e2a0b5">
+      <statement statement-id="sa-16_stmt" uuid="3484e4ed-b62d-448e-8fa9-e015a6800ee5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f34889e-5118-4924-bb18-24038871aa01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -4827,10 +4827,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/452'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecab629e-0377-4cab-81ed-80a2c673a057" control-id="sa-17">
+    <implemented-requirement uuid="80e04c2e-b245-4ed8-b0d4-98486a33231e" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="4b0eb4f6-c1db-4d56-be34-ebfb32ba5899">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0a1ebd87-6855-42df-9697-fac21eb01f1d">
+      <statement statement-id="sa-17_stmt.a" uuid="b8f98bb3-d3c2-43cb-a631-7b2c2baed52d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3112fb2-6262-446a-9342-da6d739512d7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -4839,8 +4839,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/453'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="aa6277e2-a639-49f9-a4eb-18e117da1b0f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2bdad98b-8219-4833-a1a0-82f5f99ddd72">
+      <statement statement-id="sa-17_stmt.b" uuid="d6fd400d-1341-4af8-afd8-e9ffe9f9dced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a6fd1df-d18b-47ad-b2e5-56b3f6427135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -4850,10 +4850,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/454'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d61cf5f3-ea8c-4481-8601-cab962b46094" control-id="sc-1">
+    <implemented-requirement uuid="2625c72c-92b1-4548-82af-6938babc644a" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="28049cea-531e-4c0c-a4f6-3433694f6e43">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="910b4a9d-6cec-4722-a4ed-655f9e79f687">
+      <statement statement-id="sc-1_stmt" uuid="f38bc439-453f-4c25-9a80-0851c54f889a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4861,10 +4861,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32e6cbea-1a39-4631-949d-aa65c3828fd4" control-id="sc-2">
+    <implemented-requirement uuid="1802f562-271a-49b2-b8fe-233932e5cc4a" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="29a39980-c9c6-42e6-a71b-8ef2b17821e0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7e5de0f5-6a91-4a7b-bec0-46385940f03e">
+      <statement statement-id="sc-2_stmt" uuid="06bd0277-b83d-4889-b839-c84159733073">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57985d2c-edfa-467e-bf7d-a07c1f21b95f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4873,10 +4873,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/329'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc43e5ab-b656-4352-8a24-0c3fd43a1d47" control-id="sc-4">
+    <implemented-requirement uuid="64dbd3e9-e804-4d1f-ae06-0e1ba63f2cfa" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="7cd1ad15-e2dd-4f7d-8bb2-04b870f7d515">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="018c00b0-54a8-4856-a22b-c1046af79650">
+      <statement statement-id="sc-4_stmt" uuid="b1030c8f-0395-43ef-8801-f7822ee70831">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3d68c2c-4e9c-4b87-82ae-c684c3dfd122">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4885,10 +4885,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/330'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="472566d2-b0ac-424c-82f8-afa5934bc532" control-id="sc-5">
+    <implemented-requirement uuid="2d8b22e1-2a4e-4c7b-a58e-cc7939afb4ca" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="0cf8b13e-4561-4395-8bc1-f60fd6713564">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="693c1da7-9501-44b0-ba73-cd2bd076cb3e">
+      <statement statement-id="sc-5_stmt" uuid="96527d82-f5f8-4430-a29d-696d94426674">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4896,10 +4896,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7f2473d-53ef-48f9-adb8-ac1a5724c60f" control-id="sc-6">
+    <implemented-requirement uuid="63078761-bbb4-45e8-a384-a18f567b6d8d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="f63ebea0-834e-42bc-83cf-80633cbb7f82">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c7246d02-77f1-4df5-a080-8941a7315bb1">
+      <statement statement-id="sc-6_stmt" uuid="fb057468-46fd-4789-9cfe-cfac1480791e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5d145947-f0ba-4c5f-adb6-c267ce0aa559">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4908,10 +4908,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/331'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6301430b-21a3-49c2-bd74-a8b4c67c1e04" control-id="sc-7">
+    <implemented-requirement uuid="42b49bbd-cf98-4be6-9c0a-b46e14a35032" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="4558c933-61e5-4ab7-8297-4e02b2ef2a8d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="41062ba2-4a47-45b3-abaf-c06551a887b4">
+      <statement statement-id="sc-7_stmt.a" uuid="840a035c-b878-4c40-befd-85b83fbbd2a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f5f071a-db14-492a-9b10-094018323cc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 OpenStack can be monitored is forthcoming. This activity is being
@@ -4921,8 +4921,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="1b9a05c3-de68-49e4-8197-29d54b7c1ba9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d19c497b-d816-4112-8bcc-1ab8141bfe6e">
+      <statement statement-id="sc-7_stmt.b" uuid="95b962a5-d3d6-4a38-94dd-cec0bd717fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3646d3b3-7aa9-4e4e-96c4-bcefba78e17d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -4932,8 +4932,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="bf73776c-e979-448f-a16e-03c1ff9d50bb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a20dd7c2-2919-431f-a10d-49a33be909bd">
+      <statement statement-id="sc-7_stmt.c" uuid="62382b75-d7d8-4c36-b6e7-ceba9f3510f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f23cafc-7ab8-4a9b-849a-7b124c42cc82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can route connections to external
 systems through a managed interface is forthcoming. This
@@ -4944,10 +4944,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b9ba1af-9670-4da0-8633-dfc8e0e20722" control-id="sc-7.3">
+    <implemented-requirement uuid="75db5e9b-e19e-453f-8279-4a40fc611e71" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="8c15db71-b70a-4bac-8089-c5569718ba26">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a3a4fa7c-83a5-49a4-a683-25b8a48e2131">
+      <statement statement-id="sc-7.3_stmt" uuid="294d3eee-75e6-41e9-87ac-b707610d1a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a540e417-b9e8-405c-9923-af59799bc97d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4956,10 +4956,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/332'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21194ebf-a06f-40de-892a-b4c8c1ec044e" control-id="sc-7.4">
+    <implemented-requirement uuid="ab3e9d4b-6d06-457b-905a-be120c9f73d3" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.4_stmt" uuid="85b6b137-b022-4036-86c0-424fd0fbc714">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b2fa80bd-2db1-4294-b96e-57339f245c13">
+      <statement statement-id="sc-7.4_stmt" uuid="f8f51a92-985d-4a2e-b74c-3a2ea4b84894">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ec9adf1-d01e-4691-91ac-e8d15fbf54dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4968,10 +4968,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/333'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edcbdecb-d431-428e-bcf0-66e51d44e058" control-id="sc-7.5">
+    <implemented-requirement uuid="563f698b-0cbc-4ba1-bfa5-fdc2820ce56e" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="a8cd2eb3-46f2-475d-ab07-eae65a2f6174">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e13eef24-0f14-4620-8870-412ddf2a5cf9">
+      <statement statement-id="sc-7.5_stmt" uuid="090005ca-8287-479c-9d11-934ed7bc64b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ceac9671-c24b-45b1-b888-6dca7d007970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4980,10 +4980,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/334'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1283d453-c67c-45a6-9e6b-992b7d451ab5" control-id="sc-7.7">
+    <implemented-requirement uuid="6a70b630-e573-4b87-89ed-7ea5ec88a9ba" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="cfc5baa3-fe44-4833-be34-34c72070d02b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="9d271571-6f73-4f12-9a76-1b4869c48018">
+      <statement statement-id="sc-7.7_stmt" uuid="baf4ece9-5d89-4bb7-9479-a0635c1db647">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d45b3d68-31d0-4441-b190-798f0809be67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4992,10 +4992,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/335'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="371d7630-61ab-420e-bde3-aada276faf04" control-id="sc-7.8">
+    <implemented-requirement uuid="b2676614-4f04-4d9f-a66a-994c8cdc4d3c" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="e5c82fab-2141-4786-ad96-ed93fe769a3b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8b5d8bad-1787-4f46-bffb-6f23f892ca5a">
+      <statement statement-id="sc-7.8_stmt" uuid="4ad1d4ac-cd9c-455d-b12d-bb109c2fa518">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b55a15d-b075-40ff-9aed-7ebf38cde65c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5004,10 +5004,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/336'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76beebd5-7c19-4718-bb16-d6f169a52f45" control-id="sc-7.10">
+    <implemented-requirement uuid="b80540b1-6ccd-4f6a-bf28-0463a70eee81" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="edcecb44-e196-433c-948e-df59feab98f7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="212a24e5-fe25-4a3e-adf9-6b961595aa01">
+      <statement statement-id="sc-7.10_stmt" uuid="f0a769cf-1e94-43c7-acdf-1c75e08143d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7e37257-d66c-4d9d-87be-e47c221b4785">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5016,10 +5016,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/455'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3bf663b-fdf1-4d42-bdda-a6f42e7b7b11" control-id="sc-7.12">
+    <implemented-requirement uuid="11e75ec6-7090-42cb-acf5-12a437fe5d7d" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="bd59ac90-26f3-4d26-977f-42fd1d8f13d0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e08348c8-dbfd-41e4-85eb-6b7db78c6804">
+      <statement statement-id="sc-7.12_stmt" uuid="f0d00327-4c9f-4920-9d46-6feed94c3f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb4a39b9-80b1-48e2-ac1b-2b0913bb5ed1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5028,10 +5028,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/337'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="746600e1-70ec-48ab-8862-5604cea59545" control-id="sc-7.13">
+    <implemented-requirement uuid="fc784b4d-c761-4701-a177-57ecb02c3ccf" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="e9052b43-d3ca-4bba-ae92-54a180622370">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="85311872-4331-4adc-89c2-9277a3e42a89">
+      <statement statement-id="sc-7.13_stmt" uuid="0ab6bd11-fca3-45e0-8567-65cf4a2ba863">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5039,10 +5039,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a39312b2-5bf2-4c60-a8e6-8db531921c00" control-id="sc-7.18">
+    <implemented-requirement uuid="45d19c4e-c44b-454c-9fbb-752ded2eb9de" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="21cbe437-3726-4db1-974a-aa758f929f60">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6465f86a-887a-41d3-8fb9-41efff535b3d">
+      <statement statement-id="sc-7.18_stmt" uuid="7048700e-5098-4673-a8c1-2b3b0689e9b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a302570a-baf1-4b64-95a5-418f3b1b1884">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited through organiztional network services, and is
 not applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5050,10 +5050,10 @@ not applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e3689c0-bbc4-40ba-9c1d-b0bd7eb8d368" control-id="sc-7.20">
+    <implemented-requirement uuid="fa27d8c1-17e7-479a-ad29-79394fe5acf0" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="6a1694a5-6c24-4231-b40d-6f5d347cb798">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6261db94-f990-4653-bcd5-b5c9fe3601bd">
+      <statement statement-id="sc-7.20_stmt" uuid="7be20532-cf9b-4c51-ace0-5a58e6819c60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29a416ce-e047-4d7d-98c4-5a6aec733db5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5062,10 +5062,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/456'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24a406b3-9bcb-4623-af73-851ad313e533" control-id="sc-8">
+    <implemented-requirement uuid="8cac9748-eb4e-49a2-9a3f-26850556ddf9" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="a5f3e9b6-669f-49c0-929b-73dc15138705">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="52843a30-9867-41b8-8d7c-1e29fa8e5a97">
+      <statement statement-id="sc-8_stmt" uuid="05a077ee-ec45-4eb0-972d-771fe6ba103f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fff8264-4e8b-42f9-a917-8c375d578843">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5074,10 +5074,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/338'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1161f2d-5baa-4610-bc2a-ab96a87961c1" control-id="sc-8.1">
+    <implemented-requirement uuid="7ad17e49-df76-494a-8aa8-5efee19f33fc" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="9dec7a2f-9512-441a-89f5-a0d73830b316">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1c5845af-742c-4913-9d2a-518f442cc741">
+      <statement statement-id="sc-8.1_stmt" uuid="fb1184bb-bd4c-4763-8085-e1687cad15ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d10479d-ba41-4841-a693-22e50f8e016e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5086,10 +5086,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/339'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="414f7eb7-eb9f-4572-a8f3-1ec32695d43a" control-id="sc-10">
+    <implemented-requirement uuid="668d8d10-28a7-4f20-ba55-80b5a10459b6" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="3e46bcf3-128b-4411-81cc-f349290090a9">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a9768e4f-6c9f-44a7-bcb6-63019aeadc19">
+      <statement statement-id="sc-10_stmt" uuid="9a102272-be39-42b6-910a-6b3cb14d06f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e69115a-6801-43fc-9501-d581b94a740d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5098,10 +5098,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/340'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d92b0e5a-369b-4d1d-808d-6c231e16bea8" control-id="sc-12">
+    <implemented-requirement uuid="54fb0366-a307-49c2-90d0-947efc58cbe6" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="dae6b789-cbe0-4b0a-8577-1315957df5fb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1d2cbf71-dbd0-43de-a24f-17949c6d9e23">
+      <statement statement-id="sc-12_stmt" uuid="9f86c3ef-732b-4fec-9c08-d8d69b47c671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6499aebd-e9ec-451f-8372-48b65980dd07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -5112,10 +5112,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24ec7eaf-948e-461c-a05e-290803545bfb" control-id="sc-12.1">
+    <implemented-requirement uuid="18ee39f4-e01f-4e1e-8277-3d74967407ba" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="57c85e5a-8b71-44e2-985f-22762a25791d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="85a124b7-cb07-4983-a8e3-357df3de5d7c">
+      <statement statement-id="sc-12.1_stmt" uuid="ef94e0ca-2373-4d38-ad3d-2418babb1c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="398f0d15-b331-41ae-abba-590679fba523">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5124,10 +5124,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/341'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="510a1125-8cc0-48fd-a24f-475a0c24a729" control-id="sc-12.2">
+    <implemented-requirement uuid="84dee7d0-1501-4bf2-bdca-b823b4ebd3c3" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="a923e614-6de5-4b46-8d69-f3ea081924e4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3103a801-6c68-4245-b536-c80de8fdeee7">
+      <statement statement-id="sc-12.2_stmt" uuid="91981e67-d91d-4ca1-8dc5-1e73d0a9eb2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="007db3e9-271f-4215-a920-8c7833ea3e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5136,10 +5136,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/342'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eaee494b-88e9-4e32-814c-defca6ca88fe" control-id="sc-12.3">
+    <implemented-requirement uuid="a1c927cc-a6bb-4250-a21e-9a9b0ef86970" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="7c7df06e-f67d-4974-9af9-981cc22476fd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="c97c3910-c920-4f4a-99a2-e09098c0dd93">
+      <statement statement-id="sc-12.3_stmt" uuid="8edf7687-ecef-4b09-b856-dcbe8a7aeebf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed390d74-1ebb-4105-a780-e9957f43d068">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5148,10 +5148,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/458'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="565ac35b-bbf8-4bc9-8c3c-8d0af9590e3f" control-id="sc-13">
+    <implemented-requirement uuid="82fe73df-fe8a-46fd-93e3-6e68fd1dce01" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="73d0e076-a83f-403f-bee8-c0c3b064ddb0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="adbbdca0-628e-47c9-8d77-145a67951802">
+      <statement statement-id="sc-13_stmt" uuid="a24dfcc3-ca6e-408c-9de2-6199ee954169">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d623f946-d2e6-485f-9e63-8804ae86d1a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat OpenStack Platform's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -5162,10 +5162,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c36a847b-9a86-4626-a3e9-52a2fb06f1c0" control-id="sc-15">
+    <implemented-requirement uuid="41d0736e-d38a-4f0f-8632-dd3ec102fbdb" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="0b2dde6b-ef80-41ef-9935-3d47d032af00">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="913c66fe-8bd4-4fbe-a905-194e1b4ecb7e">
+      <statement statement-id="sc-15_stmt.a" uuid="de8ded74-4758-4253-8fd5-fb3e89177f43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -5174,8 +5174,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="83b44d7e-c819-43bf-ada0-1e71a0f4b0ca">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="74502b0b-eef6-4f4a-a6f1-163179154b3c">
+      <statement statement-id="sc-15_stmt.b" uuid="3d7aebca-e951-4c6d-9696-d445fb60915d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -5184,8 +5184,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="5c15b063-3f45-47a0-8de9-5e32d98401c7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6ad1ac26-4da5-4afb-a873-9058ad23b3ec">
+      <statement statement-id="sc-15_stmt.b.1" uuid="0307a0ee-19cb-4e49-a8e0-c0e0982ceedc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -5195,10 +5195,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcdcd387-bf1d-4de4-8aba-229a1cc1865f" control-id="sc-17">
+    <implemented-requirement uuid="0c42ed7c-fe98-4751-9446-ddc704529bd0" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="d39b0140-c220-44fa-b07d-6bb04e57275b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="61c44881-0f8d-492c-8cc5-8fcaf38cffe6">
+      <statement statement-id="sc-17_stmt" uuid="6cae77a4-904d-4ada-ad8b-1ba5511c9b46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5206,10 +5206,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7a982e0-dad2-43d2-9c36-da3625097546" control-id="sc-18">
+    <implemented-requirement uuid="bba6e862-f95a-4d2e-831b-25200bdf5b57" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="ae3cc51d-bb75-44f2-9c76-bb9587dceb75">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7c93dfdd-b33f-4616-b589-dae693710286">
+      <statement statement-id="sc-18_stmt" uuid="9ba891f3-5d8a-42d6-8f71-6a8ee2015cb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5217,10 +5217,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="783107f7-9f43-4f75-a783-e64099b11880" control-id="sc-19">
+    <implemented-requirement uuid="09f8f984-7b75-48bc-a8e7-80d878910de2" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="b625345d-9014-4eac-af86-c9848c482e69">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="901f5aa0-d96a-44af-b10d-51a4e3e0d09b">
+      <statement statement-id="sc-19_stmt" uuid="d88c3e83-58ea-49ec-a1bc-6b2409e68a53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5228,10 +5228,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acfdccdb-2c73-4ef7-a5b7-41629aebc71d" control-id="sc-20">
+    <implemented-requirement uuid="587e6061-be2f-42d9-a980-af099b248ad0" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="59842e77-2d68-4277-8ec3-0c7ac4a12bc0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="20a88ee8-d46d-42e2-aa26-84c32e1d8dea">
+      <statement statement-id="sc-20_stmt.a" uuid="be3db02a-ef6f-441f-aa75-80753775c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6083d276-bc02-4ab4-b09b-aaaa8210d7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -5252,8 +5252,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="294314e8-471d-4ab6-a004-da6e2980eb54">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="197260aa-87db-408b-b4c7-a0ba360e7539">
+      <statement statement-id="sc-20_stmt.b" uuid="74d07e5d-09ca-4443-ab18-6212072e2b5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c16ee495-eaaf-4c06-a306-1c0f14762372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -5275,10 +5275,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbeb2d26-c4f3-4617-8ba0-056994a01181" control-id="sc-21">
+    <implemented-requirement uuid="b7439da0-1074-4eff-9dc8-e97a40ccd755" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="41288ae3-d515-43a9-a2e3-5fc9af3d8ef4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="49e4e618-b4ee-4cc8-b51a-c3e8e675a871">
+      <statement statement-id="sc-21_stmt" uuid="5b0ad384-b4bb-4c7a-b398-01aec1e97932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ea535dc-4d40-4390-a021-f94d268e34b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -5297,10 +5297,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b573905f-3485-4dbb-922a-d0b9a5c61b5f" control-id="sc-22">
+    <implemented-requirement uuid="e670fa18-c103-45c7-b9a4-75bf0781e6e6" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="c2f413ba-ad72-40f2-9134-0fc917da3a83">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ce7ed8cd-8426-4977-8f91-6b9071ae5573">
+      <statement statement-id="sc-22_stmt" uuid="452a4031-7e95-4f48-b97b-5c90224a8452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abf1e946-ac54-4d51-a595-1a819fe4d19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -5319,10 +5319,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aac3f6f7-ede2-49f1-b16c-74e0eec1b81f" control-id="sc-23">
+    <implemented-requirement uuid="3b63ed32-1fc9-4cf2-8f85-15b55365f768" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="33059a53-236c-4be1-a173-884dc7cb23cf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f38223d6-db25-49ae-ab69-4058af46bbb8">
+      <statement statement-id="sc-23_stmt" uuid="8d9c05ee-86dc-445c-99f0-7c3029e0f97c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c03d43f-7d1a-46f5-ac22-ee337f1a85bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5331,10 +5331,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/343'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9e5d4d5-3cb8-48f3-b762-ebf3ebd52c51" control-id="sc-23.1">
+    <implemented-requirement uuid="036afefe-673d-47ba-9418-314b4fba362a" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="497f6560-541d-4894-805c-b7777a9d48b4">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="524099b4-7d91-4144-aebd-e57ae147839a">
+      <statement statement-id="sc-23.1_stmt" uuid="88151a18-a759-4b7a-8241-4fb5f0b10349">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d3f4437-b2eb-4d15-ba72-19d77e230046">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5343,10 +5343,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/459'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="daddd1ec-a8b5-4356-80db-ed0d0c87c123" control-id="sc-24">
+    <implemented-requirement uuid="27979288-67bf-42fd-81b1-a7bc56785933" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="e2764ae9-6871-4e2a-9660-44eee6389ff8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="40a3606b-9cfc-4836-8eb3-1c536fb0a4d1">
+      <statement statement-id="sc-24_stmt" uuid="6f758f70-d324-4fe4-a811-96b2e4319c4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16eb89a5-e87d-42c2-ace0-a6df10b9bee7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5355,10 +5355,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/460'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5523830-688e-44fa-a627-b956d2aff6fc" control-id="sc-28">
+    <implemented-requirement uuid="9bf894a7-41ef-4333-9301-f712129350d0" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="149bb88c-782b-4833-a684-4442984e2518">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="990354bd-289d-4ae7-b8e5-0334def20f72">
+      <statement statement-id="sc-28_stmt" uuid="ef10eec8-3c4b-48b3-936d-b43cf7d08bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db7fee9f-746a-4496-ad0d-8ebd3587fa39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5367,10 +5367,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/344'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="facf6095-4be5-4209-8748-a807f69e34da" control-id="sc-28.1">
+    <implemented-requirement uuid="61398dd8-e71c-4b05-839a-8837b082d266" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="a97e4f47-6028-4a3e-9648-9751c145a977">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7d6e664d-942d-4fbe-b958-e15b2b3aafa0">
+      <statement statement-id="sc-28.1_stmt" uuid="364d204a-18a2-4767-a28b-05d034750867">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7946dcd9-315a-435a-9846-87107345e1fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -5379,10 +5379,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/345'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="787f9718-4344-42c7-9f37-160abde9f3fc" control-id="sc-39">
+    <implemented-requirement uuid="c9b7913f-61e7-44cd-a75e-3700a19fa70f" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="af504e3b-fa2a-4969-bc92-fabbf8931100">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fca1008c-d0b3-42e6-8cd8-8220925a5c53">
+      <statement statement-id="sc-39_stmt" uuid="dc3d7ebb-8faa-44c8-a7d7-586144f302e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91c59040-3dd5-40d8-8a46-4d9cbe3c5b93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat OpenStack Platform runs on Red Hat Enterprise Linux, 
 Red Hat OpenStack Platform maintains separate execution domains for each executing process by
@@ -5396,10 +5396,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ea627ea-a656-48b9-86e4-eee722397835" control-id="si-1">
+    <implemented-requirement uuid="36aaae06-070c-4173-9f7e-9255b0759f43" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="3ecfa701-d793-44b6-8887-6cf6567a8498">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="952b557c-76f7-40f6-9bd6-2c4cad9a8c98">
+      <statement statement-id="si-1_stmt" uuid="1bf3d73b-ec81-432a-91a3-fdcbeae4bbd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5407,10 +5407,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5ca0bbe-b074-4863-8b0a-c5ce80ba41c1" control-id="si-2">
+    <implemented-requirement uuid="e104b35c-ffc1-42d5-9aa4-e8a38a1e2e87" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="e822f8f1-3d33-4f6c-9b7f-122bf851b8a8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5f570b0e-3204-45df-bb43-faa25c6b11de">
+      <statement statement-id="si-2_stmt.a" uuid="a58d68ff-a3fe-4ff2-8eae-68a9f1e3e541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c9570cd-f6d7-42d7-a21c-c8795015c074">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their Red Hat OpenStack Platform deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -5425,8 +5425,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="d484b1a3-3047-494c-a360-b09e058d3d3d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="1cd68829-cd04-41b7-87c3-f79869dd19a4">
+      <statement statement-id="si-2_stmt.b" uuid="4e8316eb-eeaa-43a9-b306-c403125587e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c30dafd-1186-4dd6-908a-6a11de784a27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing Red Hat OpenStack Platform updates
 related to flaw remediation prior to installation. A successful
@@ -5441,16 +5441,16 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="e579c68e-2e89-4cef-8dfe-f66daacc9ff7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4a31f47b-cf0b-4e56-9220-ec3d3f157152">
+      <statement statement-id="si-2_stmt.c" uuid="5dfaf5f2-1c09-4083-acc0-418c60182226">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="d0ffbd1e-bb81-415b-8d4e-c7bcc3236e47">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e7aa3be1-77ab-46fe-ab1a-85358e7e6a0d">
+      <statement statement-id="si-2_stmt.d" uuid="87aa208d-7298-4e88-9a0d-ad50b66b39e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5458,10 +5458,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f5da844-e98a-4c2d-97a9-a3de637a4c7c" control-id="si-2.1">
+    <implemented-requirement uuid="564f0b21-b388-4c2d-a516-c053a1ea460b" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="9fd94247-6338-4461-b20d-407a2dfe4cdb">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5535cb53-c2b7-474b-a8c3-1e6069a71954">
+      <statement statement-id="si-2.1_stmt" uuid="400c3a1b-7be0-447c-b32c-db675cd27fdd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28278d73-7e41-4826-8ecd-bc08b860532b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5470,10 +5470,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/461'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c72d27b8-6aa1-4829-b565-1d96b183744d" control-id="si-2.2">
+    <implemented-requirement uuid="709d7f22-ea5c-40f1-b71b-08917dac116f" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="011fe1ce-eae2-4801-b6f7-405a52dd48ee">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ff246d40-0eff-4433-ade2-b7157cc2a930">
+      <statement statement-id="si-2.2_stmt" uuid="c2395120-5416-4236-908d-20c6e9b6b070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60f57620-5d98-4519-8f25-65f012658c99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5482,10 +5482,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/352'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bb250e1-01be-44ac-b7d6-378135604b8d" control-id="si-2.3">
+    <implemented-requirement uuid="ff3db862-1059-4928-9929-aabf66b2140a" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt" uuid="b29cc57f-b17d-46e6-a572-5ce6135326f1">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="392f5543-fdd8-4e02-992e-902a10e724a5">
+      <statement statement-id="si-2.3_stmt" uuid="3195f814-bc48-4e70-b1b4-9c64b74296df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5493,10 +5493,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d105759c-2d9f-474f-87c9-de6c3d2761db" control-id="si-3">
+    <implemented-requirement uuid="2812760f-5254-41f2-b1a1-f74814974da7" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="6ed87ec3-0096-4dbb-97e3-f19ab85f1dbf">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="62411d53-7c4e-47c1-9256-787a64f48add">
+      <statement statement-id="si-3_stmt.a" uuid="7a172af0-bc2f-4793-b91f-25ec8df73766">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a50f1a-939b-44cf-988d-c66293991147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -5513,23 +5513,23 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="42ba3ab8-1685-46ca-9671-0921642ca33b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="30cd0b68-2a62-4f2a-a939-7c29322ea4a8">
+      <statement statement-id="si-3_stmt.b" uuid="56266789-1f6e-41cc-aaeb-af9acf5beaea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="b961e96c-4d50-4772-9213-59193f536a4f">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="5cf0f583-4bbe-44bd-a50f-57c8ad2c896a">
+      <statement statement-id="si-3_stmt.c" uuid="331924f1-48dc-442d-8083-a140b791c8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bff9f-8d25-49a2-a5e6-3d8966638ce1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat OpenStack Platform, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="9c24a469-e4c5-4e0e-a55c-2742dcb91c4e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="6dd969bc-41e7-48ae-bb53-fb4297c2cafd">
+      <statement statement-id="si-3_stmt.d" uuid="91b6319b-771a-43c4-8de9-56c92a44d5d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5537,10 +5537,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cddf17c2-0533-479c-877d-6a262b09f3d1" control-id="si-3.1">
+    <implemented-requirement uuid="9b061595-98f5-4d6f-b399-08c2bb7c358d" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="1c5fc650-707a-472d-8365-93fe989fd1dd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="3df61109-67aa-4a7d-b2f6-1a10dc31984a">
+      <statement statement-id="si-3.1_stmt" uuid="d6500525-493e-41a5-8db9-8d2f5e031ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00c9f1e2-85cc-416c-9d30-f4c2ad9423c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5549,10 +5549,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/353'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06a2828e-3eee-4c80-88e7-8a81a5cec68f" control-id="si-3.2">
+    <implemented-requirement uuid="86ec2e5f-c5ed-4889-bb70-13f3c84dd65b" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="57b56a76-627b-4d1f-8b20-79dbce27ad08">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="79fdc271-c30a-413f-8e52-27f6384634a5">
+      <statement statement-id="si-3.2_stmt" uuid="7797ccc5-12d8-4524-bc14-bd33ea950bc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5aa654f4-72c1-4705-819f-50b7b3fc1947">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5561,10 +5561,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/354'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83ee784f-4d2a-4ee9-a048-45771c9372ba" control-id="si-3.7">
+    <implemented-requirement uuid="820ad5b1-5f6b-462c-98ae-5ac290ffa48c" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="00ac642a-4c5f-4763-a756-ad6a65dcc54e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="16e02fe9-806b-4492-8c06-059259108245">
+      <statement statement-id="si-3.7_stmt" uuid="87f40c2d-e397-42e6-9ded-75b48c90a4e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f403b4ce-628e-49c5-9add-c728235517e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5573,10 +5573,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/355'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="284012b2-f1ea-46ba-8981-980038151ee4" control-id="si-4">
+    <implemented-requirement uuid="015f2cf0-6be8-41c9-9664-b065997fc3b3" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="666ff8d1-dfde-402a-9e8d-f322a5b79170">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="e749617b-3ad6-4dab-b0e0-b6ef5f8590d3">
+      <statement statement-id="si-4_stmt" uuid="a1af621f-f036-4b5d-a442-f03cf89e2107">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5584,10 +5584,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fe2f6cd-3cf8-444f-8aef-499efd2615e4" control-id="si-4.1">
+    <implemented-requirement uuid="3b7fadc1-54a2-4b65-8fbc-5db46941b03f" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="e989b057-3870-4944-9fa6-092b718d855e">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fd5a16c0-2698-4cf2-bec6-d62d892a18e2">
+      <statement statement-id="si-4.1_stmt" uuid="efafa5de-dc9f-4747-831a-8ec0082ff07e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5595,10 +5595,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fb77856-1e95-4e6b-8525-ef052153c400" control-id="si-4.2">
+    <implemented-requirement uuid="4af70130-4686-4312-99c3-d2290c00372d" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="4a14f5ce-1e47-42e9-946f-24f6d72a8967">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="81860f92-6f0d-4d4b-bd8f-11db0530d37c">
+      <statement statement-id="si-4.2_stmt" uuid="425adedc-71f4-41e3-be99-f10b297c0fbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa45dee4-c612-43da-8820-a2c6cea408f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -5607,10 +5607,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/356'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="459e6b9f-c5df-49a9-9c37-86e00e3d145f" control-id="si-4.4">
+    <implemented-requirement uuid="51f88d75-231f-45e6-a8c3-7b2b73e81f0b" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="91b0417e-30f7-4129-a409-a9fde52a35ef">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="bffaeeb2-e5d2-4bf3-b350-2545b014a486">
+      <statement statement-id="si-4.4_stmt" uuid="3e97aca5-7376-4b5a-8798-f0b81c476c3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5618,10 +5618,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8acc1e2-304d-4fdc-a7dc-9f0951b68481" control-id="si-4.5">
+    <implemented-requirement uuid="df2fa7eb-f909-4f1b-b3c8-bb3606981320" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="d1b41ded-480b-4a69-bd79-a4f6cd9b60cd">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="534da8e8-7907-40d3-86a7-2ed5775cd3cb">
+      <statement statement-id="si-4.5_stmt" uuid="2b3e411e-7726-488a-b364-38cda2e71222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5629,10 +5629,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7eb6effe-955f-44fb-bbf3-83caa8fdfd07" control-id="si-4.11">
+    <implemented-requirement uuid="35bbb6f5-be42-4b19-99a2-d9438993a234" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="45407bab-ff30-4f3d-a359-29e78a06a53d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="662cca85-0c8e-4f91-b8bd-ad9f8e698eb2">
+      <statement statement-id="si-4.11_stmt" uuid="1289ff92-06d5-4a45-b055-dc210186e9bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5640,10 +5640,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="876990be-a906-48bd-84e4-61ca5389aebb" control-id="si-4.14">
+    <implemented-requirement uuid="be0fb0c5-5f8d-43ba-b386-aa7e00dd586d" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="d420409a-8620-4b70-a3bb-167501d98310">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a775d48d-7ffe-4c4d-9307-179cc042151a">
+      <statement statement-id="si-4.14_stmt" uuid="831e3075-50ce-4426-a61f-9aaa3d93f889">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5651,10 +5651,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1b2735c-6a46-487e-a5b5-d447f9e5ee85" control-id="si-4.16">
+    <implemented-requirement uuid="2af9c4d8-4fcc-4078-adc4-c5b58a4c3457" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="8d5a504f-ec04-44d2-9103-9d43791df687">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="ee898441-5d17-4880-a5ff-2cc397c40972">
+      <statement statement-id="si-4.16_stmt" uuid="c2c8c12e-e202-4e70-b875-d2f5c7672365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5662,10 +5662,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6981a79b-c86d-4c7a-9739-3f629302e0cb" control-id="si-4.18">
+    <implemented-requirement uuid="b90ba339-6cb9-4c67-8266-9f9d02083603" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="f7068254-cdbc-4852-ab60-35a66c4bc1a2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="4d22255e-def2-44ff-80c9-ad605e20990b">
+      <statement statement-id="si-4.18_stmt" uuid="f1d0cc33-e401-487e-bf26-97d7d5292c3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5673,10 +5673,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="675c4efb-c4f4-4396-a58b-affc94905d52" control-id="si-4.19">
+    <implemented-requirement uuid="be19670a-27e6-4f04-a758-64db3e2c4ad8" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="130ca224-2273-43c1-9a98-13a19bc3a5e8">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f80cca0c-86a5-4281-9b9c-8543d499884f">
+      <statement statement-id="si-4.19_stmt" uuid="bfa38528-86dc-4cd2-ae72-a47f2b516684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5684,10 +5684,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9082c32b-af1e-4e5c-b2e1-84c1e99441f7" control-id="si-4.20">
+    <implemented-requirement uuid="737ef320-a538-4153-bab5-d460012b7759" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="c43aa37d-1dae-4acb-9a29-28be6a6f0bb1">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b5fb18e7-8357-4321-825f-6b818bdf887f">
+      <statement statement-id="si-4.20_stmt" uuid="7212054f-f172-44d6-bb42-60c288c52eb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a117a0a-4b42-4aba-88d0-108561a14ea8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked
 on GitHub:
@@ -5697,10 +5697,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/462'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7c35a39-2d42-4bfd-980c-400b90f96897" control-id="si-4.22">
+    <implemented-requirement uuid="4d258593-72e0-4bf7-9bdf-eb140c0f2f28" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="56d9fb50-311f-4aac-8081-e8fbd886bf47">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="03a38d1b-3ca2-4b0b-8971-d6eacaecdc8d">
+      <statement statement-id="si-4.22_stmt" uuid="a9f8acac-7d69-4451-8ee6-02f9ee59ec97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5708,10 +5708,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd6d183c-ab5d-4f1e-83be-f91b399d6dd8" control-id="si-4.23">
+    <implemented-requirement uuid="cf6bc27e-1fce-4a08-bacb-617f5536d097" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="f927c1be-a156-49d2-8c24-4dcd78e2a50d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="69d2c4af-1577-490d-b999-6a7eea0daa8f">
+      <statement statement-id="si-4.23_stmt" uuid="a752fb6b-d49e-4cf7-87ce-9f9405813dfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5719,10 +5719,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab043e68-acbd-4adb-aa4d-34e77355e3d2" control-id="si-4.24">
+    <implemented-requirement uuid="969bbbac-a486-4e28-85b1-d855ab647e25" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="4bf14d08-3207-4185-b367-66c44840984d">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="8f083d26-17d4-4755-b36f-78a01cbcbbce">
+      <statement statement-id="si-4.24_stmt" uuid="d36b4211-7d38-4c4d-b79a-13a3778fdff1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5730,10 +5730,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="056570f9-4d15-4b69-b31f-99d340e09321" control-id="si-5">
+    <implemented-requirement uuid="a0027a0a-4d7e-4249-8cf9-d5cb3c5e9d43" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="ab6c171f-e827-4d63-982b-6deb3ddfe0c6">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="2d88b824-4591-42e6-b4d2-4ccabb7c0607">
+      <statement statement-id="si-5_stmt" uuid="294d6cea-5864-4fbd-a065-25cc729a4853">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5741,10 +5741,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5987e36e-8073-4b29-916e-dbb03d426b30" control-id="si-5.1">
+    <implemented-requirement uuid="9df2030a-d1b8-4877-a360-bc251770962a" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="634b0a62-a8c7-4b45-8c8c-8ad3f155777b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="eec668b9-2b7d-45a3-a91e-24122bdd0eb1">
+      <statement statement-id="si-5.1_stmt" uuid="ec43762f-288e-42e1-85b1-74d4c414330a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48b7f66e-e628-4594-bfaf-b200a56c5e08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being
 tracked on GitHub:
@@ -5754,10 +5754,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/463'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e9623bd-7efb-4c25-8023-9e5d972f18cd" control-id="si-6">
+    <implemented-requirement uuid="d4bd2bba-7d4c-4d6f-9f8d-06c02e00a9f4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-6_stmt" uuid="43c8c606-4e0b-47fb-9ed6-75583f9200f7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="67be9b5a-c5ee-49a5-a163-71cc9af941fc">
+      <statement statement-id="si-6_stmt" uuid="8e704439-f2ec-4401-b02f-fce8f26763c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5765,10 +5765,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17028776-74ed-4bb4-b1dd-386b61c3cafd" control-id="si-7">
+    <implemented-requirement uuid="ca323c85-f0f9-4756-ad37-f85f6f9b2bf7" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="6d856607-d20a-4746-890d-2a7ff9a918ce">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="7f6ccd9d-782c-4ed9-8df4-93d0eff8729b">
+      <statement statement-id="si-7_stmt" uuid="8d7a116b-9ad1-415e-8145-71714fd570df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40e946f0-a441-4779-8f17-ecf6c9d44b6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5778,10 +5778,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/357'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66a4745c-92f4-4e68-8242-26565601722d" control-id="si-7.1">
+    <implemented-requirement uuid="dd58363c-bfa1-4d28-a720-7f7e85ab823e" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="6d826716-c8c3-461f-9cbb-8bfef8ae94b7">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="230e498e-e5a1-475c-95cf-ed94e420b39c">
+      <statement statement-id="si-7.1_stmt" uuid="9f935daa-9bc8-4370-81cd-1cacac1f79a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbbfa090-efe7-4dd2-87e2-21e09755a049">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5791,10 +5791,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/358'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb01f0d7-2324-49c3-8e0c-de6daa67394e" control-id="si-7.2">
+    <implemented-requirement uuid="f87c798b-9f0a-40fe-aa69-deb20aa41319" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="9f9f5044-9dff-4ea9-ab85-e0eb06669c3a">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="fd1b5bb9-f8e7-4628-80e1-c273b5d6e942">
+      <statement statement-id="si-7.2_stmt" uuid="b7713486-905f-4f43-ad3d-e490cbccdb00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28900fe6-b905-4e6a-a905-14496becea9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5804,10 +5804,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/464'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7765f78d-cecc-489d-8d4e-f7bb293ea919" control-id="si-7.5">
+    <implemented-requirement uuid="c4d65cdb-458e-4f41-8484-9f939fbc15c9" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="770d3f39-8974-4674-a5f7-cc682829f725">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="972644c3-c403-4d55-ba6a-bafa020238ec">
+      <statement statement-id="si-7.5_stmt" uuid="c7d678c7-3796-406f-8370-14ccce7aa10a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96cb4b72-d50c-4fa6-b421-e7d1cd8ce3e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5817,10 +5817,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/465'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27dc9f75-d016-424e-81f3-1da9a2384e64" control-id="si-7.7">
+    <implemented-requirement uuid="d1cac6cd-a534-48ac-87d8-c99f86043a63" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="72951828-8185-458f-a313-e4253a75106b">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="dc4d75d5-45b3-41d3-b272-9d945b28fb42">
+      <statement statement-id="si-7.7_stmt" uuid="4a882c6b-aad1-4bb4-bfa4-7730002c9e1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5828,10 +5828,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1740748e-be9b-4fe6-a713-757785dd449e" control-id="si-7.14">
+    <implemented-requirement uuid="3171c5c4-988e-44cb-8eba-9ffb825309a5" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="2f00535c-1594-4d95-a0d8-0b28181259b0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a5ccd1ea-5ef3-4dfe-9a95-7a6310d1f443">
+      <statement statement-id="si-7.14_stmt.a" uuid="cee7afe0-e02c-4822-873b-39ebeaad8d0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c0d8636-2eea-4928-9858-ee4a86aef27f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being
 tracked on GitHub:
@@ -5840,8 +5840,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/466'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="7e7ef07c-8258-4503-97bc-a8820be1d541">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="0c9c78e7-7aad-42d6-8ee6-688e293900ee">
+      <statement statement-id="si-7.14_stmt.b" uuid="dc1d47b1-322e-40d1-b837-55d924a44eed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5849,10 +5849,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6749c6c5-dc81-4ec2-be7b-92bc06a06120" control-id="si-8">
+    <implemented-requirement uuid="4a2ec50f-6030-46ae-baf3-29132fe7f33e" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt" uuid="9a6d1303-8443-4bc2-907f-7a703e8ea447">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="54cf32f7-078c-4e5e-b5e2-6346a48b7635">
+      <statement statement-id="si-8_stmt" uuid="4f27fc41-928c-4630-9f82-88ff2885f2f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5860,10 +5860,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9cf56f31-4006-4df7-9cd2-f90cbc281470" control-id="si-8.1">
+    <implemented-requirement uuid="16e714db-5fbd-45f3-ad39-82aaefe53223" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="999ff134-dcad-4551-9e73-5f1eb8e63ea0">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="a3c263eb-382b-44a7-a68e-c705f59cb2c4">
+      <statement statement-id="si-8.1_stmt" uuid="7270326c-312a-4874-ae93-60940779b33f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5871,10 +5871,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c34fc05-26d2-411a-8a73-2d95b28fa235" control-id="si-8.2">
+    <implemented-requirement uuid="5303db93-adca-440a-8247-a6573f9bc82e" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="c609750d-a363-4043-b883-b85224a25867">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="d6a5fc64-8bc2-4446-befb-fe96384e425d">
+      <statement statement-id="si-8.2_stmt" uuid="1a675a3c-7a27-4677-bd6b-78fda88b4d25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -5882,10 +5882,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd86b45c-f1a1-4d8b-81a2-845e7503a97f" control-id="si-10">
+    <implemented-requirement uuid="e2660d38-4a0c-4a2a-8ef0-d695c5105e87" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="da54208d-e447-4877-bb76-ca42a18d6936">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="aa3756b6-21fa-404b-9577-5a7e8ce89123">
+      <statement statement-id="si-10_stmt" uuid="36a6ee57-3087-4cba-a2ba-b20ac07dbdea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de2bd73d-a052-48e1-81d1-e2913854bdc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5895,10 +5895,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/359'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d86d718-fa60-4a86-86d0-645ff1bf5ad5" control-id="si-11">
+    <implemented-requirement uuid="2aac5a50-245f-4443-a5ac-47b72d68f547" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt" uuid="ad533c56-4477-406d-96c3-304c8d8c81e5">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="b7169890-571c-40e0-8b72-1eb9e22f50f6">
+      <statement statement-id="si-11_stmt" uuid="2110b0ce-e256-4fca-a4c2-85adcc4b98e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0f60567-f28f-449a-9bb6-88d7b0700597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -5908,10 +5908,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/360'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5dfddbb-3d94-4bfd-b4e9-552eb5b1bc97" control-id="si-12">
+    <implemented-requirement uuid="42d0e62b-ea7c-4de8-bd7f-5fff9b0c88bb" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="5c140ba8-6755-4ce0-b3fb-81caf397e1d2">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="f9ef3a93-9062-4045-9a86-6d83d6b10392">
+      <statement statement-id="si-12_stmt" uuid="c50450b5-45de-4bbf-8ee5-07b8f34c0f29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d14b017-b855-4191-a33f-cbd27d8d8407">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat OpenStack Platform in
@@ -5931,10 +5931,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6048a3e-d281-4e66-9dff-06d64486b5bb" control-id="si-16">
+    <implemented-requirement uuid="3f335609-3bc5-4a94-ad29-eb55091ab008" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="b9d824ba-017c-4025-8cda-abdf1b820b16">
-        <by-component component-uuid="fa9f0238-251f-49cc-9b95-fc1a2e38014a" uuid="06eccd24-16e0-4026-89be-de3bb74fd671">
+      <statement statement-id="si-16_stmt" uuid="ffb9c9cb-5304-4c9d-a093-eb857932ab6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5de61587-1d30-477b-9c61-9a3dc01edcfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack inherits many memory protections provided
 by the underlying operating system. When running on Red Hat

--- a/xml/openstack-platform-13-fedramp-Low.xml
+++ b/xml/openstack-platform-13-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="10c8d8cc-b5ca-40b2-987c-1772b5266962">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="797785b4-61f5-4d16-8300-15b43fb7cb20">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.11+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.84+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="458b0c7c-1392-435e-a3f6-8369f7b7fc61">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="7f7cac39-b38a-4fa5-8513-d443da2dd98a" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="d4c77fed-9ebf-4b9c-bb04-a4dedf0bde89">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="6b2b6f51-54b1-4b23-8320-8d5b0807c155">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0187b013-1985-4137-a860-4cda811aefcf" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="4d56bc1c-772e-47c6-b220-67d898e6570d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="cd5856bb-1476-43d1-9df8-9c02264e0ed6">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f1deb50-cdeb-4c85-abbc-76f376657d1e" control-id="ac-3">
+    <implemented-requirement uuid="37a855d0-90d2-4883-8052-2b76137d3ba7" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="9958e922-1875-4ecf-946f-dec8151cd37c">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="d1d3c19b-62d4-4da6-aef5-a42350ee3b96">
+      <statement statement-id="ac-3_stmt" uuid="2da5110a-ab42-4c47-b656-d66a42f3ffba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfc41980-03f9-4cff-a609-6f46c86e694d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The OpenStack Identity service supports the notion of groups and roles.
 Users belong to groups while a group has a list of roles. OpenStack
@@ -517,10 +517,10 @@ and association to determine if access is allowed to the requested resource.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="588f274d-33ba-47ed-a9d3-7b22dc42fa0e" control-id="ac-7">
+    <implemented-requirement uuid="190b26d2-10b1-47e5-88f6-450145e92ed2" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="a31fbbee-4202-4015-81ed-19a38eb57616">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="77eb981d-bd9f-4c67-8d72-0134a0806b58">
+      <statement statement-id="ac-7_stmt.a" uuid="1bef3d71-d9b0-4cb8-879e-600174407f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -529,8 +529,8 @@ to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="3bfdb0b5-7403-4e88-97d5-f7437e0217c7">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="f35c4690-8b07-4161-833a-a3a4a1a31078">
+      <statement statement-id="ac-7_stmt.b" uuid="be2edb42-6f1f-4727-b9d5-0bfc96898c49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -540,10 +540,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c245748e-df27-4326-941a-26fcf1394e38" control-id="ac-8">
+    <implemented-requirement uuid="3c7dcd8a-8a1c-4720-a1bf-425a9b810f7c" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="2f06989a-0665-4dac-ae44-56ed09e9ee3b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3b0c5e41-53ba-4d21-96b5-be2ed80fe6e4">
+      <statement statement-id="ac-8_stmt.a" uuid="4e30b817-eda8-41ee-9a23-2f19799b50d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1018d6-5f53-474b-9d19-092699fce6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -562,8 +562,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="ac150422-6a6f-4d98-90fc-1e914916ce13">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="5e008d8b-a07e-482a-92d2-75d24367f29d">
+      <statement statement-id="ac-8_stmt.b" uuid="8cac1383-8b47-47dc-b910-b8abe32cd73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c110a8-4332-4751-8dd3-d5e9c088377f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -577,8 +577,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="e7b03e4c-e75d-42e5-a072-dcefe1973aab">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="12fc0f1a-b989-40c1-aa32-ee92b3bd1bc4">
+      <statement statement-id="ac-8_stmt.c" uuid="1959d416-63d4-4558-9ff3-02e1060844b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bad8105c-14af-47b5-a477-194b9d3efd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -594,10 +594,10 @@ It is recommended the same banner be displayed as configured in AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8216039e-ad9e-4340-a2dd-b739cbebc285" control-id="ac-14">
+    <implemented-requirement uuid="a0c92060-22e2-4929-8d06-ec1468232753" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="50dbdc51-9151-41a7-8ee8-5c3333d54bdb">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="0881f23e-3572-4f7f-8c63-abc556510ccc">
+      <statement statement-id="ac-14_stmt" uuid="1ffeb67d-0d45-487c-ba49-416acbcfa90b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="116c1ecf-7617-4874-8eee-3900fc91dadd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat OpenStack Platform Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -610,10 +610,10 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efe1ec73-a288-44f9-b730-67b1d3b0c0b6" control-id="ac-17">
+    <implemented-requirement uuid="a28a91c2-7adc-4a36-9e89-fc7a048894cd" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="9b249a58-7326-4ec6-8499-e61b84e08a1b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="ac864c53-0631-4521-aa87-8ed08d054a21">
+      <statement statement-id="ac-17_stmt" uuid="1c3ac4b9-ae12-4073-8905-ec981d0f9d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -621,10 +621,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ea6affe-ef82-4879-85ac-f4deaf5de26f" control-id="ac-18">
+    <implemented-requirement uuid="542db06a-3132-4641-b932-b44a95c3b37b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="6fe9e565-178c-434a-8d02-d3d4cb772c2a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c9aa245f-fa74-4404-9884-bcc7993cda46">
+      <statement statement-id="ac-18_stmt" uuid="bc5a066c-bcca-4690-b7da-88aa4df0ee25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -632,10 +632,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c936c5bf-4b0b-4824-b8da-c8a8bba3297c" control-id="ac-19">
+    <implemented-requirement uuid="dc10d2b7-c173-4f90-8d04-19b3de77a1d2" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="76f885fa-5642-46fb-8eee-be91d5cbbe52">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="69529832-f11f-4db2-a184-d57070d60760">
+      <statement statement-id="ac-19_stmt" uuid="b7e8d38a-57c8-4abb-9006-60327755e2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -643,10 +643,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="159416e8-17ae-48b3-9ded-b9502e4e6035" control-id="ac-20">
+    <implemented-requirement uuid="f7a0ceec-9299-4a0a-af63-ec3782f76704" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="a7ed9be8-84e3-4fe6-9f32-c07956aec8bd">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a7f2dd30-db6c-4164-887e-0db692fa8c38">
+      <statement statement-id="ac-20_stmt" uuid="2bedb697-599f-4296-8f4c-07a074100182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -654,10 +654,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e65b1e90-87ee-45ee-b375-0113233261c5" control-id="ac-22">
+    <implemented-requirement uuid="9dfce701-b6ba-4df5-a330-1fb7562f33cb" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="aae899d6-f71e-44b3-a457-b5b5268e1e72">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="db398c74-772f-49e6-892d-99aefc3204bd">
+      <statement statement-id="ac-22_stmt" uuid="2b36af0f-a585-4fe7-9ffc-093a778a9e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -665,18 +665,18 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4755cd8d-0ac5-480b-890c-440565a6d628" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="ffdabbdf-f3a7-4fc6-a110-b195ce21757e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="572dd504-4a86-405b-a5b6-e5865c661f1d">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="c660d58a-0a0f-4f47-b142-6109e505fcd3">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="2ef5defd-7fc9-44bb-9c3f-ad0583678dec">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -684,26 +684,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="628906e4-a0d6-4ffc-8db5-0575ca0b6298" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="c7a5e342-4a8f-43c6-b804-6c4d32f4ebbf">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e47719ad-1452-4f67-8f23-812f34d0e55b">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="5c22b55d-104d-4a6e-9ad2-389c3e6632fc">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4caa2432-7e19-478d-9ab7-79abf0c90281">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="3bd238c7-0dd5-4411-8c7b-c7eb81e42979">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="760277ac-3c44-4529-a36c-1ee0d9235565">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -711,26 +711,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38ea04b1-6b65-4832-a1be-234e67bbe949" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="049bb802-3bac-48fa-95e8-5a28c6c17ccc">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1c2818ae-23d7-46d2-bde0-a44bec11f8b1">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="bbf88c7b-00a0-47db-8479-e2af3015d17f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a39a88f1-0ed1-495a-927f-6c34dc3edc3a">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="ea248057-df7b-4d04-a70e-3b0e5d10e484">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="01fbd516-4de0-4cc4-9596-32010cfb0065">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -738,18 +738,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f93ca663-f5a8-42b3-bcdf-ff4778b4540b" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="bea609e3-75d8-47b2-b9fd-ba4f0c4940e2">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="341ef204-06f7-4ba8-89d7-9e2ce32f3b83">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="3ce3e5cb-8201-4bdc-bcbb-47463f947070">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="80916466-2d92-4edb-8b14-7805a71394b2">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -757,10 +757,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5144914e-af1a-4561-a178-0d913055de70" control-id="au-1">
+    <implemented-requirement uuid="9bf02c5e-bac7-426a-99ee-612029fb4422" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="79ab4e5f-4439-478b-9b45-f5116526019b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="68379ecc-c476-4e3e-9123-f0df4f07b958">
+      <statement statement-id="au-1_stmt" uuid="022814e1-5123-48e3-9bb2-414d326089f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -768,10 +768,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f433326c-887a-467e-bc50-7a21dae0e424" control-id="au-2">
+    <implemented-requirement uuid="70ebfe3a-dd07-44bb-934a-1f049c3df081" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="1027f264-5a05-4af7-873b-f8bfbfb6d342">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="994765c0-77c2-4860-b820-916e6f1680a6">
+      <statement statement-id="au-2_stmt" uuid="c740b0e8-7529-4771-86c7-7abaee9d8e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ec78773-f971-4af8-a715-99a4cfcc3d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.
@@ -782,10 +782,10 @@ Red Hat OpenStack Platform through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee4c8a32-919e-4403-9d00-8a6deab02e85" control-id="au-3">
+    <implemented-requirement uuid="fddce8ff-c1d3-4b41-ada0-b62b24cfb2b6" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="38ee49a6-b868-42dc-8959-a1b094938aa1">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="00932411-1442-46f7-9c2f-df6cf4f03e77">
+      <statement statement-id="au-3_stmt" uuid="a3c40616-3e41-45e1-a8b9-63205765ed89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6cd09a8-08a4-4f88-9f72-1429acae092a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform audit records contain this information by default. No
 additional configuration is required.'
@@ -793,10 +793,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e0ab18a-2013-42f9-ad8b-a68549d27f78" control-id="au-4">
+    <implemented-requirement uuid="3c3a6218-edb3-4574-9991-1c281a4af6db" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="57017563-3f9a-47ab-8c69-3b0ceffd3ff6">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e7c97809-7cf1-4322-9a1a-68be2c6c9d22">
+      <statement statement-id="au-4_stmt" uuid="c897c7e2-3bf6-4ea2-9c5d-0971f6de0e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b11dbe7-4a7e-4827-b1dd-da2cfd809e31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform. This control is reflected
@@ -805,10 +805,10 @@ in proper disk partitioning of the underlying Operating System.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e5d23ea-a158-4f84-8c9b-73d8ac5c03f2" control-id="au-5">
+    <implemented-requirement uuid="d867a1bc-cbd0-4edb-b26e-9b1b0ed32513" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="86da32b8-4fc6-4708-9790-2011c0135fb5">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7dd8579f-427d-4a10-9f46-ad3ce81c088b">
+      <statement statement-id="au-5_stmt.a" uuid="681d6b0c-120f-4476-863f-0a8b4bf8f3a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fc991c-c801-45c8-baa4-ba3b169595d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -822,8 +822,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="92560e42-36e7-4b71-bc4c-c129d4e7ab9e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b7177087-a34e-407d-aa00-cc6d1099daee">
+      <statement statement-id="au-5_stmt.b" uuid="ef5f7d6b-80d0-4295-9ea2-505668e025e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3dd40bb0-312a-4bed-abed-0be2db2606ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat OpenStack Platform Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -834,10 +834,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dad828c-5dd2-42b3-9e2c-4430a3538195" control-id="au-6">
+    <implemented-requirement uuid="3c5d91fa-2336-4a39-9f4a-38b9178be864" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="589ff0bd-9ab0-4fba-b7ce-b5823584e61a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="fe380fdf-64a7-48f0-8ec5-0a3e9a3777b0">
+      <statement statement-id="au-6_stmt" uuid="382fddb1-91a1-4a1a-bb6d-169861ccd7ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -845,10 +845,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b93957a-88ea-4c6d-9dfe-574efc5079d4" control-id="au-8">
+    <implemented-requirement uuid="d4452df8-ab68-4376-94f8-4849a8bfb851" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="a856eccb-8949-48ce-b12d-21a26b75446f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="6564989a-274f-4ff9-8d40-f7f054f04418">
+      <statement statement-id="au-8_stmt.a" uuid="ebf16490-e892-4926-8e04-5f05a2d4e1cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -856,8 +856,8 @@ of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="0e842c17-7087-4042-b2c4-0720110080b0">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="863341be-00ac-4ac9-8577-41f6f801f496">
+      <statement statement-id="au-8_stmt.b" uuid="9d59163b-c469-4dfb-a1f6-7425f23f0381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -866,10 +866,10 @@ of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6039e23-222b-4222-be56-ad76167f0c32" control-id="au-9">
+    <implemented-requirement uuid="146245dc-fac0-4451-80ed-bf2dec829320" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="68aead9b-c922-4d93-81b3-ecda31202bef">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c70a72d4-9a16-4177-8a8c-3070659b3fe4">
+      <statement statement-id="au-9_stmt" uuid="3733f6ae-83ff-4751-9dbe-8c2ad28014b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6dfb370-517c-4b4b-9d2f-bac24716a925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -885,10 +885,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1d12cc0-dba2-4eb6-9a51-d2c2a626fe11" control-id="au-11">
+    <implemented-requirement uuid="5c7ff55f-ec1c-4d4a-87d2-82ac5696a9d0" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="ec9e3564-e848-4fff-a5be-9925c0abfbbf">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="392a5036-d01a-4f55-9934-366734553fe0">
+      <statement statement-id="au-11_stmt" uuid="aaeb8b45-0e00-40a4-84f0-bd5cf83dbcd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c10fb204-7d24-42e8-9c63-567b6cfb25c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -898,10 +898,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20d54d63-5b59-426d-9d24-5aee4e021f22" control-id="au-12">
+    <implemented-requirement uuid="1967f2dc-1435-4eda-8ccf-ba5ba151624e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="0ed15599-110a-4505-9912-9834e931b59b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="dd326a05-843f-4a0b-b1e3-51c620156439">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -913,8 +913,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="88fdd430-e3b6-4577-9eda-f6588e54d4a6">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="6865327e-5b98-4cb0-a88d-726ac3391bad">
+      <statement statement-id="au-12_stmt.b" uuid="731aa217-5c07-46bb-ad2d-632e3255dd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f61858fc-aa00-42fc-ae4d-a24a7acf2895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -932,8 +932,8 @@ is recommended that Red Hat OpenStack Platform specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="c46a2fa3-755a-436f-9a5c-a473841f7981">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4e95ef6d-34d5-4f75-bddf-52acfbac5ab8">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -945,10 +945,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18c24a19-5c35-44c7-9943-84bbe80cc148" control-id="ca-1">
+    <implemented-requirement uuid="d87cdbc6-4547-433b-b751-62499a9ce52a" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="4103c98a-0111-4628-8559-cc9d48a9896b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a47f907b-953e-45a8-a94e-59e62823b50d">
+      <statement statement-id="ca-1_stmt" uuid="0f646fc8-76a1-46f5-93a8-c55da7cc75af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -956,10 +956,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="731bcfa5-eb53-4d9d-871b-b741e350f013" control-id="ca-2">
+    <implemented-requirement uuid="5b50db58-75fa-4448-85a1-a24cad98b5b7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="6469fad4-7cbc-4579-bec4-dff93ab51b6b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="606cef5a-055d-4202-9155-fc2771a177ed">
+      <statement statement-id="ca-2_stmt" uuid="85d565ff-b15e-45b5-aa32-a26453e7426b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -967,10 +967,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7215a39b-8d39-4925-bea5-f91b1349a8fa" control-id="ca-2.1">
+    <implemented-requirement uuid="35ae93da-4d51-44f2-bd19-c36afeaeb949" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="c570c8c7-f1bf-4dce-8931-13ad5f005c8b">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="65184ee7-63e4-4afd-a24c-d1f8d6c11474">
+      <statement statement-id="ca-2.1_stmt" uuid="11c7a1b7-45a9-4f01-b0fa-79c893a8f95f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -978,10 +978,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51adbaaa-1351-4624-ae44-ac5d1923573d" control-id="ca-3">
+    <implemented-requirement uuid="a5c5b25d-a826-4eff-affb-e56ef4c37941" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="b8816fd1-98bb-4616-b686-f6cde53250fa">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="259a0cd8-a33f-40af-ba44-436688a30ab1">
+      <statement statement-id="ca-3_stmt" uuid="1e74400d-8cf8-4cf1-828b-fc8eb630326d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -989,10 +989,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee02b0e7-d80e-4d2c-aac2-d0f01ed2c534" control-id="ca-5">
+    <implemented-requirement uuid="75bc3a7c-5883-44fe-b857-2ec0779b6f2d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="994f0dca-5edf-47e1-9cd8-dd15b88032df">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1c619016-0db7-447e-8d2d-eed3afac08d2">
+      <statement statement-id="ca-5_stmt" uuid="c898adea-56b2-496b-a95b-aead7a416a39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1000,10 +1000,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b3518f7-4695-43b3-a139-89a2276b286f" control-id="ca-6">
+    <implemented-requirement uuid="c27d2686-16bc-455e-a5c3-2f90509df2a1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="370b07be-dca1-4825-94bb-c78a9a9340c0">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="0402d899-c264-4e9d-8ef0-591aa6ffc821">
+      <statement statement-id="ca-6_stmt" uuid="66d1077a-8d5f-42f0-9078-bde3910bfabe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1011,10 +1011,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f173faf8-26c2-4613-b4fb-427d1fed56fa" control-id="ca-7">
+    <implemented-requirement uuid="b39d3be7-d4b4-4834-987a-b997656af1ab" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="e5211d49-688c-491e-ab21-d13ecc476c56">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="de453c65-13ee-4aab-99bd-9305168c5bc0">
+      <statement statement-id="ca-7_stmt" uuid="5da17598-9a18-4a3b-ba63-f89d9e00730c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1022,10 +1022,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f730cc7-c9ce-4330-b903-87e5b5df64e6" control-id="ca-9">
+    <implemented-requirement uuid="c11fdde0-925d-4e13-8c59-e9cada8a0451" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="9d3e9c13-a747-48aa-9d60-50ef48a96c8a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3a4a447f-b30f-492b-ba78-f680f96b1746">
+      <statement statement-id="ca-9_stmt" uuid="2d0f71e2-f35c-4da1-92fe-da865c00ea17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -1033,10 +1033,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a70a3a82-0094-4a8b-bbdf-3e6c125d3f92" control-id="cm-1">
+    <implemented-requirement uuid="7f9721c8-ebae-4ae2-9022-673f7b917ff0" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="bb72d5a4-2e93-4e1f-9e07-a832303def84">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1d869af0-092a-40e2-b65a-8c5e92bd7fa7">
+      <statement statement-id="cm-1_stmt" uuid="b5b2da40-ce44-4950-bcac-eabaf42efdb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1044,10 +1044,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cbff659-6cf7-44c8-b3f3-ff978e0e0dd9" control-id="cm-2">
+    <implemented-requirement uuid="08fc4016-155c-4080-a938-333e75955e05" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="c67ef2da-4ecf-48fb-8bf7-70373b4d33f8">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e0df2f70-168c-45f5-84f3-f538c07fd138">
+      <statement statement-id="cm-2_stmt" uuid="288a0964-e247-4769-bf2f-c173a3820b6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1055,10 +1055,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d27b1ad9-8f4a-4182-88f4-7f0eaa8a05d9" control-id="cm-4">
+    <implemented-requirement uuid="ca463470-1923-4e11-b2a5-04195c0cc655" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="909cbdf3-e0d8-413b-a27c-da22625a3553">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="2c9b010d-593f-400e-a9e8-c8e571fc40c0">
+      <statement statement-id="cm-4_stmt" uuid="89ab5096-0c14-4df8-8b0a-69e84ae06703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1066,10 +1066,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3056b65-448b-4acc-8dc0-172934a662b0" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="e218f2ae-0740-499f-87ef-c9272f076565">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="82aac95f-d091-4e66-8b92-e07373cfa722">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1078,8 +1078,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="12e31206-ec05-48c7-9af3-af79a4f48b34">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1faacc4e-03d0-4c96-adfa-efc6df99367e">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1091,10 +1091,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b68f556-27e9-4a26-8167-bf366c2352aa" control-id="cm-7">
+    <implemented-requirement uuid="4d976505-3f36-45be-833c-0a408af8a66e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="121a67fe-58dd-4153-8f73-c6a223c94752">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="61e6e4a7-50dc-4b92-8df0-9ac3d6a5e48c">
+      <statement statement-id="cm-7_stmt" uuid="bb4c0a1d-74c8-4548-a2ce-4453ade8ae70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea975add-2b4c-49e9-b422-e8ad807ced37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenStack provides many capabilities, ranging from elastic compute,
 software defined networking, and storage subsystems. A successful
@@ -1104,10 +1104,10 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="514ecd89-5f54-4d55-8dd5-04b5dd53bb1d" control-id="cm-8">
+    <implemented-requirement uuid="09ffc592-4a4a-4d6b-b111-0cd51b377e19" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="cb52e88f-89b1-4dcd-9f5a-c065c15c5398">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="0e2cca73-46ce-4c2c-b3b2-401f32567059">
+      <statement statement-id="cm-8_stmt" uuid="047a6256-e6c8-43f8-8e82-be0b4595340c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1115,10 +1115,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e354a74-fd49-449f-8613-1ffc54276e71" control-id="cm-10">
+    <implemented-requirement uuid="7c2f6f17-e66f-4bd9-bbe6-20acc81cd359" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="d4074d37-08b3-4c4a-ad4a-c411c6440863">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e5b99c1a-a0e1-4181-8e67-174336eb8f51">
+      <statement statement-id="cm-10_stmt" uuid="ae00dd5d-ce1a-4477-a834-6dc28807dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1126,10 +1126,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b84fad8-fda4-4c63-9252-adf6bb02900a" control-id="cm-11">
+    <implemented-requirement uuid="ee70a68a-e5fd-4583-bf65-e8129a8cd9e5" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="5c2eba12-2919-478c-bce8-0ea7231f6acb">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="59390a4a-6ac9-4711-a4bd-9dd599176f00">
+      <statement statement-id="cm-11_stmt" uuid="1cd21848-59e4-4f9f-9bd8-480b0008abca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1137,10 +1137,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50c115cc-b7d4-479d-8fea-0596f97aeb5a" control-id="cp-1">
+    <implemented-requirement uuid="d54fb627-a20c-4241-9723-7a843bffaa6d" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="d5d8af4d-4a71-4cf4-8690-603fc7ce89f4">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="ecc745a0-b480-4720-b56b-f5087c9254aa">
+      <statement statement-id="cp-1_stmt" uuid="dd2cb0b8-7e3e-4b6c-8bfe-e8cd60dc6e43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1148,10 +1148,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bc97ef2-f86b-4d89-8b3f-683198c6d5af" control-id="cp-2">
+    <implemented-requirement uuid="bffbcf7f-ed96-405c-8bc5-b2f37b429ded" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="f1efc19b-0cf1-4370-a410-c74d29746241">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="d7e5eb86-1570-4f5a-b7f2-d16f886aa4d8">
+      <statement statement-id="cp-2_stmt" uuid="8a30e876-f811-40ae-bffe-a9032187b2cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1159,10 +1159,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef2869b0-18db-4edf-b5ff-36f04e009d23" control-id="cp-3">
+    <implemented-requirement uuid="49c028d6-b83e-4f62-8980-606ce9a02364" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="9375c126-8e46-4400-8dbc-3d113ed05799">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a5336487-3334-47ff-ae4a-1a29aaa2b01f">
+      <statement statement-id="cp-3_stmt" uuid="0a69f546-afc0-425e-afd5-7e4d042ed2b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1170,10 +1170,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b0dc923-a364-4997-8034-fb65078dd069" control-id="cp-4">
+    <implemented-requirement uuid="a414e1c8-9ea0-4fd3-87d3-5d2bb0c871bc" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="cab36aaa-e4ad-4803-8ee4-c2e5f3c23f13">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="9a61fbca-35ae-46fa-b38a-22b402272410">
+      <statement statement-id="cp-4_stmt" uuid="b07bb60f-5bc0-4bed-b706-7bd175dd221c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1181,10 +1181,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97ca0d78-7990-4453-81d9-d377f9057d05" control-id="cp-9">
+    <implemented-requirement uuid="84eb20b4-b361-492b-a117-9d8ae2d2f503" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="23d29857-da8d-47ad-99c4-e045be5fd0dd">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="6172eb1a-a1d0-4aac-b58b-1c52ed0ca5d4">
+      <statement statement-id="cp-9_stmt.a" uuid="030db880-9f30-404a-963d-8118b1a36560">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="121e2947-005b-4006-b881-37d6b73e101a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1201,8 +1201,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="657eae25-2b98-4074-a4b1-f978d6962886">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b8415ac4-fed2-4f9f-bd1a-fb1281d01c01">
+      <statement statement-id="cp-9_stmt.b" uuid="bc7daf13-d4b3-4962-9ab9-97db290db49c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f481be8e-f668-45fe-8178-d3b5b7117361">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1219,8 +1219,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="f8160e9b-60ba-4e23-9f37-06e8bdc219c1">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4239a7e8-0ecb-435f-a74f-7bfa2ce44753">
+      <statement statement-id="cp-9_stmt.c" uuid="12c214d6-9769-414b-b027-1775cd63996b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="139f3266-94bc-413f-9339-5325ac829eef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1236,8 +1236,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="1a334b99-0534-44f0-835a-ceeb1c38e13d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4a1ce1b8-08e2-4f1d-bfde-ee245e85b3f2">
+      <statement statement-id="cp-9_stmt.d" uuid="af663e8a-4d5b-4da8-acea-2ada0ee4469e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d27cf6a1-258a-4b79-8c9b-15d3ebae71a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1253,10 +1253,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c20ab3b-0bfe-40e7-abbf-ab4a770d1f24" control-id="cp-10">
+    <implemented-requirement uuid="c862ea26-e36f-4fbd-95c1-b86e39715c34" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="ca1c5e4b-fed4-492d-9218-06ce6318f9fa">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="432de152-96e5-4e51-bf69-35bff9c0759f">
+      <statement statement-id="cp-10_stmt" uuid="1eca2502-2937-4113-bee4-487ad831df0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca57dba3-2f22-4e61-857c-3d7dbee1e16a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their Red Hat OpenStack Platform environment. A successful control response will detail
@@ -1265,10 +1265,10 @@ processes used to fully recover/restore the Red Hat OpenStack Platform environme
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae7a5335-947d-4b75-b05d-80cba359d9e5" control-id="ia-1">
+    <implemented-requirement uuid="c208fa13-b331-4bb3-a906-a11d825dc54f" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="929ab4b7-d52b-4fa6-9bc2-8a8a931fb533">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="37778345-1b83-4bef-a8a6-7d6068294953">
+      <statement statement-id="ia-1_stmt" uuid="ab66bff7-66a3-4f54-bdd0-426477d879b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1276,10 +1276,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c786622c-1958-4759-b38a-32be078a1b55" control-id="ia-2">
+    <implemented-requirement uuid="c59161f4-7aa0-4f74-8e7a-d70e2d287475" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="cff46560-e052-40f0-a0e0-84c271a0d737">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="dae454c0-98b4-443f-8412-38904013d959">
+      <statement statement-id="ia-2_stmt" uuid="1673fedd-fd2a-427a-939a-8df8b41f3969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30c63e3f-c480-4d92-a1d2-aeed0b3491a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -1287,10 +1287,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c988e283-760d-4161-a5c2-3c00ed819982" control-id="ia-2.1">
+    <implemented-requirement uuid="289fe0db-1b27-4024-ade0-c9f37575aa9b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="4d7288e5-013d-4196-ba9e-05ab60bb8c40">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="ee698d03-95fc-4e41-a89d-599674cec415">
+      <statement statement-id="ia-2.1_stmt" uuid="f9bc119b-3db3-4372-9611-7ae8c72f14b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9db1564a-325b-44ac-8611-3dbf6252b163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -1313,10 +1313,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b274807-fab1-4627-9749-d1fe4dc12b3b" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="495d1296-9d6b-48f4-8a31-cc0495d74be3">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="47ed19ce-d4a1-4b54-bbf1-3e9f9278e690">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -1329,10 +1329,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d544b1cb-a52f-4404-b1bc-352f9927fa3b" control-id="ia-4">
+    <implemented-requirement uuid="baf076ff-0ddc-48dc-baf1-69303b069ded" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="8c396cce-a31b-4d0b-b316-d27dd182f178">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="358e34c5-194b-430d-a971-0652e795192b">
+      <statement statement-id="ia-4_stmt" uuid="e1e9cd09-58e4-490c-a082-7e1ef882b3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -1342,10 +1342,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2c87a58-8e5e-422a-b3af-47784eb21b9b" control-id="ia-5">
+    <implemented-requirement uuid="8a61c669-9aa3-469d-830b-458a18eba93a" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="9330e69c-35e8-43d0-9203-2e20d1d6df2a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="147f3cba-0e26-4d1e-a7d5-91d706c63fa3">
+      <statement statement-id="ia-5_stmt" uuid="9f79c036-9e57-4781-83a9-ae1da8d838d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -1355,10 +1355,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdf11667-0c89-450c-8866-cc5fa30cbf9c" control-id="ia-5.1">
+    <implemented-requirement uuid="2f2060ee-3124-4509-b1b6-024ec5ed28b7" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="866619c7-ddeb-436f-9826-9586bdbf265f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="db8de32d-993d-458b-8a33-5a777dc95676">
+      <statement statement-id="ia-5.1_stmt" uuid="22c3e411-946c-4b61-a5a2-df5b89b2a412">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -1368,10 +1368,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="300d0e33-bc45-4958-9693-fb7488ce61c2" control-id="ia-5.11">
+    <implemented-requirement uuid="20d94349-ac22-43e5-858b-0743396f0631" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="b6d43675-aea2-48c2-a8b3-d9ce122421d0">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="822eac43-7e0a-427b-b4d9-205cbe88182d">
+      <statement statement-id="ia-5.11_stmt" uuid="190217c8-24cf-4786-91be-1b461696d954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -1381,10 +1381,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dff636ca-715e-4578-8b68-2ec5f91edee4" control-id="ia-6">
+    <implemented-requirement uuid="05005a74-21e3-4100-92b7-ca71ff828a98" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="795ba2fd-e5f6-4dca-b467-93df99cc6ee7">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="59cc0140-1e13-4c0f-b3fa-c91f9f103fa2">
+      <statement statement-id="ia-6_stmt" uuid="0c0685b8-0c35-4f53-a730-6ad9020ef2a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecabbad6-1b16-49fd-9b7f-cd712dcf01d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform natively obscures such information. Red Hat OpenStack Platform cannot be
 configured to be out of compliance with this requirement.'
@@ -1392,10 +1392,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="284c32b1-915e-478b-8020-6296eec81f1c" control-id="ia-7">
+    <implemented-requirement uuid="a2b87a9d-d758-4b0d-8396-3d77001d2d9b" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="45a373f9-7b47-45aa-ae14-a8b3035cbafb">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="64368ac7-1c07-4339-9b09-5889f87653e4">
+      <statement statement-id="ia-7_stmt" uuid="892b15aa-bc59-4bae-9ad7-0f86f9ffff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="526f4b91-8447-47d1-96a5-1090fb4e10dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to Red Hat OpenStack Platform nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -1417,10 +1417,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="664fd131-62ce-495b-8164-f05ed7055a37" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="748c3e26-eaaf-4c29-9145-2064998c856a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="35b5cf7d-b884-4c24-bf85-7e30959ec54c">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -1432,10 +1432,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="951ce9c3-e913-4398-a4a1-42d83ce49632" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="6077825f-74c0-4b5a-82eb-06dffcaed092">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="16a6117d-bdc7-49c9-a9cb-881f676032f9">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -1448,10 +1448,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8356e6cd-4bf6-48ef-9e44-3ea969cd434d" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="08104844-9510-4153-b19c-49708ef2b1c7">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="da332a31-18c1-4c6b-90de-4536c5aac815">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1465,10 +1465,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a78ec669-ff96-44b0-a9c8-75787e6c4a45" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="abadca7f-8956-4dcb-907c-94741a784c17">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="512127e1-8fed-4ca3-896f-10d20447671c">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1482,10 +1482,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="589fb5da-e4d5-4e71-a800-cbfe4faa2949" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="9ad3c938-9a16-48b9-af4e-d6aa145c7f0e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="cf4afe31-ad2a-49f6-82af-7316e8131062">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -1499,10 +1499,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d47f8b26-2968-4332-8f43-f77aab6d3d52" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="0828d678-07c9-4789-b0b2-d0adc05df613">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7079c69a-d17b-47cc-8672-b8fdb7ce48fc">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1510,10 +1510,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de04cf57-83ab-4222-bbab-8ff48d8067ec" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="15791cae-2806-4c1c-9f41-3a3d81dc7854">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c562978a-4c2c-4696-94ea-7772f632c31a">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1521,10 +1521,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b613a59-156b-490c-b9c3-f3bf4bffab38" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="d879bf1a-d0a7-44d5-b1db-9d62f092690d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="08c17cdf-53bf-4c59-a13e-33956c833db6">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1532,10 +1532,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4902ba49-7d28-493c-93e4-23019ca629ae" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="ce18ea0e-52de-4271-81c5-c6f4d9ceaaa5">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="062acde7-c0e1-4b36-a61c-c5a091c5e5e4">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1543,10 +1543,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="851931aa-ce90-4d8c-8bcb-e40822fce389" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="effc792d-741b-44f0-86c6-5054d9900589">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="5a54f819-bc81-40c5-81fb-fa25446fc8b3">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1554,10 +1554,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7d697c4-1f49-4415-a6f1-393a6b6c5fff" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="cb969342-8f9f-4cfb-a836-86fb36b38fea">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="dbce1994-4627-4125-83f1-196bf8d86242">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1565,10 +1565,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cdd4034-d2ad-48bd-985a-e3a17ab71015" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="7365c7ef-5aef-4304-9489-9aeb2a0d8826">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="66e5e9f4-1cdc-45de-9564-f03d291aaf2f">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1576,10 +1576,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c605851-a20e-4770-b836-95bfe0a55a1b" control-id="ma-1">
+    <implemented-requirement uuid="cdcc7eee-82eb-418a-b7cd-f5af7e84446b" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="78a2b13a-7b1c-45fa-8981-704750f71d87">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b2cc91c2-4c05-489f-bbf8-b6ccc2cfa90a">
+      <statement statement-id="ma-1_stmt" uuid="51b5eb2e-72f1-4d10-9c29-dc52c48241e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1587,10 +1587,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29f26a12-04be-4e21-9e1f-0a3008164940" control-id="ma-2">
+    <implemented-requirement uuid="2b150918-15e4-4c01-bec2-18f95a448a70" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="bf01e401-e7ed-4327-b9e4-86a799d32180">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="62c4e7ad-2524-4c7f-a3ee-ed14647604d5">
+      <statement statement-id="ma-2_stmt" uuid="3bd08678-77d8-4d13-ab91-d020826517f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1598,26 +1598,26 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84eba029-f535-41d3-b342-634b9ebf4122" control-id="ma-4">
+    <implemented-requirement uuid="35ce3515-cb78-4d93-9fb2-d9a0817d5ed5" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="7c65cc50-490e-45ac-be67-8600ad0405b5">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="008af4f7-eee0-4dff-9b68-4a6f5e9b6a5d">
+      <statement statement-id="ma-4_stmt.a" uuid="901b6f87-5fc0-43f7-ba0b-b4368c4aa5c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="04357fa9-819a-4bd5-953f-e0b69c327bfa">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1e225b05-5dd6-4d31-a91b-3ab6a7eff044">
+      <statement statement-id="ma-4_stmt.b" uuid="0dcfc21f-e41b-47cf-8395-67b48f957b89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="d53cec5c-6d29-4b1d-849a-4b30f8a102dd">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="22c0b0a1-a514-4840-8278-c5a51804c170">
+      <statement statement-id="ma-4_stmt.c" uuid="4915cca5-f41f-4273-b32e-41286a07a092">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d59d37fe-e740-46e7-afa6-f8de446e43f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to Red Hat OpenStack Platform.
 
@@ -1629,8 +1629,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="91bceb01-3001-4db8-80ff-489dfa222aa9">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4c7a952d-ec76-4ee8-b9ae-d794897207ab">
+      <statement statement-id="ma-4_stmt.d" uuid="4bb343d0-f3c3-4baa-b052-0334332b2093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08bbbc53-87da-4908-9568-93e814f2683f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -1640,8 +1640,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="151f32aa-e8a2-4fb1-a842-80a19ac7569d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7621e82d-19ae-4ca7-ac45-35f7d410a23c">
+      <statement statement-id="ma-4_stmt.e" uuid="ef823718-f510-488a-837f-5865ee720ddf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00846073-cfd1-4be2-8bee-7795424cf8b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -1655,10 +1655,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efa14c4a-2515-4c0d-b1de-10fd87bacf60" control-id="ma-5">
+    <implemented-requirement uuid="61ee1429-4ede-45ed-9531-03cb13100ffa" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="a035bfea-f584-469b-ad7d-0ff3372acca2">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c5f72fed-0b3d-4b3e-a6cc-c85c5a99a4ac">
+      <statement statement-id="ma-5_stmt" uuid="b6e18c5e-2ce4-40f6-9151-3c46e6abfbdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1666,10 +1666,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68fa3f91-88a0-433b-b268-0b2bd6e5f078" control-id="mp-1">
+    <implemented-requirement uuid="c1c191c3-7acb-4b73-a25f-55c23040e87a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="1cdfba5f-570a-46bb-a4be-baaef022b15a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="067e5d41-4577-42c8-9ba0-83608d5126bb">
+      <statement statement-id="mp-1_stmt" uuid="28755a59-183a-4e83-a21f-fcebe642f4ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1677,10 +1677,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d55cf670-642e-4275-abb4-5ac1788a023c" control-id="mp-2">
+    <implemented-requirement uuid="db07015e-b317-4432-81b9-c61e31c06b1a" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="c4fa8dfb-070d-4481-88de-5ec960019648">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="dbf6872e-7711-433c-985b-cb41fc660748">
+      <statement statement-id="mp-2_stmt" uuid="bac08d7c-1546-4d50-8e59-d09a70f8f9ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1688,10 +1688,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08d0ebb9-900d-42c6-9d13-4b4a7dbaf023" control-id="mp-6">
+    <implemented-requirement uuid="73dab637-290e-4ed2-8032-79920696e3b3" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="cf9fd65f-e8b6-4aeb-91a7-65aa0c5e8445">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="365f97e5-7c9a-4188-b50b-8d479849737d">
+      <statement statement-id="mp-6_stmt" uuid="c609d480-441b-4fb0-b14a-abbfb8e5a6ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1699,10 +1699,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26925213-7b99-4cb7-bd67-eb8499f985bf" control-id="mp-7">
+    <implemented-requirement uuid="60cf4fb1-3a3d-4f09-85b1-69dca7250ff2" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="241a05f6-9503-4b65-9f69-f317f68a0f8e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="2a9ec4c2-71d7-48ed-a018-3b109c542b6a">
+      <statement statement-id="mp-7_stmt" uuid="d11d55d4-a801-4eba-a4d6-1a042b3edf26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1710,10 +1710,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9dedafc-0935-469e-88ff-b01130ab9adf" control-id="pe-1">
+    <implemented-requirement uuid="3fe8f97e-0a71-49e5-bab8-4f23b60cdd5e" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="251c2d3f-e6e6-4937-aad0-06e60c026cdc">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7f10d8f6-17d0-47e9-bef8-d4c181e437ec">
+      <statement statement-id="pe-1_stmt" uuid="8a9e2eb1-861d-492e-8d96-e3d580aa8425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1721,10 +1721,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="791b094d-e930-4665-b5a2-ed992a9191b2" control-id="pe-2">
+    <implemented-requirement uuid="66170f39-9cad-4b12-a48c-d0d25d8049db" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="d524a4c9-09e7-4dda-8b5f-d3d25d5929e8">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="98581745-84c0-44e5-a76f-1110e846d5fc">
+      <statement statement-id="pe-2_stmt" uuid="047d6949-4e0e-4498-b589-2948f6dffabb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1732,10 +1732,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abde382c-3b6d-4d90-bcd4-d2a2ca918b11" control-id="pe-3">
+    <implemented-requirement uuid="c312262c-151d-4867-8039-e80a50115436" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="0cfdfc94-6458-4092-aba0-4f2a5332b071">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="748f7736-7ae2-476e-ae5a-9de520077b03">
+      <statement statement-id="pe-3_stmt" uuid="bb36430f-50e8-42cf-9fdb-f097525b2370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1743,10 +1743,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="425e0ad3-3569-498a-83c2-c169a6d3d6e3" control-id="pe-6">
+    <implemented-requirement uuid="ba657188-6d16-43a9-8a37-cd5d85fce9f5" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="6f1a2317-d55b-4003-9c29-1c07562dc898">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="d43bb999-62c8-4e78-b7d6-601e76df5f78">
+      <statement statement-id="pe-6_stmt" uuid="39b29d3a-8830-4285-a9a4-72430aaef0b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1754,10 +1754,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d68235c-16d1-413d-ac25-6c6553078c00" control-id="pe-8">
+    <implemented-requirement uuid="3dd3cdf9-3129-4ac3-9bc7-bb7c079bc5d8" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="637bfe23-87ed-4662-8cd4-b7ea69888064">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="f034ed61-d689-48b8-b7a2-0df2173a5abd">
+      <statement statement-id="pe-8_stmt" uuid="601d2879-30a1-47e3-893d-a0d647fa926b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1765,10 +1765,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ca439f-161b-4762-85e9-1f062bef69a5" control-id="pe-12">
+    <implemented-requirement uuid="fcc9b873-07ef-4573-9d21-c5cea7cfdd87" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="548ac86d-fab9-4c67-bc62-7014435fcb26">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="944152c9-3630-49ba-9dbf-6af3d097680c">
+      <statement statement-id="pe-12_stmt" uuid="0bf9e3fd-7b32-4587-a078-205a9ced2242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1776,10 +1776,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b988c955-c7cf-4aa2-a4a1-b915a97fc0ac" control-id="pe-13">
+    <implemented-requirement uuid="158fd9e8-75bc-46e0-a502-294ed9abcc08" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="b428fa0d-a12a-4099-975c-1191e8deb754">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="83adf517-cd60-457c-87ae-4a5c0957e0cc">
+      <statement statement-id="pe-13_stmt" uuid="e2930066-33a3-4127-afbd-337c1d217cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1787,10 +1787,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a0c4132-39e0-4d20-a2cc-771992df1256" control-id="pe-14">
+    <implemented-requirement uuid="a4abc4c0-f5a2-4974-ac4a-8cac7a0b06a0" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="f05cea3e-06f3-44ec-9001-eebdd8d7e6a8">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a5e75201-e233-4b00-b772-39e9a790e783">
+      <statement statement-id="pe-14_stmt" uuid="cffa90e1-f78d-49ba-ac4b-9ab953e61861">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1798,10 +1798,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1c8de38-5884-4933-b062-f594853386af" control-id="pe-15">
+    <implemented-requirement uuid="2c8a7cc4-34e7-4bb6-bbaa-1c473d6d0d9c" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="59417b62-2c9b-48f5-b2e5-0aa74b9fed80">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="d51ec7c6-d24f-426e-915e-df6f1d70af55">
+      <statement statement-id="pe-15_stmt" uuid="d1cdef3c-4f86-4c1b-a0df-c2b3746f6315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1809,10 +1809,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8e42be3-2afb-4210-826f-b7dae7448140" control-id="pe-16">
+    <implemented-requirement uuid="66a5c88b-e903-402e-91e2-45e8f970564f" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="fb439b66-b875-49fe-9c03-2e267df9d4db">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="d032b0ea-97df-43be-8aaf-fe4b5faf103f">
+      <statement statement-id="pe-16_stmt" uuid="076b1806-98bb-4148-b439-1fa95052ea1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -1820,10 +1820,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a813375-12ec-4d94-9d40-6f3f3f3fbd5f" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="c2d2b770-32f1-48f8-9eaa-df61dadc0886">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="2f789db0-6e52-48fb-ac58-2efd28da96e6">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1831,10 +1831,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c5026d2-9cd8-4c6c-8724-0bfe76e5f231" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="c4e1b7eb-b17f-47a6-83ab-4a4d8a75c9ec">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1f98f1d2-4962-4bb4-846d-2a784e708931">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1842,10 +1842,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45eed29c-af89-4a0f-b32c-615559d494e8" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="ae9127e6-8f8d-473d-8782-343de6ee6520">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="227d25ee-72be-4bed-bdcf-67e68aba5bdd">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -1853,10 +1853,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e83c07b1-bbd0-4dd1-b890-8713d758f6bc" control-id="ps-1">
+    <implemented-requirement uuid="3b48c5a2-3d5a-4a42-aadf-d91bae228196" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="1ae77c71-bce3-46e1-97a7-92c77c738948">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b0c53e42-f297-4b49-934d-d274c6ceba79">
+      <statement statement-id="ps-1_stmt" uuid="fa75fd4a-bd29-4b42-8b77-05c73da9a9c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1864,10 +1864,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb461fb6-c96f-4890-b63a-47163c7ddff2" control-id="ps-2">
+    <implemented-requirement uuid="4dc764f7-9a3e-4226-9a24-f708b609e0a4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="901ece31-2d30-4f7a-88da-e54de027d2dc">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="94c5f550-8220-4ca5-a3be-7405e8b8cbbe">
+      <statement statement-id="ps-2_stmt" uuid="bcd6f4f9-3499-4214-a20c-e98f1ea4516e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1875,10 +1875,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="619410bd-d357-46d0-a002-813e3f54c2e8" control-id="ps-3">
+    <implemented-requirement uuid="deb274e6-a5bc-4781-91f7-b2d9f37dbb84" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="37741560-9cc8-4110-b4d9-21ad2529854a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="dd34e69b-dee0-4451-9f38-99f0ec11b9bc">
+      <statement statement-id="ps-3_stmt" uuid="8794e81b-836d-4ded-b9ed-d93238f9eb96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1886,10 +1886,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca044eaf-63f7-45ef-a5a5-37b75c7974d5" control-id="ps-4">
+    <implemented-requirement uuid="c35fae4a-f1ac-4c7c-afe8-10ee0db02bd6" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="0c33de05-29df-422b-a773-da4c1d3a2476">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="cdd7aabc-29d5-40ae-a07a-105e227e3547">
+      <statement statement-id="ps-4_stmt" uuid="d2fabfb5-0acb-45cf-9be8-715b4ebe088c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1897,10 +1897,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b32f89a0-db0a-4ee9-88ce-06bac8183dfd" control-id="ps-5">
+    <implemented-requirement uuid="b145bc21-5681-41c6-b56e-7e483f13904c" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="e0ec81ef-5b3f-42fe-8418-b165df0eaf8f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="0761584f-9ac3-492a-a2ff-d45c6316979f">
+      <statement statement-id="ps-5_stmt" uuid="d6118325-685a-47de-9b33-6c7f9cfe48a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1908,10 +1908,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="671a01ec-86dc-4b09-8f02-99ba784b79cf" control-id="ps-6">
+    <implemented-requirement uuid="3acff718-a042-4d8a-9361-0041362e69c4" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="0b5aa75d-ed24-47ea-a5a6-7c7de1c7c933">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3bbe23a9-99ef-494b-97d7-64b5c43262c6">
+      <statement statement-id="ps-6_stmt" uuid="b85963d4-3a51-46f7-9ac8-e2d7488f3344">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1919,10 +1919,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce04048b-f322-404c-8eb8-3c7259782ce2" control-id="ps-7">
+    <implemented-requirement uuid="34569fe7-9406-466d-9dd7-6b5112324877" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="6142caea-3949-4114-aff1-60ea5db53466">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3a1ff28e-c75f-4a32-823d-e1aef6381538">
+      <statement statement-id="ps-7_stmt" uuid="7f862af0-a6d0-4654-8d86-2dc42f32a896">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1930,10 +1930,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa7debf8-8c0e-409b-acc8-acc5a343b516" control-id="ps-8">
+    <implemented-requirement uuid="d24948c8-041a-4d1e-9b5a-da8664a98f00" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="43918f5a-b1b4-4837-b4c7-127e7c6543b6">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="863ac139-79bb-4609-ba01-49b7e294a88e">
+      <statement statement-id="ps-8_stmt" uuid="bb73d28c-b949-4cf5-9dab-56d3e3fc075c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -1941,10 +1941,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fdcc2ce-dc03-4949-a8e0-e1bc09a421e9" control-id="ra-1">
+    <implemented-requirement uuid="bb09a5ef-98e5-4052-9683-cdda152142dc" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="3a56906b-5534-4b4f-bdcc-864220edd7a5">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e4ec35f4-a47f-4d23-b8e2-1167f8fddbda">
+      <statement statement-id="ra-1_stmt" uuid="6325f8de-a783-474f-850d-9eb67163626d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1952,10 +1952,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de63c5d3-3c92-4406-bfe6-042a2a47a94a" control-id="ra-2">
+    <implemented-requirement uuid="3db3a332-63e0-40ab-afcf-0f60c0218118" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="9d562173-fc94-41cf-a688-db4a340ebd6d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1e9d000f-7bcf-4f43-815f-94c68fe14c3b">
+      <statement statement-id="ra-2_stmt" uuid="01c17c2a-e66f-4d3a-aa95-4014747994c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1963,10 +1963,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e830b034-0662-43de-ba65-5b79328154e6" control-id="ra-3">
+    <implemented-requirement uuid="79f18335-4d65-4458-96a5-463bdafb81ef" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="bef31f17-2476-42c9-9db0-289cf7047a2a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="6358819a-eddb-4519-b15a-f71adfc2d4df">
+      <statement statement-id="ra-3_stmt" uuid="a3225534-b562-4304-b849-5b02450ef53d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1974,10 +1974,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c608a7e-725e-4b76-ba15-4415feedacda" control-id="ra-5">
+    <implemented-requirement uuid="8306bebd-ff3c-497d-b225-1282a4c9dc0f" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="a528c9c2-1d61-44f5-acc6-e1c696e566e3">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e8d98ca8-70ac-449e-8000-fcfb69fbd61c">
+      <statement statement-id="ra-5_stmt" uuid="eb825304-21be-41c6-9966-6a6ad67ce1fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1985,10 +1985,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="453070f1-cb7d-43f0-bc00-9a5cedb741e8" control-id="sa-1">
+    <implemented-requirement uuid="02d0bdc1-480e-4425-8654-0f01d21cece5" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="c2743a9a-0e96-4a9a-abae-269f3bfac885">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a154cd53-cf2e-4e4c-8a8a-efa49d465df2">
+      <statement statement-id="sa-1_stmt" uuid="a42234f9-5017-4911-bfca-de2060c205d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1996,10 +1996,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8dd6308-722e-4f7a-86da-e2dad506b4c6" control-id="sa-2">
+    <implemented-requirement uuid="1366cbb3-170e-49ba-8285-eb7d039de135" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="87ac6c19-3f9b-474f-b3d2-7eadc401bb98">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3b808b15-fa6d-4494-b479-1c8168f2f297">
+      <statement statement-id="sa-2_stmt" uuid="ef2b93d8-5bf5-4999-85e0-daa18920d041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2007,10 +2007,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a5d3592-5b22-498a-93a4-910197b0f06d" control-id="sa-3">
+    <implemented-requirement uuid="64776815-7b8f-4794-bb19-baa7eb7161af" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="bdac6a09-35de-4f3a-b41e-c881064da057">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="1e6f1501-262d-4c0a-a49e-70279f02f846">
+      <statement statement-id="sa-3_stmt" uuid="830adb39-0426-400a-9985-471215d597a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2018,10 +2018,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12b9f839-68ca-44ac-859c-5722e1846b03" control-id="sa-4">
+    <implemented-requirement uuid="2acbe488-3ce3-4bdb-a1da-d92a45fd52f8" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="ff2bbd70-59e6-496b-abb9-1e23d89e37c0">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b738bbf2-524c-45d8-bc5b-b41d5cf4a016">
+      <statement statement-id="sa-4_stmt" uuid="70ca8eaf-19b0-4537-a2e2-076a70d64257">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2029,10 +2029,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e88b26d4-b22b-4f7f-af29-2fe4a86f9121" control-id="sa-5">
+    <implemented-requirement uuid="49ba8a34-b4ea-4d07-b5a5-ef0a0cee838b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="09d2d753-2f2e-494d-9fb1-827d8a961975">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="452759ae-23f5-4364-8ab2-dd196faf955f">
+      <statement statement-id="sa-5_stmt" uuid="06328e4a-36cd-4e36-b2fd-4098c768433e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2040,10 +2040,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4dc684a6-7ddc-4378-84fa-0652e0d9d286" control-id="sa-9">
+    <implemented-requirement uuid="665bebaf-1273-4d6a-bfec-47c7d9736aef" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="d4b5c145-5e7c-4c3c-823b-4ffe544343dd">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="ae4d3c27-1e98-42b8-9cac-0d6afe65f253">
+      <statement statement-id="sa-9_stmt" uuid="76e986fb-b47f-41c3-9da2-5bb8b98c5980">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2051,10 +2051,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a17a4ee-6440-4d72-9db6-ecb1b56532a9" control-id="sc-1">
+    <implemented-requirement uuid="2625c72c-92b1-4548-82af-6938babc644a" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="61a9250d-a796-439b-99ec-fa28b6e065f3">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="ca4e6b68-6026-4cfb-a737-96d6e1005522">
+      <statement statement-id="sc-1_stmt" uuid="f38bc439-453f-4c25-9a80-0851c54f889a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2062,10 +2062,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02407aa1-27e0-4907-8ac3-e292679b52d2" control-id="sc-5">
+    <implemented-requirement uuid="2d8b22e1-2a4e-4c7b-a58e-cc7939afb4ca" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="d2efeba4-c242-40a0-8a9b-3d6c202cdd82">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="806509ed-58a7-46b8-b575-54df7bb78af8">
+      <statement statement-id="sc-5_stmt" uuid="96527d82-f5f8-4430-a29d-696d94426674">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2073,10 +2073,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22f8061e-cc5f-46e8-b0d9-a9ec0f6efb44" control-id="sc-7">
+    <implemented-requirement uuid="42b49bbd-cf98-4be6-9c0a-b46e14a35032" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="72b35423-3780-476b-bad1-ab3d490e8d48">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="9c67b944-9474-4759-bce5-72d546d61d11">
+      <statement statement-id="sc-7_stmt.a" uuid="840a035c-b878-4c40-befd-85b83fbbd2a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f5f071a-db14-492a-9b10-094018323cc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 OpenStack can be monitored is forthcoming. This activity is being
@@ -2086,8 +2086,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="419ed614-a59d-4abc-879c-169e65906e2e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="21b73d83-acc2-460d-baf8-0d6e0c7b39c4">
+      <statement statement-id="sc-7_stmt.b" uuid="95b962a5-d3d6-4a38-94dd-cec0bd717fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3646d3b3-7aa9-4e4e-96c4-bcefba78e17d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -2097,8 +2097,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="53e4e2ad-1cba-4289-b700-8822a31416aa">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="520556f0-e0da-4764-ba9b-9cb15bee48b7">
+      <statement statement-id="sc-7_stmt.c" uuid="62382b75-d7d8-4c36-b6e7-ceba9f3510f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f23cafc-7ab8-4a9b-849a-7b124c42cc82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can route connections to external
 systems through a managed interface is forthcoming. This
@@ -2109,10 +2109,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70819b12-c6ef-45db-893c-65d643626843" control-id="sc-12">
+    <implemented-requirement uuid="54fb0366-a307-49c2-90d0-947efc58cbe6" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="56fbddda-96e3-46c2-a909-ae4714468bbd">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="5516b88c-10b7-41c5-81c4-aa69747e391f">
+      <statement statement-id="sc-12_stmt" uuid="9f86c3ef-732b-4fec-9c08-d8d69b47c671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6499aebd-e9ec-451f-8372-48b65980dd07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -2123,10 +2123,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0ed8aa0-bff9-416e-977b-e11092dceabe" control-id="sc-13">
+    <implemented-requirement uuid="82fe73df-fe8a-46fd-93e3-6e68fd1dce01" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="ec8ee254-76d0-4dbd-942c-e0ee3fa0fb0f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="efa7c227-ab72-40cd-80df-d18f96252eda">
+      <statement statement-id="sc-13_stmt" uuid="a24dfcc3-ca6e-408c-9de2-6199ee954169">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d623f946-d2e6-485f-9e63-8804ae86d1a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat OpenStack Platform's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -2137,10 +2137,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="618b0f8f-4406-40f2-b8e3-23a0fc132886" control-id="sc-15">
+    <implemented-requirement uuid="41d0736e-d38a-4f0f-8632-dd3ec102fbdb" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="613b624c-6426-4724-a9e3-84a41ed22d53">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="b86bb73b-8267-4635-94d5-fc3faa4ea78a">
+      <statement statement-id="sc-15_stmt.a" uuid="de8ded74-4758-4253-8fd5-fb3e89177f43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2149,8 +2149,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="5f64f893-b3da-4247-858c-8c78618321f2">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="f0bddcd6-ebc2-4d30-a9e7-7a996fba5096">
+      <statement statement-id="sc-15_stmt.b" uuid="3d7aebca-e951-4c6d-9696-d445fb60915d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2159,8 +2159,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="c603e194-0d88-46eb-ad21-aee982a40d9e">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="bd582613-246b-44b0-8884-475c62566028">
+      <statement statement-id="sc-15_stmt.b.1" uuid="0307a0ee-19cb-4e49-a8e0-c0e0982ceedc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -2170,10 +2170,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90fe0e77-dfd4-4d62-81b2-4e69f7fae923" control-id="sc-20">
+    <implemented-requirement uuid="587e6061-be2f-42d9-a980-af099b248ad0" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="2cf0a4b5-05b2-4dfa-82c6-96ecea135f2d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="011cb42f-aa0e-43ae-938b-b50ea9154584">
+      <statement statement-id="sc-20_stmt.a" uuid="be3db02a-ef6f-441f-aa75-80753775c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6083d276-bc02-4ab4-b09b-aaaa8210d7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -2194,8 +2194,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="0dfc14aa-a549-4788-8840-5caea4e32a2a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="54180c35-e204-4fee-81a6-6811e460f366">
+      <statement statement-id="sc-20_stmt.b" uuid="74d07e5d-09ca-4443-ab18-6212072e2b5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c16ee495-eaaf-4c06-a306-1c0f14762372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -2217,10 +2217,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="182607c8-40d3-4d81-841d-c4bb0d9f9fc8" control-id="sc-21">
+    <implemented-requirement uuid="b7439da0-1074-4eff-9dc8-e97a40ccd755" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="8ffd9a56-385a-4067-b232-342779965f6d">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="23fc658b-2fc2-43a2-862d-62c1f54ba258">
+      <statement statement-id="sc-21_stmt" uuid="5b0ad384-b4bb-4c7a-b398-01aec1e97932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ea535dc-4d40-4390-a021-f94d268e34b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -2239,10 +2239,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d706b33-9f9a-446f-b354-c13723e23804" control-id="sc-22">
+    <implemented-requirement uuid="e670fa18-c103-45c7-b9a4-75bf0781e6e6" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="ebffccb4-6fdf-4fd3-88c8-ca77fadb1471">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7db04878-9e7e-492a-ba4f-1ecf3b99fdc0">
+      <statement statement-id="sc-22_stmt" uuid="452a4031-7e95-4f48-b97b-5c90224a8452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abf1e946-ac54-4d51-a595-1a819fe4d19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -2261,10 +2261,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2bbc4df-4974-4808-a193-b44cd22bf450" control-id="sc-39">
+    <implemented-requirement uuid="c9b7913f-61e7-44cd-a75e-3700a19fa70f" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="274f3602-6a03-417f-9932-2ca42ec631e5">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="9f00adb6-0fcf-4020-85bd-c48370be8df6">
+      <statement statement-id="sc-39_stmt" uuid="dc3d7ebb-8faa-44c8-a7d7-586144f302e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91c59040-3dd5-40d8-8a46-4d9cbe3c5b93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat OpenStack Platform runs on Red Hat Enterprise Linux, 
 Red Hat OpenStack Platform maintains separate execution domains for each executing process by
@@ -2278,10 +2278,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce27f7e1-3953-4a92-8d33-115b3f788c8b" control-id="si-1">
+    <implemented-requirement uuid="36aaae06-070c-4173-9f7e-9255b0759f43" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="ce7a2dee-b66c-4a19-a379-9247a9b7e4b1">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="e04042b8-9932-4858-a0b9-304371b60c46">
+      <statement statement-id="si-1_stmt" uuid="1bf3d73b-ec81-432a-91a3-fdcbeae4bbd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2289,10 +2289,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcf1190f-862f-4b12-80ba-a0b0c0faae06" control-id="si-2">
+    <implemented-requirement uuid="e104b35c-ffc1-42d5-9aa4-e8a38a1e2e87" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="1c7e90e7-832d-4a38-8d11-d58683b0a917">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="0ff87af5-9d10-4828-a5f5-ea3dc154b889">
+      <statement statement-id="si-2_stmt.a" uuid="a58d68ff-a3fe-4ff2-8eae-68a9f1e3e541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c9570cd-f6d7-42d7-a21c-c8795015c074">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their Red Hat OpenStack Platform deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -2307,8 +2307,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="ecba9314-ffb4-4e69-a9b5-ed21cc7e37ff">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="f6bee956-2e9c-4614-bbce-5800588947a0">
+      <statement statement-id="si-2_stmt.b" uuid="4e8316eb-eeaa-43a9-b306-c403125587e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c30dafd-1186-4dd6-908a-6a11de784a27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing Red Hat OpenStack Platform updates
 related to flaw remediation prior to installation. A successful
@@ -2323,16 +2323,16 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="1e46fdbb-c771-4cfe-9ad2-455db261ca0a">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c47f602d-dad0-448b-a0ef-7c3fe2023dfa">
+      <statement statement-id="si-2_stmt.c" uuid="5dfaf5f2-1c09-4083-acc0-418c60182226">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="5dcebf9f-1a92-44f9-83db-cef343ac7ef8">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="41d14c30-9038-4d79-9f99-ef4cfdca9c21">
+      <statement statement-id="si-2_stmt.d" uuid="87aa208d-7298-4e88-9a0d-ad50b66b39e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2340,10 +2340,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e2e52ec-042c-4004-9ce6-2b82c3039e09" control-id="si-3">
+    <implemented-requirement uuid="2812760f-5254-41f2-b1a1-f74814974da7" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="497c30bb-071b-4554-8fbc-7d52f3bfbede">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="7705031b-94f1-4d0f-bc09-2b20fdbe084a">
+      <statement statement-id="si-3_stmt.a" uuid="7a172af0-bc2f-4793-b91f-25ec8df73766">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a50f1a-939b-44cf-988d-c66293991147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -2360,23 +2360,23 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="6878bee4-fd91-4f62-86a7-3fd3f05f5471">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="3759da6b-ad65-47b8-aa37-d8f7f66781e8">
+      <statement statement-id="si-3_stmt.b" uuid="56266789-1f6e-41cc-aaeb-af9acf5beaea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="3c59491c-30a0-4fc4-bb6a-54a2f457e13f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="aa559a23-dbdb-4bea-ab37-0a9b1fa38e07">
+      <statement statement-id="si-3_stmt.c" uuid="331924f1-48dc-442d-8083-a140b791c8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bff9f-8d25-49a2-a5e6-3d8966638ce1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat OpenStack Platform, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="acf275a5-f9f1-4c8f-975f-20c09e3b6e9f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="096a95e5-18a0-4384-91f0-3cde56c8527d">
+      <statement statement-id="si-3_stmt.d" uuid="91b6319b-771a-43c4-8de9-56c92a44d5d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2384,10 +2384,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d10ee4bd-aaef-4f8f-b522-232be2275562" control-id="si-4">
+    <implemented-requirement uuid="015f2cf0-6be8-41c9-9664-b065997fc3b3" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="2ae86f83-6e11-4a0d-b727-b98b952e9415">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="c0542ad1-44fd-4d90-a6ff-78d3bd652406">
+      <statement statement-id="si-4_stmt" uuid="a1af621f-f036-4b5d-a442-f03cf89e2107">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2395,10 +2395,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="210838f6-7dd3-4fee-b0f8-d345069ee0fa" control-id="si-5">
+    <implemented-requirement uuid="a0027a0a-4d7e-4249-8cf9-d5cb3c5e9d43" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="afd371ba-93bf-4db2-9af0-62669721330f">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="a10f3f0e-6207-4a6e-b61d-7449bdf2c904">
+      <statement statement-id="si-5_stmt" uuid="294d6cea-5864-4fbd-a065-25cc729a4853">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2406,10 +2406,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42910ff0-a7c3-4284-8b3c-a04b2aa2f6c2" control-id="si-12">
+    <implemented-requirement uuid="42d0e62b-ea7c-4de8-bd7f-5fff9b0c88bb" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="a02ccbe6-cf9d-47a3-a12c-464cba61899c">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="62cfe50d-0dcc-42bd-a6d1-9b6c6f87aed3">
+      <statement statement-id="si-12_stmt" uuid="c50450b5-45de-4bbf-8ee5-07b8f34c0f29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d14b017-b855-4191-a33f-cbd27d8d8407">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat OpenStack Platform in
@@ -2429,10 +2429,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccc90807-2aee-4f92-92a4-8e7cd735e029" control-id="si-16">
+    <implemented-requirement uuid="3f335609-3bc5-4a94-ad29-eb55091ab008" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="a4020434-34c0-4404-aa0d-c276e4b7bc91">
-        <by-component component-uuid="7f205b27-d5c4-4781-95f9-62d1d0445fe7" uuid="4b7f131d-1ce6-4dac-94cc-d14eb1d5d350">
+      <statement statement-id="si-16_stmt" uuid="ffb9c9cb-5304-4c9d-a093-eb857932ab6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5de61587-1d30-477b-9c61-9a3dc01edcfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack inherits many memory protections provided
 by the underlying operating system. When running on Red Hat

--- a/xml/openstack-platform-13-fedramp-Moderate.xml
+++ b/xml/openstack-platform-13-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="ec835285-b96b-4a86-b057-f1b1757447f7">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="82562ea4-c242-448d-b8e8-20929d55d525">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.14+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:19.89+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="aadd6702-5541-4e6c-8a73-3d16b9c5e82b">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,28 +484,28 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="fb4c1000-4a4e-4371-9fa6-9fc4a3366a11" control-id="ac-1">
+    <implemented-requirement uuid="b3ce8c82-d3eb-491a-94fa-a89da455928d" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt" uuid="8f7d421e-cca8-445b-add9-a8da46ce3da2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cc507b77-b231-4e54-96ee-3c3b148be846">
+      <statement statement-id="ac-1_stmt" uuid="39df66e7-c65d-40f6-af11-916751fc5829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97992245-b096-4b4a-bbd1-7a5e037b51dc" control-id="ac-2">
+    <implemented-requirement uuid="2173dd3d-0b7e-4ad7-93f4-e8952b2fe4b9" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt" uuid="04963bdf-2c8a-49fa-a797-19dbb099c648">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8a2fcafe-1b80-4f5c-8ae6-16784e7fdd79">
+      <statement statement-id="ac-2_stmt" uuid="26822768-17f0-47a5-8c73-cf12a222a1e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e524add8-c9e9-4872-b895-b095b68ef98c" control-id="ac-2.1">
+    <implemented-requirement uuid="07848e9f-19d5-45b4-b443-e08f500bd595" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="e2e4cc15-fcab-422e-b75f-5fc53a146d7f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3da0295d-bd88-4718-931f-fd42ad1579ff">
+      <statement statement-id="ac-2.1_stmt" uuid="1298ec9f-c861-4b6b-a616-1053749c932c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b34c1845-4cae-4578-a741-80f3dcbe2368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Usage of an external identity management system, such as Red Hat IdM,
 is recommended. A successful control response will document if an
@@ -515,28 +515,28 @@ OpenStack is configured for its use.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ed76520-a6d0-4fcb-bc96-bc8f442bea83" control-id="ac-2.2">
+    <implemented-requirement uuid="2b859479-3f51-4790-b100-a8540237870e" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="208b2fe2-4306-4061-807e-449ad7023fd0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f7124377-38ad-4410-95aa-b39424ea5801">
+      <statement statement-id="ac-2.2_stmt" uuid="ea1fc28b-24bc-49b0-b5f2-1367977532e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4bd6828-b43d-4b9c-8f2c-7da6ab2e784f" control-id="ac-2.3">
+    <implemented-requirement uuid="b731de9f-ecbb-4c4f-9c4c-2d8bef96bea0" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="8571e06c-4167-4f30-859e-4c2bdb29a382">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7aa0a1c6-ce76-4580-a630-f976cde6c225">
+      <statement statement-id="ac-2.3_stmt" uuid="a1e9ab12-2a19-4e37-9b75-8f361c825231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff7060c8-f745-4b2b-a479-c1a57eeae347">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p></p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f015d8d-222e-488e-a103-5ca22c593ae1" control-id="ac-2.4">
+    <implemented-requirement uuid="d960c57d-23d0-464d-9caa-86051d74c135" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="cd983062-0f01-4593-813e-3dd434d4f35f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cbf13e86-90cc-46c7-8e68-c6e32446510f">
+      <statement statement-id="ac-2.4_stmt" uuid="55d2b336-8e53-419f-a6b2-54a639df4315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="679e2c1d-555b-4510-8ba4-4947616b8edd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked in
 GitHub:
@@ -546,10 +546,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/159'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3fcfe21-6ffa-4937-ae13-db8248a8c86c" control-id="ac-2.5">
+    <implemented-requirement uuid="8f0f4ef6-7b3e-41b6-8f6c-f49a4646651d" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="65749ee9-92b2-4b30-a814-ec8d11223fe6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="24ff1aa2-736d-45de-9bd2-541fbac76722">
+      <statement statement-id="ac-2.5_stmt" uuid="762b4739-a18b-41ec-a576-797447578643">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98ecc7ca-7e19-4ca1-9b47-1e5273e52952">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked on
 GitHub:
@@ -559,10 +559,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/160'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2041544a-5e6d-4113-91bc-87e118b20665" control-id="ac-2.7">
+    <implemented-requirement uuid="95429a97-42d9-4170-bd5b-0cc7ffb00b9f" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt" uuid="5e813f91-19be-47d8-9660-f0919729737e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="2a6df331-dd80-4f01-b990-bfb92fa6c829">
+      <statement statement-id="ac-2.7_stmt" uuid="6611ba37-306d-4571-907b-6268b329a7b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="478dab26-e94a-40f3-a866-d4d89a006611">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on meeting this control is being tracked on
 GitHub:
@@ -572,10 +572,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/161'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73007290-d0d1-46bf-b773-9c2060706532" control-id="ac-2.9">
+    <implemented-requirement uuid="eef60bfd-bfe6-484d-a3aa-5e897b7bb082" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="fa04beb5-a9cc-4f27-9922-31b1ff920262">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5da30944-ea71-4b8d-8e29-6d963becf7c2">
+      <statement statement-id="ac-2.9_stmt" uuid="6f28be9b-63cd-434d-b7f6-b2423778b4cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c9e3ac2-45f0-44f6-a23a-2ef244ee79f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (9) is an organizational control outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -583,10 +583,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60a4aff5-ed63-4435-9b36-2f23e82b2810" control-id="ac-2.10">
+    <implemented-requirement uuid="6e54a7ba-c5f9-46e9-a067-112a3d7c3f54" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="9196c5eb-5355-424d-863c-ec57c85d1695">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="383aedd3-5041-46fb-9a47-66dc4988c7d6">
+      <statement statement-id="ac-2.10_stmt" uuid="7774106a-ae0a-4750-8cf3-4ab273b7d81b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a885466-bf19-4117-b700-b36d2174c796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (10) is applicable to external identity management components,
 and is outside the scope of Red Hat OpenStack Platform configuration.'
@@ -594,10 +594,10 @@ and is outside the scope of Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d07f5a49-4c97-45b9-9445-4bd4ffd87d97" control-id="ac-2.12">
+    <implemented-requirement uuid="e741cd30-ae0c-406e-acf9-37a26c891b17" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt" uuid="6cc5928c-d580-4765-9ba0-f73a8b13691e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f9988524-375d-4069-854c-20009222d429">
+      <statement statement-id="ac-2.12_stmt" uuid="4d53d1e1-c3a4-44f3-86bb-e1f65176282e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07303c50-704b-4341-815d-3b8b39155940">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-2 (12) is an organizational control that applies to centralized
 audit reduction tools/capabilities, and is outside the scope of
@@ -606,10 +606,10 @@ Red Hat OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="930936c9-1adf-42e5-bdfd-3b07bbf1f6ad" control-id="ac-3">
+    <implemented-requirement uuid="37a855d0-90d2-4883-8052-2b76137d3ba7" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="8626e721-2063-4ef9-9349-f87ecf9a70b2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1eb1ec41-1aa7-4243-8642-870bc5f5cb16">
+      <statement statement-id="ac-3_stmt" uuid="2da5110a-ab42-4c47-b656-d66a42f3ffba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dfc41980-03f9-4cff-a609-6f46c86e694d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The OpenStack Identity service supports the notion of groups and roles.
 Users belong to groups while a group has a list of roles. OpenStack
@@ -621,10 +621,10 @@ and association to determine if access is allowed to the requested resource.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6dd6253f-7f20-4973-beb4-a7fa750031ae" control-id="ac-4">
+    <implemented-requirement uuid="52b5c69b-8164-4ca2-a7dc-6d63a9788900" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="07942a91-51ce-4897-bffa-6437799e49b1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="865c6864-f057-4b45-bf78-fdd7a8a2dd8f">
+      <statement statement-id="ac-4_stmt" uuid="bb5fa4f3-14cd-4e58-82be-becb36bdc52f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc04d97f-de87-4185-8ab8-04a6686fe95e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance relating to information flow enforcement is
 being tracked on GitHub:
@@ -634,10 +634,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/166'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70dbb3c8-15d2-4464-a543-3bfe75387e82" control-id="ac-4.21">
+    <implemented-requirement uuid="d3f19230-48a6-4382-8ea8-edd3a87bb7db" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="56e1a136-207f-431e-bf5b-8343ebd0846a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="be8b6fa6-1f29-489b-bb6b-a8ddfe171802">
+      <statement statement-id="ac-4.21_stmt" uuid="2b4dce12-a702-4709-8c29-22485c9a200b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a75e2d9-f7dd-4df1-b0a1-1e9e14f71c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on logical separation of information flows
 is being tracked on GitHub:
@@ -647,10 +647,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/167'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8bb4273-3cc4-46a1-9789-d2afb07a4b0c" control-id="ac-5">
+    <implemented-requirement uuid="e441e4c5-e2c9-4388-92e9-b18105ea3ac4" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-5_stmt" uuid="1501e767-a8e6-4105-b0bd-1afadad87273">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="99461cbc-6366-4548-b753-6110d2fc42b1">
+      <statement statement-id="ac-5_stmt" uuid="ef4fa400-e84a-463f-b529-cec225ea787d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4beec2e6-51ea-4b4b-8ce4-f8c0e1d3c527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance of role/duty enforcement is being tracked
 on GitHub:
@@ -660,10 +660,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/168'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddaede6a-e169-4073-80e0-3522c3a5ea72" control-id="ac-6">
+    <implemented-requirement uuid="dd0056e7-e775-4913-9609-a69f6c40b224" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="a207f461-0870-4d27-bd62-0538156cbe8e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="da825528-9416-4097-b732-a64d75149514">
+      <statement statement-id="ac-6_stmt" uuid="160d5a7e-da64-4a68-991c-0ed8b4a8ffff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73ddf83b-136f-46ec-84ef-0cea4a711319">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how Red Hat OpenStack Platform follows and
 enforces the concept of least privilege is being tracked on GitHub:
@@ -673,10 +673,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/169'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a76fa774-fe6b-4242-88e0-7c6fba6f713e" control-id="ac-6.1">
+    <implemented-requirement uuid="1eb234da-ca27-4db9-84f6-3c54bdc1060f" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="3770ba41-1418-4448-9f28-1a3fadbbec95">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e62cbfdd-f4cd-4045-85c7-ab0133b5764b">
+      <statement statement-id="ac-6.1_stmt" uuid="b2b2277e-5717-477a-aa10-341c7b5786e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9a4880d-bd6e-490b-8f1d-c1ebe085554e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how RHOSP requires explicit authorization
 for elevated privileges is being tracked on GitHub:
@@ -686,10 +686,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/170'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a7e38e5-cc12-4a56-a46d-162d6b2cf16b" control-id="ac-6.2">
+    <implemented-requirement uuid="708b2f0c-4724-4f04-a480-07e6586cd928" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="6a27d083-1d22-4586-8f2e-5a578668eb8c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f77741c8-3e70-4508-9f94-717d11fd0ed5">
+      <statement statement-id="ac-6.2_stmt" uuid="09a21427-da3d-43ad-b647-403eda9cdc5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b38197d-3bf2-4c92-ae57-6c9263b7dff3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked in GitHub:
 
@@ -698,10 +698,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/171'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5927a55-1028-428b-aae6-30d0c501d606" control-id="ac-6.5">
+    <implemented-requirement uuid="bf126577-dc18-4815-bd31-07729084ac85" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="397e73aa-70a1-434c-9ac2-1357ec282c1f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c0ef909b-7248-41aa-8aff-e2ffa43853a4">
+      <statement statement-id="ac-6.5_stmt" uuid="8d0fe372-e1ea-43fe-aa9a-cb8182c447c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f63cbc-85b2-48e1-9c0e-b9f50b9b0dd5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'AC-6 (5) is an organizational control outside the scope of Red Hat
 OpenStack Platform configuration.'
@@ -709,10 +709,10 @@ OpenStack Platform configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc4f78a8-9b27-48fe-9b73-fdaa93cf3a02" control-id="ac-6.9">
+    <implemented-requirement uuid="f50ade8d-7a8c-4de9-b73a-2564df17a82a" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="8a5eff51-0f08-49db-8329-86f775c218c0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cabee25e-faeb-4b96-9d0c-781cd726ab41">
+      <statement statement-id="ac-6.9_stmt" uuid="ffde3865-039f-40b2-a74a-1f68e136b1f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2fc24a5c-d8f8-40dc-a35e-4a7e79b6a3fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -721,10 +721,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/173'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7e2045f-6f6c-439d-a533-787e7f74e129" control-id="ac-6.10">
+    <implemented-requirement uuid="89f45c9f-a394-4530-8e45-04680613806f" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="0af67608-6a29-4116-9a8b-36784ef63ab9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="91d37a29-06b4-4e65-b53a-d15eb0ea0c21">
+      <statement statement-id="ac-6.10_stmt" uuid="fceed92c-d62d-4a0a-a529-a7d0c9a0694a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0091b60a-a998-438e-970f-c40425e34b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -733,10 +733,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/174'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25a64b64-70df-44c9-b90a-99964ee79e7d" control-id="ac-7">
+    <implemented-requirement uuid="190b26d2-10b1-47e5-88f6-450145e92ed2" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="4861cd56-c47e-4e8b-b980-24931f45145d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="03cde8a9-8d11-4d1b-b608-0bc8efbdb85e">
+      <statement statement-id="ac-7_stmt.a" uuid="1bef3d71-d9b0-4cb8-879e-600174407f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -745,8 +745,8 @@ to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="6d927847-92c4-47af-aa97-362bc8619211">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="69d4526b-64b8-415c-8712-1609443da9af">
+      <statement statement-id="ac-7_stmt.b" uuid="be2edb42-6f1f-4727-b9d5-0bfc96898c49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7d4537a-985e-4f19-9ade-ad8c77c6f2b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'It is recommended that OpenStack be integrated with an external
 identity service, such as Active Directory, Red Hat IdM, or generic
@@ -756,10 +756,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0636dab0-16e4-46d6-9aac-766a0c2adff4" control-id="ac-8">
+    <implemented-requirement uuid="3c7dcd8a-8a1c-4720-a1bf-425a9b810f7c" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="0e309b92-bcd1-41a3-ada7-127270ed251e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ab29fd4d-3f61-4d63-9ba7-5d0e49a3d71a">
+      <statement statement-id="ac-8_stmt.a" uuid="4e30b817-eda8-41ee-9a23-2f19799b50d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1018d6-5f53-474b-9d19-092699fce6a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -778,8 +778,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="844450ea-7f06-4df4-a8b5-afc3beb64feb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5a14e946-2d42-475b-8d0f-5c335b25a21e">
+      <statement statement-id="ac-8_stmt.b" uuid="8cac1383-8b47-47dc-b910-b8abe32cd73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c110a8-4332-4751-8dd3-d5e9c088377f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -793,8 +793,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="f0c2d049-7c3b-4116-a77b-ad8173b5cf25">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ac420664-e02f-44dc-8f83-654d0c1be7bc">
+      <statement statement-id="ac-8_stmt.c" uuid="1959d416-63d4-4558-9ff3-02e1060844b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bad8105c-14af-47b5-a477-194b9d3efd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -810,10 +810,10 @@ It is recommended the same banner be displayed as configured in AC-8(a).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2af093a4-ff45-49f1-9c7f-83c1ad65a021" control-id="ac-10">
+    <implemented-requirement uuid="b5c501dc-2d33-43ee-a740-c738c6967713" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="cc3257c8-7bd3-4e0f-869d-3f8df827c1e8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0b2068be-ed0d-426d-9a1f-2df50b7ffc34">
+      <statement statement-id="ac-10_stmt" uuid="f2ec3f3b-a703-430f-99f5-1b941bba3c19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9101acb9-2324-41e4-8d88-3a58c3c1ff39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -822,10 +822,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/175'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33c92507-64ca-418b-b17a-730f68d1ccef" control-id="ac-11">
+    <implemented-requirement uuid="0c8021ef-996f-45ac-9c86-e84bdf27c7bb" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt" uuid="2450d145-0100-4ca1-a6d1-d0a47e9778eb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="51d48b26-a010-4f18-9053-cbddbd49b8bb">
+      <statement statement-id="ac-11_stmt" uuid="2d6dfadc-2986-4d13-9125-35c4edf87846">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f660c858-925e-4e13-82dd-1f4c1995e15a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 behavior of Red Hat OpenStack Platform is to disconnect the idle user
@@ -834,10 +834,10 @@ from the user interface.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e813f3-669c-4179-bdfa-7205a5142863" control-id="ac-11.1">
+    <implemented-requirement uuid="79f3136c-e316-4f56-9ddc-7d86218b44ad" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="df9e9f6c-8ebb-48a7-8df6-de83b9f5b171">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="855f2b49-57fb-40ab-99ff-0e2818cd4b0c">
+      <statement statement-id="ac-11.1_stmt" uuid="7ad56d48-1943-4978-a4c5-debc5fc63bea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f660c858-925e-4e13-82dd-1f4c1995e15a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Not applicable. When AC-2(5) is implemented, the non-configurable
 behavior of Red Hat OpenStack Platform is to disconnect the idle user
@@ -846,10 +846,10 @@ from the user interface.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62a66d50-ee24-4666-838b-0ef7bec98e6b" control-id="ac-12">
+    <implemented-requirement uuid="9d2b376a-4ca6-4370-ad29-487832ee0337" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="7ce24f11-19e7-4432-a808-27f6256fedf6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="db335bd2-8a31-4e8a-9c25-4fd6bb287466">
+      <statement statement-id="ac-12_stmt" uuid="5a6399aa-82da-44d8-a878-61b4b7f6a99d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19f5f9c0-c90a-4a34-8106-2d55b0fc7805">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being tracked on GitHub:
 
@@ -858,10 +858,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/177'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00cbc7fc-060e-4373-89a4-232c8fa45659" control-id="ac-14">
+    <implemented-requirement uuid="a0c92060-22e2-4929-8d06-ec1468232753" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="942827c3-2e0c-4599-a8fa-c416ce6552f1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="85b4b733-4cd7-4d40-b0c6-2b3daec69400">
+      <statement statement-id="ac-14_stmt" uuid="1ffeb67d-0d45-487c-ba49-416acbcfa90b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="116c1ecf-7617-4874-8eee-3900fc91dadd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Regardless of access mechanism, such as the Red Hat OpenStack Platform Console or remote
 access attempts through SSH, unauthenticated users will only be shown the
@@ -874,10 +874,10 @@ prior to granting resource access.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31935dc2-9d54-4435-a21a-6ce511428a00" control-id="ac-17">
+    <implemented-requirement uuid="a28a91c2-7adc-4a36-9e89-fc7a048894cd" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt" uuid="729e28b3-8bf9-40af-bad7-29b309d7499f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e803ee0e-3990-4e7e-be95-18f15501d463">
+      <statement statement-id="ac-17_stmt" uuid="1c3ac4b9-ae12-4073-8905-ec981d0f9d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -885,10 +885,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8999edb1-c5e6-43b3-b46b-c001692b84e5" control-id="ac-17.1">
+    <implemented-requirement uuid="c8c9ecb8-9cfb-48c8-a912-6ec66f8ba20b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="7e0ced75-6e7f-411c-891e-b765e384cf1e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9677d2bd-1756-44c7-b28c-f9a64816a3d1">
+      <statement statement-id="ac-17.1_stmt" uuid="a9cc62a3-9b32-41e9-b53d-989ae960e5ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a55eea32-503a-4f72-a32a-f8c81f703b37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'As a network accessible service, all connections to Red Hat OpenStack
 Platform are treated as remote access. No additional configuration is
@@ -898,10 +898,10 @@ non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6488f9bb-308b-4fba-945f-281e44c13132" control-id="ac-17.2">
+    <implemented-requirement uuid="3321fd05-4ccd-4d57-b78b-80a9451924b1" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="51ffb84d-d7b8-414b-afeb-376e8c04e4b8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cf04092f-0f79-4fcd-94c0-ffdbdd39a4cb">
+      <statement statement-id="ac-17.2_stmt" uuid="d8056d08-02d8-468d-9074-747e33c783be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3727dca-2c9a-4379-9985-60a962b0f92d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -910,10 +910,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/179'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33b0647e-36cb-42d3-a066-b78988ad12fa" control-id="ac-17.3">
+    <implemented-requirement uuid="e1557dfc-c802-4b95-bd3e-8bda4aad4d24" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="d2ff2849-9caf-4f0d-acda-dd7535460a5e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="327c0490-c5d5-49ba-b86c-27b5762bfe9a">
+      <statement statement-id="ac-17.3_stmt" uuid="16ece187-9ea3-47a7-a964-b780a0c961b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7dd9924-e1e6-4bcb-b643-93c98091670b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -922,10 +922,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/180'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cee7698b-c438-40e4-ad90-7b1bdf7e29ed" control-id="ac-17.4">
+    <implemented-requirement uuid="6399c737-d4e2-484b-86bb-a81ed044be10" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt" uuid="50b2ba1a-0393-470c-9f44-da6456c4498e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="00825846-6c37-43cd-b341-2015c1ea2648">
+      <statement statement-id="ac-17.4_stmt" uuid="c4b067f8-0f70-4d23-817f-1e136a9044f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3538a779-2e89-4b5b-8973-163eb68c55a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable. Due to the native of cloud
 computing, authorizing activities over remote access is
@@ -935,10 +935,10 @@ procedures) are provided in AC-2.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f37d526-48f7-4f89-a658-0067d26fca91" control-id="ac-17.9">
+    <implemented-requirement uuid="931abcc4-6424-4b1b-93bf-2686fabc7573" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="8dd7f7f9-f70b-4959-9c29-e9b147a4eb07">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1f680d00-155f-456d-ac11-f92116fb7021">
+      <statement statement-id="ac-17.9_stmt" uuid="a054f60f-9388-4160-84e7-2201b57b7bb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60862f-8ec8-4267-b5a8-4aed2dd6abd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -947,10 +947,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/182'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ab011ec-1a44-4d6d-9ca8-f0e769015369" control-id="ac-18">
+    <implemented-requirement uuid="542db06a-3132-4641-b932-b44a95c3b37b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt" uuid="fee9f7b9-4f8d-4467-97aa-045f6ce8be62">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c778a4ef-b537-4895-873b-beb9b3c72831">
+      <statement statement-id="ac-18_stmt" uuid="bc5a066c-bcca-4690-b7da-88aa4df0ee25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -958,10 +958,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc7ddf9a-16d9-4297-96d8-4e0f5273b847" control-id="ac-18.1">
+    <implemented-requirement uuid="02e0f4c1-4de2-4bdd-a531-0d0f4a6b3e7d" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="b81df253-2ddf-4f17-a05e-92d8d167fb71">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9138e826-7ef8-4e6a-bfe5-cf593b551bff">
+      <statement statement-id="ac-18.1_stmt" uuid="567a40a8-8f12-4386-9fff-618e4670dfef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a16a28f-3ed2-4ba6-a22a-2c872c22f0dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies
 at the network access layer, and is not
@@ -970,10 +970,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d87982a-bcf0-41d4-839d-1628876a6828" control-id="ac-19">
+    <implemented-requirement uuid="dc10d2b7-c173-4f90-8d04-19b3de77a1d2" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt" uuid="fbc43a5f-da5f-486c-a109-59935a53e395">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3a01bd12-08e5-4083-8d7c-851464855610">
+      <statement statement-id="ac-19_stmt" uuid="b7e8d38a-57c8-4abb-9006-60327755e2f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -981,10 +981,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c32385c4-7209-481e-9bff-03f8b77cef22" control-id="ac-19.5">
+    <implemented-requirement uuid="32e8c3b8-9583-42e3-b494-c015d4f940f9" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="5b442cb2-3b14-4308-9924-4a58ceb9efa2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cb5ef81b-1321-44e7-a80e-26ccacecb726">
+      <statement statement-id="ac-19.5_stmt" uuid="0d19cdba-cb75-4c89-843a-3499d88a0984">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d875880-2b77-477f-9f42-83b997dab5f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is applicable to mobile devices, and is not applicable
 to the configuration of Red Hat OpenStack Platform.'
@@ -992,10 +992,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e09eea6-2dbd-4225-973d-e7fe46938a38" control-id="ac-20">
+    <implemented-requirement uuid="f7a0ceec-9299-4a0a-af63-ec3782f76704" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt" uuid="1a0c65c8-46a1-4816-8503-48ce6fb88ad6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a40012a2-8753-4ec9-86bd-49f24a0e933b">
+      <statement statement-id="ac-20_stmt" uuid="2bedb697-599f-4296-8f4c-07a074100182">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1003,10 +1003,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34aa355c-3330-4435-b2ac-55ef27b49b71" control-id="ac-20.1">
+    <implemented-requirement uuid="1bc859f5-ee47-4a7d-948f-42c93837e228" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt" uuid="e06be40f-3d1a-4e6d-b6ad-d44c450d1d65">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="db16e0c9-f54a-4898-ac41-ca76c50c4160">
+      <statement statement-id="ac-20.1_stmt" uuid="fa04c320-5921-4eb6-bdc8-54a1f7e8d571">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a44d7b8-b146-4b2e-9c19-e1489de600a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies for
 external information systems accessing the Red Hat OpenStack
@@ -1016,10 +1016,10 @@ configuration of Red Hat OpenStack Platform itself.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c4eb47e-4e2f-419c-b521-4a2c210a89a3" control-id="ac-20.2">
+    <implemented-requirement uuid="44420817-8343-4af0-9873-0e72aa3c38f5" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="adb3d936-f58d-418b-a808-e68597e4bea8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7f17427a-64b7-4772-9349-dbb6e247e45d">
+      <statement statement-id="ac-20.2_stmt" uuid="fe0c6d1f-5353-4844-a99e-33220430613c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd672133-4435-4dc4-9567-3e57628a7eab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies outside
 the scope of configuring Red Hat OpenStack Platform. This control
@@ -1028,10 +1028,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31b67ea2-4e44-43a2-8652-b4a1b43b80e7" control-id="ac-21">
+    <implemented-requirement uuid="40e95b8f-9bf4-46cd-93ed-f29e7d0fa5f9" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt" uuid="d46784d6-605c-4a2f-9db5-7597d84b79d8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1184c066-934e-4b9e-a028-b0a940d87884">
+      <statement statement-id="ac-21_stmt" uuid="acbfe654-15b8-4274-bc7a-769dc9b9310b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd672133-4435-4dc4-9567-3e57628a7eab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies outside
 the scope of configuring Red Hat OpenStack Platform. This control
@@ -1040,10 +1040,10 @@ is not applicable.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fecf503-c49f-4eac-8ace-5d6109cc5e96" control-id="ac-22">
+    <implemented-requirement uuid="9dfce701-b6ba-4df5-a330-1fb7562f33cb" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt" uuid="4524c266-4391-4eec-bf59-adfcea915053">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4d991a1b-e11c-41d1-8285-174394e006d4">
+      <statement statement-id="ac-22_stmt" uuid="2b36af0f-a585-4fe7-9ffc-093a778a9e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1051,18 +1051,18 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dca9959b-240f-45a0-8e9b-2140fd9a01f1" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="9467a459-fa9b-437c-aa35-6b1bee261cf3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ff7893b1-de61-42e0-b5ee-06f8a737f384">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="2a562176-e3c5-417a-abe1-17bbcd379bfb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0bb72b69-3cde-452e-b00f-e2b5c6d4f1bd">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1070,26 +1070,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2621d902-840a-4e8e-8aca-6f81d289588e" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="08ac6fe1-652c-4189-b177-a27de3c92a06">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="492ff421-3e7d-4fe9-8f90-5c89ce4a5291">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="9f3ca48f-183d-4b00-b254-3eca0e9b6ea1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ccf5f21a-fb40-4fa0-afd1-26ee1f4d8cd8">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="136f7f4b-65a4-4895-90fd-7dec29df7d6b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="62f1e50a-7dea-4a4b-b267-be278d9cf55d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1097,10 +1097,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b39d9a4-bce2-4886-be87-952ec37ba64d" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="5193957c-4b04-43d7-b6f6-87977844005c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="38699402-dec2-4de0-b0ce-88a3ab4bb11c">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1108,26 +1108,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03811345-94a6-4d42-9e04-1752f4541e0c" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="39e8dfea-61ae-468f-be63-74b8c3792bb1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="80f29a34-3856-4a37-a927-7ef365392277">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="9f270d7b-5159-43a7-ade5-ff547a0900cc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9d57732c-abe6-41a7-ab1d-8cc443c29c84">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="b680f47e-f960-4be2-840f-c830712502c2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f8db006a-0336-4c1d-8848-50db1c95bb81">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1135,18 +1135,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24d0b149-79fe-4e85-a6c1-672d6b468463" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="8516a453-c3ba-4caf-84d4-3b075eb2d811">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="856e211e-be68-4569-b576-636f80decb19">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="75b082b7-25f4-448f-88fc-dabe2e30c0cd">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ce205c40-9e67-4719-9684-804e48cafdd7">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1154,10 +1154,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c2d1322-c139-4a0a-a847-205243afc8c9" control-id="au-1">
+    <implemented-requirement uuid="9bf02c5e-bac7-426a-99ee-612029fb4422" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt" uuid="4e88af06-4809-450a-a43a-9aad0921a685">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4a0a375e-c5c7-49db-9e1f-905d9f34f9f1">
+      <statement statement-id="au-1_stmt" uuid="022814e1-5123-48e3-9bb2-414d326089f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1165,10 +1165,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a94242f-5f17-4137-b8cc-b2d6a9f067a5" control-id="au-2">
+    <implemented-requirement uuid="70ebfe3a-dd07-44bb-934a-1f049c3df081" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt" uuid="93e6328a-7e34-4f57-8bd6-a74bbf8cf483">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f59ca9a5-044b-4c23-b7d0-c983b2f6d934">
+      <statement statement-id="au-2_stmt" uuid="c740b0e8-7529-4771-86c7-7abaee9d8e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ec78773-f971-4af8-a715-99a4cfcc3d4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.
@@ -1179,10 +1179,10 @@ Red Hat OpenStack Platform through actions specified in AU-12.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="052f9a11-33a2-4b4f-b7b5-4703f99b6b1f" control-id="au-2.3">
+    <implemented-requirement uuid="dd80b246-db52-45ae-a248-b309e468f7f8" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="6b851a1c-a329-4de7-b0f1-f0cc0348f37a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="15744036-bca0-4d5e-b585-16dbaa850314">
+      <statement statement-id="au-2.3_stmt" uuid="6acaa086-c812-4ef4-af83-9aeff07f5229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1190,10 +1190,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55ea0380-35bf-4b63-9dfc-db967f496ffb" control-id="au-3">
+    <implemented-requirement uuid="fddce8ff-c1d3-4b41-ada0-b62b24cfb2b6" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="4d00e481-3bbb-46b1-b225-97aa9bd6774c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c8bf689d-a1bc-4b99-bc85-66efe94a1e3e">
+      <statement statement-id="au-3_stmt" uuid="a3c40616-3e41-45e1-a8b9-63205765ed89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6cd09a8-08a4-4f88-9f72-1429acae092a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform audit records contain this information by default. No
 additional configuration is required.'
@@ -1201,10 +1201,10 @@ additional configuration is required.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5f5f646-6884-4948-9fec-9c525bb2d064" control-id="au-3.1">
+    <implemented-requirement uuid="f3d92c70-33c5-492e-ac77-5c5def090b58" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="704ef634-804d-4fc1-8473-2c1cd8be88db">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5bc88394-2c1f-44b8-bbb1-f6cf6970a6f4">
+      <statement statement-id="au-3.1_stmt" uuid="5a15922f-d663-4724-8e07-8b412792a2e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1212,10 +1212,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a66c966d-7efe-4dff-bfd8-ce3a98cafc82" control-id="au-4">
+    <implemented-requirement uuid="3c3a6218-edb3-4574-9991-1c281a4af6db" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="8555b017-1a57-4242-b335-2bd70f798a43">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="eab1b465-dbe8-404b-8f3d-7eb7b9137bc3">
+      <statement statement-id="au-4_stmt" uuid="c897c7e2-3bf6-4ea2-9c5d-0971f6de0e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b11dbe7-4a7e-4827-b1dd-da2cfd809e31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform. This control is reflected
@@ -1224,10 +1224,10 @@ in proper disk partitioning of the underlying Operating System.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa8ea131-bd2e-4d7c-8d05-251982578c05" control-id="au-5">
+    <implemented-requirement uuid="d867a1bc-cbd0-4edb-b26e-9b1b0ed32513" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="1296bf2d-c61b-40ae-9509-a6630d528f4f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="35ba50b4-8672-457c-aee4-2516315d1819">
+      <statement statement-id="au-5_stmt.a" uuid="681d6b0c-120f-4476-863f-0a8b4bf8f3a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1fc991c-c801-45c8-baa4-ba3b169595d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform Administrators  are responsible for alerting personnel
 or roles in the event of an audit processing failure. A successful
@@ -1241,8 +1241,8 @@ https://securitycentral.atlassian.net/secure/RapidBoard.jspa?rapidView=4&amp;pro
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="f0cd422c-658a-483d-8eeb-88e9e75e0398">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a0f57066-2853-495d-9c56-f7d2ff815940">
+      <statement statement-id="au-5_stmt.b" uuid="ef5f7d6b-80d0-4295-9ea2-505668e025e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3dd40bb0-312a-4bed-abed-0be2db2606ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the event of an audit processing failure, Red Hat OpenStack Platform Administrators
 are responsible for: overwriting the oldest audit records for low
@@ -1253,10 +1253,10 @@ failure occurs.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45a1e046-0715-402b-8166-f33fcb38aa77" control-id="au-6">
+    <implemented-requirement uuid="3c5d91fa-2336-4a39-9f4a-38b9178be864" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt" uuid="7ee05cc1-6604-4456-a9f2-82eb9e757976">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f1990264-1ef3-4947-9591-d72641a04291">
+      <statement statement-id="au-6_stmt" uuid="382fddb1-91a1-4a1a-bb6d-169861ccd7ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1264,10 +1264,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0aa99ec-c636-425c-9fdf-0c5bf970f5ee" control-id="au-6.1">
+    <implemented-requirement uuid="c27f6618-4d69-4d1a-a512-ffb85b8b222c" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="31128c86-02aa-4d2d-8958-8839d4c506b5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="702f7945-f03f-447d-a05d-40afaa72fa8e">
+      <statement statement-id="au-6.1_stmt" uuid="c600f133-736b-4549-8757-aa96f7fe1c70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1275,10 +1275,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf94f336-bb0a-42cd-8d3c-deadf5c12c59" control-id="au-6.3">
+    <implemented-requirement uuid="dad2591f-3b7e-4daf-b55f-b0311685704d" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="4f586c9c-ebbb-4635-abde-cc9339790778">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8963c527-14de-4c01-b8a3-3de308e3273a">
+      <statement statement-id="au-6.3_stmt" uuid="d1a97bba-193e-48e2-b9d4-7dd0e063ad4b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1286,10 +1286,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6d601f0-c27e-4bf0-aec6-fea0c23a826c" control-id="au-7">
+    <implemented-requirement uuid="ac3f3fb8-cacb-47ba-988b-84e28ef73483" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt" uuid="088ec02d-9a92-41fc-b8f5-bee78930fddf">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="34749425-25a1-4898-9fbf-dca1082e2a4b">
+      <statement statement-id="au-7_stmt" uuid="30027b2a-b6b7-4718-9455-bf662140182a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18aff937-f527-4130-9c1e-fb9dba74b466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on GitHub:
 
@@ -1298,10 +1298,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/196'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9325c70-b8de-4649-891b-878d3af14627" control-id="au-7.1">
+    <implemented-requirement uuid="7a28db6c-28a7-4dde-abd4-3582910a0b68" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="58480629-f419-4c96-a8d9-5cd24d2c91d4">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="91c8f853-77a2-451a-9087-c9a3205a2199">
+      <statement statement-id="au-7.1_stmt" uuid="99c25fcf-8a36-4dff-a460-97fbc61e1beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28f6789b-879b-4f0f-b557-8ff0bc201133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on GitHub:
 
@@ -1310,10 +1310,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/197'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe725ba9-1c71-46bc-b21a-4c58c529f525" control-id="au-8">
+    <implemented-requirement uuid="d4452df8-ab68-4376-94f8-4849a8bfb851" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="2161bcfc-6d72-4560-87d4-007c27f1be23">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4756cd81-13bd-42a9-9ae6-dca36e32e845">
+      <statement statement-id="au-8_stmt.a" uuid="ebf16490-e892-4926-8e04-5f05a2d4e1cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -1321,8 +1321,8 @@ of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="6c671787-c938-40de-87b4-687fc4ce62c4">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7ca3b3fa-16d1-4047-a6ff-e65b0117591c">
+      <statement statement-id="au-8_stmt.b" uuid="9d59163b-c469-4dfb-a1f6-7425f23f0381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d6a7d44-9cc1-4264-946d-cb55cf9bc936">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform time keeping relies on the time services provided by the
 underlying operating system. This control is not applicable to the configuration
@@ -1331,10 +1331,10 @@ of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a8dd45f4-ccc3-4bb6-8d06-920392a95812" control-id="au-8.1">
+    <implemented-requirement uuid="b1a55688-ef6b-4dd4-8d0a-762d8369ff70" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt" uuid="65fbd244-5e74-453b-a540-f36f2079260a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="00826d94-d70a-47f1-926d-b9321df76727">
+      <statement statement-id="au-8.1_stmt" uuid="ea929555-934d-4492-b753-52e6555e936d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3353df5e-a8a7-4611-aa8d-96739561a1d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform utilizes the time services of the
 underlying operating system. This control is not applicable
@@ -1343,10 +1343,10 @@ to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8e9837a-d72a-48ad-867a-b6aadc761367" control-id="au-9">
+    <implemented-requirement uuid="146245dc-fac0-4451-80ed-bf2dec829320" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9_stmt" uuid="045ffb2f-cb01-4098-9a97-9bfaa5faefc6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dc9b4e4e-35f5-4745-9af2-2a6b4c613500">
+      <statement statement-id="au-9_stmt" uuid="3733f6ae-83ff-4751-9dbe-8c2ad28014b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6dfb370-517c-4b4b-9d2f-bac24716a925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Customers are required to protect the audit information and audit
 tools from unauthorized access, modification, and deletion. A successful
@@ -1362,10 +1362,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="926aae60-0b93-44f4-84ed-9dd3ac1cf9a5" control-id="au-9.2">
+    <implemented-requirement uuid="eb803f8c-a05e-4905-8b4e-244c896317df" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="53a9d99f-9694-4bd5-b361-b78adbed34a1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4565118f-ffe8-4c71-a47c-6e80c53b01d5">
+      <statement statement-id="au-9.2_stmt" uuid="e15236f0-7845-479a-a742-0342b07464d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ebc2640-0c1a-4e83-a0fb-569cfed6f0dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring OpenStack to perform
 centralized audit logging to a central facility is being
@@ -1376,10 +1376,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/199'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01493aec-d090-4bdd-823b-3a40f80e9bd2" control-id="au-9.4">
+    <implemented-requirement uuid="0efafc69-ef1b-4196-8a68-aed6d114b8bb" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="645db878-e150-4899-9cb3-948dbfc98de7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7558e32b-147b-4c63-aedd-e833c2ba787d">
+      <statement statement-id="au-9.4_stmt" uuid="d143d0da-572d-424b-b97d-01e8c2c8ce3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e38b8b6-6e83-4434-a440-47a364f74a1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on configuring Red Hat OpenStack Platform
 logs to only be accessible by a subset of privileged users
@@ -1390,10 +1390,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/200'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66a8db86-dfef-418c-a313-a335fccec1b2" control-id="au-11">
+    <implemented-requirement uuid="5c7ff55f-ec1c-4d4a-87d2-82ac5696a9d0" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="bd1a872a-1b53-4268-a7a6-8ab5346f8bd9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="283b1e7a-5ee2-4ff7-8518-92075143c58a">
+      <statement statement-id="au-11_stmt" uuid="aaeb8b45-0e00-40a4-84f0-bd5cf83dbcd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c10fb204-7d24-42e8-9c63-567b6cfb25c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/instructions on audit retention is being tracked
 in GitHub:
@@ -1403,10 +1403,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8cd53ad-ff37-4929-8066-39afceb43962" control-id="au-12">
+    <implemented-requirement uuid="1967f2dc-1435-4eda-8ccf-ba5ba151624e" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="e4143d97-4184-431b-aa6d-a8bb4b7622b2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="da1f9091-1bcf-4bd5-88cb-15f729e79080">
+      <statement statement-id="au-12_stmt.a" uuid="d8dd4ef4-cdb2-4aee-b37b-fc851093599e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53aef63a-c315-4b30-a198-f9cea31695e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to provide record generation capability for the
@@ -1418,8 +1418,8 @@ defined in AU-2.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="9ab1a177-04a7-46cc-926b-9a2c849ef00a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8165becf-6be5-4fce-a09a-59faaf91ff6a">
+      <statement statement-id="au-12_stmt.b" uuid="731aa217-5c07-46bb-ad2d-632e3255dd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f61858fc-aa00-42fc-ae4d-a24a7acf2895">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to allow defined personnel or roles to select
@@ -1437,8 +1437,8 @@ is recommended that Red Hat OpenStack Platform specific audit rules be added to
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="b6d5b80a-fa5d-46a6-bf48-29e6430379de">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="99dc5341-633f-4535-bdd0-aaad922318ed">
+      <statement statement-id="au-12_stmt.c" uuid="44430558-566f-45b4-a248-a4ddb5725174">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d16933d-428f-4a2c-a836-78a6b24c6c62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'//*
 Customers are required to generate audit records for the events
@@ -1450,10 +1450,10 @@ the requirements defined in AU-2 and AU-3.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a625141f-5790-4006-bc83-5c5b6aa2e9a9" control-id="ca-1">
+    <implemented-requirement uuid="d87cdbc6-4547-433b-b751-62499a9ce52a" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt" uuid="0d663eb0-8cec-4417-a12e-b85474a8b624">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="d7ae57f3-8e73-4c2b-9c81-e997dfd8a520">
+      <statement statement-id="ca-1_stmt" uuid="0f646fc8-76a1-46f5-93a8-c55da7cc75af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1461,10 +1461,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2189ac24-0134-4b41-b1f6-a71bb8a1fd48" control-id="ca-2">
+    <implemented-requirement uuid="5b50db58-75fa-4448-85a1-a24cad98b5b7" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt" uuid="18fcd5a6-c61d-484f-a493-f70a7e701dcc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e8059ddb-240c-4f2d-9107-9ad486cef940">
+      <statement statement-id="ca-2_stmt" uuid="85d565ff-b15e-45b5-aa32-a26453e7426b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1472,10 +1472,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74a1095c-bfac-4a93-8b3a-229296e83d93" control-id="ca-2.1">
+    <implemented-requirement uuid="35ae93da-4d51-44f2-bd19-c36afeaeb949" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="2992fd32-6a41-4401-af11-72311af4478f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="195cff50-ed80-44cf-a722-03534565bd4a">
+      <statement statement-id="ca-2.1_stmt" uuid="11c7a1b7-45a9-4f01-b0fa-79c893a8f95f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1483,10 +1483,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfeec623-3c08-4d72-b955-a36b3dd0ba9a" control-id="ca-2.2">
+    <implemented-requirement uuid="c3e8546d-85a3-4155-b0ad-6f293fd47519" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="6311516e-66bb-4fe3-b07a-e353b5cb7a73">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f5507c8e-f284-4bba-bdbd-00c12b6f86f2">
+      <statement statement-id="ca-2.2_stmt" uuid="b965a20d-28fe-44a1-9e78-8889797ddf84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1494,10 +1494,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b410c20-83fd-44ac-8241-f2c2b25082a0" control-id="ca-2.3">
+    <implemented-requirement uuid="80259878-8ffb-4ab0-a7ae-9e3ef2f9600c" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="eafb7ab2-1e6a-44ee-babb-afe737496d76">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7ed4eb72-53dd-4bb1-9819-61dd22a9ac0c">
+      <statement statement-id="ca-2.3_stmt" uuid="42143f0e-7af5-4e6d-bf35-eb5cc958c307">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1505,10 +1505,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5380ffcb-3c90-46dc-ae08-440620ca1291" control-id="ca-3">
+    <implemented-requirement uuid="a5c5b25d-a826-4eff-affb-e56ef4c37941" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt" uuid="5d21f478-4410-473f-8d18-aa0669a41c86">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="30c37f01-6c05-4c31-95da-066fd4028e5a">
+      <statement statement-id="ca-3_stmt" uuid="1e74400d-8cf8-4cf1-828b-fc8eb630326d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1516,10 +1516,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3aec8576-af63-4a3b-8f8d-399e759f6e06" control-id="ca-3.3">
+    <implemented-requirement uuid="3dcb907d-a220-471e-87d4-31157dff1d4f" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="bf05bd18-db9e-4039-9446-b5836bab16ef">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="228f3129-d2f5-4620-bceb-663630a69531">
+      <statement statement-id="ca-3.3_stmt" uuid="191fcc8e-fef9-4594-bea7-6233eb59c71c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1527,10 +1527,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6dbbfae3-496e-468e-bd8f-4d899453fb81" control-id="ca-3.5">
+    <implemented-requirement uuid="eeabf62a-5c1a-46cf-8a13-718e38a78dc4" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="77e344c6-f924-4842-8552-3b489215aa72">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="bb8449cb-779d-4e56-bebb-dc922e85341d">
+      <statement statement-id="ca-3.5_stmt" uuid="8eef30a2-434e-40b4-815a-afb50caacd79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7b50cf8-2f8c-48eb-8949-4305e6b821ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to implement traffic flow policies is
 being tracked on GitHub:
@@ -1540,10 +1540,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/204'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25fd842a-f615-40ca-a3cd-418594f44dcc" control-id="ca-5">
+    <implemented-requirement uuid="75bc3a7c-5883-44fe-b857-2ec0779b6f2d" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt" uuid="f02c04b8-f934-4e5a-b92c-97df6b710b32">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="17502356-5814-443c-a0fa-442148719724">
+      <statement statement-id="ca-5_stmt" uuid="c898adea-56b2-496b-a95b-aead7a416a39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1551,10 +1551,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ab2cba3-356f-4313-8b5b-f51248d1da46" control-id="ca-6">
+    <implemented-requirement uuid="c27d2686-16bc-455e-a5c3-2f90509df2a1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt" uuid="ca47e7ab-d398-4c47-8329-6d0daba7e89b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7a3eda95-31e9-469f-80d2-9a7697bd98ff">
+      <statement statement-id="ca-6_stmt" uuid="66d1077a-8d5f-42f0-9078-bde3910bfabe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1562,10 +1562,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c390d6a-2e70-40b9-8114-d3d8c052cee6" control-id="ca-7">
+    <implemented-requirement uuid="b39d3be7-d4b4-4834-987a-b997656af1ab" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt" uuid="6e14e2dd-ab8a-4e04-b732-f67dcac81f24">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ebedef45-4067-4a61-bf78-bb2a3e33a887">
+      <statement statement-id="ca-7_stmt" uuid="5da17598-9a18-4a3b-ba63-f89d9e00730c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1573,10 +1573,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51c11858-91ad-4069-989f-79583a474703" control-id="ca-7.1">
+    <implemented-requirement uuid="48fd5e62-c030-48d0-bbc6-c766f385e887" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="3c8113cb-87ae-48ea-aa8f-f5353f0ece96">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6e71e050-cb01-44ea-b657-40f33accb8e8">
+      <statement statement-id="ca-7.1_stmt" uuid="4a8d334b-6dbd-4da7-ab95-afd467d1c4de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1584,10 +1584,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebea6f3c-e9ea-4e83-9eb8-6e86e429555c" control-id="ca-8">
+    <implemented-requirement uuid="026aa160-ea10-40a9-be7b-d300ccfc9d3a" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="f877c5be-f1f6-45ee-92b8-f164fd8e3e96">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5511eacf-10ba-465b-a0f8-7a00f24df6c9">
+      <statement statement-id="ca-8_stmt" uuid="2ae2c566-e4ad-44dd-92df-3baf7027983c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1595,10 +1595,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15432442-a9e7-45f9-9304-f1c684c434c9" control-id="ca-8.1">
+    <implemented-requirement uuid="051d1fb3-685a-4a11-af63-dfbc60007600" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="4872878a-89bd-42fe-853c-179fcceed9db">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="bf393f67-a922-406c-a640-86b18fa12350">
+      <statement statement-id="ca-8.1_stmt" uuid="90eb101d-5581-48dc-a61b-f378f1ae31f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1606,10 +1606,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd7a60fc-e902-46e7-9587-fbf59583a1f7" control-id="ca-9">
+    <implemented-requirement uuid="c11fdde0-925d-4e13-8c59-e9cada8a0451" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-9_stmt" uuid="f96f6b14-dafb-4704-8292-7b3b4af264f0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a50f8ff8-7133-46df-bdb5-e7dbdbd3d3a3">
+      <statement statement-id="ca-9_stmt" uuid="2d0f71e2-f35c-4da1-92fe-da865c00ea17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -1617,10 +1617,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74b7e122-a390-4688-84d9-f173cf7e4f79" control-id="cm-1">
+    <implemented-requirement uuid="7f9721c8-ebae-4ae2-9022-673f7b917ff0" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt" uuid="1d71d2e8-78c3-49d3-a8bb-356de7792d80">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c0e654a6-c153-4cdc-88a4-26206ec664a5">
+      <statement statement-id="cm-1_stmt" uuid="b5b2da40-ce44-4950-bcac-eabaf42efdb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1628,10 +1628,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e5f0a38-0084-4151-b37e-0869d27c6f79" control-id="cm-2">
+    <implemented-requirement uuid="08fc4016-155c-4080-a938-333e75955e05" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="d68a70ca-15e2-4418-9fc0-47c185e9d691">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cfc15fe7-d913-4614-bfb8-36d3ed480687">
+      <statement statement-id="cm-2_stmt" uuid="288a0964-e247-4769-bf2f-c173a3820b6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1639,10 +1639,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afdaebc5-e391-43a2-8cd8-17e0787a01de" control-id="cm-2.1">
+    <implemented-requirement uuid="8f20847a-f87c-4199-a4e6-f0a5602df0bf" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt" uuid="ca5b2b74-cd67-4312-b077-9eba5bbf6b48">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c0855325-2919-4d41-91dd-2b2363eb9c21">
+      <statement statement-id="cm-2.1_stmt" uuid="a6e5379c-f3b4-4d4c-81c3-dd8e4acfa71f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1650,10 +1650,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f272f590-de20-41b8-8e52-32d4299fc325" control-id="cm-2.2">
+    <implemented-requirement uuid="676fc1d4-5625-4d09-9a13-6a649a5f9b4e" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="da37c544-1059-46a3-93db-910531461eab">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0ef60d2d-f392-4c6e-b6da-0d890f65dd82">
+      <statement statement-id="cm-2.2_stmt" uuid="5f74a076-498d-4e5a-b1d7-5e1776c25d07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b0548c2-79dd-4735-92e8-d9aaf0f05cbb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on lifecycle management of Red Hat OpenStack
 Platform is being tracked in GitHub:
@@ -1663,10 +1663,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/210'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cca8a1f4-4fb3-4939-b628-bb2e5130af04" control-id="cm-2.3">
+    <implemented-requirement uuid="968542a1-3000-4341-a4d4-556b263056d8" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="16f50d25-e9de-4171-a9e9-e418101de440">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ab08723e-9c2e-4a89-b975-2ad1169211fd">
+      <statement statement-id="cm-2.3_stmt" uuid="21b3950f-812b-45c7-9759-ca6a7bdf8103">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58ad83df-ca9c-436e-bee4-c5dbccad5901">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on retaining previous baseline configurations
 of Red Hat OpenStack platform is being tracked on GitHub:
@@ -1676,10 +1676,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/211'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0befa5d6-287e-4811-bdba-bb03a696c8a8" control-id="cm-2.7">
+    <implemented-requirement uuid="332d45f8-8ab8-4efc-b98e-544515224e7a" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt" uuid="bbb0191d-0f01-4166-801a-aaa493dbd615">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dafa442f-3c9c-4c54-9c37-64e4d9df22ec">
+      <statement statement-id="cm-2.7_stmt" uuid="de106cf1-5f32-4e96-96e5-5dd28b9d85dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1687,10 +1687,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff4ef51d-e28a-44b1-9ba3-9c00f3859ff6" control-id="cm-3">
+    <implemented-requirement uuid="0f12eae9-54f8-4d1a-9263-461694950c5d" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3_stmt" uuid="61e34c47-af56-4d2f-a021-4f26607ed397">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5272cdcc-ff44-458a-a531-6ff1f3b9c5a3">
+      <statement statement-id="cm-3_stmt" uuid="833fb41c-f11d-4e39-94a9-8739654b4e7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ba9415d-fc25-476b-b362-c4cebba10e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on establishing configuration change control
 for Red Hat OpenStack Platform is being tracked in GitHub:
@@ -1700,10 +1700,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/213'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="921635fd-2ee3-4d56-92de-d421841685b0" control-id="cm-4">
+    <implemented-requirement uuid="ca463470-1923-4e11-b2a5-04195c0cc655" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="eb46454d-fc46-4b38-8cf6-6b91e4fb4142">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="efc41294-a550-4d76-97cd-54fa37f06760">
+      <statement statement-id="cm-4_stmt" uuid="89ab5096-0c14-4df8-8b0a-69e84ae06703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1711,10 +1711,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="910b9252-488e-46ea-b631-efec271adf93" control-id="cm-5">
+    <implemented-requirement uuid="b2e6927d-4be9-46d3-8642-31cad06633a7" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="aac8a554-5af4-4025-9cb0-175d62217e3b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="519345c7-9a07-466e-96ca-f32e8705cbb4">
+      <statement statement-id="cm-5_stmt" uuid="17547a3d-b8c0-4ebb-9725-805cf5c7f8d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cc2b60-d387-43a9-9c68-95cbfe76c421">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enforcing access restrictions associated with
 changes to Red Hat OpenStack Platform is being tracked on GitHub:
@@ -1724,10 +1724,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/214'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="168cf7cd-abc1-4481-a539-a02a2aa06c6b" control-id="cm-5.1">
+    <implemented-requirement uuid="c8652b8e-6f79-40f0-b8de-e79e50692782" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="533c0676-9aa7-4c87-8fc0-f131e3066949">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="21d8c6fc-604a-4372-be8d-f50537decd02">
+      <statement statement-id="cm-5.1_stmt" uuid="ce75ef50-f920-4147-8a29-3da51b115577">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d88ebd57-15b0-4f52-afb4-599e6b3aba04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on ensuring Red Hat OpenStack Platform enforces
 access restrictions and supports auditing of the enforcement actions
@@ -1738,10 +1738,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/215'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7488d00c-254f-4cc7-bc3a-9d83ab00ff0d" control-id="cm-5.3">
+    <implemented-requirement uuid="ea627fe1-e001-44c2-90d8-e8652ff7a238" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="d3dcb1c5-acb4-450e-84f1-6bb873a79ed2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b167dc69-bafa-46bb-985e-062c07d8faa4">
+      <statement statement-id="cm-5.3_stmt" uuid="0f52e976-5dc8-4455-86df-302541eb12bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="324bdbd3-f6bb-48ca-8720-cdf33cefb0b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform binaries are installed through the package
 management tooling of the underlying operating system. The
@@ -1752,10 +1752,10 @@ configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6225b84-c1a5-4d30-ba65-7d064ae99a13" control-id="cm-5.5">
+    <implemented-requirement uuid="cb627402-f188-4afd-97fb-8ebc8b2c2f81" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.5_stmt" uuid="72275704-9bce-44df-8f2e-d32c2af12ea8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="596e57f5-9d21-4131-a600-80a907d6e7f2">
+      <statement statement-id="cm-5.5_stmt" uuid="3ab52e26-97f5-4f26-94c1-38c78a58bbc3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1763,10 +1763,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a36f9ae-93e4-4f63-8d0f-e4ab7d1a84ab" control-id="cm-6">
+    <implemented-requirement uuid="ae94996b-ead9-4f77-8db2-c27d1906e7b5" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6_stmt.b" uuid="fc0884d0-9c38-4976-a4f7-ae50d75ad5cc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="54c9f50a-be59-465c-a5ed-6ba5993cca31">
+      <statement statement-id="cm-6_stmt.b" uuid="bfaab8b3-8d88-4542-a3c7-fe70933df2a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c53c89c-8be7-4a9b-b470-6a2bd70cb9b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1775,8 +1775,8 @@ include the process or documentation followed.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="0d1ac3ad-d7c4-472e-ad5a-0fb612ad4ee7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="99d81f3d-2d34-4bcc-9023-7f791123d8ac">
+      <statement statement-id="cm-6_stmt.d" uuid="d6df8203-f5ac-4d81-9de4-cd7addee99c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf3c73f-4f88-43c9-84f5-31954c645fe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1788,10 +1788,10 @@ track and approve changes.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59c1e973-4876-4139-b4c4-5295c74bdd62" control-id="cm-6.1">
+    <implemented-requirement uuid="8bfb6bea-093d-48d9-99ca-47c09e70c82d" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="72155c70-c3d4-49bf-9657-35c63614ca93">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="58dc3755-e8ef-426a-89d0-8adef42e542b">
+      <statement statement-id="cm-6.1_stmt" uuid="9abd6936-7599-4fbc-8602-daa325275f7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="657b97a6-63dd-41cc-8752-4ea0f944b412">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1800,10 +1800,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/218'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4df65a8f-2a24-4fe8-b46f-b2a54cd5745a" control-id="cm-7">
+    <implemented-requirement uuid="4d976505-3f36-45be-833c-0a408af8a66e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt" uuid="bab12b8b-b7a8-4d74-8c0b-4c6b7a02c2f0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8b37a4db-8820-4c26-b118-eb429f7aa9a6">
+      <statement statement-id="cm-7_stmt" uuid="bb4c0a1d-74c8-4548-a2ce-4453ade8ae70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea975add-2b4c-49e9-b422-e8ad807ced37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'OpenStack provides many capabilities, ranging from elastic compute,
 software defined networking, and storage subsystems. A successful
@@ -1813,10 +1813,10 @@ and their mission purpose.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2da3405-2f92-4193-b368-bc0d74e8a8a8" control-id="cm-7.1">
+    <implemented-requirement uuid="48a39b77-4ce0-447c-a02b-439e04d1896a" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.1_stmt" uuid="6c5c6fa9-4080-46bf-9f34-795227e8b8f2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7807810d-9236-417f-af1c-1c4fd4cd6303">
+      <statement statement-id="cm-7.1_stmt" uuid="275a8df8-1ec0-4caf-863b-7267ccbe63df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1824,10 +1824,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebde1443-7ca4-4f64-b20f-19377063b3f0" control-id="cm-7.2">
+    <implemented-requirement uuid="9684a7fc-19d9-4a8a-9c62-0a153b3115e3" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="5b1fb652-6814-465e-b02f-c2d630ad8a2c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7a9e3ea0-c132-47e6-bb34-e1eb718b47ac">
+      <statement statement-id="cm-7.2_stmt" uuid="0c19c364-3e04-4e7b-ae38-3a7c379356f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7184f2a5-5a9e-4626-a714-ef464b1ed472">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Software execution is a function of an operating system, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1835,10 +1835,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f77a753-af4d-43db-b0a0-9def41e59135" control-id="cm-7.5">
+    <implemented-requirement uuid="17db50eb-feff-451d-b0d4-c6f591de4534" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.5_stmt" uuid="fbdeb976-e200-4264-a9f1-ed1fff0311bf">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ad4f008b-1987-49ec-a9b4-7775f6e45aa9">
+      <statement statement-id="cm-7.5_stmt" uuid="f5bef52a-d45f-4233-8a67-fe750f264bcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="851e61f7-7033-4872-abb0-27cd97151bd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Software whitelisting is a function of an operating system, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1846,10 +1846,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78707964-3570-40b0-bb29-7644427af25b" control-id="cm-8">
+    <implemented-requirement uuid="09ffc592-4a4a-4d6b-b111-0cd51b377e19" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt" uuid="72915a6b-d18c-41f6-91c2-e69d6e006339">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0b6e7c09-3a04-4e65-912d-ec953be65b04">
+      <statement statement-id="cm-8_stmt" uuid="047a6256-e6c8-43f8-8e82-be0b4595340c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1857,10 +1857,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab3cb1fc-81b1-4582-9a12-fffb46019ca4" control-id="cm-8.1">
+    <implemented-requirement uuid="6df1e099-d7aa-4750-9689-da94f5e2d388" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="5c6c61db-467d-4005-bb60-e1b1aa03e9ea">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="88ed0594-b584-48f7-9170-e37f203cc857">
+      <statement statement-id="cm-8.1_stmt" uuid="75d9d43f-f1d4-4925-9fb5-b75dee187096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e9c23f0-11b7-4899-929a-9b1e9bf3cee5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1869,10 +1869,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/222'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db9030b6-5f93-47cb-81c5-b0ffb8adf15b" control-id="cm-8.3">
+    <implemented-requirement uuid="7fc2f137-9721-46ec-92de-2cff911a2eda" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt" uuid="7982bdd5-0454-4c1c-891c-36a1ce50e188">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="04d440d6-d815-4bcd-a9bb-b896b8afb5b4">
+      <statement statement-id="cm-8.3_stmt" uuid="6e32a8c4-ef08-4fb6-910b-c6f2c98d819f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b00de6a-54bb-4ace-8a6d-ed5f7503ab01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -1881,10 +1881,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/223'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f73b18cb-4aaa-4178-a230-8f98f99f2ab7" control-id="cm-8.5">
+    <implemented-requirement uuid="b44fcc73-2920-4d16-8c02-78729ecf74e7" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="4004bbc4-b419-4ed3-b4dd-300a762afb49">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="542004c6-672b-4e91-8f3a-ea7b5dc1a0d5">
+      <statement statement-id="cm-8.5_stmt" uuid="4ef62b9c-cc5a-49f3-832e-d2d0f24e0508">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1892,10 +1892,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="186d763b-5311-4360-a6d0-3ba313634cad" control-id="cm-9">
+    <implemented-requirement uuid="91d8ed99-c23f-4c85-b263-3c8ee46eb80d" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt" uuid="4c85cecb-38d6-4938-98b0-0223643be8f0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="745e7082-b8b0-4dbc-a1b6-8a800d6cd2f5">
+      <statement statement-id="cm-9_stmt" uuid="992168c7-e4f9-49db-b02e-7a8155706981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1903,10 +1903,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91321033-449b-4676-8798-b8f0e93fdbd2" control-id="cm-10">
+    <implemented-requirement uuid="7c2f6f17-e66f-4bd9-bbe6-20acc81cd359" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10_stmt" uuid="a9b7cacf-3f3b-40ed-8cb9-6db2bd419140">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cf88a51c-d708-4a00-948b-addabe97a1e5">
+      <statement statement-id="cm-10_stmt" uuid="ae00dd5d-ce1a-4477-a834-6dc28807dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1914,10 +1914,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc7d9016-8ec0-4eaf-97a1-c6501a76bdd6" control-id="cm-10.1">
+    <implemented-requirement uuid="8ee32b4c-de62-4e65-82c0-cd54eacf4837" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="31692a7e-eaf2-4bb5-bf97-48e762f1f5dc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9b4a0847-d887-4708-ac97-656009bb8a26">
+      <statement statement-id="cm-10.1_stmt" uuid="4e0e3594-e2f0-4bb0-aaad-6f72f67eb56c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cee3bfa9-3e86-4195-83de-e3deb6cf111f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.
@@ -1929,10 +1929,10 @@ of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36f6b39d-03cb-42ed-bcd2-fdbbed44d8ce" control-id="cm-11">
+    <implemented-requirement uuid="ee70a68a-e5fd-4583-bf65-e8129a8cd9e5" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11_stmt" uuid="e6319321-fa39-4823-80c9-d18d2c3b2070">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1cd17ed1-fb6e-44a5-9b11-0cd2bf9c2967">
+      <statement statement-id="cm-11_stmt" uuid="1cd21848-59e4-4f9f-9bd8-480b0008abca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1940,10 +1940,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="276135d0-0e26-4e1b-9551-dc7a9c8e0ba0" control-id="cp-1">
+    <implemented-requirement uuid="d54fb627-a20c-4241-9723-7a843bffaa6d" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt" uuid="9cc4d17a-2ca0-4594-9c33-e9a11b75fad0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="54f8c0f5-019f-4a25-9bcc-65c6a51faa80">
+      <statement statement-id="cp-1_stmt" uuid="dd2cb0b8-7e3e-4b6c-8bfe-e8cd60dc6e43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1951,10 +1951,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="799d8d9f-99ac-4584-8053-ac91f6c59697" control-id="cp-2">
+    <implemented-requirement uuid="bffbcf7f-ed96-405c-8bc5-b2f37b429ded" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt" uuid="ad8fffa4-c824-411e-8ecc-2561999b351c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="94515b6f-f93f-49b2-91aa-73ad6327d938">
+      <statement statement-id="cp-2_stmt" uuid="8a30e876-f811-40ae-bffe-a9032187b2cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1962,10 +1962,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26aa0661-48d3-400a-9cc1-11cf01939d19" control-id="cp-2.1">
+    <implemented-requirement uuid="e67dc6e9-2798-4812-925d-fcf3a1fa0802" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="df032818-6302-4954-9861-d5158b360da2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a7aa624f-3c3a-48e2-8f85-6eaaf63f60a4">
+      <statement statement-id="cp-2.1_stmt" uuid="8499a58b-9df8-4509-b8ce-5c6db5f489c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1973,10 +1973,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f453be1-58d6-4ec6-9064-236442611d05" control-id="cp-2.2">
+    <implemented-requirement uuid="bbe2c8fc-bbe8-4646-a86b-a84d3b728ac1" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="800c4772-4306-4eeb-bca6-383c25dd3103">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a49fe7cd-34fd-436d-b81b-8faaa80da5a4">
+      <statement statement-id="cp-2.2_stmt" uuid="78f846c0-632c-4afa-8429-17bb48b65ecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="186bc4ea-e2b3-4ced-99f7-8d979860e4bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on capacity planning for Red Hat OpenStack
 Platform is being tracked on GitHub:
@@ -1986,10 +1986,10 @@ http://ssptool.securitycentral.io/certifications/FedRAMP-med/NIST-800-53/CP-2%20
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="304f77ee-96b0-47fc-8b20-e9a0a6a0b254" control-id="cp-2.3">
+    <implemented-requirement uuid="17ee05db-7b84-48e1-9f3c-0908b49a8ab5" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="131091cc-f1fc-4cf4-a3d0-2532399648d0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c3d7617d-8f45-4f1e-b7af-2b6063609d85">
+      <statement statement-id="cp-2.3_stmt" uuid="b0b876cf-0de2-4670-985c-bdb68b690981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -1997,10 +1997,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51a5d675-c241-45d0-a6c5-f96aad34d693" control-id="cp-2.8">
+    <implemented-requirement uuid="6b2b7657-05a3-41d8-bd2c-2ddfcc0b157e" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="d5452911-14a7-4c9e-b60b-c04fecea204b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="947410d8-d29c-4d35-afd6-49c2e0f342cb">
+      <statement statement-id="cp-2.8_stmt" uuid="009dec9e-9053-4c37-be5e-24807813daac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2008,10 +2008,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bd537f2-80d3-40c4-aed0-8894266e595e" control-id="cp-3">
+    <implemented-requirement uuid="49c028d6-b83e-4f62-8980-606ce9a02364" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt" uuid="921d7f3a-1e27-4cfe-9cfe-c12c86e2d40a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="33a074ea-198e-4d7f-9bfc-cffa6830a594">
+      <statement statement-id="cp-3_stmt" uuid="0a69f546-afc0-425e-afd5-7e4d042ed2b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2019,10 +2019,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7d35af9-6d0c-4e76-b852-c1f792950612" control-id="cp-4">
+    <implemented-requirement uuid="a414e1c8-9ea0-4fd3-87d3-5d2bb0c871bc" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt" uuid="2c480f84-dbdc-4dfe-9f0b-daf04c8f59ec">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="50371767-24d4-4e28-9b98-2222c22eb2a7">
+      <statement statement-id="cp-4_stmt" uuid="b07bb60f-5bc0-4bed-b706-7bd175dd221c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2030,10 +2030,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea121f16-4d61-4e2f-af58-9a40a5528a7b" control-id="cp-4.1">
+    <implemented-requirement uuid="4005220b-cbf7-401e-b498-35684f3ee065" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="3677a260-46db-4eeb-aced-47298dd8a073">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4b0f8ec9-5d09-48d1-b71a-93e58c60ace5">
+      <statement statement-id="cp-4.1_stmt" uuid="332c0b19-73a5-4aa5-839e-aa2016142f16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2041,10 +2041,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04b767db-86c2-47b9-96fb-cfb28d00c34a" control-id="cp-6">
+    <implemented-requirement uuid="f51835c3-5fb3-4920-b1ad-d05e6b731161" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt" uuid="e57bb17c-12b8-4c29-b11f-0885066fc9d7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e354f08b-cb71-422d-86dc-e3238948536b">
+      <statement statement-id="cp-6_stmt" uuid="19eaebb5-c1c2-47cb-be27-0cc5b96953a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2052,10 +2052,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6ac2a0c-5f0c-426a-94ce-1b8ea9c859b5" control-id="cp-6.1">
+    <implemented-requirement uuid="ca4d5841-9e0a-4f6e-8c46-f6181413caca" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="435630b2-8563-4c86-8bcd-eb1ca64c392e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3b0f98ba-9a3c-4536-a368-b4c0fa0647c0">
+      <statement statement-id="cp-6.1_stmt" uuid="fa235989-6811-4523-8e76-8f4474402575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2063,10 +2063,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fd570a2-67ac-4aa5-a55b-5635b4ed7f13" control-id="cp-6.3">
+    <implemented-requirement uuid="ba6f6dd5-86cc-4556-8db6-a87b0f0b3ef0" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="0d7f1c2c-0d4d-42f5-90c2-b14fbb7aa3c6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6bf6e141-0f04-4426-a3bb-7bc2beb81e7b">
+      <statement statement-id="cp-6.3_stmt" uuid="67b89cc6-e5c5-41a4-a2e0-49358bdee8fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2074,10 +2074,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4487a2b3-94a5-4691-ba5c-da6da7fc447a" control-id="cp-7">
+    <implemented-requirement uuid="82944e30-f1aa-45f4-87f9-7ecfab123441" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt" uuid="f30cda0e-5cc9-4e3e-b37d-fc1b8c99dd93">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="40e7271d-ff59-471c-91ac-6ee260ce0947">
+      <statement statement-id="cp-7_stmt" uuid="21fa537e-5626-437e-aa43-b08f869b2fb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2085,10 +2085,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="912b9f6f-25b8-4324-a2be-3fa37710413e" control-id="cp-7.1">
+    <implemented-requirement uuid="6c768450-20cc-4fed-a167-540582a13452" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="3c07b2a7-fa08-4453-bd21-85db22c00a26">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cff46d71-8fab-4b3d-b895-31d36b4894ba">
+      <statement statement-id="cp-7.1_stmt" uuid="f79ca17f-984a-4530-8b46-367d3a855299">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2096,10 +2096,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fc334c1-9aae-4eb5-8209-b97454020c62" control-id="cp-7.2">
+    <implemented-requirement uuid="819495f6-490a-41a1-baf2-a216bdd61a4f" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="c2ca3b88-2e73-49a4-a94b-b2c24e7c52b8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="18fbb7d4-2b8b-4034-aaff-cd3cc1fbcfb6">
+      <statement statement-id="cp-7.2_stmt" uuid="a8dd17f7-2700-4539-9d47-943699077096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2107,10 +2107,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4400d5b1-9c71-46da-96d9-b17a09d6782a" control-id="cp-7.3">
+    <implemented-requirement uuid="e26964e2-4165-41c6-9056-b69af2491d6d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="3376d8d3-0dae-433e-a28a-1d62bbdd4e7e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="28893624-fd88-4fba-80f5-25ff71fb1e1e">
+      <statement statement-id="cp-7.3_stmt" uuid="ab5fe666-2f92-4436-96cc-dfcc191dc63f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2118,10 +2118,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c396b06f-afa4-4f87-9c52-ff4ff44f2c43" control-id="cp-8">
+    <implemented-requirement uuid="5b70ed26-e4c1-464b-8d06-f70ce228c952" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="1f865687-2f3d-4c0a-9af5-32634938b23e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="213f37d3-903b-4062-99be-d856694755c9">
+      <statement statement-id="cp-8_stmt" uuid="b1219b90-3eb8-4de8-8ea8-825a17184254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2129,10 +2129,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3a4fbee-0d94-4b00-a8a5-e47491e7a9a5" control-id="cp-8.1">
+    <implemented-requirement uuid="2532a38b-74a8-4e8c-861d-45394b047115" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt" uuid="4e0be951-0149-41b4-ad62-120033e71759">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8682806b-97a2-4c8e-87de-2499b1fa8a00">
+      <statement statement-id="cp-8.1_stmt" uuid="5d1a8e04-db4f-4019-8ce2-1108d327738e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2140,10 +2140,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08381a76-79c7-4750-b59f-e63eac8797d8" control-id="cp-8.2">
+    <implemented-requirement uuid="337bdd77-2d01-40d7-b364-63ee9922c51f" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="7229152b-c8bb-47fe-a34f-b4ec3b0ba64c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5acf19f0-31a1-42d7-b8b3-33f0d408618f">
+      <statement statement-id="cp-8.2_stmt" uuid="de065898-ab89-4342-bd60-e7cfe611e249">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2151,10 +2151,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31f3d342-ae25-457d-8d7d-a2d116e48361" control-id="cp-9">
+    <implemented-requirement uuid="84eb20b4-b361-492b-a117-9d8ae2d2f503" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="8db1763a-5e44-460d-8176-41e18696ffef">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="51b55708-3048-496e-9fbd-26060dc8c46f">
+      <statement statement-id="cp-9_stmt.a" uuid="030db880-9f30-404a-963d-8118b1a36560">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="121e2947-005b-4006-b881-37d6b73e101a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -2171,8 +2171,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="8d8dd858-0e1a-4c46-8db0-37489ac3d37f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c97b0648-1316-403e-b2b3-d3ff538b9eb9">
+      <statement statement-id="cp-9_stmt.b" uuid="bc7daf13-d4b3-4962-9ab9-97db290db49c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f481be8e-f668-45fe-8178-d3b5b7117361">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -2189,8 +2189,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="9b1ba86d-a1ae-4f43-8ff0-0347aecada1d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7a6dd2c7-f830-4728-b403-a51ea4743ba1">
+      <statement statement-id="cp-9_stmt.c" uuid="12c214d6-9769-414b-b027-1775cd63996b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="139f3266-94bc-413f-9339-5325ac829eef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -2206,8 +2206,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="76462042-9eae-4638-a0d8-72fbaeee2582">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f09d451a-de93-4a0a-93a3-45c213ef8741">
+      <statement statement-id="cp-9_stmt.d" uuid="af663e8a-4d5b-4da8-acea-2ada0ee4469e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d27cf6a1-258a-4b79-8c9b-15d3ebae71a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2223,10 +2223,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcde09fb-5fbb-49ae-a34c-eef33706aeec" control-id="cp-9.1">
+    <implemented-requirement uuid="1aa069f3-92cf-4f5a-89dd-5396244aed23" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="b62731e3-1727-4d0a-a389-443f2d88fd20">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="79375381-b3c5-4f26-8759-093538827611">
+      <statement statement-id="cp-9.1_stmt" uuid="2d84aee9-cd36-4c32-b495-0f1fb3b25d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2234,10 +2234,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0148c70b-d2dd-4cb8-bc11-2232bb049287" control-id="cp-9.3">
+    <implemented-requirement uuid="d4bf350c-c08e-44ee-afcc-b6524197ac75" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="0d41c6fe-558c-4550-9239-74f8281dbcd5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b0da23e7-7ec8-4236-8cf2-bea95a2ddb75">
+      <statement statement-id="cp-9.3_stmt" uuid="18d7b007-91a2-421e-ad2c-b9f441f60b94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2245,10 +2245,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84257ef3-4966-4dfc-9aed-ca2bc3ca5bfc" control-id="cp-10">
+    <implemented-requirement uuid="c862ea26-e36f-4fbd-95c1-b86e39715c34" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="454cc5dc-5748-4c13-8ba7-7aa89175ddce">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="560dbb40-71d9-4b74-b260-c2e8dd65e628">
+      <statement statement-id="cp-10_stmt" uuid="1eca2502-2937-4113-bee4-487ad831df0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca57dba3-2f22-4e61-857c-3d7dbee1e16a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for documenting how to reconstitute 
 their Red Hat OpenStack Platform environment. A successful control response will detail
@@ -2257,10 +2257,10 @@ processes used to fully recover/restore the Red Hat OpenStack Platform environme
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ebe770f-fcc6-455d-ab45-cf6a2549b852" control-id="cp-10.2">
+    <implemented-requirement uuid="0b0f85ec-3b8e-4bcf-8bdb-730fb07fd966" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="a7855305-c2d2-4d21-b038-1094b3c25e7c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f07a7fe1-000c-4017-95bd-8098a42483f1">
+      <statement statement-id="cp-10.2_stmt" uuid="cf295bf3-9f25-4f2f-893f-f56574bcfaf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e0331bb-538b-4b0e-bcee-03869df85a49">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this requirement is being tracked on GitHub:
 
@@ -2269,10 +2269,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/232'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c230d94f-c1b7-45aa-8b41-a82d5bf3282a" control-id="ia-1">
+    <implemented-requirement uuid="c208fa13-b331-4bb3-a906-a11d825dc54f" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt" uuid="fedbfd22-0f10-4a24-90e6-e24ff3135dc3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="59037085-0703-4fb3-95f0-8a363dffa74e">
+      <statement statement-id="ia-1_stmt" uuid="ab66bff7-66a3-4f54-bdd0-426477d879b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2280,10 +2280,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92b74249-323f-4f6a-8702-232f6aaab958" control-id="ia-2">
+    <implemented-requirement uuid="c59161f4-7aa0-4f74-8e7a-d70e2d287475" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="537ac44e-753e-417e-a121-3d97a6abad29">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="81df0a10-0152-472f-9302-bf11bfb15ac1">
+      <statement statement-id="ia-2_stmt" uuid="1673fedd-fd2a-427a-939a-8df8b41f3969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30c63e3f-c480-4d92-a1d2-aeed0b3491a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform assigns unique identifies to users, groups, and processes
 acting on behalf of these categories. This is non-configurable behavior.'
@@ -2291,10 +2291,10 @@ acting on behalf of these categories. This is non-configurable behavior.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="debe8516-59a8-44b3-a322-74902306d410" control-id="ia-2.1">
+    <implemented-requirement uuid="289fe0db-1b27-4024-ade0-c9f37575aa9b" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="287d5da1-0595-45a0-b3d3-604a8e94fd9f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="921b9cf8-d12d-4d07-ad25-b1f97c7bf89f">
+      <statement statement-id="ia-2.1_stmt" uuid="f9bc119b-3db3-4372-9611-7ae8c72f14b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9db1564a-325b-44ac-8611-3dbf6252b163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to privileged accounts.
@@ -2317,10 +2317,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09f65040-a4d8-4bb4-814b-c74ac21a36f5" control-id="ia-2.2">
+    <implemented-requirement uuid="b2020e8d-9b88-4cff-a546-9048c19a474f" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="e070f33a-ff11-4ee9-8432-285ae8b32eae">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5c6f37ed-a119-4259-8dc9-b954f2148ce7">
+      <statement statement-id="ia-2.2_stmt" uuid="6e97b211-dce0-4d4e-96cf-f31a88105d6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="feca902d-8065-4184-8b96-573f763dbff1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for network access to non-privileged accounts.
@@ -2343,10 +2343,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4737844d-9428-48e3-9192-bf4127527ec6" control-id="ia-2.3">
+    <implemented-requirement uuid="74d7b087-d10c-4660-be79-f045941dad6e" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="143ec09a-58ba-4b20-a596-cc1cbbca85cb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9068a211-a03b-4e7f-bbfb-62775eafcb5c">
+      <statement statement-id="ia-2.3_stmt" uuid="93081a9f-90a4-4f85-8cae-9bdb5d2e02c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7cc3e2d6-ed15-4747-a244-ade6730b7438">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for implementing multifactor
 authentication for local access to non-privileged accounts.
@@ -2369,10 +2369,10 @@ Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05765ff7-419f-436d-b4ee-6baa57f6c264" control-id="ia-2.5">
+    <implemented-requirement uuid="e02c19c1-b78e-471e-a847-506eee7ebaeb" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="2b298274-5d61-4637-bd91-af04a1897772">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="db6790f5-f885-4697-ac03-85c245e47f4b">
+      <statement statement-id="ia-2.5_stmt" uuid="b413065f-9686-44cc-9338-45943bcb2a68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="65aec7e0-8b96-4feb-92cc-282025ae3453">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform requires all users to have a unique
 identifier, of which each user first authenticates against prior
@@ -2383,10 +2383,10 @@ configured to be out of compliance with this control.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ad07b2c-79a5-4dff-94f5-997747b16944" control-id="ia-2.8">
+    <implemented-requirement uuid="9018d6a5-e8e0-4e74-a756-90c8d7ed021e" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="0a44c6be-3110-429a-bcea-fafa6570e9f0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a4e39c8c-3f4e-44fc-b6d6-1cb16371bfba">
+      <statement statement-id="ia-2.8_stmt" uuid="cc23fe32-e1bc-4719-bb59-0623309932d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="433aadb1-c80f-44d0-857b-40734780a125">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on enabling replay-resistant authentication
 is being tracked on GitHub:
@@ -2396,10 +2396,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/249'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e37c34f-cfa0-4659-85c5-1abde498e844" control-id="ia-2.11">
+    <implemented-requirement uuid="7b8c8787-a825-4f4a-8411-cd1b2f954302" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="6edf48f3-81ee-4131-a033-b23694027038">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4f6685b4-e3f7-440a-829f-651eeca184b1">
+      <statement statement-id="ia-2.11_stmt" uuid="42d6c994-f63e-4f82-801e-b0c355aaa8bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffffa5b6-49a7-4e8b-a24c-0453d9cc45d8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked on
 GitHub:
@@ -2409,10 +2409,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/250'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c72113cc-3304-41b8-8966-c964a40ab059" control-id="ia-2.12">
+    <implemented-requirement uuid="348a7cde-c4e6-40bc-9ecc-3fea77bf7d84" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="82d1f43a-28e9-48cb-b420-ca5b0b865dd2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7087f0e3-05ed-45b6-a27f-87345cd34792">
+      <statement statement-id="ia-2.12_stmt" uuid="6f107911-f29a-455c-bb2b-8c510b63e7e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe5832f8-9a07-4687-aa17-fa4cec0e79f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those credentials
 issued by federal agencies that conform to FIPS Publication 201 and
@@ -2425,10 +2425,10 @@ Federation Services (ADFS).'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35211ca4-ee61-42a6-b9fd-d9ce4431835b" control-id="ia-3">
+    <implemented-requirement uuid="ffe89caf-865b-4d27-92d9-2588245a16b2" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="bd47d082-9b7c-49c4-9e89-45ea0e13b4f9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="56f58011-b74e-41cf-823e-e4c93caa195e">
+      <statement statement-id="ia-3_stmt" uuid="35de0580-a5b5-4c1e-a4b7-5a14f7d582fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb2ba80c-0967-4b98-ad92-87881ef6f476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -2438,10 +2438,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/251'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b7ad4e3-26c4-4deb-8ea7-8829f2633691" control-id="ia-4">
+    <implemented-requirement uuid="baf076ff-0ddc-48dc-baf1-69303b069ded" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt" uuid="1ce5dccd-5ce4-4a0b-9ab5-92da937dbe16">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ed69b99f-0605-4e0c-ba83-3f2bcd222c45">
+      <statement statement-id="ia-4_stmt" uuid="e1e9cd09-58e4-490c-a082-7e1ef882b3c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -2451,10 +2451,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34dd1035-5d95-4d54-840e-896ca73927ab" control-id="ia-4.4">
+    <implemented-requirement uuid="e6aba87c-5c25-441a-841f-3172722c0809" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="4707ead2-d63b-4190-9e37-8f9e4d29e19f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e18ef18d-a8e9-4806-bd41-7d1abe07cd0e">
+      <statement statement-id="ia-4.4_stmt" uuid="95bd075f-12c2-4604-ab58-113542a4213f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a30b3352-fb58-466d-b91e-d7a05ce1fecb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -2464,10 +2464,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/252'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62bcdf5f-946d-4670-b842-5677f8461d73" control-id="ia-5">
+    <implemented-requirement uuid="8a61c669-9aa3-469d-830b-458a18eba93a" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt" uuid="f03cd0b4-3317-41f7-9450-c67d90cb62b3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="401e4e21-a2c1-467f-b2fc-d5262e245b8d">
+      <statement statement-id="ia-5_stmt" uuid="9f79c036-9e57-4781-83a9-ae1da8d838d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -2477,10 +2477,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0c1be66-b8fb-4e53-9f19-9a5a0a787269" control-id="ia-5.1">
+    <implemented-requirement uuid="2f2060ee-3124-4509-b1b6-024ec5ed28b7" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt" uuid="fa238bd7-5b59-47f3-91a2-c1a7e6fdd09e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6682bda1-4d48-4c25-b0e2-2ffc5fc07d23">
+      <statement statement-id="ia-5.1_stmt" uuid="22c3e411-946c-4b61-a5a2-df5b89b2a412">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -2490,10 +2490,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40c146e7-ae1b-4634-9fb8-7cc9dd68e6f8" control-id="ia-5.2">
+    <implemented-requirement uuid="7972f4df-c218-411b-bde3-d4e1f3a1517a" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="bd0a8abc-d9a3-497f-9b9b-aecde0f3afa8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="d701f771-88d7-48c5-88e5-3fb8810c2362">
+      <statement statement-id="ia-5.2_stmt.a" uuid="289932dc-c12f-4a3b-816c-b178b261346f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4208ad47-2a7d-4003-ab7f-8a4894cb8df1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on establishing certificate validation and
 trust anchors is being tracked on GitHub:
@@ -2502,8 +2502,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/253'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="3066a326-b59b-4666-ad59-8242f3e6af6d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="853025a2-4263-4551-8125-2dc0acb6b642">
+      <statement statement-id="ia-5.2_stmt.b" uuid="3e5ba83f-d533-4a80-b6fe-8d0be413b5c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffc6d2e5-74b9-46da-aea3-125a25f93f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance regarding enforcement fo authorized
 access to private keys is being tracked on GitHub:
@@ -2512,8 +2512,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/254'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="e48ea707-8d3c-4e83-92ca-0cb4d840b7c3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1d794cfa-5cfa-4776-93af-c107bf94b078">
+      <statement statement-id="ia-5.2_stmt.c" uuid="654adb6a-7c4b-4d05-ba90-93e2fad8c5a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e002d79-7595-4caf-a4d2-ee042f656219">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance regarding mapping identities to individual accounts
 is being tracked on GitHub:
@@ -2522,8 +2522,8 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/255'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="09335871-38c7-4f11-b0af-74604c99002c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="72ebe047-a5b6-4184-9998-6b6a36bfc297">
+      <statement statement-id="ia-5.2_stmt.d" uuid="2db89e81-061e-42c8-9d42-3ad6a07963e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c818bc3f-5cf7-451a-bcd4-ceec2861c05b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on implementing a local cache of revocation
 data is being tracked on GitHub:
@@ -2533,10 +2533,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/256'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f9a1b6e-3ea1-4a1e-9a44-328cac159c75" control-id="ia-5.3">
+    <implemented-requirement uuid="fc5d4018-650b-40de-b766-c1206411ae90" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="fed385c3-3e85-407d-aca9-cf27505fb4bf">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="78451ec8-fdab-4624-b28b-f7f3d600aaaa">
+      <statement statement-id="ia-5.3_stmt" uuid="6830c1e5-8a8c-4cd0-a092-79708f1b5b97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2544,10 +2544,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4a203db-8cf3-4abf-8b81-f7b4560bd280" control-id="ia-5.4">
+    <implemented-requirement uuid="d4fc2f08-ae06-4c52-9dec-4c8c476da653" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="f33b3dfe-8ad8-4e21-b9e5-b1328760f684">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="903e435f-a548-4e4c-ba64-0fb512d80c16">
+      <statement statement-id="ia-5.4_stmt" uuid="64f95f88-8b72-4344-95b7-4cce904ceb5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2cd99c54-0871-4211-8217-1ab84e99779f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet FISMA Moderate and/or FedRAMP Moderate controls, Red Hat
 OpenStack Platform should be configured to use an external identity
@@ -2558,10 +2558,10 @@ is not applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2227657c-f2d2-415e-aa4b-0b6d3666ae58" control-id="ia-5.6">
+    <implemented-requirement uuid="af95e832-1c2c-45dc-86a0-6d9ea75f2e41" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="33f0dc28-c486-415f-9b11-8236401d5a7b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="01d168aa-e0a8-44cf-9b31-b041af961281">
+      <statement statement-id="ia-5.6_stmt" uuid="258b8145-49b5-4660-8712-b4ec8d46b05e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a93c2a02-4467-4f37-aa99-40e8ce5c9178">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how Red Hat OpenStack Platform protecs
 authenticators is being tracked on GitHub:
@@ -2571,10 +2571,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/257'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0ea276b-069a-4230-a93e-84f381574ac9" control-id="ia-5.7">
+    <implemented-requirement uuid="d81eb0c3-1e37-4a79-a43e-c0c21ac70b14" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="19f69355-1577-46c5-a468-c8056f06661a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="05035b9f-9707-41cf-bb4b-b237f9f7f0ac">
+      <statement statement-id="ia-5.7_stmt" uuid="aeb99828-fe08-4592-b7ac-30b2eea4be65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="961f12fa-b2d0-4848-b4ed-32cb7317beba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on how to ensure unencrypted static authenticators
 are not being embedded in applications or access scripts or function keys
@@ -2585,10 +2585,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/258'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ab86ae2-d24f-4b0b-9dbd-00c5dd2cc51b" control-id="ia-5.11">
+    <implemented-requirement uuid="20d94349-ac22-43e5-858b-0743396f0631" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="afef51d3-51da-4e2d-9c85-94e476a36a8f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0d8f98bc-6f46-4cb2-8ecc-be2d27a7fa1d">
+      <statement statement-id="ia-5.11_stmt" uuid="190217c8-24cf-4786-91be-1b461696d954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="016e1b9c-372b-4ff2-9478-405513aad702">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'To meet NIST 800-53 identity and authorization requirements, Red Hat OpenStack Platform
 must be configured to use an external identity system (such as Red Hat
@@ -2598,10 +2598,10 @@ identity provider, not Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59ea2054-b702-41ef-b9a2-7d6ecf66549f" control-id="ia-6">
+    <implemented-requirement uuid="05005a74-21e3-4100-92b7-ca71ff828a98" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="e8f70253-3460-4a27-89f5-b576cbca8805">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7eff4a8e-966c-463b-a15a-b6d17787a921">
+      <statement statement-id="ia-6_stmt" uuid="0c0685b8-0c35-4f53-a730-6ad9020ef2a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecabbad6-1b16-49fd-9b7f-cd712dcf01d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform natively obscures such information. Red Hat OpenStack Platform cannot be
 configured to be out of compliance with this requirement.'
@@ -2609,10 +2609,10 @@ configured to be out of compliance with this requirement.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a089b004-03f2-4b52-ba00-e29e42d484c4" control-id="ia-7">
+    <implemented-requirement uuid="a2b87a9d-d758-4b0d-8396-3d77001d2d9b" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="0dd60221-d251-4a1e-acea-b32c433590d9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="63119a42-aa6f-4e5a-855d-11f85764e3aa">
+      <statement statement-id="ia-7_stmt" uuid="892b15aa-bc59-4bae-9ad7-0f86f9ffff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="526f4b91-8447-47d1-96a5-1090fb4e10dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Administrative access to Red Hat OpenStack Platform nodes is performed over SSH. To
 limit SSH ciphers to those algorithms which are FIPS-approved, update
@@ -2634,10 +2634,10 @@ FIPS 140-2 certification for enabled modules.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e49d59f-adb6-47e2-8f5d-f2c7d10ef63a" control-id="ia-8">
+    <implemented-requirement uuid="e7305d68-b817-4208-8501-a8cc3eaa90cc" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="c3cc7296-2af4-44cd-85c9-6580cb6d92f7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="fb0091e5-8f1e-4bc8-972b-3c6682fb868e">
+      <statement statement-id="ia-8_stmt" uuid="944cb4bd-7dff-483a-be3c-fc4436e09fa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e841354-f5b4-4ae8-b8f3-be63bd90310d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for identifying and authenticating
 non-organizational users accessing the customer application. A
@@ -2649,10 +2649,10 @@ identification and authentication for organizational users.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87a5735e-0ac9-4d26-8bf9-c910e4290964" control-id="ia-8.1">
+    <implemented-requirement uuid="86dd2242-f950-410d-b6fb-0d8faa711c41" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="265d8ddb-9989-49ad-87fa-5f8786c4d627">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6510db0e-69b9-405b-a3e3-86e4f2f32921">
+      <statement statement-id="ia-8.1_stmt" uuid="c85aded2-32ab-4faa-b773-b3b45d015902">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08fa3f1-a6ce-475f-bb09-6187032ca48d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Personal Identity Verification (PIV) credentials are those
 credentials issued by federal agencies that conform to FIPS Publication
@@ -2665,10 +2665,10 @@ through Active Directory Federation Services (ADFS) or Red Hat IdM.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ac494ef-7aa7-4f20-a9ff-ae0b03919140" control-id="ia-8.2">
+    <implemented-requirement uuid="6b8afbc5-151b-4267-bcb7-f9a2c29165d0" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="ce70dc26-beb5-4dc4-9ab5-61e9b334b067">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="40c3a7a2-f69a-4174-b557-ff20a03d9e6d">
+      <statement statement-id="ia-8.2_stmt" uuid="2c0d88a9-fbc0-42c3-a982-7472decadd0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2682,10 +2682,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4bdbd0f-68e9-440b-8089-95c88753669a" control-id="ia-8.3">
+    <implemented-requirement uuid="3fb11514-540e-4d3c-af78-47c2d802e6a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="ebcc7034-27cd-4718-be20-aa39abbe8aca">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f56bb456-4ac6-4c3b-88cf-32d9567b26b1">
+      <statement statement-id="ia-8.3_stmt" uuid="8264d1d5-bbc3-40ca-af76-b2704d06bebe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2699,10 +2699,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2eb9a4a1-f06d-4857-b8a1-d9a03e8edd9b" control-id="ia-8.4">
+    <implemented-requirement uuid="088d9a8c-09c1-436a-9240-5fc00a5f7578" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="956b1580-a48d-46b7-a029-b271cae1949b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cbacb18d-f3fd-40d7-a3bc-abafc619c4e6">
+      <statement statement-id="ia-8.4_stmt" uuid="5c143dd8-e7ae-4d2d-b822-cd0584d3267f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2883a9-6e11-4179-b475-a0f408c1e47b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'FICAM approved credentials are those credentials issued by nonfederal
 government entities approved by the Federal Identity, Credential, and
@@ -2716,10 +2716,10 @@ customer system is through Active Directory Federation Services
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4afd0414-ac8c-457c-a22a-0c4ca6be3b56" control-id="ir-1">
+    <implemented-requirement uuid="5f584414-db13-4824-bf0f-79d55edccaea" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt" uuid="6282cc39-af0c-4cca-a03f-728b3fa5f22d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="405cc7ae-7000-46e5-b7d5-ad86e9188514">
+      <statement statement-id="ir-1_stmt" uuid="1cbb5a11-f5a0-4963-92a7-5ca29b1c813e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2727,10 +2727,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cef5bce-e263-43f7-a0a0-75c03429645d" control-id="ir-2">
+    <implemented-requirement uuid="b516b08f-a020-4a10-8148-941f24a6542d" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt" uuid="aca26734-51f0-4aaa-9d20-476aafefdbff">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="eff6e20c-e7d6-4f29-ad90-6478078cb822">
+      <statement statement-id="ir-2_stmt" uuid="835d5547-6b6b-49f6-b6a2-7446938e8ad9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2738,10 +2738,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92cc32c9-8531-42d3-8b39-aa81030c86d4" control-id="ir-3">
+    <implemented-requirement uuid="932b564f-92c0-486f-8687-e72c48b521ac" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="6ae45246-a6bc-4460-93ea-d0801c396350">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="aa0d7b72-6f55-44e3-9bc2-604586a99b98">
+      <statement statement-id="ir-3_stmt" uuid="7ed2d891-1f97-485e-ab94-c6c9d83861c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2749,10 +2749,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a276bafa-fd95-4abb-9056-1988ff33c582" control-id="ir-3.2">
+    <implemented-requirement uuid="b301e876-086b-43d4-ab11-2b68636906f3" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="2a04e72b-a355-4f5e-939a-7ca4e957955d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="846fb144-1f9f-4abc-9c4e-e03aa45498bf">
+      <statement statement-id="ir-3.2_stmt" uuid="f319f323-8d61-4434-bc38-3b0223736ad4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2760,10 +2760,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="144a28e7-9c97-42a7-bde3-9f84af7d476f" control-id="ir-4">
+    <implemented-requirement uuid="1b6cabe7-397e-4cb2-aec5-f6ce39e5b9c5" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt" uuid="c8ccb991-02a8-4d50-8ae9-78daeb855b64">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e8bd938f-2adc-4554-868e-185ebf422964">
+      <statement statement-id="ir-4_stmt" uuid="dc88e196-fc02-4735-8f37-5e1606aea204">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2771,10 +2771,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7aaf87d0-f60e-40e4-9d96-d031cf35674b" control-id="ir-4.1">
+    <implemented-requirement uuid="6030a0b6-ad83-4cc9-87b0-b7a719028469" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="55031591-cd97-4145-9626-548a49f8f475">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c3938ddc-3d65-4691-941a-41f53085a8de">
+      <statement statement-id="ir-4.1_stmt" uuid="855f3260-0ca3-43f5-b53c-b8bbea8ac899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2782,10 +2782,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac62f88b-20c3-4781-ab9d-994ed6c3a604" control-id="ir-5">
+    <implemented-requirement uuid="6bb05618-5851-4e3d-b55e-b997c806710a" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="c47c54cb-32bf-4fb8-b577-1a458178bb63">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b67b1213-cbaf-43f9-8e47-6e6c25d7430e">
+      <statement statement-id="ir-5_stmt" uuid="2d0859ba-76b9-4057-b0b6-2914afe3c79f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2793,10 +2793,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b10005b2-25dc-4735-8115-cd46e508a940" control-id="ir-6">
+    <implemented-requirement uuid="9afaa0a6-dde3-4696-ae38-34f3662ebf20" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt" uuid="da992eae-94bc-47f3-b6d2-fdbf86825713">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9f5aa424-b1fc-4019-87d6-2e61abee6586">
+      <statement statement-id="ir-6_stmt" uuid="c0337ffb-b261-4698-bba0-521595ce42d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2804,10 +2804,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c14203a-e5a0-4b60-aa5a-ac307b9ed3a6" control-id="ir-6.1">
+    <implemented-requirement uuid="5065a490-9271-4fcf-bcd7-18f5bd885877" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="0f49bc49-8168-4e8b-8da0-57c80962abbb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="922f4999-5a1e-44cd-ae0e-2b156d43d878">
+      <statement statement-id="ir-6.1_stmt" uuid="1b90d72b-678c-4463-909e-cc118aa9ef77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2815,10 +2815,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68a1f8c5-f508-49b3-a7f5-aa1be0fe3f31" control-id="ir-7">
+    <implemented-requirement uuid="a61a5edb-55c6-4110-9fc6-ebc5ddc70bc2" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="c3212e1a-2b6f-499d-a8d5-9e335636fb12">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="02322d30-5beb-4207-9dae-0a88f517dbb3">
+      <statement statement-id="ir-7_stmt" uuid="b96790cb-3915-483a-b928-33e78bab81d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2826,10 +2826,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="873ef6aa-a136-4bd8-b242-04f8b064c1fd" control-id="ir-7.1">
+    <implemented-requirement uuid="03664c31-f853-43c5-9fe5-3ded27e8a83e" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="54aebbb7-bac9-4ef2-aa38-b936784aa356">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="428bc5fd-227e-472a-b370-5a6c17a7663b">
+      <statement statement-id="ir-7.1_stmt" uuid="67807c84-b83a-427d-88c2-d5ebbd7168d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2837,10 +2837,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24176cc3-a77d-4e7a-a343-bff7b6e9e59d" control-id="ir-7.2">
+    <implemented-requirement uuid="d1d034cd-52de-4fe2-8423-3631035947d9" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt" uuid="d563f3d0-35b3-469e-919f-9c36577c3748">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="bc9f1444-1884-4434-9f68-cd112af4cfcc">
+      <statement statement-id="ir-7.2_stmt" uuid="4afbe802-f792-4c99-b02f-0543e24e302d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2848,10 +2848,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc371913-d7ef-4f39-ab0a-8783881f2ec1" control-id="ir-8">
+    <implemented-requirement uuid="e8deddd2-7da3-4d94-a815-b55a882139a2" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt" uuid="1414a301-fe3a-4aa0-af9a-91671d9316d9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="41e7aa3d-fd7e-4202-975d-ae9917c36dbf">
+      <statement statement-id="ir-8_stmt" uuid="a442cc26-8674-4689-8915-2c96f33e53bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2859,10 +2859,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66705b22-7619-4a44-8a60-d1db80203a40" control-id="ir-9">
+    <implemented-requirement uuid="ba54c704-2d5d-4a68-8687-1766b27b3126" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt" uuid="b482a8f0-59b8-4ac5-b720-efa8decab61b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="eca7b4ca-4cb1-46dc-a704-1c35930eea52">
+      <statement statement-id="ir-9_stmt" uuid="76e1e30b-45a8-427b-87ef-93b66dbfccd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2870,10 +2870,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e419891-e6b2-48fd-944a-0ad5a3cae287" control-id="ir-9.1">
+    <implemented-requirement uuid="ca2a0c37-4bb2-4f22-a436-8507a468add2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="4845c41d-4217-42ec-aa27-923e578dd12e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="2be8284d-f561-4858-9988-15f02768c18b">
+      <statement statement-id="ir-9.1_stmt" uuid="a1e3997f-c610-475e-80a6-92bc274325c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2881,10 +2881,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2462c1f2-d89e-44bc-895d-ad73ba870eab" control-id="ir-9.2">
+    <implemented-requirement uuid="df878cee-a332-4494-8b51-0a3dcc80c643" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="df380215-f761-4c24-864e-ca4821ed19a0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4b107701-f116-4e1c-a5cf-58b95df33ec8">
+      <statement statement-id="ir-9.2_stmt" uuid="cb24cdc7-d98d-4c94-a7e5-2fbebe4ec0ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2892,10 +2892,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08fa076e-5114-4fd3-aa83-6833e474716a" control-id="ir-9.3">
+    <implemented-requirement uuid="27b13e81-aec1-42f6-b809-57b1be807fd1" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="e633e1b6-0482-4b99-b5a7-80f8626fc24a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0c23d994-b65f-45a4-b628-7e22ca30042d">
+      <statement statement-id="ir-9.3_stmt" uuid="2cb79dae-ed0f-48fb-aada-654cd009c389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2903,10 +2903,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66e8a8fc-e22a-44e7-9c44-2395e46dcd41" control-id="ir-9.4">
+    <implemented-requirement uuid="68ecdb0d-808b-4b50-ab94-d33783cd443f" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="12e627e8-641e-4b60-9dd9-b6d495dde4e0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5c1b6c63-47c0-4ac7-a57f-5c2f880de710">
+      <statement statement-id="ir-9.4_stmt" uuid="27dedc63-bb21-4a31-896b-ad0a2b7184b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -2914,10 +2914,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88e23f64-2fce-48b6-bf98-2a98e185b1d1" control-id="ma-1">
+    <implemented-requirement uuid="cdcc7eee-82eb-418a-b7cd-f5af7e84446b" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt" uuid="ca6875b3-14ac-410d-ba72-ff455d1114ce">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="39876fc0-8cd9-4d76-9286-cd8e097466f8">
+      <statement statement-id="ma-1_stmt" uuid="51b5eb2e-72f1-4d10-9c29-dc52c48241e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2925,10 +2925,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7dd4661-056c-4835-b1b8-4a46869be14b" control-id="ma-2">
+    <implemented-requirement uuid="2b150918-15e4-4c01-bec2-18f95a448a70" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt" uuid="5bc6fac0-b273-423f-8e82-e8d05644aca3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="05cbb2ae-9f08-44dc-9cdc-5bdcd07e9aec">
+      <statement statement-id="ma-2_stmt" uuid="3bd08678-77d8-4d13-ab91-d020826517f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2936,10 +2936,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78a635c5-f435-4c1b-a6e3-bbb0953db5b1" control-id="ma-3">
+    <implemented-requirement uuid="db0ed605-ad59-4c08-a6db-4dc4f7027414" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="1fe4905a-c70d-48d5-9e51-62cf0ec7b7df">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8d15751a-f854-4b50-8e6d-ff2bc99515b0">
+      <statement statement-id="ma-3_stmt" uuid="60216967-46ff-4c09-8861-e83e6610eaf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2947,10 +2947,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8357bba9-19ba-4d63-b1b8-9d1b9058c4aa" control-id="ma-3.1">
+    <implemented-requirement uuid="c8fb1723-0b96-4527-a4a4-7335dda6739c" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="9af5439f-9e5b-47ec-99e7-203738988c88">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9f3d2bdd-ff8b-466d-a5d3-15cd22a2c296">
+      <statement statement-id="ma-3.1_stmt" uuid="0b221eb2-52c2-4232-b148-3c47be0cca9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2958,10 +2958,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76562fd0-85d4-4bbc-af80-1a01293333b2" control-id="ma-3.2">
+    <implemented-requirement uuid="08161030-d06f-4580-be12-4f0dfedb8c93" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="5340b2d0-39f8-4ef1-a5a4-83f065076444">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cb9b2f4e-f5f9-4701-9adf-4b9d3160eb8c">
+      <statement statement-id="ma-3.2_stmt" uuid="d489394c-0b43-4d58-b164-2c5da5ab7944">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2969,10 +2969,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19e0cc0e-a70c-4c9d-844a-b2a8ae12387e" control-id="ma-3.3">
+    <implemented-requirement uuid="cdc121e7-32d8-4970-8593-f3a9a99ca03d" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt" uuid="305957da-47ab-4295-accf-818db45ad864">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="2f9e7ed7-31b1-421e-ac37-619feeb3792c">
+      <statement statement-id="ma-3.3_stmt" uuid="25304008-9e2f-4652-a579-fc83eaf49143">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -2980,26 +2980,26 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73d9f96c-cede-4a1a-b26a-28c14b103b5c" control-id="ma-4">
+    <implemented-requirement uuid="35ce3515-cb78-4d93-9fb2-d9a0817d5ed5" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="6d102e49-461e-47bb-bd50-8ab012977158">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="d7f149f8-0181-47ee-b6c2-da59890880d2">
+      <statement statement-id="ma-4_stmt.a" uuid="901b6f87-5fc0-43f7-ba0b-b4368c4aa5c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="a1b6736a-7175-4d6b-b815-f05ab6b70809">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="79193012-17c0-440a-a86b-4aed4fd4ea1b">
+      <statement statement-id="ma-4_stmt.b" uuid="0dcfc21f-e41b-47cf-8395-67b48f957b89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="f0aeae00-c5f5-4c0c-a69a-68711acd5877">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="21dab5d9-8f06-4a3c-b208-0c5289403d89">
+      <statement statement-id="ma-4_stmt.c" uuid="4915cca5-f41f-4273-b32e-41286a07a092">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d59d37fe-e740-46e7-afa6-f8de446e43f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is not applicable to Red Hat OpenStack Platform.
 
@@ -3011,8 +3011,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="1d9ea9a3-b7a2-4491-9ee4-f370df9fe3cb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dd8d8ece-113d-4710-80b5-c19b89090854">
+      <statement statement-id="ma-4_stmt.d" uuid="4bb343d0-f3c3-4baa-b052-0334332b2093">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08bbbc53-87da-4908-9568-93e814f2683f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'With the exception of access established through physical presense 
 at the hardware and underlying operating system layers, connections to
@@ -3022,8 +3022,8 @@ to this control; no independant control response is required.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="7499492a-6d51-432d-8f7e-02b623ebbd54">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a5685406-3263-41c2-9aaa-cc93f75ccda0">
+      <statement statement-id="ma-4_stmt.e" uuid="ef823718-f510-488a-837f-5865ee720ddf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00846073-cfd1-4be2-8bee-7795424cf8b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for terminating the session and
 network connections when non-local maintenance and diagnostic activities
@@ -3037,10 +3037,10 @@ underlying operating system.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="099b1530-3262-4037-a558-767b666e4dfd" control-id="ma-4.2">
+    <implemented-requirement uuid="eafea2c1-56a4-489c-baa2-802e2c42e6c3" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="cc438088-6706-4b33-a949-e51b6ab72e85">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f799a851-db32-4ddf-8403-1e789576a8d7">
+      <statement statement-id="ma-4.2_stmt" uuid="a2f330a7-3cab-4230-ba4e-32bdae18d6fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3048,10 +3048,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b495c309-3834-40d4-b5a3-c17269ffef0e" control-id="ma-5">
+    <implemented-requirement uuid="61ee1429-4ede-45ed-9531-03cb13100ffa" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt" uuid="25f51a79-feb9-4f5b-8114-ce94bbcc5552">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dd6c6d4f-8a8b-48ce-b58d-6379af9ff09f">
+      <statement statement-id="ma-5_stmt" uuid="b6e18c5e-2ce4-40f6-9151-3c46e6abfbdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3059,10 +3059,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9a1d517-358f-449f-9837-39a9de433fd4" control-id="ma-5.1">
+    <implemented-requirement uuid="f7ee8167-7fc7-4a78-a3ee-30f56a3094ea" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt" uuid="89bf1a83-e6a2-4e85-b0a7-8ae9d4643956">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3a0297ce-8246-494c-a77e-dd14aa6c3036">
+      <statement statement-id="ma-5.1_stmt" uuid="362221fb-2477-474f-832a-1bd6f85aaf27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3070,10 +3070,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0638b71b-0f4d-400f-9429-e3a1aeb77830" control-id="ma-6">
+    <implemented-requirement uuid="43a3148e-3f6f-4291-9d3f-8a98ab4717d0" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="0a8c99c7-03fc-4bf0-b9d6-f8935708fc71">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="d888c9f2-c608-4342-80eb-afceb3dc5dd8">
+      <statement statement-id="ma-6_stmt" uuid="03201c85-743b-4aa6-8dfd-fa9547f1f0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2246625a-e556-49af-8b07-b9804d0e2a85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -3083,10 +3083,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/275'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70b0d6b1-ec8c-4490-83ae-6e69f39dbd44" control-id="mp-1">
+    <implemented-requirement uuid="c1c191c3-7acb-4b73-a25f-55c23040e87a" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt" uuid="0cd41408-f83d-4b6f-9b28-27747a0edac0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="fe5c9256-812d-4f41-ac76-9c3a1d1b86f8">
+      <statement statement-id="mp-1_stmt" uuid="28755a59-183a-4e83-a21f-fcebe642f4ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3094,10 +3094,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f28ee4d8-23d6-42a9-8fcf-af01bdffe497" control-id="mp-2">
+    <implemented-requirement uuid="db07015e-b317-4432-81b9-c61e31c06b1a" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="fde21ef2-43de-4eee-8167-bf467bb8ab46">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="739f555d-01b5-4efa-a9f5-70fae185c32f">
+      <statement statement-id="mp-2_stmt" uuid="bac08d7c-1546-4d50-8e59-d09a70f8f9ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3105,10 +3105,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35038835-0655-4934-80d5-5473ac2a207b" control-id="mp-3">
+    <implemented-requirement uuid="6e41f304-f675-4e35-984a-d3048a61ca64" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt" uuid="9c869388-2a14-4f0b-a81b-44d73fbb3fd1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f9f31c68-7c9f-416a-88e4-f1674651572c">
+      <statement statement-id="mp-3_stmt" uuid="cd8da023-d985-42b8-ba2d-64d4e8dad66e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3116,10 +3116,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e0f8d09-6997-48fd-913e-055615d8db5a" control-id="mp-4">
+    <implemented-requirement uuid="de914eda-7907-4c3b-9e2e-225169a20d0f" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt" uuid="22ef3aa7-9b51-4ef8-ac90-d78d8fcff722">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6cf5b3c3-3687-413f-837b-961840b38adb">
+      <statement statement-id="mp-4_stmt" uuid="8794e798-1ad0-4892-8e4d-17fb6b0f6fa3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3127,10 +3127,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4850ade6-8aaa-403b-b885-8c638bc98f21" control-id="mp-5">
+    <implemented-requirement uuid="fe7174ad-2b39-4efa-9301-b568a3170c36" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt" uuid="933ac1f0-8ef2-427c-af20-b6d55b31a8ac">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="646272d6-82ce-430f-af96-e893565c4011">
+      <statement statement-id="mp-5_stmt" uuid="3f368593-316c-4afb-aaa9-a79d8446941e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3138,10 +3138,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c225ea1-d1c6-418a-a34a-319d88ec8c8d" control-id="mp-5.4">
+    <implemented-requirement uuid="f4e10691-6e85-44b1-bd4c-03bbdae7d003" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="ee0205b7-f1f5-45b4-9d8f-fab42f39bca4">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="70d23f0c-1288-4982-a209-9a92ecc8f347">
+      <statement statement-id="mp-5.4_stmt" uuid="9205055c-0ad7-473d-9e02-d895bab0d8ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3149,10 +3149,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f706607e-9ec1-4989-a95e-0e8998f67fff" control-id="mp-6">
+    <implemented-requirement uuid="73dab637-290e-4ed2-8032-79920696e3b3" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt" uuid="d228d555-ec0e-4914-b3f0-0dc8a3563333">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b68cd9d7-170e-4c49-8021-18affa087476">
+      <statement statement-id="mp-6_stmt" uuid="c609d480-441b-4fb0-b14a-abbfb8e5a6ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3160,10 +3160,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04980e72-32c7-4523-b5a4-c6f98975c856" control-id="mp-6.2">
+    <implemented-requirement uuid="faa86668-0630-4ce5-9345-13af47b14ebe" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="58f5e85f-a2bf-4ae2-8223-bb0d6ab6e997">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="29e56057-472f-4144-8fcb-b6631dca8a92">
+      <statement statement-id="mp-6.2_stmt" uuid="b5a85ab5-1044-46da-85c9-c8df4f9dfc3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3171,10 +3171,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bea1bc35-6054-451a-8c09-546bcbe1991f" control-id="mp-7">
+    <implemented-requirement uuid="60cf4fb1-3a3d-4f09-85b1-69dca7250ff2" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="fe5752e1-c43d-4754-b828-fcf1cf0c0049">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e0b0bdcf-5c44-4fc9-af9f-5b252c01c793">
+      <statement statement-id="mp-7_stmt" uuid="d11d55d4-a801-4eba-a4d6-1a042b3edf26">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3182,10 +3182,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cedca8f-0654-4403-bf9e-f8f3e67b15da" control-id="mp-7.1">
+    <implemented-requirement uuid="f447a86e-4d48-47de-a63b-5bcb1cd20407" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="ea924cc0-bf8d-4b5c-b3b1-f3bb5935b736">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="914e2582-6171-4ff7-b990-2e7a374c824e">
+      <statement statement-id="mp-7.1_stmt" uuid="0b9f6ba6-3937-4b59-9a24-4ace518213c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3193,10 +3193,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="380f2fad-94e5-44d2-9811-263a9604dfcd" control-id="pe-1">
+    <implemented-requirement uuid="3fe8f97e-0a71-49e5-bab8-4f23b60cdd5e" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt" uuid="e8a3acad-f9e4-4a01-9a00-536f067420a3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4121286d-eabc-4236-b643-b60f51d0bfb8">
+      <statement statement-id="pe-1_stmt" uuid="8a9e2eb1-861d-492e-8d96-e3d580aa8425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3204,10 +3204,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13882233-9dbf-4452-aded-318957602a1d" control-id="pe-2">
+    <implemented-requirement uuid="66170f39-9cad-4b12-a48c-d0d25d8049db" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt" uuid="f2392a10-e604-49c8-ba38-0d45fdde580b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0ab036fd-a359-4644-978b-dd2186d21b51">
+      <statement statement-id="pe-2_stmt" uuid="047d6949-4e0e-4498-b589-2948f6dffabb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3215,10 +3215,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="682cfc2c-3e37-46d2-a87e-90d5d3912d5b" control-id="pe-3">
+    <implemented-requirement uuid="c312262c-151d-4867-8039-e80a50115436" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt" uuid="cc6c5aec-6a3d-458b-bea2-4be8114029a6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="39f1b258-a2c4-4044-92ce-589615dbad0f">
+      <statement statement-id="pe-3_stmt" uuid="bb36430f-50e8-42cf-9fdb-f097525b2370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3226,10 +3226,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb273543-b4d6-46ac-b326-195b210d9f33" control-id="pe-4">
+    <implemented-requirement uuid="918e3dd9-8676-4153-ae9b-390016e5a17f" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="18bfd64e-6e7b-4c23-8b85-3dac181bfac8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5c3f6169-5796-4cf9-8d54-dc0002326362">
+      <statement statement-id="pe-4_stmt" uuid="ab53c5d6-71ad-4998-9335-7339dbf2d686">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3237,10 +3237,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9539a892-356e-4fbd-b116-201eba434bb1" control-id="pe-5">
+    <implemented-requirement uuid="814592b0-b7db-4ff6-99f8-eca022f97115" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="3e94461d-bf96-4e31-b0a5-6b75db1b252d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="39e6c94c-1268-4cce-a2a1-715fbc7511fe">
+      <statement statement-id="pe-5_stmt" uuid="e87429f3-9556-44d9-99e9-077ffe87607b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3248,10 +3248,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6abfabe4-a2d7-4e86-9c04-06440c9f444b" control-id="pe-6">
+    <implemented-requirement uuid="ba657188-6d16-43a9-8a37-cd5d85fce9f5" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt" uuid="587f5a84-3617-444b-b977-a4e8ac4e0911">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="62820846-83fe-411f-b9c8-e87b026d3638">
+      <statement statement-id="pe-6_stmt" uuid="39b29d3a-8830-4285-a9a4-72430aaef0b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3259,10 +3259,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5d720aa-68a9-47fa-90b8-fc2ec53449f9" control-id="pe-6.1">
+    <implemented-requirement uuid="3ebcd570-89aa-4cec-845b-acbf8d943bfd" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="7dba0d6e-cf46-41a1-9a86-78a24ec8878f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="048c109e-ba58-4279-a9b7-59d1743296a9">
+      <statement statement-id="pe-6.1_stmt" uuid="d835c343-1ef8-48a1-8f89-2ed9120e9bb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3270,10 +3270,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be74d73c-a10d-4c38-9909-e2a9998cb993" control-id="pe-8">
+    <implemented-requirement uuid="3dd3cdf9-3129-4ac3-9bc7-bb7c079bc5d8" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt" uuid="83329262-9f26-4a2a-a893-dec578757b8d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="015951d2-df2c-409c-9664-7421e6c49aa1">
+      <statement statement-id="pe-8_stmt" uuid="601d2879-30a1-47e3-893d-a0d647fa926b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3281,10 +3281,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1946d1dc-7933-4206-9bc4-8348670308af" control-id="pe-9">
+    <implemented-requirement uuid="5e59f398-8a1a-4d89-97d1-36a4453531ef" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="1e7d5c71-7c44-49d5-928f-7b7311c80338">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="aac517df-ad61-4ba0-a712-d398f3286528">
+      <statement statement-id="pe-9_stmt" uuid="d0306de5-ecec-4258-8031-ba37d5ccb8e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3292,10 +3292,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fff5b6d7-f70d-4875-ba78-2367b58de753" control-id="pe-10">
+    <implemented-requirement uuid="9c92af63-6a49-4829-b868-2775814b4274" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt" uuid="1f30a637-e9f8-4002-bc49-167e0480454b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ef952928-a3aa-4149-a848-69559015801d">
+      <statement statement-id="pe-10_stmt" uuid="e8a80447-c1b9-40be-8873-5d02121aeca6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3303,10 +3303,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0fbfaae-c61d-46f3-9082-392b83be26a5" control-id="pe-11">
+    <implemented-requirement uuid="6b660040-bcd9-4035-9186-db59f90eb67f" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="55aa7aaa-2478-489a-80db-5f77ffa7f575">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3bb60802-baac-4d31-8091-87fc1c2dfdd6">
+      <statement statement-id="pe-11_stmt" uuid="7ca82d0f-2e2f-4c36-9915-cdf1ad79dfbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3314,10 +3314,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b693cd94-f42d-4155-9c60-02cdfa58da76" control-id="pe-12">
+    <implemented-requirement uuid="fcc9b873-07ef-4573-9d21-c5cea7cfdd87" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="71a152f2-513d-45fb-9c2e-008338a01494">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0328c956-4ac9-4a93-a97f-e45585dfad13">
+      <statement statement-id="pe-12_stmt" uuid="0bf9e3fd-7b32-4587-a078-205a9ced2242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3325,10 +3325,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52053276-d0d1-4e9e-99dc-05bce4bc9c77" control-id="pe-13">
+    <implemented-requirement uuid="158fd9e8-75bc-46e0-a502-294ed9abcc08" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="168c7ff1-728b-489e-8291-f3b5c8879040">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="514d9c5d-8c3c-4568-b69d-53fee9a90b0b">
+      <statement statement-id="pe-13_stmt" uuid="e2930066-33a3-4127-afbd-337c1d217cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3336,10 +3336,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ba83871-e94b-460e-bf0a-c8394632918f" control-id="pe-13.2">
+    <implemented-requirement uuid="aaaa3fd5-682d-4bed-afc7-7dee10fb3ad4" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="1db68104-7952-4706-accc-2700d22bb91a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="efdc4725-9524-4898-8c03-cafa77e6d586">
+      <statement statement-id="pe-13.2_stmt" uuid="92401cda-a58a-42de-8990-8b269f820e69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3347,10 +3347,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b74a4dc-6c7a-49cb-b9e7-f2035118cc80" control-id="pe-13.3">
+    <implemented-requirement uuid="eaa34a90-3ae8-43c5-8b87-5e20b6607b7f" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="4d21b6f1-9369-469f-80f8-db6fcc6da5e5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="022a6ab9-6a85-45f1-9034-d56cac2a12b6">
+      <statement statement-id="pe-13.3_stmt" uuid="bc8770ac-fcbb-4e0e-bd53-4bd55cd1d60f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3358,10 +3358,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e935b5ca-a0af-47e8-9940-270329c8a72c" control-id="pe-14">
+    <implemented-requirement uuid="a4abc4c0-f5a2-4974-ac4a-8cac7a0b06a0" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt" uuid="fdc6d2ea-eb0f-48ad-b429-93239d77bf4d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8e5901e8-1c22-4770-ae4c-824e0e21cd25">
+      <statement statement-id="pe-14_stmt" uuid="cffa90e1-f78d-49ba-ac4b-9ab953e61861">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3369,10 +3369,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b7d0f72-1100-468d-a798-8f315a987642" control-id="pe-14.2">
+    <implemented-requirement uuid="2d49f52d-c35d-4be3-89d6-483f03f08f64" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="ea890fb1-2fdf-4a89-ac24-d0fb0f31ddca">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1d61c998-39b0-4c36-b789-c4fbe4804efe">
+      <statement statement-id="pe-14.2_stmt" uuid="9270b99c-8d32-4047-ab59-d4842d13f465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3380,10 +3380,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="781ce49d-6208-46d4-8b40-c058d002d95b" control-id="pe-15">
+    <implemented-requirement uuid="2c8a7cc4-34e7-4bb6-bbaa-1c473d6d0d9c" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="ee1dc2a5-a9f1-4cad-aea3-d5fd97a10f3d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f9e2ed4d-f198-4f97-908f-45f7ab6947ca">
+      <statement statement-id="pe-15_stmt" uuid="d1cdef3c-4f86-4c1b-a0df-c2b3746f6315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3391,10 +3391,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c8b7743-b71d-41b5-b599-c59ab100fe18" control-id="pe-16">
+    <implemented-requirement uuid="66a5c88b-e903-402e-91e2-45e8f970564f" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="0f166cd6-53e3-46a7-a4f3-1b1db655ad51">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ba159e29-c2df-4ed7-8df4-32a61f5ba4a8">
+      <statement statement-id="pe-16_stmt" uuid="076b1806-98bb-4148-b439-1fa95052ea1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3402,10 +3402,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bedd38f-5f14-497e-825a-6615cdaa58bd" control-id="pe-17">
+    <implemented-requirement uuid="709e1697-d052-4067-93f3-2c4c64edfd6a" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt" uuid="7d839cb0-22b4-49fb-972f-d2e2e610d4fe">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="289a7bfc-8859-4762-ae3c-701019a58460">
+      <statement statement-id="pe-17_stmt" uuid="a22aa1e5-e0f3-472e-830c-7a955d1f427d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db928b3b-fb6a-42dc-bd5d-edcae3fde6bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is outside the scope of Red Hat OpenStack Platform
 configuration.'
@@ -3413,10 +3413,10 @@ configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d311d37-e1c0-4e52-80c0-9b97ddbb27f5" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="f7262d1e-6f8c-439b-ad68-9b40684c5017">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="14c705be-c9eb-4fa6-abca-9c10863f9a3d">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3424,10 +3424,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf326676-9157-4f46-8978-2e45c87304f4" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="02871125-d279-4ade-8eea-5464478ccf93">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8fc9a3c2-83e4-423f-9ac4-4e11d8a03dc4">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3435,10 +3435,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50e7fda5-8876-4c7e-95ee-5b96034ca948" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="99e7aaa2-510e-43c9-8042-9b000a487ec1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3348f273-e291-4da0-a59c-4048b8ab8647">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3446,10 +3446,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2d8b6ae-78ff-49e7-9504-3c1e49a53b44" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="f7dc38a0-93f3-43d1-b659-35e3df5bb94a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="5bb2c389-cf24-4cfa-83fb-498e498fda46">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3457,10 +3457,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c963586a-42d8-4755-bdec-58f46ea8d421" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="fa5f34ee-750a-4119-8190-3b00122aab54">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="abb08690-035b-40a4-b175-bad2b18967b8">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3468,10 +3468,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cff17b0-aa3f-41b2-af62-8d7a99a1562b" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="04121b8a-2873-4cfd-aeb5-8b66b03b56c1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3cd1d566-ce9a-4551-a8da-03a9c9769568">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3479,10 +3479,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a857eb77-797e-49e6-97ec-363046bdeb5f" control-id="ps-1">
+    <implemented-requirement uuid="3b48c5a2-3d5a-4a42-aadf-d91bae228196" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt" uuid="bf3949a4-b1f4-49a9-8144-c32c91505de2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="67a9c114-8156-4db5-9e1c-fe0b203abc32">
+      <statement statement-id="ps-1_stmt" uuid="fa75fd4a-bd29-4b42-8b77-05c73da9a9c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3490,10 +3490,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c99b2118-ca4e-461d-9cd0-f13609b59913" control-id="ps-2">
+    <implemented-requirement uuid="4dc764f7-9a3e-4226-9a24-f708b609e0a4" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt" uuid="40f9482c-fbfe-47e3-af91-bc8de67fa4ea">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8867e197-9040-4946-9d47-4f95775d3595">
+      <statement statement-id="ps-2_stmt" uuid="bcd6f4f9-3499-4214-a20c-e98f1ea4516e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3501,10 +3501,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbd5a7ef-1af6-4831-8113-1eab7cf65d5a" control-id="ps-3">
+    <implemented-requirement uuid="deb274e6-a5bc-4781-91f7-b2d9f37dbb84" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt" uuid="df09ccbe-f089-48ca-a4fc-6ec8ba313b23">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e8779581-f9e6-4e68-9076-18e83367593b">
+      <statement statement-id="ps-3_stmt" uuid="8794e81b-836d-4ded-b9ed-d93238f9eb96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3512,10 +3512,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddcaf635-ee4b-4ed2-a4c0-663f3aa1313b" control-id="ps-3.3">
+    <implemented-requirement uuid="07f1ae4e-e503-441c-9cba-e72fa4af49a6" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt" uuid="8fe73d09-84c8-4a04-9a42-a7d0b5d922f2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0ef4de9b-f323-41b4-9993-0ae812157f5e">
+      <statement statement-id="ps-3.3_stmt" uuid="238c63c9-ecea-429c-9a98-3ee9cb31dde3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3523,10 +3523,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b7aada8-9ce2-4784-82fa-3caa5487065b" control-id="ps-4">
+    <implemented-requirement uuid="c35fae4a-f1ac-4c7c-afe8-10ee0db02bd6" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt" uuid="de76ccb2-ef70-432e-b56c-0447cf49660a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8610c4f0-763d-473c-b893-3ef02e2ce2c5">
+      <statement statement-id="ps-4_stmt" uuid="d2fabfb5-0acb-45cf-9be8-715b4ebe088c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3534,10 +3534,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="924456c2-8f7e-4c48-a0fd-013d4139cfbb" control-id="ps-5">
+    <implemented-requirement uuid="b145bc21-5681-41c6-b56e-7e483f13904c" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt" uuid="296138b6-27cc-41b7-9f46-c4a9b2cb0a28">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="96b551fd-e515-4319-b97e-7d6e0f37db7f">
+      <statement statement-id="ps-5_stmt" uuid="d6118325-685a-47de-9b33-6c7f9cfe48a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3545,10 +3545,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ec4867c-26a8-4347-9879-c8dc1f077c2c" control-id="ps-6">
+    <implemented-requirement uuid="3acff718-a042-4d8a-9361-0041362e69c4" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt" uuid="a152b4d8-1da7-4aea-94cf-ae35db32a7bc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7b3ea3ef-70eb-4392-8153-29e5e74d4644">
+      <statement statement-id="ps-6_stmt" uuid="b85963d4-3a51-46f7-9ac8-e2d7488f3344">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3556,10 +3556,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b5f8bce-8f3d-4fdb-92fc-ed9832a6f2ad" control-id="ps-7">
+    <implemented-requirement uuid="34569fe7-9406-466d-9dd7-6b5112324877" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt" uuid="1b2e6657-0f8e-4039-8c6f-6829e5a533ae">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="fb8793c7-2857-443f-8203-659f99bd44fd">
+      <statement statement-id="ps-7_stmt" uuid="7f862af0-a6d0-4654-8d86-2dc42f32a896">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3567,10 +3567,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4ba2112-a999-4b95-a83b-60fca5117a12" control-id="ps-8">
+    <implemented-requirement uuid="d24948c8-041a-4d1e-9b5a-da8664a98f00" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt" uuid="252bfc1a-4d89-4da2-945a-6964dda9c023">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="811296ac-16c9-4ad3-9702-04bdb5aa9740">
+      <statement statement-id="ps-8_stmt" uuid="bb73d28c-b949-4cf5-9dab-56d3e3fc075c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbbcd3fd-c019-4d6b-b2eb-ed6ccf00d112">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'##
@@ -3578,10 +3578,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'##
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f90775d8-24b9-40e8-a510-5f0012cc82f4" control-id="ra-1">
+    <implemented-requirement uuid="bb09a5ef-98e5-4052-9683-cdda152142dc" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt" uuid="f7d2eb37-c382-4d28-95ae-d43a58d63b26">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b456ad61-b29f-45d1-9cb3-83fe2174cfcf">
+      <statement statement-id="ra-1_stmt" uuid="6325f8de-a783-474f-850d-9eb67163626d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3589,10 +3589,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74528937-94a5-4b2c-b03d-42dbe854bc87" control-id="ra-2">
+    <implemented-requirement uuid="3db3a332-63e0-40ab-afcf-0f60c0218118" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt" uuid="170910d5-431d-475f-a218-ad88e03217b5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ca80c098-46c0-4ccc-8d5a-2fa4e8734a85">
+      <statement statement-id="ra-2_stmt" uuid="01c17c2a-e66f-4d3a-aa95-4014747994c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3600,10 +3600,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afc15bde-8c77-491f-871e-62b842d85d02" control-id="ra-3">
+    <implemented-requirement uuid="79f18335-4d65-4458-96a5-463bdafb81ef" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt" uuid="3075887d-a800-4ce3-ae16-6584d1b6ac33">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="186feb73-4bbc-4c29-80fb-c90a9325023a">
+      <statement statement-id="ra-3_stmt" uuid="a3225534-b562-4304-b849-5b02450ef53d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3611,10 +3611,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad44bd0d-e27b-4f58-adf3-9070d9b03871" control-id="ra-5">
+    <implemented-requirement uuid="8306bebd-ff3c-497d-b225-1282a4c9dc0f" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt" uuid="25eda25a-9a4a-48dc-8d9e-95476a392483">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a7acd1bf-fe30-4b21-8fa0-ea42eae4753f">
+      <statement statement-id="ra-5_stmt" uuid="eb825304-21be-41c6-9966-6a6ad67ce1fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3622,10 +3622,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7daa8a5-851d-4ed6-83aa-bf441f68d23a" control-id="ra-5.1">
+    <implemented-requirement uuid="47ee0ee0-ba05-4161-9633-83ae0a900757" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="e397588f-579c-4e20-8087-e52a0d71e957">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6ff5cc1e-9e16-4906-92f6-1b41c0b8e75a">
+      <statement statement-id="ra-5.1_stmt" uuid="22f1f7ae-ce80-44a5-8c6b-51e9882d4d21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="637748c8-e910-4b35-bbf0-2bbf61aa9746">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat Satellite, the systems management platform provided by Red Hat,
 offers this capability. Managing Red Hat OpenStack Platform baselines
@@ -3636,10 +3636,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/304'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6fa8b05-ef1a-4373-9d59-b076de1547cb" control-id="ra-5.2">
+    <implemented-requirement uuid="5a421e40-0c80-4fff-b852-863fcb41b955" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="1a78b14e-6cfd-4784-9ce1-ed78a7cd8f9a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8efabd65-b341-456b-8cd2-9f14d6cac522">
+      <statement statement-id="ra-5.2_stmt" uuid="e89c5e34-5b7c-4560-8ca5-6f5ddc53f9d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="088c710d-d866-4515-a72b-13053b2eee15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control relates to the operation of vulnerability management tooling.
 As such, it is not applicable to the configuration of Red Hat OpenStack
@@ -3648,10 +3648,10 @@ platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae295b42-d6c8-40ea-9cda-1ca4f8cf3b1f" control-id="ra-5.3">
+    <implemented-requirement uuid="6e87f6f3-3790-485a-9c4c-243614e7138d" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="5239cd4c-9dc1-4ebe-b117-43b4f1d1864a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c87caa66-cbcf-40c4-b785-6a1db20bd1af">
+      <statement statement-id="ra-5.3_stmt" uuid="a7b4692e-bf4e-405e-9b19-d6fb24f6ace9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3659,10 +3659,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c300f21-9915-443e-bde2-9f7b8a2712b0" control-id="ra-5.5">
+    <implemented-requirement uuid="7a684614-1ec5-41af-9ad6-af02f5dd4157" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="fa5e7744-65cd-4697-9b05-33eaf13deb39">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7c2c77b4-2eba-4e66-8de7-b2cc099c361e">
+      <statement statement-id="ra-5.5_stmt" uuid="89a1ca8f-3e3a-46f3-a32e-ef247dd92c50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3670,10 +3670,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54d194e4-8481-4e14-91ea-c9ba4294eda7" control-id="ra-5.6">
+    <implemented-requirement uuid="80c879c0-97ae-4d83-9d85-ef046dc1e1f7" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="a5128ff7-5ba3-4d05-841d-4cb82b0970ff">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="d2f0abf9-2ecd-4b63-a303-b9988c091d10">
+      <statement statement-id="ra-5.6_stmt" uuid="54956832-98db-473a-90b4-f9f2d0e7729c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3681,10 +3681,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e829f19-f3fd-4e52-9de9-cde22dc25294" control-id="ra-5.8">
+    <implemented-requirement uuid="3ab51cd2-45d9-49a5-93ab-4837bbb5cee0" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="77f2e847-ad48-4c1d-bae6-c91a4baf8f85">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="82c8e0b9-f066-407d-b8b6-6f475041b3ac">
+      <statement statement-id="ra-5.8_stmt" uuid="c357e6a3-c67d-492b-9c05-f09a324ae8dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3692,10 +3692,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8cdce839-c290-43a1-b2e3-8dd4c6c83925" control-id="sa-1">
+    <implemented-requirement uuid="02d0bdc1-480e-4425-8654-0f01d21cece5" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt" uuid="7f843dd4-277a-4ace-b4cb-3c6fdd127882">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="44b54aab-ba90-40f6-b3a3-11ad1d1f877f">
+      <statement statement-id="sa-1_stmt" uuid="a42234f9-5017-4911-bfca-de2060c205d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3703,10 +3703,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eca870fc-d92e-4f19-9a33-34cb11e9e92c" control-id="sa-2">
+    <implemented-requirement uuid="1366cbb3-170e-49ba-8285-eb7d039de135" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt" uuid="3405125e-5d2e-4fe0-84de-fe0877b27f6e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="abb83dfe-d4aa-4e5a-9cc6-fdadf38f0482">
+      <statement statement-id="sa-2_stmt" uuid="ef2b93d8-5bf5-4999-85e0-daa18920d041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3714,10 +3714,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9074248-aa77-44c1-8af1-b4138288094e" control-id="sa-3">
+    <implemented-requirement uuid="64776815-7b8f-4794-bb19-baa7eb7161af" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt" uuid="0b214fc3-fdb1-4f20-95d9-4ef598637e2f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0900b874-c203-4689-aae0-6125667780f7">
+      <statement statement-id="sa-3_stmt" uuid="830adb39-0426-400a-9985-471215d597a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3725,10 +3725,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96f32196-125b-4a3d-b9d3-01aa41602bee" control-id="sa-4">
+    <implemented-requirement uuid="2acbe488-3ce3-4bdb-a1da-d92a45fd52f8" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt" uuid="e9bc572f-b232-4f83-8f32-83ce0a93cbc9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b280b6a9-9882-4989-bc80-fce3b36c6bc9">
+      <statement statement-id="sa-4_stmt" uuid="70ca8eaf-19b0-4537-a2e2-076a70d64257">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3736,10 +3736,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f3c26a5-b521-4009-a063-6ab4ba318fc9" control-id="sa-4.1">
+    <implemented-requirement uuid="21a880ab-a8ba-4163-904b-bc3dc360934c" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="923f630c-ee17-4f05-89cb-aa165aee19ce">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e3cc85b1-6876-4b72-911e-86ad32a0b943">
+      <statement statement-id="sa-4.1_stmt" uuid="ba0d4ef3-5005-40a2-ac16-ef6b50fab441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="132c9508-eea2-4fac-afae-e39ccb68e92c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on functional properties of Red Hat OpenStack
 Platform is being tracked on GitHub:
@@ -3749,10 +3749,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/305'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="673e12df-f82f-4e5d-b00c-ea4ec6dd5562" control-id="sa-4.2">
+    <implemented-requirement uuid="4d50a6e5-8dc9-4ccb-a57b-42603244635d" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="8e93507b-4b18-4c68-be58-d491ffce02fc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9a156018-5bb5-434a-9642-085643b66ffd">
+      <statement statement-id="sa-4.2_stmt" uuid="1f5469d3-3361-4c8a-a3a5-315ca31f0f3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b28339d0-d9ed-43f8-9453-7c0f55331c7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -3761,10 +3761,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/306'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2121f0ef-4580-49c7-8fde-ba38e0fb4340" control-id="sa-4.8">
+    <implemented-requirement uuid="442a5864-d2e1-4d7a-8a0c-ef095b3b66cc" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="79cf185f-7992-4f57-8360-0d8cc289dbf0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ee4935ae-3ab0-42aa-ad7f-12ca0aa95095">
+      <statement statement-id="sa-4.8_stmt" uuid="9c477646-e6b8-42e5-bade-2ecfac2edaaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="55d3d437-0dca-444e-b8d2-ed0c7cc376e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -3773,10 +3773,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/307'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d76ea98a-8920-4c3c-94c8-7da36808dfb6" control-id="sa-4.9">
+    <implemented-requirement uuid="87b20b9e-be6b-49e9-aa06-240405b68c3f" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="4a2938fe-cae1-448a-ba9f-b8ff4ba9a592">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f19946cf-718e-44fc-8f21-eaa134f52fb3">
+      <statement statement-id="sa-4.9_stmt" uuid="ce5bbc2a-f398-42fa-aefb-a1c7bbde3d1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c547f19-a228-4304-8169-e059ab431d20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance for this control is being tracked on GitHub:
 
@@ -3785,10 +3785,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/308'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34e58690-bfe3-46fe-8268-fa6fc84263b8" control-id="sa-4.10">
+    <implemented-requirement uuid="e9678b93-f40c-4898-a0ff-b3c31f4ce95b" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="593dd83e-1c62-451b-9e59-1ecb3bae8be4">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ba9e06b0-1e12-4fae-9ded-60be5c303bc8">
+      <statement statement-id="sa-4.10_stmt" uuid="6aa75d79-dde0-4fb3-9f9b-f80614199c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3796,10 +3796,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20e7b6e6-1dba-4940-b9c8-d88e39dd9e62" control-id="sa-5">
+    <implemented-requirement uuid="49ba8a34-b4ea-4d07-b5a5-ef0a0cee838b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt" uuid="e8d829fd-a9a0-44dc-8d1b-51f8482ff3cf">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7f2dd626-366b-4b79-8baf-f8b3bdff1c19">
+      <statement statement-id="sa-5_stmt" uuid="06328e4a-36cd-4e36-b2fd-4098c768433e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3807,10 +3807,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55b1b9ee-6c48-4831-8480-7c9396d09c29" control-id="sa-8">
+    <implemented-requirement uuid="a72a3bb0-7cdc-4b04-9959-e4a22a4794df" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="96d778dd-4fa9-4e2e-b48d-aa397d781c49">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="16beee7b-5efe-4c01-bae9-2630c664c161">
+      <statement statement-id="sa-8_stmt" uuid="eb80de8e-fa10-4701-821c-a1cb07df496e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3818,10 +3818,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="408357ea-17f4-4c96-97ee-02666e54c5f0" control-id="sa-9">
+    <implemented-requirement uuid="665bebaf-1273-4d6a-bfec-47c7d9736aef" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt" uuid="fa04e227-c093-4894-bd0c-42e78afc78f2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6e9e38c6-44d7-4971-996a-80054ed23024">
+      <statement statement-id="sa-9_stmt" uuid="76e986fb-b47f-41c3-9da2-5bb8b98c5980">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3829,10 +3829,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f690655-bf22-4fe3-ad09-e3d180ea54f0" control-id="sa-9.1">
+    <implemented-requirement uuid="9e77951d-992a-48db-b8e6-05413be8eba6" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt" uuid="1793f492-3c28-46c0-bddd-c2e9a708495c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="792b0533-55ea-4786-987a-b812e17ef618">
+      <statement statement-id="sa-9.1_stmt" uuid="2381ca69-305e-4415-9744-53ea547211b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3840,10 +3840,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2279959f-cbac-4af9-a744-d20b37cd5c30" control-id="sa-9.2">
+    <implemented-requirement uuid="29b25e38-7c08-4114-9acb-d7961ff7a9e8" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="0621e7d8-1f82-400f-9536-d20c2edb8d4d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b23f1e17-a04d-4ffa-ae17-82a8fb52d14f">
+      <statement statement-id="sa-9.2_stmt" uuid="996cb1a8-04d5-4ac5-9bb8-45a2182e3aed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3851,10 +3851,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4597b34e-daae-45ea-83cd-c82eecb5c9e4" control-id="sa-9.4">
+    <implemented-requirement uuid="194e12e2-3f59-4f8a-9a4a-16e8dc056f75" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="85855692-3460-4785-b6f5-72df3aa194ff">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b3a9e0c1-05b0-4aa2-9039-2cdbd4626256">
+      <statement statement-id="sa-9.4_stmt" uuid="95d9ab3c-115b-40e5-b24d-869b15dbaefe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3862,10 +3862,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fc2b113-90c6-4bfa-97ac-f4b59049c67f" control-id="sa-9.5">
+    <implemented-requirement uuid="a920d4f0-c221-4dd1-b192-db73da4ffe1f" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="04422e19-4ae8-49d6-9988-28667598e7a2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="f79d5c2b-61e5-4a22-a8df-d5d95b7172d2">
+      <statement statement-id="sa-9.5_stmt" uuid="00e98fe0-e70f-4616-8f68-aeba63c2ad0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3873,10 +3873,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f05f68a-19b3-4388-bf9c-397802b027f3" control-id="sa-10">
+    <implemented-requirement uuid="8a7e5a26-8532-40b9-ba82-f1ca894f05bf" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt" uuid="5937002c-49e0-4e52-a86c-02168a92c012">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a6291cc0-0208-4467-afc9-9c987076bfa4">
+      <statement statement-id="sa-10_stmt" uuid="e4117a38-d40e-4bd7-a85f-ba2b97d92c5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="036f33f0-d228-49a9-a330-50fd2652d66e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3885,10 +3885,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/310'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ada11c3-1ffa-4207-9f70-a8d2f526d607" control-id="sa-10.1">
+    <implemented-requirement uuid="fe3da24f-31eb-448d-b3c5-a85525c5f632" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="37b31ae5-40d8-4f5c-a001-df4ae9188447">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4c8d3856-d3c1-4b2c-a9ff-3acb51f41f6d">
+      <statement statement-id="sa-10.1_stmt" uuid="a4a59990-e902-4179-affe-9400d9d867bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05de491d-0456-4c3c-86d6-986a7b88880b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3897,10 +3897,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/311'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47183515-ca9a-4977-a2d4-d074df2c7416" control-id="sa-11">
+    <implemented-requirement uuid="eab33382-35cc-46ab-b7c5-a3cbad82b60d" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt" uuid="775d4698-c338-430f-ac80-c9063857d43b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4724d7a3-56bb-44b9-b100-9b035db47643">
+      <statement statement-id="sa-11_stmt" uuid="6aa3a962-5972-4b06-a19a-1e4b6d6db27b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36142ae2-76a8-4d0c-bea3-ab3863eddb55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3909,10 +3909,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/312'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3140c5f7-dc12-4790-aa96-219cfefb1dfd" control-id="sa-11.1">
+    <implemented-requirement uuid="1ea467e5-fc82-4dc7-93cc-b7ca46f80c1b" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="2d7c0d8f-0ce0-4a63-90bb-534935941c8e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b2e52069-1402-4357-b451-a56db3e62deb">
+      <statement statement-id="sa-11.1_stmt" uuid="a4727343-0e91-436c-ad01-65b94b5bccad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80fd44bd-3be8-428a-8b8c-0a06b51191a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3921,10 +3921,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/313'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab45d8ac-0eed-4621-9bf7-bda1e79c18b7" control-id="sa-11.2">
+    <implemented-requirement uuid="80fe8bbd-648f-4925-b6f5-88c9d3f6b3df" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="b03fc921-e149-4b7e-ae55-2224567a85b5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="2b0e284a-9aee-4e97-a10f-04ad07d44d42">
+      <statement statement-id="sa-11.2_stmt" uuid="574d2e67-3758-41f1-9d9b-05c9e6d0c20e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c7ed2e9-be16-4288-b69c-c13e97e53f94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3933,10 +3933,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/314'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e31508ac-e950-4ee4-8868-34ac38b86453" control-id="sa-11.8">
+    <implemented-requirement uuid="16d603bb-d9c1-4351-a6d6-f5576ccde5ec" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="34c9a60e-28b5-4336-9fdc-574196544869">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a50089ec-87b3-42ac-8519-23aa3c983cee">
+      <statement statement-id="sa-11.8_stmt" uuid="cb1281e6-e91b-40fb-81fa-9d5a43b1b5e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f42acbe6-caea-40b9-9200-f4666e65505d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation to satisfy this control is being tracked on GitHub:
 
@@ -3945,10 +3945,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/315'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f16df3d-307d-4c50-908c-8872b491937e" control-id="sc-1">
+    <implemented-requirement uuid="2625c72c-92b1-4548-82af-6938babc644a" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt" uuid="6d37417b-fe9d-49da-a6c1-f54d23b99d3b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e18b59aa-5d34-4e21-91fc-64239ec40819">
+      <statement statement-id="sc-1_stmt" uuid="f38bc439-453f-4c25-9a80-0851c54f889a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3956,10 +3956,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b3a802e-8e6e-44d7-a8f4-dd39226f81a1" control-id="sc-2">
+    <implemented-requirement uuid="1802f562-271a-49b2-b8fe-233932e5cc4a" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="173e0eef-4910-45e4-bfaf-b3adfc889dd1">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7278e3d0-a8c7-4211-b23d-e769868c0160">
+      <statement statement-id="sc-2_stmt" uuid="06bd0277-b83d-4889-b839-c84159733073">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57985d2c-edfa-467e-bf7d-a07c1f21b95f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -3968,10 +3968,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/329'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15e72c58-2d71-4e2c-af00-3465052b9946" control-id="sc-4">
+    <implemented-requirement uuid="64dbd3e9-e804-4d1f-ae06-0e1ba63f2cfa" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="43cfca0b-2e2a-4792-8d9d-c1d52e69b90b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9ed211fe-44d7-42a8-b15c-29c9f879ac2c">
+      <statement statement-id="sc-4_stmt" uuid="b1030c8f-0395-43ef-8801-f7822ee70831">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f3d68c2c-4e9c-4b87-82ae-c684c3dfd122">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -3980,10 +3980,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/330'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe0c8c18-48ed-4401-a41a-63aa0a730eff" control-id="sc-5">
+    <implemented-requirement uuid="2d8b22e1-2a4e-4c7b-a58e-cc7939afb4ca" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="c0549145-3519-49ec-9c38-fd25499aec66">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c7754d1e-70d5-48a5-abe1-54b812b0f985">
+      <statement statement-id="sc-5_stmt" uuid="96527d82-f5f8-4430-a29d-696d94426674">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -3991,10 +3991,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e26a4c17-7a9c-4f03-ad78-0a50f230ac4e" control-id="sc-6">
+    <implemented-requirement uuid="63078761-bbb4-45e8-a384-a18f567b6d8d" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="9f91de43-aff3-487e-8081-f29854e67bbf">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="34983e8e-c6c2-43e2-8d1b-258ff331de21">
+      <statement statement-id="sc-6_stmt" uuid="fb057468-46fd-4789-9cfe-cfac1480791e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5d145947-f0ba-4c5f-adb6-c267ce0aa559">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4003,10 +4003,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/331'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4385801-3974-435d-adf6-3f1d5b42053b" control-id="sc-7">
+    <implemented-requirement uuid="42b49bbd-cf98-4be6-9c0a-b46e14a35032" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="7ab48c9a-534e-462f-8dee-1054e41bbab3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b8619ebd-8030-479c-88a8-577e069a9cdb">
+      <statement statement-id="sc-7_stmt.a" uuid="840a035c-b878-4c40-befd-85b83fbbd2a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f5f071a-db14-492a-9b10-094018323cc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation on how communications at key internal boundaries of
 OpenStack can be monitored is forthcoming. This activity is being
@@ -4016,8 +4016,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="313026a1-7143-4d5d-b009-57a317f6376f">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a1601cdc-4246-4df5-bc30-bd141a662f39">
+      <statement statement-id="sc-7_stmt.b" uuid="95b962a5-d3d6-4a38-94dd-cec0bd717fd2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3646d3b3-7aa9-4e4e-96c4-bcefba78e17d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can implement subnetworks
 for publicly accessible system components is forthcoming. This
@@ -4027,8 +4027,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="a5c2daad-ce0d-4e3c-8655-b71703a37b64">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a030d27f-3249-4f33-a766-0597bb1c7d49">
+      <statement statement-id="sc-7_stmt.c" uuid="62382b75-d7d8-4c36-b6e7-ceba9f3510f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f23cafc-7ab8-4a9b-849a-7b124c42cc82">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform can route connections to external
 systems through a managed interface is forthcoming. This
@@ -4039,10 +4039,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a59f3dfb-2eed-4f26-891a-664d40f83532" control-id="sc-7.3">
+    <implemented-requirement uuid="75db5e9b-e19e-453f-8279-4a40fc611e71" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="6489b23d-c867-4c02-989f-8c2423f0de9c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="718a15f4-5043-4a7f-b3a0-e7112e1a3ac3">
+      <statement statement-id="sc-7.3_stmt" uuid="294d3eee-75e6-41e9-87ac-b707610d1a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a540e417-b9e8-405c-9923-af59799bc97d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4051,10 +4051,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/332'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="871d1b6b-c4d1-4159-ac1b-ba3c15163c2d" control-id="sc-7.4">
+    <implemented-requirement uuid="ab3e9d4b-6d06-457b-905a-be120c9f73d3" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.4_stmt" uuid="be0f8a75-674b-485c-a139-692b33492c21">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="914f71fd-9c27-4591-a3d5-e2078f910ecc">
+      <statement statement-id="sc-7.4_stmt" uuid="f8f51a92-985d-4a2e-b74c-3a2ea4b84894">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ec9adf1-d01e-4691-91ac-e8d15fbf54dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4063,10 +4063,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/333'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa50b446-2a3e-4f0d-9b57-2a81a6d662a6" control-id="sc-7.5">
+    <implemented-requirement uuid="563f698b-0cbc-4ba1-bfa5-fdc2820ce56e" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="b35c611b-5150-4062-b74c-30e669ab809e">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7d3c08ad-dc59-4f91-beeb-040d9c4e1edc">
+      <statement statement-id="sc-7.5_stmt" uuid="090005ca-8287-479c-9d11-934ed7bc64b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ceac9671-c24b-45b1-b888-6dca7d007970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4075,10 +4075,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/334'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f10fe565-67a3-47ec-ab49-6f75c49d1fe9" control-id="sc-7.7">
+    <implemented-requirement uuid="6a70b630-e573-4b87-89ed-7ea5ec88a9ba" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="a0c4ed50-8a61-4970-a231-f1ca6879b043">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9aa25069-5f67-425e-811f-de7f814a0fc8">
+      <statement statement-id="sc-7.7_stmt" uuid="baf4ece9-5d89-4bb7-9479-a0635c1db647">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d45b3d68-31d0-4441-b190-798f0809be67">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4087,10 +4087,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/335'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fe971bb-c9ee-48b1-8293-15b3f81a4a09" control-id="sc-7.8">
+    <implemented-requirement uuid="b2676614-4f04-4d9f-a66a-994c8cdc4d3c" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="a0b1cd8d-9c56-43ef-a917-70ee05762227">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e6377418-24f6-4b9b-aad8-32090b234c05">
+      <statement statement-id="sc-7.8_stmt" uuid="4ad1d4ac-cd9c-455d-b12d-bb109c2fa518">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b55a15d-b075-40ff-9aed-7ebf38cde65c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4099,10 +4099,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/336'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30aa7a62-ab02-466b-98ab-1abecbb5ce0c" control-id="sc-7.12">
+    <implemented-requirement uuid="11e75ec6-7090-42cb-acf5-12a437fe5d7d" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="7328067c-6a73-446a-8b9b-2a3f6d2dca0b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6c1d9029-56b5-45ae-a798-600b456a5f89">
+      <statement statement-id="sc-7.12_stmt" uuid="f0d00327-4c9f-4920-9d46-6feed94c3f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb4a39b9-80b1-48e2-ac1b-2b0913bb5ed1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4111,10 +4111,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/337'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e88d385-e3c4-4f97-9169-1015ff28aac8" control-id="sc-7.13">
+    <implemented-requirement uuid="fc784b4d-c761-4701-a177-57ecb02c3ccf" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="f79f325f-d0fb-41f1-aafe-991be13ea3fa">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="274ff5a5-76a7-49bd-aea4-ebe5eea13f78">
+      <statement statement-id="sc-7.13_stmt" uuid="0ab6bd11-fca3-45e0-8567-65cf4a2ba863">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4122,10 +4122,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff3c7211-b4a0-4cde-a00d-7f98b27f8d29" control-id="sc-7.18">
+    <implemented-requirement uuid="45d19c4e-c44b-454c-9fbb-752ded2eb9de" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="b13dc9ff-c87e-48e5-8b7a-66ee202a6026">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dadae092-2a35-4f5d-b9ab-753da8146e31">
+      <statement statement-id="sc-7.18_stmt" uuid="7048700e-5098-4673-a8c1-2b3b0689e9b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a302570a-baf1-4b64-95a5-418f3b1b1884">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control is inherited through organiztional network services, and is
 not applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4133,10 +4133,10 @@ not applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9684f7c-559c-4204-ada4-5e3c495fb9b8" control-id="sc-8">
+    <implemented-requirement uuid="8cac9748-eb4e-49a2-9a3f-26850556ddf9" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="e17d1479-7b13-43fc-ac4a-ad72762a5ceb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="36df4cf8-9b96-40d3-816f-803aa9242a14">
+      <statement statement-id="sc-8_stmt" uuid="05a077ee-ec45-4eb0-972d-771fe6ba103f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fff8264-4e8b-42f9-a917-8c375d578843">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4145,10 +4145,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/338'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00fed1d0-0a9a-4f6f-9487-201f2b7385b6" control-id="sc-8.1">
+    <implemented-requirement uuid="7ad17e49-df76-494a-8aa8-5efee19f33fc" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="7a0b3766-03f5-4418-8d07-5821309f2931">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c5a84929-26f4-404b-b46a-58ef54809358">
+      <statement statement-id="sc-8.1_stmt" uuid="fb1184bb-bd4c-4763-8085-e1687cad15ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d10479d-ba41-4841-a693-22e50f8e016e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4157,10 +4157,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/339'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37a21595-c891-45f9-904d-75d54522decb" control-id="sc-10">
+    <implemented-requirement uuid="668d8d10-28a7-4f20-ba55-80b5a10459b6" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="40e3f2f3-c17a-4b07-903a-47d25a68eb4b">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="cd8f7997-e6c1-4b76-8689-d1af2428e0c0">
+      <statement statement-id="sc-10_stmt" uuid="9a102272-be39-42b6-910a-6b3cb14d06f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e69115a-6801-43fc-9501-d581b94a740d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4169,10 +4169,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/340'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6e79979-65bb-47f3-9ae8-1254e4d03184" control-id="sc-12">
+    <implemented-requirement uuid="54fb0366-a307-49c2-90d0-947efc58cbe6" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="fadcc82f-5d98-431c-838d-b56541a4b3be">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="16f4239a-979a-49f7-aec9-6396993d075b">
+      <statement statement-id="sc-12_stmt" uuid="9f86c3ef-732b-4fec-9c08-d8d69b47c671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6499aebd-e9ec-451f-8372-48b65980dd07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding how Red Hat OpenStack Platform generates, distributes, stores,
 accesses, and destructs, cryptographic keys is forthcoming. This
@@ -4183,10 +4183,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6b569f6-f9be-4180-858c-6e93ac900905" control-id="sc-12.2">
+    <implemented-requirement uuid="84dee7d0-1501-4bf2-bdca-b823b4ebd3c3" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="501e127e-db53-4904-8185-df056c4bf1a7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="877b36f0-335b-421a-ad9e-729481ffc066">
+      <statement statement-id="sc-12.2_stmt" uuid="91981e67-d91d-4ca1-8dc5-1e73d0a9eb2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="007db3e9-271f-4215-a920-8c7833ea3e97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4195,10 +4195,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/342'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b534bc2b-e1bf-40ca-81a8-ddc58436b6b5" control-id="sc-12.3">
+    <implemented-requirement uuid="a1c927cc-a6bb-4250-a21e-9a9b0ef86970" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="cabba5a6-2b3c-49ad-afa6-d6f503563ea2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="4c52cbbe-74f9-469f-b16c-092954485bd8">
+      <statement statement-id="sc-12.3_stmt" uuid="8edf7687-ecef-4b09-b856-dcbe8a7aeebf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed390d74-1ebb-4105-a780-e9957f43d068">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4207,10 +4207,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/458'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d44a291-6971-4c6e-92cb-96f4ea4c13ae" control-id="sc-13">
+    <implemented-requirement uuid="82fe73df-fe8a-46fd-93e3-6e68fd1dce01" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="943355fe-d5ac-484b-9005-33d957511fef">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="dfb89e38-a0d7-42ab-81b4-45b9ed28ab17">
+      <statement statement-id="sc-13_stmt" uuid="a24dfcc3-ca6e-408c-9de2-6199ee954169">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d623f946-d2e6-485f-9e63-8804ae86d1a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation regarding Red Hat OpenStack Platform's usage of cryptography
 and applicability to Federal laws is forthcoming. This
@@ -4221,10 +4221,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc3d3271-6a76-442d-b3ad-39b1d259fe79" control-id="sc-15">
+    <implemented-requirement uuid="41d0736e-d38a-4f0f-8632-dd3ec102fbdb" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="0ee4d3cf-a6ac-481d-86f5-09604a094505">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="417142f4-4d85-4df2-8f8d-2dcb14e14bd6">
+      <statement statement-id="sc-15_stmt.a" uuid="de8ded74-4758-4253-8fd5-fb3e89177f43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4233,8 +4233,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="3f56de21-bf84-4790-9aec-c67f14dafbc5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9779d7eb-808b-4390-af25-6c7e4f2435c8">
+      <statement statement-id="sc-15_stmt.b" uuid="3d7aebca-e951-4c6d-9696-d445fb60915d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4243,8 +4243,8 @@ a collaborative computing device.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b.1" uuid="6bce8dbd-110a-4e2e-ae93-6c331db64a42">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b3f19dc3-6dde-4d74-9d5d-4207f50d3a3c">
+      <statement statement-id="sc-15_stmt.b.1" uuid="0307a0ee-19cb-4e49-a8e0-c0e0982ceedc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17765ea3-d221-49c5-8522-6e08594d524d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4254,10 +4254,10 @@ a collaborative computing device.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3c198a2-d54b-482d-9af4-3180c7536c80" control-id="sc-17">
+    <implemented-requirement uuid="0c42ed7c-fe98-4751-9446-ddc704529bd0" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="ad85e18a-6f6e-49b0-a547-4fe1a9f6dcbc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="059719ed-3238-4d13-994c-5ad77b662a0a">
+      <statement statement-id="sc-17_stmt" uuid="6cae77a4-904d-4ada-ad8b-1ba5511c9b46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4265,10 +4265,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89eaaec4-4bd7-428e-b667-f779a77dfe6b" control-id="sc-18">
+    <implemented-requirement uuid="bba6e862-f95a-4d2e-831b-25200bdf5b57" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-18_stmt" uuid="e9e542c1-deed-4c76-aa3e-812aa27d2457">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="6ce29df6-f055-4335-b36f-4a9b315c36b2">
+      <statement statement-id="sc-18_stmt" uuid="9ba891f3-5d8a-42d6-8f71-6a8ee2015cb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4276,10 +4276,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="484d85ad-c4c9-41fd-a671-c05b6ca4838a" control-id="sc-19">
+    <implemented-requirement uuid="09f8f984-7b75-48bc-a8e7-80d878910de2" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-19_stmt" uuid="3f4e66c6-2614-43ba-9572-644fac5e77f8">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="377b7ac0-4566-42c0-8f62-00ca058ca857">
+      <statement statement-id="sc-19_stmt" uuid="d88c3e83-58ea-49ec-a1bc-6b2409e68a53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4287,10 +4287,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7916b72-9179-4451-9d3b-7bba947acb48" control-id="sc-20">
+    <implemented-requirement uuid="587e6061-be2f-42d9-a980-af099b248ad0" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="a976072f-23d0-4350-9fe2-198622fcd8e7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="043706b0-fca2-4c73-942f-c0119685729a">
+      <statement statement-id="sc-20_stmt.a" uuid="be3db02a-ef6f-441f-aa75-80753775c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6083d276-bc02-4ab4-b09b-aaaa8210d7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -4311,8 +4311,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="8e924986-d011-4e81-9533-c0bc93c42cbd">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b2f84a05-93e3-41ea-8e5a-01c48d7dabd2">
+      <statement statement-id="sc-20_stmt.b" uuid="74d07e5d-09ca-4443-ab18-6212072e2b5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c16ee495-eaaf-4c06-a306-1c0f14762372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -4334,10 +4334,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d044166-35c5-4fb2-a392-8dd83164b87d" control-id="sc-21">
+    <implemented-requirement uuid="b7439da0-1074-4eff-9dc8-e97a40ccd755" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="8529e0e1-7b47-412c-a1bb-6fcc8f7ec657">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="edb5c38a-7094-4bbd-b97c-74adf9cf4412">
+      <statement statement-id="sc-21_stmt" uuid="5b0ad384-b4bb-4c7a-b398-01aec1e97932">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ea535dc-4d40-4390-a021-f94d268e34b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -4356,10 +4356,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db3f993f-cfbb-472d-8798-364e132a959d" control-id="sc-22">
+    <implemented-requirement uuid="e670fa18-c103-45c7-b9a4-75bf0781e6e6" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="b7e8c1e9-dedd-4ca5-8d47-aacf49752403">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9137028c-bbb9-4aab-baf8-e0b12861084f">
+      <statement statement-id="sc-22_stmt" uuid="452a4031-7e95-4f48-b97b-5c90224a8452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abf1e946-ac54-4d51-a595-1a819fe4d19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack Platform has a built-in DNS so that services can be reached by
 the service DNS as well as the service IP/port. Red Hat OpenStack Platform supports
@@ -4378,10 +4378,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11dfe8a6-a952-43a9-a74b-4aa38a049495" control-id="sc-23">
+    <implemented-requirement uuid="3b63ed32-1fc9-4cf2-8f85-15b55365f768" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="4a84d4e7-5c73-4707-b86b-38e5cbc75bfb">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7a4cc3a2-192f-450f-9059-6687c5e119cf">
+      <statement statement-id="sc-23_stmt" uuid="8d9c05ee-86dc-445c-99f0-7c3029e0f97c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c03d43f-7d1a-46f5-ac22-ee337f1a85bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4390,10 +4390,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/343'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6ca7fef-4b7d-4c47-bf07-1fdd17492119" control-id="sc-28">
+    <implemented-requirement uuid="9bf894a7-41ef-4333-9301-f712129350d0" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="61f4e16d-d08c-4008-ad39-042740e6ed8d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b404c429-6e1a-4e43-b7fa-a75d637b0a54">
+      <statement statement-id="sc-28_stmt" uuid="ef10eec8-3c4b-48b3-936d-b43cf7d08bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db7fee9f-746a-4496-ad0d-8ebd3587fa39">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4402,10 +4402,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/344'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="deaf7ee3-61e2-4dba-abc1-27952940cde7" control-id="sc-28.1">
+    <implemented-requirement uuid="61398dd8-e71c-4b05-839a-8837b082d266" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="4cf434f3-574f-4f02-8554-600f3dcde5be">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="9007d424-1872-4c87-84bd-3ffd6ae33bbe">
+      <statement statement-id="sc-28.1_stmt" uuid="364d204a-18a2-4767-a28b-05d034750867">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7946dcd9-315a-435a-9846-87107345e1fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on this control is being developed on GitHub:
 
@@ -4414,10 +4414,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/345'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c3b2e43-3c82-4fbd-9a4d-a658e41c9ac2" control-id="sc-39">
+    <implemented-requirement uuid="c9b7913f-61e7-44cd-a75e-3700a19fa70f" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="32ffe09b-a13a-48da-ba9c-2c7c1c636ae9">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="73db445d-a732-4418-bac3-327d47b19c94">
+      <statement statement-id="sc-39_stmt" uuid="dc3d7ebb-8faa-44c8-a7d7-586144f302e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91c59040-3dd5-40d8-8a46-4d9cbe3c5b93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'When Red Hat OpenStack Platform runs on Red Hat Enterprise Linux, 
 Red Hat OpenStack Platform maintains separate execution domains for each executing process by
@@ -4431,10 +4431,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59c232f2-e196-4762-a74d-0d1a2e3c3524" control-id="si-1">
+    <implemented-requirement uuid="36aaae06-070c-4173-9f7e-9255b0759f43" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt" uuid="c1663e75-2cc0-4432-8b56-76dd93d99e63">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e06f29c7-148e-42c6-9146-1acbc9f33ad2">
+      <statement statement-id="si-1_stmt" uuid="1bf3d73b-ec81-432a-91a3-fdcbeae4bbd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4442,10 +4442,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9f40cd0-d811-4dc6-b687-c93d5f5f4c23" control-id="si-2">
+    <implemented-requirement uuid="e104b35c-ffc1-42d5-9aa4-e8a38a1e2e87" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="e6284761-c0f8-4a74-92d6-e4d0572980af">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="8efced3c-ec13-4830-b4b7-d4c707fa223e">
+      <statement statement-id="si-2_stmt.a" uuid="a58d68ff-a3fe-4ff2-8eae-68a9f1e3e541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c9570cd-f6d7-42d7-a21c-c8795015c074">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for analyzing their Red Hat OpenStack Platform deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4460,8 +4460,8 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="10a584fc-300e-47d4-9f8a-e307185832ad">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="e571ac41-7874-494a-858d-4918c3ffe1f5">
+      <statement statement-id="si-2_stmt.b" uuid="4e8316eb-eeaa-43a9-b306-c403125587e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c30dafd-1186-4dd6-908a-6a11de784a27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for testing Red Hat OpenStack Platform updates
 related to flaw remediation prior to installation. A successful
@@ -4476,16 +4476,16 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="2df1d0dd-4e03-45df-b484-3f3c59bee1d0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="82a3657e-e4ba-48fd-92ff-f97c39b9ed91">
+      <statement statement-id="si-2_stmt.c" uuid="5dfaf5f2-1c09-4083-acc0-418c60182226">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="a8622e1a-049d-419b-bf97-bfecb43659e6">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a3fbbb25-31eb-4a16-9ca4-607da00db51a">
+      <statement statement-id="si-2_stmt.d" uuid="87aa208d-7298-4e88-9a0d-ad50b66b39e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4493,10 +4493,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19c88fa0-b487-41cd-8e7a-af179b60e73b" control-id="si-2.2">
+    <implemented-requirement uuid="709d7f22-ea5c-40f1-b71b-08917dac116f" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="1d88fca9-7c29-43ba-8a86-f71745ad5173">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="728f5c62-6e3d-48ff-a9d9-9c6f2153f4d4">
+      <statement statement-id="si-2.2_stmt" uuid="c2395120-5416-4236-908d-20c6e9b6b070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60f57620-5d98-4519-8f25-65f012658c99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -4505,10 +4505,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/352'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f99134-7400-470d-9ad3-30fd2fcb9705" control-id="si-2.3">
+    <implemented-requirement uuid="ff3db862-1059-4928-9929-aabf66b2140a" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt" uuid="46a1b78e-05ec-46c7-8a2e-03f65faa93e5">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="1ff62e8d-60a4-4670-88ae-463272f10ea4">
+      <statement statement-id="si-2.3_stmt" uuid="3195f814-bc48-4e70-b1b4-9c64b74296df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4516,10 +4516,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49965deb-73b2-41d9-b3e3-d9922a5343f9" control-id="si-3">
+    <implemented-requirement uuid="2812760f-5254-41f2-b1a1-f74814974da7" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="806f4dd4-acef-4bc9-add5-168c26bad9aa">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="780746af-4dbc-4de1-b9f3-4101c77c65b4">
+      <statement statement-id="si-3_stmt.a" uuid="7a172af0-bc2f-4793-b91f-25ec8df73766">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a50f1a-939b-44cf-988d-c66293991147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4536,23 +4536,23 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="c3a2b7ce-1fdf-4111-aaea-280520eae4aa">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="25d76ce4-2602-48a2-aab5-c8d3ee955b23">
+      <statement statement-id="si-3_stmt.b" uuid="56266789-1f6e-41cc-aaeb-af9acf5beaea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="eca77db5-1552-4742-9583-8667b61cf3d0">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="00860031-faef-43b0-bf68-115040480c29">
+      <statement statement-id="si-3_stmt.c" uuid="331924f1-48dc-442d-8083-a140b791c8a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bff9f-8d25-49a2-a5e6-3d8966638ce1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'In the scope of Red Hat OpenStack Platform, this control is duplicative of SI-3(a).'
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="a43977ca-e8be-4fa9-a16a-1d3e24fbb0da">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="0214840d-02a4-4a02-91c0-c03cdfe2796a">
+      <statement statement-id="si-3_stmt.d" uuid="91b6319b-771a-43c4-8de9-56c92a44d5d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4560,10 +4560,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c37139a-e4b2-4633-9a59-ad26d7af1d38" control-id="si-3.1">
+    <implemented-requirement uuid="9b061595-98f5-4d6f-b399-08c2bb7c358d" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="680fd3da-77eb-4604-b2bb-33e0725cc022">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b58b26b4-5d31-4cb5-a2a4-8ed79ac8c3f6">
+      <statement statement-id="si-3.1_stmt" uuid="d6500525-493e-41a5-8db9-8d2f5e031ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00c9f1e2-85cc-416c-9d30-f4c2ad9423c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -4572,10 +4572,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/353'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08794995-2178-44b9-b5a9-e16336de2bd7" control-id="si-3.2">
+    <implemented-requirement uuid="86ec2e5f-c5ed-4889-bb70-13f3c84dd65b" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="35b166e1-f752-4012-92eb-0a193b63df86">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ff4bd3e3-0fcd-4afa-96db-75f04320c927">
+      <statement statement-id="si-3.2_stmt" uuid="7797ccc5-12d8-4524-bc14-bd33ea950bc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5aa654f4-72c1-4705-819f-50b7b3fc1947">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -4584,10 +4584,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/354'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80154895-258a-42cb-9a12-68495e777d55" control-id="si-3.7">
+    <implemented-requirement uuid="820ad5b1-5f6b-462c-98ae-5ac290ffa48c" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="d69c453c-1142-4814-9357-3f0798ec4b2d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3874caf4-a366-4986-982b-63dc399145fa">
+      <statement statement-id="si-3.7_stmt" uuid="87f40c2d-e397-42e6-9ded-75b48c90a4e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f403b4ce-628e-49c5-9add-c728235517e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -4596,10 +4596,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/355'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5957f4c5-c597-42fa-9e37-5d0d977e7bd8" control-id="si-4">
+    <implemented-requirement uuid="015f2cf0-6be8-41c9-9664-b065997fc3b3" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt" uuid="0dd4a254-d161-40e4-b662-54a7f8a6f999">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="3fcdac22-39f2-41db-b99e-c35375aa3aa2">
+      <statement statement-id="si-4_stmt" uuid="a1af621f-f036-4b5d-a442-f03cf89e2107">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4607,10 +4607,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17973123-0156-46f7-95d5-28af9412bf9c" control-id="si-4.1">
+    <implemented-requirement uuid="3b7fadc1-54a2-4b65-8fbc-5db46941b03f" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="e651bb40-99d3-47ec-b647-61c4a0bf10e7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c1d1335b-e874-415f-90cd-1270f8280035">
+      <statement statement-id="si-4.1_stmt" uuid="efafa5de-dc9f-4747-831a-8ec0082ff07e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4618,10 +4618,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b34bcc5-9924-478a-945d-b150fc0f05d5" control-id="si-4.2">
+    <implemented-requirement uuid="4af70130-4686-4312-99c3-d2290c00372d" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="f6147581-8304-4415-930a-e68d26564ded">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="c0a8f1ee-fe8e-4479-a669-9c86afd7e5a0">
+      <statement statement-id="si-4.2_stmt" uuid="425adedc-71f4-41e3-be99-f10b297c0fbe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa45dee4-c612-43da-8820-a2c6cea408f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance addressing this issue is being tracked on GitHub:
 
@@ -4630,10 +4630,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/356'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7d6bddc-7e72-4293-ab89-2f2a478be1c8" control-id="si-4.4">
+    <implemented-requirement uuid="51f88d75-231f-45e6-a8c3-7b2b73e81f0b" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="09311b63-72f3-43fa-8550-900083eea99a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="51b8147b-970e-46cb-88bf-45d50dd8c550">
+      <statement statement-id="si-4.4_stmt" uuid="3e97aca5-7376-4b5a-8798-f0b81c476c3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4641,10 +4641,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="082ae7cc-0046-4a5a-9a42-7d7e5a979319" control-id="si-4.5">
+    <implemented-requirement uuid="df2fa7eb-f909-4f1b-b3c8-bb3606981320" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="3ad987b1-9b12-4d73-b043-023f6186fd87">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="979feb26-1357-4f84-96cf-8cb7fcab5c73">
+      <statement statement-id="si-4.5_stmt" uuid="2b3e411e-7726-488a-b364-38cda2e71222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4652,10 +4652,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57804e01-2999-40e1-b71d-2fa93b8cc956" control-id="si-4.14">
+    <implemented-requirement uuid="be0fb0c5-5f8d-43ba-b386-aa7e00dd586d" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="0d134255-4ffd-43a0-9a61-f9d9a0d9c13a">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="31c8691b-1913-42d3-82f9-04b0cd2c8675">
+      <statement statement-id="si-4.14_stmt" uuid="831e3075-50ce-4426-a61f-9aaa3d93f889">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4663,10 +4663,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a88330b6-ba0f-449d-a92d-4d7a97efe95e" control-id="si-4.16">
+    <implemented-requirement uuid="2af9c4d8-4fcc-4078-adc4-c5b58a4c3457" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="64f2bd51-08ed-4adb-a1e8-619d30633bdc">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b18d2804-cacc-4711-a59e-a057021f0bae">
+      <statement statement-id="si-4.16_stmt" uuid="c2c8c12e-e202-4e70-b875-d2f5c7672365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4674,10 +4674,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c65cef74-200b-4cdb-914a-21d23f5752f5" control-id="si-4.23">
+    <implemented-requirement uuid="cf6bc27e-1fce-4a08-bacb-617f5536d097" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="31aa0a63-b45a-4a7f-bc56-46c3ef0c2ce3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="bcc8b33b-2171-4b6e-8e43-ed23db3f0fd4">
+      <statement statement-id="si-4.23_stmt" uuid="a752fb6b-d49e-4cf7-87ce-9f9405813dfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4685,10 +4685,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b8ef9a6-c6f3-49a6-9294-ba317e8708e0" control-id="si-5">
+    <implemented-requirement uuid="a0027a0a-4d7e-4249-8cf9-d5cb3c5e9d43" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt" uuid="141529e2-2a93-4c0c-888c-4feb3500ba2d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="00f41939-79e7-45d5-ac88-0a91ad9f3362">
+      <statement statement-id="si-5_stmt" uuid="294d6cea-5864-4fbd-a065-25cc729a4853">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4696,10 +4696,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f271471-8982-4c9b-b0d3-b2984b0b622d" control-id="si-6">
+    <implemented-requirement uuid="d4bd2bba-7d4c-4d6f-9f8d-06c02e00a9f4" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-6_stmt" uuid="931be5b4-4208-47d1-aedd-4b9e5bbb1455">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ce661a73-a690-4a2b-8b76-47d2dc6bcb9e">
+      <statement statement-id="si-6_stmt" uuid="8e704439-f2ec-4401-b02f-fce8f26763c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4707,10 +4707,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2ed75c8-ec2d-40ae-8348-a3f925e5d70c" control-id="si-7">
+    <implemented-requirement uuid="ca323c85-f0f9-4756-ad37-f85f6f9b2bf7" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="0cf6be53-2d9a-4366-9dc8-d70f337baa38">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="a29ec2e7-a8bb-48b2-a214-37792b1024b2">
+      <statement statement-id="si-7_stmt" uuid="8d7a116b-9ad1-415e-8145-71714fd570df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40e946f0-a441-4779-8f17-ecf6c9d44b6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -4720,10 +4720,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/357'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3134e5e3-4995-40a9-98d6-47ba1396323f" control-id="si-7.1">
+    <implemented-requirement uuid="dd58363c-bfa1-4d28-a720-7f7e85ab823e" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="f324b5ce-64e3-440c-b8ac-775cf23b0b4c">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="7908a8ac-9eae-4196-b590-7424ef5b2a49">
+      <statement statement-id="si-7.1_stmt" uuid="9f935daa-9bc8-4370-81cd-1cacac1f79a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbbfa090-efe7-4dd2-87e2-21e09755a049">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -4733,10 +4733,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/358'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9975d8c7-d6ff-459f-b7e8-c9b19b2a21f4" control-id="si-7.7">
+    <implemented-requirement uuid="d1cac6cd-a534-48ac-87d8-c99f86043a63" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="223cd453-6deb-4c84-9350-7ada5de207c7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="327c56c0-7f00-4549-bff8-72b2227fd751">
+      <statement statement-id="si-7.7_stmt" uuid="4a882c6b-aad1-4bb4-bfa4-7730002c9e1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4744,10 +4744,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47018358-5793-4db7-83b9-79fdd0f020d5" control-id="si-8">
+    <implemented-requirement uuid="4a2ec50f-6030-46ae-baf3-29132fe7f33e" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt" uuid="342627c0-a06c-4144-94fc-7cbbbae47f76">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="da02c259-6265-4936-88d3-9502cb1a9cff">
+      <statement statement-id="si-8_stmt" uuid="4f27fc41-928c-4630-9f82-88ff2885f2f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4755,10 +4755,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f68d2fc5-d243-4b83-b5d9-201b750182fe" control-id="si-8.1">
+    <implemented-requirement uuid="16e714db-5fbd-45f3-ad39-82aaefe53223" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="12dd0f92-d951-410e-8107-13a0ef4620a3">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="ca3786f6-c35e-453c-8790-2a3c6d97af37">
+      <statement statement-id="si-8.1_stmt" uuid="7270326c-312a-4874-ae93-60940779b33f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4766,10 +4766,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c15a2dc0-6153-4704-8ea1-40b4fd7e3ba0" control-id="si-8.2">
+    <implemented-requirement uuid="5303db93-adca-440a-8247-a6573f9bc82e" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="7f05741c-3c9a-48eb-ad01-85623ae60fdd">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="143e9cf1-8748-4768-aa33-ade42251202f">
+      <statement statement-id="si-8.2_stmt" uuid="1a675a3c-7a27-4677-bd6b-78fda88b4d25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9473dca-b2eb-4199-9580-3bd5b42e974b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat OpenStack Platform.'
@@ -4777,10 +4777,10 @@ applicable to the configuration of Red Hat OpenStack Platform.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c27ac13-817a-4108-9f48-4cc1ebe3bbb3" control-id="si-10">
+    <implemented-requirement uuid="e2660d38-4a0c-4a2a-8ef0-d695c5105e87" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="d3e78c1e-169d-4ff7-a2cb-6eb92e79336d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="39566954-08d3-4528-9746-97d9f9d242f2">
+      <statement statement-id="si-10_stmt" uuid="36a6ee57-3087-4cba-a2ba-b20ac07dbdea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de2bd73d-a052-48e1-81d1-e2913854bdc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -4790,10 +4790,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/359'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e50ee3cd-3ff8-44fa-a0d9-5ed66972f143" control-id="si-11">
+    <implemented-requirement uuid="2aac5a50-245f-4443-a5ac-47b72d68f547" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt" uuid="2e88de1d-9c09-4d75-b8c2-9ca9f2651ab7">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="db15c0ab-b14c-483f-aae3-ea906d9d84bb">
+      <statement statement-id="si-11_stmt" uuid="2110b0ce-e256-4fca-a4c2-85adcc4b98e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0f60567-f28f-449a-9bb6-88d7b0700597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Documentation/guidance on satisfying this control is being tracked
 on GitHub:
@@ -4803,10 +4803,10 @@ https://github.com/ComplianceAsCode/redhat-openstack-platform-13/issues/360'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9805e810-668f-4acc-aca1-d6868ee448c7" control-id="si-12">
+    <implemented-requirement uuid="42d0e62b-ea7c-4de8-bd7f-5fff9b0c88bb" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="4c317ddd-450e-4714-bd6e-b46cb00ed4e2">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="60f2766a-d324-4050-b807-1632b37ea942">
+      <statement statement-id="si-12_stmt" uuid="c50450b5-45de-4bbf-8ee5-07b8f34c0f29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d14b017-b855-4191-a33f-cbd27d8d8407">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat OpenStack Platform in
@@ -4826,10 +4826,10 @@ https://github.com/SecurityCentral/redhat-openstack-platform-13/projects/1'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="469432da-da48-4b13-b868-4e6700ed71b3" control-id="si-16">
+    <implemented-requirement uuid="3f335609-3bc5-4a94-ad29-eb55091ab008" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="a8d4795a-6fb7-4777-b288-51a9f4a7fc2d">
-        <by-component component-uuid="6013479f-830d-47ed-8fb4-b6d17c482a09" uuid="b8a0be33-469c-43f3-8f4c-003fbdca8195">
+      <statement statement-id="si-16_stmt" uuid="ffb9c9cb-5304-4c9d-a093-eb857932ab6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5de61587-1d30-477b-9c61-9a3dc01edcfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'Red Hat OpenStack inherits many memory protections provided
 by the underlying operating system. When running on Red Hat

--- a/xml/rhacm-fedramp-High.xml
+++ b/xml/rhacm-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="fbeff8ce-e02f-4144-b6fb-ab2918ef3295">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="05a0a643-be5e-415b-9bb8-d260cc597cfa">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.41+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.34+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="6e1c7389-34c5-4781-9203-c34a7624ce21">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="213d5cdf-330d-463f-b526-d6b1335e0a31" control-id="ac-1">
+    <implemented-requirement uuid="446a37a9-8d6e-46ec-bd4a-d588b86fc059" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="da55c634-b59d-49fc-9015-83f0aed84e50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fefcdfaa-72fb-4f56-a591-09e5ba26ca26">
+      <statement statement-id="ac-1_stmt.a" uuid="a46fa548-3227-4b5c-9e93-b4551e31bdfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36092e00-4d2c-418b-880b-8666504caae1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination of organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.1" uuid="cc87ea42-b77b-405e-992e-cbc8e41198d4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="daecb2ef-2dc4-4696-abf9-cb58c9e00944">
+      <statement statement-id="ac-1_stmt.a.1" uuid="f0061df9-be8c-426d-9430-6f55ca66a31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="848b0235-1b1a-4fcf-942c-013642a9448e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An access control policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance is an
@@ -503,32 +503,32 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.2" uuid="507cc0aa-365d-4366-826a-b77d7a1a7fb3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8df012b5-5cdc-42d2-86a9-ff72436a780f">
+      <statement statement-id="ac-1_stmt.a.2" uuid="c8f713b3-3d22-40d0-bec1-0fd90c1d94c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="1586952e-a418-4d12-9336-77f296ee9c3a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="eda99c58-9d22-4fc4-ad64-56a999a768d2">
+      <statement statement-id="ac-1_stmt.b" uuid="51ec5615-5e67-4f8c-94e2-6e1b8ce61aef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a99e9c01-39cc-4093-864f-9a0ea60cdf5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating current access control policies and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.1" uuid="11ac1513-2036-492d-af33-c971774aa647">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a37cd1e5-41bb-4ead-9afc-d2d0400144db">
+      <statement statement-id="ac-1_stmt.b.1" uuid="458d23f0-08aa-4e32-97c6-abd0be9e9bce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0679509e-52fb-4b00-a43b-3ef62a41877a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.2" uuid="65616d94-7925-4aa0-950a-2bff62c2cb6b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c25a4fff-1f6f-44a6-9dee-fdcabffd1f2f">
+      <statement statement-id="ac-1_stmt.b.2" uuid="a729a20f-9875-4d17-ac07-0c78a62d7653">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3355f100-b665-40a9-ac04-a26e35f125e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -536,32 +536,32 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57b5380d-a589-4362-ac7e-81e697db0ffd" control-id="ac-2">
+    <implemented-requirement uuid="f48afcad-3715-41c6-abcd-de0aeb8f62c4" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="bb9ae72f-f6ba-43c9-ae13-20e0426c8fb9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f2a90ede-d838-4d9a-a363-a1b63e1959ff">
+      <statement statement-id="ac-2_stmt.a" uuid="071c595b-1c04-45fd-8884-54a98c532e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd99f31e-58f4-4550-8889-f7593dd8fec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying and selecting the following types of information system accounts to
 support organizational missions/business functions is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="91f9fc95-2123-473d-9407-e9360af7b8da">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a03abad7-e4d6-4ca6-99aa-c940f3f4373f">
+      <statement statement-id="ac-2_stmt.b" uuid="056e1235-b35d-4b33-9e7d-6f66114715e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0db68032-e217-4080-ba94-6adfd1e97616">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning account managers for information systems is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="81d2d0d4-1613-4d18-a51a-4e14db500f92">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="66836967-8d69-4b18-a373-9b9a5224d5c4">
+      <statement statement-id="ac-2_stmt.c" uuid="d4922d23-07c1-4882-b9a9-ae68419ba2c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af87783f-3e43-45ae-a397-c22e28fc4bc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role memberships is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="6e95e678-6798-4693-bbb9-3ba8dafe8d2a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a57a81da-8384-466f-9823-368e963bdfa9">
+      <statement statement-id="ac-2_stmt.d" uuid="e608893e-0645-4161-9404-db3af18049bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d23ed55-db60-4784-9945-229baa1dba09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specifying authorized users of the information system, group and role membership,
 and access authorizations (i.e., privileges) and other attributes (as required) for each
@@ -569,16 +569,16 @@ account is an organizational control outside the scope of Red Hat Advanced Clust
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="e3f01e65-21e8-4322-bfb5-8893f3140388">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2b6d465d-870e-4e36-b154-d4cccf045eaa">
+      <statement statement-id="ac-2_stmt.e" uuid="96007fe4-1aa9-461b-b1c7-f57af74c3bc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3b5f0a1-6cca-46c6-8d74-a4d7af405163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring approvals by the organization-defined personnel or roles for requests to
 create information system accounts is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="2a840199-7c24-4cf9-8382-75e15f5ff865">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="48ef7768-33fd-4930-9fa9-a6f99d5a4d79">
+      <statement statement-id="ac-2_stmt.f" uuid="94b4eded-4c6c-4732-9b2b-e1b523bfc2e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb1bba66-5aec-4056-8637-f249f7d9b368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating, enabling, modifying, disabling, and removing information system accounts
 in accordance with the organization-defined procedures or conditions is an organizational
@@ -586,71 +586,71 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="8e68b52b-0ad4-445a-a636-59c7327814ca">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2c102420-bdbd-40b8-8e1b-a277d8515805">
+      <statement statement-id="ac-2_stmt.g" uuid="71d1f487-08fd-4033-adf0-511d6baced01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5813133d-dc14-464f-a80e-a458308b0924">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the use of information system accounts is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="81431a8b-c0ef-4a2f-ba2c-347935a23225">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ae17a417-cb84-43de-9105-2fd180e10f78">
+      <statement statement-id="ac-2_stmt.h" uuid="9dfc8529-1ae8-455a-9f16-4ccd2e30b472">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5d5918ea-bff0-4d9f-862b-87eed7745465">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers based on organization policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.1" uuid="b38c2261-b5b0-4836-bb86-bd0feb489b21">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d552b2ee-35e6-4a5d-a7c4-0f43d28a5b9f">
+      <statement statement-id="ac-2_stmt.h.1" uuid="6f3a1a5d-0e5c-4fa5-859a-2c354cbf7bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3bf8a-966d-4ce5-99af-2112ab2db55a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when accounts are no longer required is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.2" uuid="22f353fb-b119-4635-85ba-e5f6cdbe1bd2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f37eaf0f-8efe-4e47-ab37-a46a372db611">
+      <statement statement-id="ac-2_stmt.h.2" uuid="5410d25d-7179-4c37-b207-9770f42388ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eefeca77-e7cb-4309-ab70-98e43ee0f21a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when users are terminated or transferred is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.3" uuid="0d8f06c0-bfa1-4a4c-8de2-e0f4260540ce">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="84e0051c-6326-4fa2-80d0-5a39ab7357fe">
+      <statement statement-id="ac-2_stmt.h.3" uuid="59a7dfb3-5417-40ca-8b68-fb05f204c519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709fa778-591d-43b1-99f1-57d85da2c984">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when individual information system usage or
 need-to-know changes is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="cc4285f1-7a52-4166-9063-d6cc74b37cf1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0f5443ac-9983-4ac8-b9b9-0f17791ceee7">
+      <statement statement-id="ac-2_stmt.i" uuid="72153925-174b-4b9b-aebd-3c4ee81886ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3deedd5-b309-475d-8c14-2d3c4bd9d324">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on organizational policies is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.1" uuid="2086f0ca-8ade-41f3-9f04-061293043d50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ea56a86b-ab3b-4bcd-9117-1972c591252c">
+      <statement statement-id="ac-2_stmt.i.1" uuid="fc866425-422a-458b-b692-66f3ddba4077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bdf2292-5cea-48c9-a97b-03c440bb886d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on a valid access
 authorization is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.2" uuid="0c4db544-b8c4-4279-9151-1e3941004f14">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b2f7376b-09fc-4644-b1a9-00f001a278ee">
+      <statement statement-id="ac-2_stmt.i.2" uuid="733525f4-4f43-4c42-b223-c7cda170e955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b59c0b1-9f0f-4807-ae5b-3dc2cfd8f3d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on intended system usage is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.3" uuid="898b2a44-0a23-4ab6-a39d-08372c76e6d2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="afcc69b8-b909-40b6-bbd7-5f69851780ae">
+      <statement statement-id="ac-2_stmt.i.3" uuid="39eb2761-3339-46ff-9006-e58ad19cc724">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="063e440e-bf85-4f03-a941-ba604aeecb07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on other attributes as
 required by the organization or associated missions/business functions is an organizational
@@ -658,16 +658,16 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="2755ff01-19b2-41c1-ad2e-0e0bc9d5d43b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bd65eb57-2ea2-47cd-a520-d26d067f9aaf">
+      <statement statement-id="ac-2_stmt.j" uuid="880ba87d-a493-4868-8e58-499d98903b59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29ccfaaa-25ca-486a-a1c7-7f75266738e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing accounts for compliance with account management requirements is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="cd3ea4e9-a1b6-4d88-9853-ff644371ecbb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f7e8b0eb-554c-4e24-aebe-5a4374593a3a">
+      <statement statement-id="ac-2_stmt.k" uuid="e887fc23-6372-426c-a670-f40a1eee3726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adf77389-1a12-412f-b327-7b6a5a0cb558">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for reissuing shared/group account credentials (if deployed)
 when individuals are removed from the group is an organizational control outside the scope
@@ -675,10 +675,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5ec3b1d-0cf8-4b5b-a27d-3fdfddd9b1b6" control-id="ac-2.1">
+    <implemented-requirement uuid="f7399bf2-752d-4761-9093-e193ecd06ab8" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="80002f4a-7ca0-4bad-8fb1-5a36e4f1b84f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c40cb787-48e2-4c78-b633-3dcfb2b6aff3">
+      <statement statement-id="ac-2.1_stmt" uuid="bc485ba6-d871-4923-ae69-474368ae183f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bda05ad4-f3a1-47e7-84f6-1ffa3f3644a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to support the management of information
 system accounts is an organizational control outside the scope of Red Hat
@@ -690,10 +690,10 @@ accounts and system activity by logging of related information.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="549e61d2-7e60-4191-8b73-81d19e8c8986" control-id="ac-2.2">
+    <implemented-requirement uuid="02f80c5f-9d81-47fd-a15f-169298ee2ab2" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="88a713a2-52c9-4da1-baa1-19555290daa4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b8b06754-e3a6-4fe4-87c1-ff1298060258">
+      <statement statement-id="ac-2.2_stmt" uuid="196ba0d7-9ccf-4679-807b-4da4732e1705">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06ebc894-7ef2-4457-8e8c-402ebc90c1f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically removing or disabling temporary and emergency accounts after a defined
 time period is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -707,10 +707,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d03ba82-130c-4cbb-89e6-ad249b504c25" control-id="ac-2.3">
+    <implemented-requirement uuid="7af6f57b-ddcf-434d-baf2-551f78ff5bfe" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="9b22f152-0612-4518-a413-2eacdabb8125">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="647a48a2-0fd2-4fba-8552-7abb8f719968">
+      <statement statement-id="ac-2.3_stmt" uuid="d797a971-ede9-449e-bd4a-083cde68f974">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49665e5b-422c-4d5b-a7a2-eee36d55890f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically disabling inactive accounts after an organization-defined time period is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -724,10 +724,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7959a699-f7c1-4ca4-83ad-be3330d0b311" control-id="ac-2.4">
+    <implemented-requirement uuid="a69547c8-3022-4ed2-861f-a1d7f6912151" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="d9a782c8-c6d2-4fb6-9893-0ab5d53d19bc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c7ba4505-bc3d-4360-9a5c-143a5b14415f">
+      <statement statement-id="ac-2.4_stmt" uuid="08b0ed07-18c3-468e-8956-35f32cd0db20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8c8cdd6-cf77-4d42-8a4d-4cf68c95bd9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically auditing account creation, modification, enabling, disabling, and removal
 actions, and notifying appropriate individuals is outside the scope of Red Hat Advanced
@@ -738,10 +738,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a95a4e8-d189-4a5f-a02b-b0f482445c2a" control-id="ac-2.5">
+    <implemented-requirement uuid="fcc3ebeb-bcb2-439e-b2d3-34ca27978ba5" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="b1f13219-0e0e-4864-b1a0-02b9af4d5523">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="907751ea-60f7-4470-95ff-46fbb415f81a">
+      <statement statement-id="ac-2.5_stmt" uuid="a5d395b8-d242-481c-ac50-135e4bca69b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0442fea5-8a3d-4cd2-b1e1-57b356c29a07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that users log out after an organization-defined time period of
 inactivity is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -751,10 +751,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18e7453b-4f9f-4dee-aeab-4decd4c3fb4b" control-id="ac-2.7">
+    <implemented-requirement uuid="bab47875-ff44-42c1-be76-846295c07035" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="c54c0557-6104-4ef8-8c55-4b83308391e1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0cde9d6d-5405-44ec-8bf2-d69d874c14d6">
+      <statement statement-id="ac-2.7_stmt.a" uuid="6b15c7f2-959a-4ed2-815b-82b772804851">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1497d780-46c3-479c-bbce-7c0fff4ccadd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -762,15 +762,15 @@ privileges into roles is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="21b28242-ad9e-411a-a08b-1df6074a2870">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aecd83ed-fc44-4f8d-9dc0-3d7cb1d55725">
+      <statement statement-id="ac-2.7_stmt.b" uuid="da5b3975-8b02-48c6-b63f-92b60fe828ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac765034-4571-46c6-9cdf-78c5ef7480ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="388510d5-eeec-459e-9cf6-fca6990b2694">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b7cea619-2455-47a3-80ed-252915b7482b">
+      <statement statement-id="ac-2.7_stmt.c" uuid="91e4b8b3-8b3d-4e1c-bf22-2ab452555188">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c446e20-0a1e-4487-ab97-5544c100d3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of Red Hat Advanced
@@ -778,10 +778,10 @@ Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="005524c0-ba67-42f7-8d24-7ff5d7196b0e" control-id="ac-2.9">
+    <implemented-requirement uuid="9e48496c-0216-4bbe-91a9-936eb3e5b665" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="30f19fca-bbee-46ad-9d7a-54d218156c9e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bc5f68a4-349b-4148-9d4e-0e2d22c57349">
+      <statement statement-id="ac-2.9_stmt" uuid="9feb2350-7307-4d0b-a3a2-631a606d6d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e05ec4ca-2862-4b5e-823f-95c8554fc775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Permitting the use of shared/group accounts that meet organization-defined conditions
 for establishing shared/group accounts is outside the scope of Red Hat Advanced Cluster
@@ -789,20 +789,20 @@ Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82769d1b-4129-40f0-a903-6921155ae6e0" control-id="ac-2.10">
+    <implemented-requirement uuid="da64370c-16d3-4dec-8138-1d6011f37044" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="534c918b-80f8-4c3b-bfce-1ba0ff1e4f2c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4e99ce2a-cfd9-483c-a61c-7e96c2a80eed">
+      <statement statement-id="ac-2.10_stmt" uuid="9b08132b-7046-4141-a124-38fa13f8b225">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a782a25a-dd18-4222-bc50-8f58d339ccb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Terminating shared/group account credentials when members leave the group is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3106fee-d2f3-490a-8f24-7ca63afb7042" control-id="ac-2.11">
+    <implemented-requirement uuid="6d5d59cc-5c24-42a8-a42a-3beccfb34476" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="c2c917c1-f159-44ea-a34c-147b5ebd910c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="590da4c4-1e03-4da9-a58e-b56ec1468f27">
+      <statement statement-id="ac-2.11_stmt" uuid="1f1deabe-57b3-4c3b-86b8-8678780e4693">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="18e78a3d-4027-4630-aa88-1cbb1ab8a8c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcement of organization-defined circumstances and/or usage conditions for
 organization-defined information system accounts is outside the scope of
@@ -810,10 +810,10 @@ Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a97dc187-cff5-43ac-9218-0cc2191b51af" control-id="ac-2.12">
+    <implemented-requirement uuid="fd2235e0-861f-40b0-835e-56d782ec6b32" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="6dd54284-e676-48d9-9b77-2d005c919e87">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fe4ea623-bd3b-4d62-8239-693679d5f1ac">
+      <statement statement-id="ac-2.12_stmt.a" uuid="0a7ee324-2d6b-473c-9948-135bbb36a007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="394fa83e-a22a-4483-bf3d-1e1d27faad2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring information system accounts for organization-defined atypical usage is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -822,8 +822,8 @@ Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="9424b3da-ef73-44c0-9c76-62e4d95c979f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="800dec73-7146-4dcc-ad15-119ee2fe98c3">
+      <statement statement-id="ac-2.12_stmt.b" uuid="f918cb14-5300-461a-bc8d-e005b243d992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c02ea8fa-17f9-40c0-ae6b-f824bf0cdf30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting atypical usage of information system accounts to organization-defined personnel
 or roles is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -833,10 +833,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9cfa78f9-7c21-469b-8e39-ae455993ed99" control-id="ac-2.13">
+    <implemented-requirement uuid="627cc533-4dd2-41fe-83e1-cba96418ce10" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="77d2bd05-ada5-4df9-92dd-31e5a90d04bd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af7eb181-158c-4055-bc72-99f4f2bb7c9b">
+      <statement statement-id="ac-2.13_stmt" uuid="f55b26f9-073d-4c18-ad46-da5bd2e07bc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c98ad3b5-087b-4a88-bcaa-fa21c30f0b03">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the accounts of users posing a significant risk within an
 organization-defined time period of discovery of the risk is outside the scope of
@@ -847,10 +847,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="200e2efb-f34f-45ea-9d20-8cd245279243" control-id="ac-3">
+    <implemented-requirement uuid="1d94fe0c-7b3f-4b68-9e0c-a2f16f5ad4b2" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="66caeaeb-45a5-4073-aa12-6cda9b520e82">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b280d036-a56b-4e33-b30c-324ec5666129">
+      <statement statement-id="ac-3_stmt" uuid="f9fb34c9-0b6c-4915-91ad-f5ec8476b3f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4a3ed62-15b5-4c8a-b32a-1ae088add7fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing approved authorizations for logical access to information and system resources
 in accordance with applicable access control policies is outside the scope of
@@ -861,10 +861,10 @@ relies on OpenShift for access enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70fee0ae-d3c0-4e4d-b617-2f514c0a95c5" control-id="ac-4">
+    <implemented-requirement uuid="b30397b2-37ee-4bea-9108-93c9f663a6b8" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="72d49bb8-4391-42a4-9988-f85f5975f2f3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4b4e8e71-8f31-4f94-812d-09d9fd8e442a">
+      <statement statement-id="ac-4_stmt" uuid="0a189e7e-c272-479b-96e9-555a015f8556">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff281e97-29b2-4f16-9dc1-d39c3ecf2f9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing approved authorizations for controlling the flow of
 information within the system and between interconnected systems based
@@ -876,10 +876,10 @@ for information flow enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cacb56f-8c6d-4c58-bdf8-499b69b3ce99" control-id="ac-4.8">
+    <implemented-requirement uuid="319c03d8-bd1a-490a-8b23-d32ef0828e46" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="5ce3fc5d-8b74-48da-8f29-fecbe08ba925">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e7329245-9b1c-4a50-bb7b-505bc071b782">
+      <statement statement-id="ac-4.8_stmt" uuid="c54d21e6-bf7a-4101-8bdf-cf36e9ed476a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fed39001-f96f-490f-85f2-5a33bfa9f053">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing information flow control using organization-defined security
 policy filters as a basis for flow control decisions for
@@ -888,10 +888,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="107f0613-509d-47e7-9cf6-31df2489bae9" control-id="ac-4.21">
+    <implemented-requirement uuid="98648fb2-edd0-403c-a544-2970341f61d7" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="4b326330-d6c7-4d89-a8f7-63d2f481a904">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="87acf8e9-31b2-4b71-a5de-c9aca758782a">
+      <statement statement-id="ac-4.21_stmt" uuid="38f968a6-b0d4-4c4d-81d1-2ddd557cb762">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="228d3a03-1d84-4d1a-96af-e69a5d6956da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separating information flows logically or physically using
 organization-defined mechanisms and/or techniques to accomplish
@@ -900,10 +900,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></re
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f1a97b4-95e1-4a5b-962c-3abc01a1337c" control-id="ac-5">
+    <implemented-requirement uuid="225e169b-6a2a-4012-a8ac-199fbc303432" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="8d79facf-58f9-4698-bea6-44e951d2f3f3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="033ed321-1a61-45db-823c-12b27e95f844">
+      <statement statement-id="ac-5_stmt.a" uuid="679544be-dedf-493b-9316-9d007868e832">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16396d80-e1eb-428e-9601-1cbb426d78da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes.
@@ -916,8 +916,8 @@ Cluster Management for Kubernetes RBAC capabilities can be found at
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="adefd0b6-373e-4106-8e2a-eb1f975d684e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a0adde8f-e15a-4fc0-b4b3-e772777c46a0">
+      <statement statement-id="ac-5_stmt.b" uuid="b9e1e69c-8b64-40db-ab76-e3a04e23e311">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23200d4d-9439-496f-9009-b7d766de648e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -932,8 +932,8 @@ found at
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="da4e9ba0-ede9-449a-aa19-ca8f5df4867f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1ec0c540-bb97-499f-9d30-34ace14bc35b">
+      <statement statement-id="ac-5_stmt.c" uuid="52a67292-3ab4-442f-8c00-98675e44d595">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e67f2e8-50f3-4e7b-9afb-f342b1276ea4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside the scope of
@@ -949,10 +949,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b2cccac-6d57-400e-8b50-720253ca9e75" control-id="ac-6">
+    <implemented-requirement uuid="8b506624-a626-421a-bc6d-b699dbf28956" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="1dfa8419-4abc-4ba1-9a3d-659e4212871b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ee3f64f9-bb2f-435d-9915-74e0f5a536dd">
+      <statement statement-id="ac-6_stmt" uuid="9008c49e-958d-4f07-9771-aba441779704">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7a99744-ee3b-41e8-9c2a-ddd4238dda53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -960,10 +960,10 @@ https://issues.redhat.com/browse/ACM-187</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e168b2f-3a4e-411f-9f49-3e4ba36bbae1" control-id="ac-6.1">
+    <implemented-requirement uuid="9d9b4b69-7f28-4a21-b9c7-eba66270a577" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="66016ce7-f547-4d0e-95ee-6b191feb2791">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0b1a7a76-507c-4168-809e-d90ce0f1ff0b">
+      <statement statement-id="ac-6.1_stmt" uuid="4665194e-a7c2-41c0-b68c-bd1c131f6cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2cda8c4-890b-4a20-9242-cd99b9e7140e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Explicitly authorizing access to organization-defined security
 funcitions and security-relevant information is outside the scope of Red
@@ -979,10 +979,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="555becb5-6443-488c-869f-36da6029850a" control-id="ac-6.2">
+    <implemented-requirement uuid="5ecea140-1d51-4ec4-bc7d-b53fb6f0d979" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="0afd94fb-ff9b-4a32-9815-6d023542fea8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5c2947f0-169d-4832-97fd-65408b8c5b3f">
+      <statement statement-id="ac-6.2_stmt" uuid="c6c2aaeb-39a7-452c-8410-7212ac30b942">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e9eb3b7-5b9c-422c-bb22-f572ac5d43cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that users of information system accounts, or roles, with
 access to organization-defined security functions or security-relevant
@@ -1000,10 +1000,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d9ea9fa-0d83-4d32-beca-b7f188ec7a40" control-id="ac-6.3">
+    <implemented-requirement uuid="88571cad-9413-4830-bffd-b706e7477581" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="180ebbe4-98c6-41c8-af9c-b22d24637fe4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b72674e5-60cf-4532-9419-709c410b4158">
+      <statement statement-id="ac-6.3_stmt" uuid="50cf522b-c517-40c2-89b4-ca66ac73c472">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f37f6883-ee2c-41bd-ab5f-4b3479b3b9a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing network access to organization-defined privileged commands
 only for organization-defined compelling operational needs and
@@ -1016,10 +1016,10 @@ for authorizing network access to privileged commands.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bca9818f-2ea0-45d4-8e84-535c64b8980c" control-id="ac-6.5">
+    <implemented-requirement uuid="6a6ce6ca-b559-4ed4-b0e0-cb56805fd7f3" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="c5405f31-4eac-4d49-87c7-2fbea70d0441">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d36de9cf-9276-44fa-8a32-2d34c7cb524e">
+      <statement statement-id="ac-6.5_stmt" uuid="270d270e-c4a8-49c1-a670-167184c022b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="472b7ea1-8b87-4144-87b4-a033fc0f50fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Restricting privilege accounts on the information system to
 organization-defined personnel or roles is an organizational control
@@ -1027,10 +1027,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></re
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f59203e9-ad97-4fcb-adfb-ae9b3ccb5495" control-id="ac-6.7">
+    <implemented-requirement uuid="a79b570e-beef-42b6-90cd-dcd481f60848" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.7_stmt.a" uuid="947e4861-6509-4077-b12e-9308e0e0a710">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="742f34af-336a-4a39-a901-d69c0f6f1663">
+      <statement statement-id="ac-6.7_stmt.a" uuid="5982550f-29d0-47a4-aac8-8abcc4bb14af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2eb01f99-ab36-4af1-8e03-76dd2b4b649f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the privileges assigned to organization-defined roles or
 classes of users to validate the need for such privileges is an
@@ -1038,8 +1038,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-6.7_stmt.b" uuid="c57fee92-9652-40cf-b165-00ac853d35e3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="618152b9-57c0-4f82-9b6b-899145a5a9e6">
+      <statement statement-id="ac-6.7_stmt.b" uuid="101db883-3485-4c3f-8311-cc0bc3d0e413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e65c731d-23f6-4d76-8107-9ec6dc9637f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reassigning or removing privileges, if necessary, to correctly reflect
 organizational mission/business needs is an organizational control
@@ -1047,10 +1047,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></re
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1a3f45c-e0b1-48ca-b1e6-fd88d85221e9" control-id="ac-6.8">
+    <implemented-requirement uuid="26844b28-e1b3-47f8-82e7-66954fafaeb1" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="6c210eb8-63e9-4460-a161-a1de1fc2422c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e3bbbcc8-f09e-4521-8bc2-8e8d5e454071">
+      <statement statement-id="ac-6.8_stmt" uuid="f6cc22c8-0567-49e9-aa45-79d76fed5cfc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7a99744-ee3b-41e8-9c2a-ddd4238dda53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -1058,10 +1058,10 @@ https://issues.redhat.com/browse/ACM-187</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29e105e4-3916-46ae-9030-33268ac832a8" control-id="ac-6.9">
+    <implemented-requirement uuid="f668c333-325e-4781-99c6-432d9568fc11" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="88589fe3-cdd2-42ac-b294-415b454bc430">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fc67b851-a5c2-4867-8c67-2490e7265617">
+      <statement statement-id="ac-6.9_stmt" uuid="04743cde-7e51-45ef-b80a-99feb9a5529b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbef4610-bfe8-41fd-9f3d-a2245008da60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -1074,10 +1074,10 @@ https://issues.redhat.com/browse/ACM-355</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a9f1adf-63cb-40e7-b4f9-e965ee90e7eb" control-id="ac-6.10">
+    <implemented-requirement uuid="0de2473e-99df-4e0f-8b7d-4cf41cbf524d" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="3c3aaf90-718c-43d8-bb00-c145e2e037d9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e2c83df8-10bb-4775-ab42-040bd25a426c">
+      <statement statement-id="ac-6.10_stmt" uuid="8fee44e3-4e25-4e67-9715-9091aa75ab2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f05cbb23-1d8e-468d-85b9-fb9d8b74ff83">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes prevents
 non-privileged users from executing privileged funcitions to include
@@ -1091,10 +1091,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6887f0d2-ac32-4f7f-906b-efe0299e8c9e" control-id="ac-7">
+    <implemented-requirement uuid="9e1db829-fdaa-4194-8af7-a78edf04eba6" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="9913b366-16a7-4287-9730-f9af1bebb4de">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="84f54f22-f241-41e9-9566-fcf10a5453b6">
+      <statement statement-id="ac-7_stmt.a" uuid="b3e410d3-f272-4815-90b5-03a1d6ee4c39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5e9720c-eebc-40e0-942d-9fb08a7b54ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a limit of an organization-defined number of consecutive
 invalid login attempts by a user during an organization-defined time
@@ -1105,8 +1105,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="87541e09-57a5-437a-b5ff-c420d2fbd4bd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4ccbef03-0f8d-45f2-83ab-20762469062c">
+      <statement statement-id="ac-7_stmt.b" uuid="c17db2f7-5064-4071-b4f2-c01afee07259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52cbafe5-5b89-4cfe-aa8b-04f8077546a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically locking the account/node for a defined time period, or
 locking the account/node until released by an administrator, or delaying
@@ -1119,20 +1119,20 @@ for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f299db-a8cf-4579-a7d0-1ba6cda6ba76" control-id="ac-7.2">
+    <implemented-requirement uuid="ff09797e-b3cc-4ff3-ad87-f0d315084586" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="bc74ef5f-53e7-4453-bf2c-120f83cf0299">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="89ddeb63-1e54-4495-9376-a23bdcc411e6">
+      <statement statement-id="ac-7.2_stmt" uuid="c5b24a78-56d8-455d-aeaf-42526d01afaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1d669d0-5ad5-45c2-bb79-12f165e1f7a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Management of mobile devices is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes relies.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24adda20-23a3-489a-bdc4-87d4ac44e04d" control-id="ac-8">
+    <implemented-requirement uuid="9dca821d-7949-44d6-846b-6c1c3258ca23" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="c56916b0-f99e-4c8d-adcb-b4f57384c7fc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af690be2-eb59-4616-ad90-d36bd7b2b3ab">
+      <statement statement-id="ac-8_stmt.a" uuid="3db1117e-7344-4b25-bad6-9fa07294bbe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0939dbe-e45c-4303-a828-f73439cd2cb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -1147,8 +1147,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="3462073c-5cf3-4188-8e87-3174285d8102">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ff48633f-d289-4595-851b-fd8b0a6285e8">
+      <statement statement-id="ac-8_stmt.b" uuid="1e505d13-6d01-4048-bc14-9c124464989a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57fefa6e-7f03-40b3-bf9b-2cd97e8e9287">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -1162,8 +1162,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="116c63d2-5ead-48a3-ac08-1aee42ba70c2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="596724a2-d5c2-4869-aaaf-1672704d227e">
+      <statement statement-id="ac-8_stmt.c" uuid="72c013ea-4aa0-4188-a6df-1a2abd22eb65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2671d163-9697-45bd-bf8c-8da3de9c7630">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1180,8 +1180,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="b561f5e3-6139-40ab-aaa7-fe8ff7fd9cdd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b953651c-bdd8-462d-a423-2eb3f6359235">
+      <statement statement-id="ac-8_stmt.c.1" uuid="5e025568-70db-436b-b07a-1263236aeb2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="505b0b2e-9e7e-4ed4-b3fe-8b8f917769f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1193,8 +1193,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="df0b4434-9f6e-4039-b47c-9946bfcd8443">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="351577be-f90b-440b-b798-8ec772c9a9a2">
+      <statement statement-id="ac-8_stmt.c.2" uuid="4cc4d223-2e5e-4486-96d3-f09d672416f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f33d5c8e-5121-42ab-a713-f12b260eb0ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1207,8 +1207,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="36d0d89b-4a6d-4c2c-8d18-cca8bac388d8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4ac37c15-5395-4d86-be88-d5a3bacb7059">
+      <statement statement-id="ac-8_stmt.c.3" uuid="291f26ac-e5ec-40c7-ba2a-a5c85fe69824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69f46d8e-dfdb-4489-b4a7-5489aa0c8f4a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1223,10 +1223,10 @@ https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a61aa7b1-fb53-45d4-9d7a-1bb8ff9f68a5" control-id="ac-10">
+    <implemented-requirement uuid="6dbea49e-d7b6-409b-8281-f06e95eccf7d" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="80ef5ba8-ccba-41ac-b6fd-a524f86550dc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3ca56032-dd7f-45f5-b4ad-901007e51f7e">
+      <statement statement-id="ac-10_stmt" uuid="773bc3ff-9cb1-4c94-934d-731b9fd008c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92c68bbf-6191-46a8-9440-f6944313a740">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Limiting the number of concurrent sessions for each account and/or
 account type to a TBD number is outside the scope of Red Hat Advanced
@@ -1237,10 +1237,10 @@ for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdb0f13d-deac-47ca-b105-29b083a9553e" control-id="ac-11">
+    <implemented-requirement uuid="c3d16a60-dd06-410e-b40c-4051aeb8901a" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="4084389f-a6d2-4325-ad57-f86027d133f4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5729e4af-9da5-4092-acd1-7591781f03e1">
+      <statement statement-id="ac-11_stmt.a" uuid="2cb7c4f7-0f04-4ff3-b011-c57b352ca058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a2b5d5d-e88d-407c-ae70-3b7d5374b56a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing further access to the system by initiating a session lock
 after TBD time period of inactivity or upon receiving a request from a
@@ -1251,8 +1251,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="8bfe99e6-912e-43fb-9643-a2bf13b76d70">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4ed29d0d-80fc-4405-a018-2d419e2e60e1">
+      <statement statement-id="ac-11_stmt.b" uuid="4cd02a73-89d3-4f02-80ee-f4b680839b1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8b09f05-bb16-4d7c-bcce-93bfa003a34f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retaining the session lock until the user reestablishes access using
 established identification and authentication procedures is outside the
@@ -1263,10 +1263,10 @@ for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecd43ccc-0435-424d-b293-2ce18cfe1258" control-id="ac-11.1">
+    <implemented-requirement uuid="fb3fa2f1-e44d-40fd-a916-2068b8f9da1b" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="b7e6839a-d950-4616-8811-fcfd4edf147d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="51135ce5-4185-4581-a726-67b39623444a">
+      <statement statement-id="ac-11.1_stmt" uuid="48b0f08a-e598-4410-ae91-caf86d2a827c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="971983be-8edd-48e0-8331-19d4dfaf7bf7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Concealing, via the session lock, information previously visible on the
 display with a publicly viewable image is outside the scope of Red Hat
@@ -1274,10 +1274,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c37ce54-88d5-4a4f-bf26-655154235477" control-id="ac-12">
+    <implemented-requirement uuid="91c1866a-ff60-4073-b5ce-0a4b9c43c7be" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="25a5d1f3-7c78-490a-a98f-47ae8c30ba92">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4149ef73-6c65-43ed-a357-7f87e38194b0">
+      <statement statement-id="ac-12_stmt" uuid="e4b0cfc8-c775-4e65-b7cc-87a71482004d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e9cca5d-f411-4c0e-a5aa-826b1cdb6951">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1287,18 +1287,18 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20c26ae8-05d7-45c0-aa9e-7a037b927c90" control-id="ac-12.1">
+    <implemented-requirement uuid="cb4b2349-9d4d-4102-a51f-5a276d7cb4d8" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="6b5ac52c-2723-473f-85b2-58856036b634">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="60dd2bd4-a8f5-4a07-85d3-dc9bdf0a1b3b">
+      <statement statement-id="ac-12.1_stmt.a" uuid="9e3dc863-1593-463b-bc56-9b9da3b8788e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef07916d-4119-42c6-a774-54a1da35fa80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing a logout capability for user-initiated communications sessions
 whenever authentication is used to gain access to resources is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="dee1f5a1-c5c3-4992-93f4-df3da2b6d600">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aeaac34c-a8ae-4742-9b00-9f567c09ae0d">
+      <statement statement-id="ac-12.1_stmt.b" uuid="0157f054-981b-4c67-92b5-9cbcdc5620a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5f5495a-6104-42fe-a226-d2720c1f7209">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Displaying an explicit logout message to users indicating the reliable
 termination of authenticated communications sessions is outside the
@@ -1306,10 +1306,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4155ec8-c1f3-4193-a897-2e35dfdaa09a" control-id="ac-14">
+    <implemented-requirement uuid="77a08b50-4be7-4f66-8f4f-84855ef1cc49" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt.a" uuid="938d8a46-beb3-4268-8def-925eee30d61f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bcdbbcea-121f-4a24-a8ef-1bd49690717e">
+      <statement statement-id="ac-14_stmt.a" uuid="5629b5ea-36ab-455c-8d73-cf6c88bfa332">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1255ed5a-781e-4085-9ebf-573f7faa1c7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organization-defined user actions that can be performed on
 the information system without identification or authentication
@@ -1318,8 +1318,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-14_stmt.b" uuid="614fe0f9-d459-4971-a2db-faab85151d7c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="47bf9aa4-9d7d-4d36-8126-aebcbbf70ebf">
+      <statement statement-id="ac-14_stmt.b" uuid="368700cb-708a-4db2-b713-a770859e28d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce50b336-a265-411a-bc40-27ece30bac20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and providing supporting raionale in the security plan for
 the information system, user actions not requiring identification or
@@ -1328,10 +1328,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ac825a9-32b4-479e-ae77-401e3258811e" control-id="ac-17">
+    <implemented-requirement uuid="7128e417-6249-45af-8571-c712eb28d094" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="87c2d2c9-5c6b-4932-9738-a14fc6300dec">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c6704387-2302-4117-a66b-9ae392951c9e">
+      <statement statement-id="ac-17_stmt.a" uuid="68cff69d-2bb8-4591-8f38-62249ae0b657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15acf2ac-db91-4dd0-9b79-e7e64fb6a447">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing nd documenting usage restrictions, configuration/connection
 requirements, and implementation guidance for each type of remote access
@@ -1339,8 +1339,8 @@ allowed is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="a677937a-3f96-40bb-92fe-d346bf8fb94a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="77f4e042-eca0-4e2f-a2b2-ac5e631b63d0">
+      <statement statement-id="ac-17_stmt.b" uuid="40ccd22d-b36a-4e0d-8390-e043a4dc09ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81512212-759c-488e-af52-ac47b733dd17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing remote access to the information system prior to allowing
 such connections is an organizational control outside the scope of Red
@@ -1348,10 +1348,10 @@ Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="290dd211-676c-4399-8eaf-81a0c8d682f5" control-id="ac-17.1">
+    <implemented-requirement uuid="37096164-49ae-4cea-b803-b76ca98c35d1" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="91b2faa5-9c0f-4e56-a024-b322189a07e1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e409e2ec-b48a-48cd-83cd-7fba34f1032a">
+      <statement statement-id="ac-17.1_stmt" uuid="cb656773-600a-4190-8b5e-805429cb603d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91205a50-2b5b-40e5-9b38-4110053d1ed0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring and controlling remote access methods is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for
@@ -1359,10 +1359,10 @@ Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c27bc41-fb39-48c2-ad8e-2641cbfd78de" control-id="ac-17.2">
+    <implemented-requirement uuid="fe9e919c-c9ce-40ac-8d76-90d61bfd40dc" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="bf5d0025-23a7-42b3-ae72-a580cabba787">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e92793f-5899-4b51-8f5e-b7c55b606481">
+      <statement statement-id="ac-17.2_stmt" uuid="0605ccc0-9c8f-4d12-ad37-764b30a9f641">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17d88f5d-c975-458c-a207-747d6a2fb16c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes implements
 cryptographic mechanisms to protect the confidentiality and integrity of
@@ -1371,10 +1371,10 @@ protocol, which all use TLS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dc4cfca-91e1-4dc1-b3f9-3095803b53d6" control-id="ac-17.3">
+    <implemented-requirement uuid="76edd369-da6c-4ba4-a209-017b6c80bb8f" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="362e080b-7fff-4056-8b0e-2d0ede833874">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="14e76dc9-5010-4252-94fa-40fd2037d3c3">
+      <statement statement-id="ac-17.3_stmt" uuid="bf97bc49-2f3b-4d89-a402-9637ae81e305">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b86dc3-6e47-47f5-bfab-bd7ea5610c37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Routing all remote accesses through organization-defined number managed
 network access control points is outside the scope of Red Hat Advanced
@@ -1385,10 +1385,10 @@ for managed access control points.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3b33eb7-8a4a-4e5a-b7d1-8d85e73f1f93" control-id="ac-17.4">
+    <implemented-requirement uuid="7af95b09-3ed0-49f3-bba5-31f47b115b96" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="c256da11-8b67-4631-99fc-58e506b4f800">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9a42f97c-1441-4ff0-a792-2121f211cc85">
+      <statement statement-id="ac-17.4_stmt.a" uuid="144663b9-b8fc-4d3d-8f75-c3364716da4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08da1fb-461c-4b21-afed-d2727e2850a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to
 security-relevant information via remote access only for organizational
@@ -1396,8 +1396,8 @@ defined needs is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="63355909-78c5-456f-82a8-f5efed181731">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="998edd5f-8616-4a9c-8bf6-b9c222013a21">
+      <statement statement-id="ac-17.4_stmt.b" uuid="f94b663d-a948-4d67-9970-10b822124250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16349eb9-d9b9-41b1-a7a2-d6ea7feb00bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and
 access to security-relevant information via remote access in the
@@ -1407,10 +1407,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4a6d7a5-5f4f-4464-b748-3bbab7c30e4a" control-id="ac-17.9">
+    <implemented-requirement uuid="345736be-8ef5-479f-9c0c-94cbbff09ff4" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="fdf4c15e-d37b-47a5-8732-5e370564ed1a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="03cb5f78-65a8-406f-b365-5bd67b0dedb7">
+      <statement statement-id="ac-17.9_stmt" uuid="e3309500-e30e-4fff-98bf-2a4348eba457">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8ec9c2e-4fbe-4f8a-a152-5c1eb1fe2d2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the capability to expeditiously disconnect or disable remote
 access to the information system within an organization-defined time period
@@ -1422,18 +1422,18 @@ for disconnect/disable access.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2808f800-1ef7-4beb-8b93-8e188a327268" control-id="ac-18">
+    <implemented-requirement uuid="81b0da80-f4cc-4d8e-9e32-03731ed286ce" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="5fbf8cdf-d1ae-4214-b4c4-250ee5c4528e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="547ad0ec-5d0d-42d6-9fc9-bcfa2a331443">
+      <statement statement-id="ac-18_stmt.a" uuid="ac4516ea-59d7-4493-9f0a-360aa160ccac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="706e0ed7-6e8d-4399-8bdc-3284bdc4d24f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless access
 usage restrictions are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="76248e63-a5f3-4812-b905-66e5b3794a40">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="781b5f5d-52a2-4502-99ae-845aaa849ee4">
+      <statement statement-id="ac-18_stmt.b" uuid="0571c9d5-0dc7-4fa2-8fe5-70ddeb67d2bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d4bd5c-e641-4851-81a8-29309766ceb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Advanced Cluster Management for
@@ -1441,78 +1441,78 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aef426cf-5cef-4576-adb7-8bfd10d71c6e" control-id="ac-18.1">
+    <implemented-requirement uuid="74d59e77-d7bc-4645-99b0-c47cb642addf" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="cbd46ece-624e-4866-ad82-8a371ef6a7f7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ce9a4ec3-b892-4d1a-ad53-a52b9a7c48a2">
+      <statement statement-id="ac-18.1_stmt" uuid="6c5cac66-a4b8-43d7-bee1-889ccd138200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6314063-6205-42f7-a8f5-280934e258a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25ec9854-2d4d-428b-a6b3-54a1a44846eb" control-id="ac-18.3">
+    <implemented-requirement uuid="d0a8a7f4-fffc-4ea7-bcf4-a758ce35e29c" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="0e31d508-c830-4732-867d-e992b2bf867b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e3d628d5-3c1d-4628-9927-a08b3b7a01aa">
+      <statement statement-id="ac-18.3_stmt" uuid="6be5daaa-116e-4c4a-884c-94835c0bf6d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6314063-6205-42f7-a8f5-280934e258a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5206bff-6f5b-4970-bf0d-c522d778c71d" control-id="ac-18.4">
+    <implemented-requirement uuid="a60b7b49-f4b6-4144-84c8-cd22450dcfea" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="4498f923-9818-4971-a00b-5b49498ebff4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="db39d5ec-84e0-458f-a59a-57324013aa0c">
+      <statement statement-id="ac-18.4_stmt" uuid="ca08e25c-7863-46bb-ac36-1e31ee446014">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6314063-6205-42f7-a8f5-280934e258a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa79b5eb-76c9-4ca7-bf40-c175303f6214" control-id="ac-18.5">
+    <implemented-requirement uuid="e0d63736-7953-4d98-b29f-ef5d42e879bd" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="680e7a36-e497-425d-a10e-1e5bb3e9d7f8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="77014ee4-d096-41f6-a67e-1e1064d00d75">
+      <statement statement-id="ac-18.5_stmt" uuid="daca51ad-0441-42e8-9f22-afbacffd73e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6314063-6205-42f7-a8f5-280934e258a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70404506-c419-43e6-a522-ccfdb4bf1bda" control-id="ac-19">
+    <implemented-requirement uuid="ab1ce503-1654-45eb-88e7-f92f730772f4" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="eee47c2c-f1a4-4f2f-baa7-6101829c58fc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d6b1c8a4-6162-4216-85c9-703d1e2ed34a">
+      <statement statement-id="ac-19_stmt.a" uuid="01754353-65da-42c5-a2ba-a8fbb18820bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aabd43cd-5bb9-47d2-9b2f-f270d6af778e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="f5ffd8fc-b31e-48a9-95b1-f9db2799874f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="eb3efb24-3be9-472f-a125-e3566192beff">
+      <statement statement-id="ac-19_stmt.b" uuid="ddf9d051-c971-4d22-8dd4-1a4bf09571b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0007f9d-320c-4743-92e6-918f64f1605e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6ba6d81-8448-4394-b138-2de93569a7e1" control-id="ac-19.5">
+    <implemented-requirement uuid="caa10d5c-bbd7-4d0a-bd3d-adb8efbaa01c" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="868b2f6f-f129-4dee-8cc3-c8bf4d9c64e2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9eafe470-4c74-491f-8864-7dfc6a56e3d9">
+      <statement statement-id="ac-19.5_stmt" uuid="9c01348b-0f6e-4f7d-9230-8aaa41878375">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfa0b654-c704-4be2-a3a5-15dd773baf7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a776006-64a0-4b9b-b22b-53ebd68aa764" control-id="ac-20">
+    <implemented-requirement uuid="21f8c09b-b7fc-46d0-9ab8-c90adab0f1ac" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="ce83039f-a0ec-4ed2-81e2-c7320999ed31">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="62d3d31f-6b8a-4ba3-869f-0439e7a8f958">
+      <statement statement-id="ac-20_stmt.a" uuid="e95daffc-210d-4201-b395-9d40aaaf8f2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d7a03b-2e25-4575-b1c4-9c3d3634b60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for
 accessing the information system from external information systems is
@@ -1520,8 +1520,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="2add53ae-a882-4bc2-b2bb-01f68b486ca2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="84216ad6-ebb9-439b-8451-d330607b11de">
+      <statement statement-id="ac-20_stmt.b" uuid="f4553ed7-066b-4f8f-bc8d-87ccf77e5546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3e2dcd3-f967-4d44-982b-9a17aa45ef34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for the
 processing, storage, or transmission of organization-controlled
@@ -1530,18 +1530,18 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99747d8b-0727-402a-8ed1-a7e7e9911c97" control-id="ac-20.1">
+    <implemented-requirement uuid="0a24ab17-f521-4377-8bd3-fd25854e66f9" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="9d5b5875-332c-493a-90df-c46148613bc3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e6f260ce-1a3a-4ef6-8b35-23549f86e3ce">
+      <statement statement-id="ac-20.1_stmt.a" uuid="24dde360-4fd7-4329-811e-77bbb8e74425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef917df8-9533-470e-9e3a-5143129bbad8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="42296839-bb28-483e-bc37-8a8e8bb824f8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bec7ca92-d32f-411f-a364-f0108ee372c0">
+      <statement statement-id="ac-20.1_stmt.b" uuid="720b867a-34bc-4908-a065-e588deb5862c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af341842-1e0e-4e2a-ace9-2fda5cf675c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external information
@@ -1550,10 +1550,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9901c96-9a30-4159-b869-bb197a243490" control-id="ac-20.2">
+    <implemented-requirement uuid="f9cbc530-f767-484d-96d2-c9b8fa053aee" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="a95811b0-ad4a-4623-af84-5d3bd4ba98d6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7d972c0e-3679-463a-bd96-4c51c5b1fee0">
+      <statement statement-id="ac-20.2_stmt" uuid="9fa9fa0d-abaf-4879-8cfa-5b56478d67da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="645b3fc8-5952-4846-9ee4-14168cb5a23b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or prohibiting of the
 use of organization-controlled portable storage devices by authorized
@@ -1562,17 +1562,17 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5346869f-fa3e-4e97-aaaa-081647bdffe9" control-id="ac-21">
+    <implemented-requirement uuid="75e7af21-f9b9-4128-ac42-e7b6e42262c0" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="da118cd1-07f2-4657-81ad-e2a80a4751f0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8001edd2-b123-4ffd-87a2-d24b29231da9">
+      <statement statement-id="ac-21_stmt.a" uuid="ca38dbf3-f21b-475a-8dc5-106366c68536">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25a62fc8-0f04-4aa9-b834-d3062fe4adf3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="b71da246-6251-40c0-b57e-9333a3e563d5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6b4777a8-9e5f-4ca1-ad03-0c3c5abc41c3">
+      <statement statement-id="ac-21_stmt.b" uuid="fdf10e02-a231-4361-9f06-546262765adb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71526be0-f003-4ed9-bde1-6b703f32f85c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside the scope of Red
@@ -1580,10 +1580,10 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06c67898-e160-49f7-a7cc-eab1729b0ebf" control-id="ac-22">
+    <implemented-requirement uuid="675bf8d7-bd6f-4f1f-9e04-44762cc751f3" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="6e062f3c-76de-4a4e-9b18-27db1a2b2382">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b7ad2d5d-62cc-4fda-bd99-3e361ade86df">
+      <statement statement-id="ac-22_stmt.a" uuid="14806bcc-f83f-4408-922c-53f570a5cf0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2636d175-e8a1-4668-9723-bebf0f555433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1591,16 +1591,16 @@ system is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="9b8151f9-4aeb-491f-861c-49e86276734d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="66ffbe01-be99-4433-bd47-939d4b14fcb8">
+      <statement statement-id="ac-22_stmt.b" uuid="ed069c5d-4f75-460c-aa1e-937e618e2d0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d07655f-56af-4e87-bc90-2467e6b3df99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="9c0f51da-1a6b-48e7-aa64-24f9ef996ca0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2427f83c-0a4e-4cd0-822f-98e6bc2e577d">
+      <statement statement-id="ac-22_stmt.c" uuid="fa8310c4-487f-4cc1-9e79-e0c0360f2413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72fc5d98-cf5a-4240-b0bd-bdf9d0bfa482">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto the
 publicly accessible information system to ensure that nonpublic
@@ -1608,8 +1608,8 @@ information is not included is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="abe59fe5-9dc5-4f60-b339-cbd121e7ba06">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="05b785ce-e491-44d5-ad60-9c869322b978">
+      <statement statement-id="ac-22_stmt.d" uuid="c8214e90-c694-4709-a058-085720e7ede6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f4c2c7a-9aa2-4c48-a223-dad78aac1f7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system for
 nonpublic information at an organization-defined frequency and removal
@@ -1618,10 +1618,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3c087eb-e66c-4e28-bccf-5a4731ebc9f9" control-id="at-1">
+    <implemented-requirement uuid="3d53f5ba-0388-464e-9ed2-226cdbaf9b51" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="cf66ba03-8006-4b82-8d26-c0cba98d1d04">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0f01f3bf-667c-4fe6-8106-c9cc3ab9c3df">
+      <statement statement-id="at-1_stmt.a" uuid="7db712a1-e7a4-40f2-8040-fa0b61ce15de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a2fc15b-b52c-4d67-9db2-82f2b71fbeb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
@@ -1629,8 +1629,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.1" uuid="9f9b214b-b77a-4add-8f02-3ac188276e28">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e923d254-d9fb-455d-a410-b031c9385834">
+      <statement statement-id="at-1_stmt.a.1" uuid="c36d15a6-7c20-415f-aec2-db0d8b83ffe8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3624a79a-adf7-4b9a-a6c1-bece2aa3f97a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles a security awareness and
@@ -1641,8 +1641,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.2" uuid="c2e215d4-28bd-4c7d-92a7-07de0acd0b24">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e6b87b56-37cc-4324-b6cb-94ceae177843">
+      <statement statement-id="at-1_stmt.a.2" uuid="e07b53ed-3179-401d-a4a2-d3fdea6560e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5d8f64c-5e67-4b22-bf59-9d33772a5147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles procedures to facilitate the
@@ -1653,8 +1653,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="b59024f4-8feb-44ce-b1a3-ce70e8c95b30">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="444707ef-8716-4b9d-9203-3c2dc81158f9">
+      <statement statement-id="at-1_stmt.b" uuid="f01cc4c9-9890-48b2-930c-1aabdc40f441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a296282-0d22-40c0-a0ae-d7297eff630c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness training policies
 and procedures is an organizational control outside the scope of Red Hat
@@ -1663,8 +1663,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.1" uuid="c7e2ed81-2b30-4e38-ae3b-0260724ce05d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="14bf5d74-c0ce-4124-b973-ce5b822da9f7">
+      <statement statement-id="at-1_stmt.b.1" uuid="6a893871-b841-4f12-8149-b6894e65aae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="573a8d1d-647c-4672-994d-e1a08cb74495">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 policy on an organization-defined frequency is an organizational control
@@ -1673,8 +1673,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.2" uuid="3850c75d-94ae-4c8e-9319-a70ad558ec50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bd8b91bd-f360-46c5-9339-f0f379469010">
+      <statement statement-id="at-1_stmt.b.2" uuid="224d4d2e-cfff-409a-b773-0910fb235c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9659903-f239-41f0-bbc3-f13d2e6d3a01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 procedures on an organization-defined frequency is an organizational
@@ -1684,10 +1684,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e11638c-54ef-482b-b14d-3355a34159bd" control-id="at-2">
+    <implemented-requirement uuid="e6ed68bb-0870-4dcb-9b24-17c1ebce64a8" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="f45135ff-8c08-4228-884a-fe1952a5631e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d25471e5-a75e-43cc-9233-8e0fc90e9639">
+      <statement statement-id="at-2_stmt.a" uuid="8503c131-86bc-4578-a094-8bdda4893fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14ebc016-0547-4d5d-b10d-d315cba099ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) as part of
@@ -1697,8 +1697,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="d5143152-88d1-402f-882f-6fa98bf7d546">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="235ec687-8aa0-46e7-a9b6-31642fa5d33b">
+      <statement statement-id="at-2_stmt.b" uuid="01cdbb14-ba93-4579-bd0b-1c3cf8b62da0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46d6e9ac-9d48-4d7c-baec-7c7a2083c708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) when required
@@ -1708,8 +1708,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="dfc3f5b2-159e-47c3-8431-b385fe344fbe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2f597938-7e02-4b61-a692-f686635abd3f">
+      <statement statement-id="at-2_stmt.c" uuid="da6133dd-b73d-4380-bb5a-861448a188fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="132b46ae-43ce-48f6-a591-be355da2ce1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) on an
@@ -1720,10 +1720,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="387162ac-cc6f-43ba-a521-c5fcfce87cc5" control-id="at-2.2">
+    <implemented-requirement uuid="19712fc7-3765-46e8-adb5-b70150fbf51a" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="7096fef7-9562-4bec-afe4-b4c468138e32">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0af454d9-2016-4900-8e82-68e732979c97">
+      <statement statement-id="at-2.2_stmt" uuid="8466cbc8-5e6e-4c7e-9b94-65889620de9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31358141-fbf3-47ba-8df5-97f90e9df0b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including ecurity awareness training on recognizing and reporting
 potential indicators of insider threat is an organizational control
@@ -1733,10 +1733,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c4de5fb-35c0-49dc-b159-20f824fcca74" control-id="at-3">
+    <implemented-requirement uuid="a16777d8-142c-4f9a-906d-b955c88bf4a0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="0334d46d-1f3a-4bb0-9f6e-80980f32ca88">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="eda0ca32-062d-4c06-be6f-74284ef2f7ab">
+      <statement statement-id="at-3_stmt.a" uuid="7b4ef1c4-73cb-4b9c-a509-733b33d61428">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb373e0-5af9-4d04-be11-a02bfbef71c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities before authorizing access to the
@@ -1746,8 +1746,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="2ced1eaf-6656-45f5-b0cb-f4cd59dd84c2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ce0c0b5e-b840-4653-9bed-bd8d7e58f45a">
+      <statement statement-id="at-3_stmt.b" uuid="f6d28bf3-3ac5-4c73-9c71-7230cced8cec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="903135ca-e9e4-493b-a7a6-add2514eebcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities when required by information system
@@ -1756,8 +1756,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="a6ce8a4c-a232-4d7f-8fb0-c618bc06173a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0369d5e7-5afd-4b2e-b4dd-e0c9034fb5fc">
+      <statement statement-id="at-3_stmt.c" uuid="86749632-bd79-45d4-b60f-9b5fcc96a451">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4aa49d88-350e-43ed-9ee8-dfd4807cdf61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities on an organizational-defined
@@ -1767,10 +1767,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98127f09-1d5c-4a31-8222-423a08ab0a44" control-id="at-3.3">
+    <implemented-requirement uuid="f2d5baa7-f041-49eb-bd9c-edba47859394" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="8617f151-3fcb-435c-a2bf-e7c4a2842217">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="680f0b14-50e9-4c19-8956-011fd7b1480e">
+      <statement statement-id="at-3.3_stmt" uuid="a84a1ef4-791b-4b65-92b6-9046f634199d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6029a4c3-9b55-463c-9efd-b5c73787e194">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including practical exercises in security training that reinforce
 training objectives is an organizational control outside the scope of
@@ -1779,10 +1779,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ef5787b-910a-49c3-9741-227809c0abc7" control-id="at-3.4">
+    <implemented-requirement uuid="9703bd9c-b92e-478e-938d-ea1582c1af65" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="825b5fdc-d3b8-4635-985d-d9e13e7e02a9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bbfcd93e-697a-46e2-9d92-7c4329539af3">
+      <statement statement-id="at-3.4_stmt" uuid="315210f8-41be-4b5c-a1b2-acfe8aa8ff23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4717dd3a-c830-4557-b4ec-5581a81c2076">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing training to its personnel on organization-defined indicators
 of malicious code to recognize suspicious communications and anomalous
@@ -1793,10 +1793,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22594bc7-b003-4adb-aaca-1f26b1b24953" control-id="at-4">
+    <implemented-requirement uuid="d8b591f0-19de-4755-ae3e-345052f4cb56" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="325f2a54-0525-402b-9364-a5c2c31a36e6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d79f7e27-8dde-4203-a499-2da6481649c8">
+      <statement statement-id="at-4_stmt.a" uuid="0087eb27-174e-490b-b0fc-dcf52ce768b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22f347b7-eaef-495f-a58e-700c61644f3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and monitoring individual information system security
 training activities including basic security awareness training and
@@ -1806,8 +1806,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="43b34f8d-1e5d-46f6-b7bc-32bb5da8cbcd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0e6b46c7-c447-40ca-b3fe-0886f8b7a46a">
+      <statement statement-id="at-4_stmt.b" uuid="9904e3c3-abb9-4091-8f38-c1bbafa94d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="225f3983-c3eb-4a20-8b70-52480656e170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retaining individual training records for an organization-defined time
 period is an organizational control outside the scope of Red Hat
@@ -1816,10 +1816,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cb2ff9b-7dfb-4109-a425-81eb25966bb7" control-id="au-1">
+    <implemented-requirement uuid="93522bc6-7b1e-46e0-b2e9-4fc565ab55d1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="e9881ae3-b7d3-4fb4-97f7-0bff0b1ad492">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="74d69b4f-a9b3-43aa-a2a2-840d379b09d9">
+      <statement statement-id="au-1_stmt.a" uuid="89ecb81a-977e-453b-aa96-fb6e0cb4b418">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce489d2-2ab4-40a3-8a56-d77d87a28670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Advanced Cluster
@@ -1827,8 +1827,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.1" uuid="de24181f-f1d6-4233-959c-bda25d34d1e3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c53f4efb-2d1a-4ab3-bca2-651423eca5b0">
+      <statement statement-id="au-1_stmt.a.1" uuid="c2e804c1-4b19-42f5-8170-b199f7f06f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="128c9f3f-1bff-4316-98c6-5cb24150cc87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy that addresses purpose, scope, roles, responsibilities,
@@ -1838,8 +1838,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.2" uuid="357a5adc-1193-485e-925c-0297407c8980">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e5c8eb1f-edeb-4dc2-abe4-80a3fa9add15">
+      <statement statement-id="au-1_stmt.a.2" uuid="fbdb7c26-1ad2-4e01-b276-caefef2baddc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2d115ed-16a4-4dfe-a543-32be43c3d405">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level procedures to facilitate the
 implementation of the audit and accountability policy and
@@ -1849,8 +1849,8 @@ for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="322ec8e4-8381-4bce-9883-47b3132d9f61">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0bcbeb1e-28f9-406c-855b-97ffc654edf1">
+      <statement statement-id="au-1_stmt.b" uuid="e55963d2-5a06-4ec1-bb13-1bf5f9ae9a96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147568cb-e0e1-4ce7-97d1-3b200534508d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat
@@ -1859,8 +1859,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.1" uuid="cbcbc1b6-19f9-4ecd-b383-7785ea7462ae">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="096e7027-08d4-4710-898d-e4f088d07ef0">
+      <statement statement-id="au-1_stmt.b.1" uuid="d7166a9b-8fdf-4cf3-8af2-84a77d67636b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e63d95d9-1312-427d-b9f8-0a6704c04dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy per a defined frequency is outside
@@ -1869,8 +1869,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.2" uuid="609e98f5-d65e-4f8e-967a-8c9b3dc3324d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d95a870f-1649-4bd0-af04-6eb931b10e67">
+      <statement statement-id="au-1_stmt.b.2" uuid="8ef977d8-1e69-4b30-a44c-d8f1fc5b5070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e298296-2a66-4578-998f-b5bce664d747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating an organizational-level audit and
 accountability procedures per a defined frequency is outside
@@ -1880,10 +1880,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5b09e2b-62b5-49ab-97b8-6b458ee650e9" control-id="au-2">
+    <implemented-requirement uuid="b03e41af-2673-4478-b4ef-fabb7dfc78bd" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="42695477-0830-48f3-848f-4de84d74635b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5468ac54-d7fa-4913-a9c9-00242f9a406c">
+      <statement statement-id="au-2_stmt.a" uuid="1b8b0e5b-da43-45bb-ba31-0b2bb2e19836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1894,8 +1894,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="d4a01e13-a64b-4ca0-beba-98afa1da2514">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="52cad55f-a3be-4d97-9f86-0e9ec36b4299">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1903,8 +1903,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="21857b0c-8838-4fb3-948c-aab83fd2b551">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="10b3948d-be8c-4afb-b8df-86d87ad47b99">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1913,8 +1913,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="d1430411-3ef6-44b5-a8dd-dd8d56683fb1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9dffe43f-3205-4464-a910-76e7faa8a76c">
+      <statement statement-id="au-2_stmt.d" uuid="21380c65-89e0-46ae-9f7c-c077c3f43f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1926,10 +1926,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf6e9375-fdc5-4bd4-b620-fac31ab9bd47" control-id="au-2.3">
+    <implemented-requirement uuid="37d962d0-0fea-41fb-9346-03a18cab003e" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="f3faaf99-d98a-477a-9e2a-e254ddf72829">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="da358e5a-1a53-41d1-baf7-3f05b3f405db">
+      <statement statement-id="au-2.3_stmt" uuid="29f0f773-5045-4a4b-8027-f47dee16b1c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2ecc01-ef39-4c49-9e65-022c289bbd65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -1937,10 +1937,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64de4d3c-eebd-48d1-9ea9-502185f59184" control-id="au-3">
+    <implemented-requirement uuid="565157ed-c989-45de-9051-e3e39cdc5baf" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3_stmt" uuid="e410c773-4e50-4519-a64e-fd8c9bca196d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cca89123-cbbc-4c11-a0e1-903db63720c3">
+      <statement statement-id="au-3_stmt" uuid="efd94e80-a7d7-4e59-9d8b-d97f7418a986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1952,10 +1952,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32628955-651f-45c4-931f-1b1ac3cc17c5" control-id="au-3.1">
+    <implemented-requirement uuid="d2d30979-56de-415e-97dd-3a1bcf12d5b8" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="c69d5c3a-1871-4978-9359-617eb70e4794">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="93eff55e-c702-4baa-a364-5aa8ea0c4ae0">
+      <statement statement-id="au-3.1_stmt" uuid="fc45f333-f6bc-4119-87c8-8f870ed410b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1967,10 +1967,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a1f1054-bcb7-486b-b1a4-d6d06407be39" control-id="au-3.2">
+    <implemented-requirement uuid="9247d7b8-6cf8-4ec5-a442-00f5981794a5" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="8d15b51b-b12c-4a92-b7ee-2aabc1b4eb6c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="914fd21a-effc-4fd2-bcfd-84c641e2988d">
+      <statement statement-id="au-3.2_stmt" uuid="9204db3e-a91a-4c74-a5b7-aceb2902fbe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1982,10 +1982,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5259ed96-e767-4a64-8721-48e1c7271259" control-id="au-4">
+    <implemented-requirement uuid="fda69e31-a6eb-4841-8f77-97b9def4c605" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="6a666d73-d4c3-441f-b6ca-6a899ed297da">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bbc15682-449f-47a5-85aa-950981697448">
+      <statement statement-id="au-4_stmt" uuid="621babff-ebe8-45d6-bb9c-8ededcfc5c0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1997,10 +1997,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0366c659-6814-42b8-a5ac-6935e60060f7" control-id="au-5">
+    <implemented-requirement uuid="f1968243-07bd-4385-bba0-7104ebd712e0" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="d953961b-aa29-4c73-acdd-38f0dfa9663f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b7e001a6-21e7-4726-8e7c-3cdd63f9bc20">
+      <statement statement-id="au-5_stmt.a" uuid="151d383a-efd6-44e0-b745-12d1fc7d6ac1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2011,23 +2011,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="84e72b22-b96c-4d9d-81a3-2f04cbac6c84">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c8867529-2af8-4d83-9a71-89518206dc89">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
-OpenShift for auditing capabilities.
-
-This control is applicable to the OpenShift Cluster Logging
-Operator and to the OpenShift cluster and is outside the scope
-of Red Hat Advanced Cluster Management for Kubernetes configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="821a6789-7115-48b4-b970-2a60e38a65d6" control-id="au-5.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="e6f3bf20-3ff0-43a2-8d26-df2580d821e5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2d20b147-479d-468f-8dab-b9bc75d601b8">
+      <statement statement-id="au-5_stmt.b" uuid="a6646919-06bb-478a-bcdb-b2d8386b09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2039,10 +2024,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="762a39ad-c552-47ed-94d9-435337954cb7" control-id="au-5.2">
+    <implemented-requirement uuid="e51dfa35-e2ee-4ed7-ae58-51342c4cd649" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="b45a132e-a914-4e72-a4d6-ceea26884ca5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a3d96a34-b601-4fc3-b359-84282c91fa9c">
+      <statement statement-id="au-5.1_stmt" uuid="3eb638db-3855-4796-bb12-b3751d5cb98c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2054,10 +2039,25 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ef419f5-0d13-46b1-bf43-3c168375bd39" control-id="au-6">
+    <implemented-requirement uuid="2c33433e-0c76-42a4-b968-6373dbc195a0" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="7737d2bb-40d9-4c7f-977f-8ef3390d37b5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5fdea397-6053-4df3-ad4f-2054293a30af">
+      <statement statement-id="au-5.2_stmt" uuid="27358188-1821-4307-9300-ba8adcade640">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
+OpenShift for auditing capabilities.
+
+This control is applicable to the OpenShift Cluster Logging
+Operator and to the OpenShift cluster and is outside the scope
+of Red Hat Advanced Cluster Management for Kubernetes configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="f402cea2-a394-465d-a946-c6d65a71f86f" control-id="au-6">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-6_stmt.a" uuid="bad96ef8-562a-4ccb-a6dd-0b1bcff62f78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27f022e-887b-4ae9-8345-28848b08f1f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -2066,8 +2066,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="73bf1943-d530-4753-ade2-3bf475cbea2e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ea523557-3b4b-4f70-94de-fc44a1ae1dda">
+      <statement statement-id="au-6_stmt.b" uuid="b4d9453e-3213-4bd7-b194-30d0da550f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dd55b1d-9d68-43e2-8156-2c1d86cf1a3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -2076,10 +2076,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7117ea80-6591-42e2-a641-1ff680935ae0" control-id="au-6.1">
+    <implemented-requirement uuid="1777b50d-0b9b-4d2f-ad93-56a76d10a9f0" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="3fd8ceef-ba1b-4e16-ab10-c06b58329aa5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9c6efcfa-695a-4fb7-9816-97b40e14a628">
+      <statement statement-id="au-6.1_stmt" uuid="e214be91-36b0-4a5c-8dcf-1ddcc04834de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2091,10 +2091,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b548f242-ce16-4f06-8e62-12e2a8abeb9a" control-id="au-6.3">
+    <implemented-requirement uuid="a85ff011-d8ef-4a1f-85cf-6f3b7121cd4e" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="e9dcec2c-7dcf-4896-9eda-37f73a6190de">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f821c29c-affb-42bd-b619-208c31df4040">
+      <statement statement-id="au-6.3_stmt" uuid="959cc9c1-1262-4d42-85bc-5074b990d64b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed0a8afe-8cc5-43e6-b7c0-0bec5161dfd1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -2111,10 +2111,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83971414-5e0d-4655-9d2c-a025fee86965" control-id="au-6.4">
+    <implemented-requirement uuid="05385660-037c-4b23-8a30-3226cc978887" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="56978251-e437-43f8-a0ce-2417c669ab8f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ce4afbfe-e06b-4dd0-8d2e-189d633a51c6">
+      <statement statement-id="au-6.4_stmt" uuid="8d14a81c-0e5a-45a5-8082-53bbdb0d90d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="677b8e44-421d-4b4b-bc6d-2f5dab205ccd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to centrally review and analyze
 audit records from multiple components within the system
@@ -2123,10 +2123,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="974a28fb-1cd4-48ae-b015-400779ac8d84" control-id="au-6.5">
+    <implemented-requirement uuid="e41f50af-97b2-4caf-bf8a-9d6fb1bf2ef9" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="e2e37e96-87a3-4d93-ad60-c1bbda2f69e6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b339011f-690e-4449-ace4-c516720b5308">
+      <statement statement-id="au-6.5_stmt" uuid="f74ad8c0-d04a-4343-9b20-c4ca190e464d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52cc4c1f-ff4c-4983-8031-51d89d6c2c2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to integrate analysis or audit
 records with analysis of additional organization-defined
@@ -2144,10 +2144,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07542735-3e39-4be5-989e-e6f842ec500a" control-id="au-6.6">
+    <implemented-requirement uuid="5b629f25-bc59-4539-b433-a643e24ccd9a" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="6cb14de9-7299-4f4c-8424-287a2096f47c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5b45cd1f-8310-4189-bf6b-8943b7fd6381">
+      <statement statement-id="au-6.6_stmt" uuid="088d360f-caf1-41db-b81a-fc077bb16e99">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d02071da-1003-4e59-bb16-10751765a858">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to correlate information from
 Red Hat Advanced Cluster Management for Kubernetes audit records with information obtained from monitoring
@@ -2165,10 +2165,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73045be8-d67b-432e-9aeb-3187a502ebc6" control-id="au-6.7">
+    <implemented-requirement uuid="0e03b0fc-a309-4046-a178-e51da5aef68a" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="974ed0c4-ab3d-4290-8b43-8898dea4aa8f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="01cf6ba4-0c82-431e-bcde-ff31ed6c9c39">
+      <statement statement-id="au-6.7_stmt" uuid="40e67ec4-e3ff-4d52-817a-e9a7ce0ad33d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c869e0b1-5ada-4637-9d57-f3216817d0eb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational specification of permitted actions for
 information system processes, roles, and/or users, associated
@@ -2178,10 +2178,10 @@ information is outside the scope of Red Hat Advanced Cluster Management for Kube
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdbc982c-261d-41b8-baa3-9585b59c5950" control-id="au-6.10">
+    <implemented-requirement uuid="cba5758a-684c-4340-9ed6-8016824b7c10" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="fea68610-1ef9-4bc0-8833-d56d518bfc9c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c202d20b-1c61-4914-99a5-d8250051fe72">
+      <statement statement-id="au-6.10_stmt" uuid="cbfda6f9-08f8-4da5-a57b-1967d461e718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e362967-d17b-483c-a158-660ddd929029">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational adjustment of the level of audit review, analysis, and
 reporting within the information system when there is a change in risk
@@ -2192,10 +2192,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33fd5e4c-f2e4-4d2a-8fc2-b823b19a2ef2" control-id="au-7">
+    <implemented-requirement uuid="3a5af7ba-cc6c-4809-aef3-603b089d188a" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="16d7c944-b704-4c39-bc83-39356d5f908d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="122aeb62-16ae-482c-86d4-601381fa409b">
+      <statement statement-id="au-7_stmt.a" uuid="0d0bb9c5-1b89-4c9d-8a7b-4e6e52ce640b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2206,23 +2206,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="8b27f872-c94f-4783-87e1-6008c1bd5347">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="df726049-0802-4cdb-9f2d-a7a86a1d687a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
-OpenShift for auditing capabilities.
-
-This control is applicable to the OpenShift Cluster Logging
-Operator and to the OpenShift cluster and is outside the scope
-of Red Hat Advanced Cluster Management for Kubernetes configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5a8e3218-391b-4534-bdf7-804f84c867d5" control-id="au-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="3f9f7aa6-11a2-49f0-9658-a38feffb4c20">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="da55bfb2-d05d-431b-a5ab-a7265b90ea69">
+      <statement statement-id="au-7_stmt.b" uuid="72263aa4-0732-4a98-b0e3-0f760ae34bd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2234,10 +2219,25 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afe96f02-ee21-4f3e-bc5e-862cf70d46e7" control-id="au-8">
+    <implemented-requirement uuid="355be9b1-ea23-4a88-a9b6-f1505e85f6d2" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="33544b3e-6baa-44d9-b075-75a5c96335c6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4d3d36a4-00de-48b0-96bb-46050a37d889">
+      <statement statement-id="au-7.1_stmt" uuid="4f83c856-2c1b-4ab5-8fb3-f1c07e768b56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
+OpenShift for auditing capabilities.
+
+This control is applicable to the OpenShift Cluster Logging
+Operator and to the OpenShift cluster and is outside the scope
+of Red Hat Advanced Cluster Management for Kubernetes configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="bc57b069-5a92-4967-af4d-a8b7d562cf0a" control-id="au-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-8_stmt.a" uuid="2514ddf3-efed-429e-bbbe-4de6676b6a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2247,8 +2247,8 @@ Operator and to the OpenShift cluster and is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="585296e8-2824-452c-9580-966988346b72">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0f614631-b4ca-4a15-899f-4d2c9ba94fa8">
+      <statement statement-id="au-8_stmt.b" uuid="0f88897c-bea3-40de-8f58-22ce0807fdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2259,10 +2259,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="979537d9-72c7-4ded-99f6-79a2a1963766" control-id="au-8.1">
+    <implemented-requirement uuid="f349c83c-1886-454c-b7e5-738690311868" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="c2a18f5a-9d01-4ec2-a571-f2bde032fff2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4f7a03a3-07b4-44f0-883a-bf295e0680c0">
+      <statement statement-id="au-8.1_stmt.a" uuid="089785b2-37ff-45f3-a096-1cc0102ccb84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33c5076-4803-493c-a2e9-571ea66e69c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing and time synchronization capabilities.
@@ -2273,8 +2273,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="b6d4bccf-3786-44ca-8e3f-f33f7945300f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e9341c0f-a688-49f8-b70e-dd4f2c15bbdb">
+      <statement statement-id="au-8.1_stmt.b" uuid="12cbfe02-8198-43fa-84b2-e1ceeb039cdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33c5076-4803-493c-a2e9-571ea66e69c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing and time synchronization capabilities.
@@ -2286,10 +2286,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc716438-c46d-4674-829f-4c848f7891e6" control-id="au-9">
+    <implemented-requirement uuid="fa8e2aa7-1ffa-4aa6-a9a7-7ffd06c379da" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9_stmt" uuid="060357e9-3ed8-4f74-af2a-a2628c12bd60">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="93fcd41f-b814-4d8f-803a-66b04895a35b">
+      <statement statement-id="au-9_stmt" uuid="0636913e-ee07-4cc2-a565-a356ba89844c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2301,10 +2301,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67e3ddfa-d8b9-4fa1-8822-8a9560c3ccc3" control-id="au-9.2">
+    <implemented-requirement uuid="5a7abf91-c139-46ba-ba7f-f47a0adc590c" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="f83aa9fc-2e59-45b1-97a5-a5b5f1db0940">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f41e9de5-0ab9-4f4b-9cae-312a9d07c28a">
+      <statement statement-id="au-9.2_stmt" uuid="2f285e35-8a64-48cc-9d5e-ad12a86a8f31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9dd5404-7995-4778-a75a-cdd8bfcfa8c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2315,10 +2315,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a8254d1-4f00-4f2b-83f2-b7a25a277f36" control-id="au-9.3">
+    <implemented-requirement uuid="b79a5439-5210-4721-9213-cabc1c9e89b8" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="5fe56967-da11-4415-b489-1f7735e8dda7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af6e6d84-d57f-4db8-95be-d8792e0f216f">
+      <statement statement-id="au-9.3_stmt" uuid="90fc8da8-eb65-4951-8813-c3963fc99760">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2330,10 +2330,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32e3cd52-cf64-49cd-becd-5ba357b003ad" control-id="au-9.4">
+    <implemented-requirement uuid="3ea16657-1a47-4e4a-aa09-73c4bb429903" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="737d6348-46c7-4c99-b646-a26f4b25ed9d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3e495eac-be1e-47dc-bd7c-e287f9b44df9">
+      <statement statement-id="au-9.4_stmt" uuid="ab2f8b34-6e04-4192-baaf-01df458fc575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2345,10 +2345,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f2c7a72-193b-44ad-a22f-1d2c97748e37" control-id="au-10">
+    <implemented-requirement uuid="d37b37d5-1137-4b71-ad81-0c818ffa8f8c" control-id="au-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-10_stmt" uuid="f5fa3c18-563b-4d1e-a255-614369368290">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2117ee8a-0850-4ed1-b2a5-40144afe0e07">
+      <statement statement-id="au-10_stmt" uuid="75ee0660-4d67-4e43-948d-024a9fa0dccf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2360,10 +2360,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1ae1649-2dcb-4155-9dbc-061df2798f28" control-id="au-11">
+    <implemented-requirement uuid="e7bcea13-2029-4aea-8e07-ba3593be0301" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="20af718a-0d97-41d1-8aa1-957d44148be8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6ade4a3e-7c0e-4dc3-9dbb-19810a93a8ee">
+      <statement statement-id="au-11_stmt" uuid="d7e22308-ca97-42d6-b7b7-39775e6e92e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2375,10 +2375,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09d0d127-2286-4641-bd48-e3d140e36fc5" control-id="au-12">
+    <implemented-requirement uuid="6da943ff-8ed1-4a0e-9856-1c6f0d776cf4" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="a4ff085b-7e9f-4869-ad7a-be4c64164e31">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7446b4f1-1b20-4776-a0be-429f52539b8a">
+      <statement statement-id="au-12_stmt.a" uuid="e8e03e01-00af-4235-89ef-f45557254e07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2389,8 +2389,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="412063b8-237d-4109-ba1e-79ef08d5baef">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="be873a70-8835-498a-9018-73cf6dac65e5">
+      <statement statement-id="au-12_stmt.b" uuid="766ed89b-14a8-478c-b140-61e909d67881">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2401,8 +2401,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="b346bcd1-b59d-401d-8a5b-bacc5495fc57">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="33a574e8-9054-4092-aa1a-e7615cd29c26">
+      <statement statement-id="au-12_stmt.c" uuid="c6e873a5-a73d-4a3e-8264-7b1b0848562d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2414,10 +2414,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ea661cf-c649-42ef-956e-b87fb2bd14f9" control-id="au-12.1">
+    <implemented-requirement uuid="bb53fc7c-f72a-433b-976a-ce9254dd4cbe" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="8d9b61a1-176b-4819-b6b5-a051dcd0b791">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a86a5feb-77e2-4ed4-93e1-8c82097e17b1">
+      <statement statement-id="au-12.1_stmt" uuid="09343f44-40a4-419f-a6bd-4c3c4a567d29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2429,10 +2429,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f355bd07-51cb-4e35-883a-1e2173f455ab" control-id="au-12.3">
+    <implemented-requirement uuid="f36f4ebe-f69c-4f7d-9ac5-a6b65195fd01" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="6e30a36f-0473-45dc-ab72-756673698a03">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fbcd64d4-2e3d-49f5-8747-f33702458bd0">
+      <statement statement-id="au-12.3_stmt" uuid="23ef8d5b-189f-4b7b-8325-0729de1de4ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2444,18 +2444,18 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1234e9e1-4729-42d8-9f9f-c5ddc42c8b34" control-id="ca-1">
+    <implemented-requirement uuid="01f4c3ba-c968-46bc-8330-f85b6bcc8467" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="bc62b582-adfb-4791-98d8-2ca3d8e6afc4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="10d726b3-87c3-4f59-adbc-5147ad3ba947">
+      <statement statement-id="ca-1_stmt.a" uuid="519ae86e-7b1a-4ca9-bed4-cff7f2c53d33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="ca96b0ea-24c8-4548-bcb7-750a13691130">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="97049d48-8cbb-45e8-90f2-d891af5ed164">
+      <statement statement-id="ca-1_stmt.b" uuid="2639125c-d328-4613-a73c-3e9c3beae532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2463,34 +2463,34 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration gu
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24972c1a-8a56-4ecc-ad89-b7ae12595faf" control-id="ca-2">
+    <implemented-requirement uuid="c672dd8d-a42c-4506-b5c5-aa859ae35fa6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="8985627e-3238-43c7-bb9f-c5874a195b75">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fcffc235-7de8-4f4b-99c7-6dddae395e2e">
+      <statement statement-id="ca-2_stmt.a" uuid="5ad78120-51f6-4cb6-9f11-60323121f058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="8ad0816b-2aa1-4135-87ac-96d749952f5e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6e5c0142-8f89-40cd-99e0-313248bde675">
+      <statement statement-id="ca-2_stmt.b" uuid="55b6f393-d145-48bf-bb19-b8c5f9152e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="7025bf7c-aa6f-4e05-b66b-4ce7d97f54d5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8ce32095-0d36-4d64-bb23-d0b4e37d9fb9">
+      <statement statement-id="ca-2_stmt.c" uuid="a48b116e-64f7-43bf-bfb8-d5400123afc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="0f026b20-a6cb-4ac6-b2bd-ee13ad193c20">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7f84946b-1d00-468e-b1e8-7b26795352da">
+      <statement statement-id="ca-2_stmt.d" uuid="32344de1-3c92-4154-951e-ef77e7e0b719">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2498,10 +2498,10 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f20f4305-feae-4e7c-8157-ae6986bbe0b1" control-id="ca-2.1">
+    <implemented-requirement uuid="b2a4477a-ef14-4efe-a747-daf74eff8f74" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="7e131cdc-3257-4c21-b287-ae053d78050b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="52694ee1-84d2-4e26-a6cc-72f2ff7fabd3">
+      <statement statement-id="ca-2.1_stmt" uuid="72d3ad7f-82e8-448f-8abf-ef69c5c57aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2c057b-c13b-497d-baf4-043ee1ee1c6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2509,46 +2509,46 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bec77cf3-6f12-4b77-8628-ef58db0dc966" control-id="ca-2.2">
+    <implemented-requirement uuid="2b305009-330f-4203-b115-7e11c27188e8" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="a6c580f5-806b-42f0-a0bf-ed37c246622a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="db551f30-9081-4377-aca2-70bd34118252">
+      <statement statement-id="ca-2.2_stmt" uuid="a60077d8-9f00-4a1a-8656-12dc34a1a416">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06346907-f2f2-457b-a898-5055fecd7763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="989c85cd-def4-4f89-87b3-7eb57cc09b27" control-id="ca-2.3">
+    <implemented-requirement uuid="a9227041-a057-4a35-accc-64c89dd63d50" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="85196447-00de-428b-990c-34bad7778fa5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4df7ea80-a696-478f-b645-45bb3381c04a">
+      <statement statement-id="ca-2.3_stmt" uuid="abac2599-1413-4510-aabf-611d6f605ee1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="517a0930-155d-4826-bfed-87a5125cacea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a1eb794-8060-4bf5-aee3-4ff8643678de" control-id="ca-3">
+    <implemented-requirement uuid="b57f061e-790a-4ea9-aef1-3bdeaae3d6a7" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="f90393a4-e67b-45f9-8fe9-65b48abf74a1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9096903c-b4c2-4289-83f9-00be95e49f1f">
+      <statement statement-id="ca-3_stmt.a" uuid="1ed9d428-4eff-4ed9-9345-c103b6e33df6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="e68d1678-1374-45cc-ad23-1bbded1b1fa4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1fd8d604-129f-48c2-928d-257509874f59">
+      <statement statement-id="ca-3_stmt.b" uuid="2625543f-8485-4cce-aadf-f54753f5eff0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="d9ccb711-1cf4-4347-b31a-b821d5e5de8a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="906294a5-568c-43dd-8537-053cc6271f2f">
+      <statement statement-id="ca-3_stmt.c" uuid="1a5d17dd-405b-4e8f-8d25-dbef8f40a7cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -2556,20 +2556,20 @@ configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24829846-b5d2-403e-b1b6-c0c2bd45e05d" control-id="ca-3.3">
+    <implemented-requirement uuid="c3c6ad16-99fe-4e42-a6f1-8ecab2864dbb" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="d21718dd-e39a-4e63-ab7f-387709d8dba0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="908ad005-3b3f-477e-b97c-566fd2e94fb2">
+      <statement statement-id="ca-3.3_stmt" uuid="a89dfb51-25c6-435c-9266-1c853cd21229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d93a1ea-756b-4fd4-b976-abc36c0f8a8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b914b52-20fb-420d-a199-ad1fd10e0e19" control-id="ca-3.5">
+    <implemented-requirement uuid="c2663155-a5dc-46db-a1bb-12ba75737c0a" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="6c425a89-bd96-4863-88eb-36ea19202183">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b246a869-36b7-4561-a709-d73a09213bd1">
+      <statement statement-id="ca-3.5_stmt" uuid="92a48818-080d-4a8d-97e2-54fe007a6c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8079fd90-8044-449d-a968-1d5e85ec38e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing an allow-all, deny-by-exception; deny-all, permit-by-exception
 policy for allowing organization-defined information systems to connect to external
@@ -2583,10 +2583,10 @@ organization and to the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc4494d4-b345-4a93-9dff-01c2fe6ff584" control-id="ca-5">
+    <implemented-requirement uuid="1bd5743e-193f-4be9-b335-a1ac7999bbb4" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="0ef44ed4-d828-45cb-94cc-369ff218f3a0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3e379341-c001-4e36-b4eb-71cdfc6d510f">
+      <statement statement-id="ca-5_stmt.a" uuid="959605c7-23fd-4050-b5c1-48d5ac034bb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f79d6ae-edfe-441a-b485-8f3c80a8a60d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Advanced Cluster Management for
@@ -2602,8 +2602,8 @@ Management for Kubernetes POA&amp;M, Engineering progress can be tracked at:
 https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="f61f4ae3-dd56-494e-a2de-5e5b987c56ad">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="98ccb447-e6f4-4e22-996e-efdf7040a7c1">
+      <statement statement-id="ca-5_stmt.b" uuid="84692ecf-2d34-4137-9dd1-aa808d86317d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="112a979a-cc94-4e65-903c-099daa507bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2618,34 +2618,34 @@ https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1864e652-64cf-42ba-aa3a-6e1f20bbe57c" control-id="ca-6">
+    <implemented-requirement uuid="9cac12f1-c86a-48a1-9afb-2b3110154cc6" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="864c15e9-fdbe-40f3-9dc4-ce95dc24f475">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="22489907-dda4-4eff-83d5-1f12e4994a14">
+      <statement statement-id="ca-6_stmt.a" uuid="9bd01460-b742-446b-9268-e6cde83176df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="424552f7-6e41-4407-89a0-4aa273ed9fe1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e41056de-126b-480d-974a-06c39e215d57">
+      <statement statement-id="ca-6_stmt.b" uuid="fb426be2-214f-4715-9254-482db9f1bc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="8f8a4c53-86e8-4649-b4d1-344596e5cebf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6d8919cc-1e34-4e92-8c1f-52c5a4bd4dcb">
+      <statement statement-id="ca-6_stmt.c" uuid="9c030712-735c-49b7-801f-b934d6b58413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66e1213b-e8e9-45b8-9320-ae27c2c5301e" control-id="ca-7">
+    <implemented-requirement uuid="6c564476-fae9-49f2-a572-42196d208bbe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="e39e0818-3eef-4ff1-8f8e-cccf9c418e79">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dcde8fd0-4ac9-4c01-8794-0d7274d0753e">
+      <statement statement-id="ca-7_stmt.a" uuid="3283410d-f341-42d7-8822-c01d1690337b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758b258c-4b30-4271-92f4-8e61b4afbda4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2653,8 +2653,8 @@ monitored is an organizational control outside the scope of Red Hat Advanced Clu
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="292dfae7-cd6d-4142-9fa1-f41b24ce99cd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9006e638-75a7-4e28-a105-04dbd9d7410d">
+      <statement statement-id="ca-7_stmt.b" uuid="48871aa8-8b97-4cbe-9e3e-931acd8a9136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15daea3c-f9bf-4a50-b2d4-42ae6bf92ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2662,40 +2662,40 @@ monitoring and assessment of such monitoring is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="c41e8c47-ba3a-4a26-9aaf-35da6e295832">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d446f6c9-7608-418d-b65c-8b22742dfee8">
+      <statement statement-id="ca-7_stmt.c" uuid="c61aefca-5fb6-4ec0-b86b-8a3c2ae2cf5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="50de36c1-25ff-48a0-9a0a-389531d6aed0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b2c75b41-95b5-4de9-8635-ffd035ea8601">
+      <statement statement-id="ca-7_stmt.d" uuid="fa928e68-9aee-43a7-bf4a-6c6b78cbce0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="bb57bc0b-5c4a-4d77-b542-c0c61411d3a7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0b1d0509-7852-46f4-a174-3369767c7719">
+      <statement statement-id="ca-7_stmt.e" uuid="6a25579c-105d-4374-9cb5-d4253403d253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="4aeb4bd1-7fbb-4d20-bee8-1997904df99f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af1bcff1-27e3-4d60-bc87-6265940a072e">
+      <statement statement-id="ca-7_stmt.f" uuid="a2f92bfc-f9f8-40c7-ab30-00922de2c237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd1e0580-e27c-4e69-91c6-a25f4f1ebfbe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="9ca66c9e-a4a1-4bf4-ba9b-65880d3344c6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dd486934-7db7-46b5-8d3b-cfcc50cd9071">
+      <statement statement-id="ca-7_stmt.g" uuid="909988f3-0b2f-4ed8-a609-43f5e85394ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="defb78fb-f730-4013-87f4-f1eeb599f705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2704,20 +2704,20 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98a09f46-12e0-46f5-80bd-9c3b74fff103" control-id="ca-7.1">
+    <implemented-requirement uuid="4a38d6f0-dcb6-4942-b2fc-5d2f35f3638d" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="0f9a2b0b-e57e-49f5-9098-c19772ebb85f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b16dbc2b-63b0-4c09-a4f2-4f974a57bf19">
+      <statement statement-id="ca-7.1_stmt" uuid="495c5a5e-ac22-4de0-b173-eac526866e47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caf9edee-197a-4fa3-9b81-f1afe07fd21e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d7ba789-5077-4c15-9d0e-9134dcec6333" control-id="ca-7.3">
+    <implemented-requirement uuid="8bb51eb9-54b5-4843-9546-e904f5117e75" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="c1cce347-37a1-4839-860a-7a8ca22e8512">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="53035a62-1e38-4789-bb32-c61b5efe27da">
+      <statement statement-id="ca-7.3_stmt" uuid="8eb82b20-84cb-497e-ac8a-60e6907b55e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="963e90f5-67ad-4491-aab5-06f34dd26011">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational trend analyses processes are
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2725,20 +2725,20 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73034dea-e080-4d10-84ff-b5117aa061f3" control-id="ca-8">
+    <implemented-requirement uuid="e12b1330-30a8-43fa-abbe-01e152b4a631" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="2ceadc9e-47b6-4e00-a4f1-06c763add77d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8eeb3964-53eb-46fe-ab02-906323c79fd5">
+      <statement statement-id="ca-8_stmt" uuid="36ab4fb9-ea1b-4666-963e-d6ce37b7a8d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ae5b32f-75ee-4887-9ba6-48e7a5a313dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f4ab317-0985-49c7-bcb2-914147e65beb" control-id="ca-8.1">
+    <implemented-requirement uuid="28decff2-883f-43d9-9228-7d77d0a4de4c" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="2438eaeb-6547-4a36-90f4-0037942e0ae5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4477d8d6-319e-4938-91cd-9a54061d06a0">
+      <statement statement-id="ca-8.1_stmt" uuid="71258c91-d662-4a14-a1ee-49feab12a8f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5035d9e-753e-42db-8950-0f435a49658a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2746,18 +2746,18 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21d10d21-5adf-457f-8649-579ec46fe362" control-id="ca-9">
+    <implemented-requirement uuid="fb8dae49-0d16-4648-b836-94ba226c896a" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="2a4f2c12-9662-45ac-b185-d62dcbb1d910">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c123b8f0-05d0-4816-bf23-f67dc2493e09">
+      <statement statement-id="ca-9_stmt.a" uuid="3766cc50-8615-4b7b-bb50-d26dffcf813d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30b2b449-8b0e-4aec-8bca-769e02bc9335">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing internal connections of organization-defined information system components
 or classes of components] to the information system is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="6ffe0ea6-89a9-44f2-966f-2fac920edb28">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="59a154a4-3a47-4ff2-8edc-d9c5eb682aa7">
+      <statement statement-id="ca-9_stmt.b" uuid="45f6f5ac-2298-4437-ab64-74ffa3b7f354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ed18582-8a10-4c66-bbc4-d598891b6257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting, for each internal connection, the interface characteristics, security
 requirements, and the nature of the information communicated is an organizational control
@@ -2765,18 +2765,18 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a80296d7-426d-43df-a482-27fde0d5c8e5" control-id="cm-1">
+    <implemented-requirement uuid="48bb0d88-da47-4cbc-9d34-bf0ccaed2fad" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="c83623e9-71fd-4824-bb07-2a7b5a250276">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7d878e8f-ce77-4a5e-a376-5b501b3bdf29">
+      <statement statement-id="cm-1_stmt.a" uuid="60c79fbc-29d7-4e5a-b683-463c626aad98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f517f39-42dd-4978-b5c0-209b1d8a2ff4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="7945e194-5bda-4b54-9892-983acd96afb3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2518f408-b801-44f9-9f0a-15b38bfff731">
+      <statement statement-id="cm-1_stmt.b" uuid="baf16baa-b205-4934-8794-c50d0b74a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1070a7df-1715-4de8-a48e-ed5d829e68c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
@@ -2784,10 +2784,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d74fe63-440a-4c71-92d4-7553cede593a" control-id="cm-2">
+    <implemented-requirement uuid="a1d079dd-398c-4f9c-b11e-3c65e3cd857a" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="dd0f5f5f-3807-494a-9391-0d341dedfafe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="54a95259-ceb4-4b46-b09f-3ef3ef858b49">
+      <statement statement-id="cm-2_stmt" uuid="a9e3b1c4-87e9-45c7-a9d8-90ee1adcc060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dcacec4-2e1f-4a03-975a-494dd6fbf8fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management for Red Hat Advanced Cluster
 Management for Kubernetes (RHACM) is to implement the principles and patterns of GitOps
@@ -2806,10 +2806,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df58da8c-57e0-4140-93ce-51b0d311f3c9" control-id="cm-2.1">
+    <implemented-requirement uuid="2d58debb-50d8-49b5-a2e8-a0243facb356" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="d497b352-eb75-4cad-a385-813e17781065">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c8da583a-a508-495c-a7cb-4b55a2a67a3f">
+      <statement statement-id="cm-2.1_stmt.a" uuid="5fd409eb-b7cc-4f45-ba9b-494e72aa4950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73f930a6-75f4-4929-8f8e-66e385cbd00e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 Red Hat Advanced Cluster Management for Kubernetes per an organization-defined frequency is
@@ -2829,8 +2829,8 @@ managing channels for GitOps approaches using RHACM, see:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="16fcd383-9be8-4860-9b9c-58684ddf259b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b37f5ccf-63e1-4b0d-bb16-2e82fc6bfee8">
+      <statement statement-id="cm-2.1_stmt.b" uuid="a9fa4de9-f38b-486b-a042-fa7d9b6d3c28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6079308c-7bd1-43e8-a116-61090c1b09c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of Red Hat Advanced
 Cluster Management for Kubernetes when required due to organization-defined circumstances
@@ -2850,8 +2850,8 @@ managing channels for GitOps approaches using RHACM, see:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="13a79c15-db74-4f16-9219-683a78d28886">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8f011cd4-bf5b-4903-afff-aa9bdc744743">
+      <statement statement-id="cm-2.1_stmt.c" uuid="c319cc1c-795c-400d-975e-2884cc5d514a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e14b719f-5d5a-4d61-a3e9-390483dc9b27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of Red Hat Advanced
 Cluster Management as an integral part of Red Hat Advanced Cluster Management for
@@ -2873,10 +2873,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bb199b7-cc7b-4b1d-9cb8-99ba5e6aa9ad" control-id="cm-2.2">
+    <implemented-requirement uuid="439445b8-c667-4f59-ad42-eca4439f8813" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="2e45ec36-9e2e-4caa-adf8-3dc52d4430ac">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="17f5009c-6fac-460e-bb32-003f1f967da4">
+      <statement statement-id="cm-2.2_stmt" uuid="c3b10a55-49af-4e69-b7d9-a06c24d0c996">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f820247f-7dda-4b28-b932-6295fe3321cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2885,10 +2885,10 @@ https://issues.redhat.com/browse/ACM-357</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46de7280-6ae1-469d-bc3a-4787c34eecf3" control-id="cm-2.3">
+    <implemented-requirement uuid="def72b46-b60b-4e0b-9039-0fe60a9c5a13" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="892a086e-4c96-44a5-aa4a-04a3fd34a484">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c26e17d9-430b-41bb-8e42-2d7bfb6d26f9">
+      <statement statement-id="cm-2.3_stmt" uuid="efbf48d9-e820-4cb6-a7e6-487ba704dab1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09ff01a3-40ce-44c0-b3de-fd22309bca26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2909,10 +2909,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="190385be-6623-49db-9a7b-db4f6d09dca7" control-id="cm-2.7">
+    <implemented-requirement uuid="f52d45a3-512a-4a4e-97df-ac310e26600a" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="b7ed99f8-3154-474e-9fda-ff9e4be49693">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cc584466-8f00-44c5-9415-80a4b524549c">
+      <statement statement-id="cm-2.7_stmt.a" uuid="f5b79b72-89f0-4438-9d75-16984540c112">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f4fa786-5509-4e45-8913-8da939d5aa34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2921,8 +2921,8 @@ organization deems to be of significant risk is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="a1a8bf01-b50b-45bf-9a98-9fd4ad71dfa5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e685ceed-6ca1-4b7b-be7e-72ccf522872d">
+      <statement statement-id="cm-2.7_stmt.b" uuid="5ec0484b-35c2-4a7f-bf19-bb67adc77178">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcaf3e43-a6d9-459f-bd5e-79f9cedd536a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2930,10 +2930,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbdbb273-e8ba-485a-92b1-ea25912092d8" control-id="cm-3">
+    <implemented-requirement uuid="6a168e12-7f15-4610-870a-7de7e1dcce67" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="54bf47d7-d33a-4a06-b8b7-9ae4ab9f4ccf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ea6d6ef3-e42e-4170-b6b4-2eb25c85b58c">
+      <statement statement-id="cm-3_stmt.a" uuid="96a7ac9e-b6f6-4d0a-b5f5-c3c0427c53d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2941,8 +2941,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="b3ba8a2d-1742-4dbd-a5cc-7fcaf8ac0424">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9d63f629-0eed-4f97-a51f-297ca0aae1be">
+      <statement statement-id="cm-3_stmt.b" uuid="3cb30e6b-fb54-4480-a031-cf2ad73423f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2950,8 +2950,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="d81df689-83c0-456e-859c-3028a0ddf1b5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="243de591-f23e-478a-86d5-9b5c1af085ae">
+      <statement statement-id="cm-3_stmt.c" uuid="52bb3395-737a-436f-9eae-6c5ccd36ebd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2959,8 +2959,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="9bbffcb2-baa2-47dc-b531-39020005560a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e74e4949-bbe7-42dc-8df3-28dfbe271f59">
+      <statement statement-id="cm-3_stmt.d" uuid="19b0a41d-89cb-4177-92ae-9d2ce720f010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2968,8 +2968,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="b9b1c814-935f-4a3e-a778-4668277a3686">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="146757d6-750f-4c17-a122-33ba79af7f4b">
+      <statement statement-id="cm-3_stmt.e" uuid="fc11469e-518b-4d61-834f-76d9e510c0bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2977,8 +2977,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="8f74b005-e2ba-4e5d-af86-db8ecef5f309">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2333cafd-474e-424c-a361-d026e92bd35a">
+      <statement statement-id="cm-3_stmt.f" uuid="f53cca64-48ac-42ac-9fd6-78ac3150b14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2986,73 +2986,73 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="dad32742-ab1f-4229-b040-28cb189f8572">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7a32df07-c3ca-478d-8c6f-95d93ed77bec">
+      <statement statement-id="cm-3_stmt.g" uuid="e205a09b-8ec0-41a1-95c4-9a430d11a297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65229fc9-7b80-4aae-af55-56be42f16ac0" control-id="cm-3.1">
+    <implemented-requirement uuid="1376651d-bf24-47e0-ac08-6ec512452536" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt.a" uuid="ee8d39b3-e310-4483-ad31-f07612c94a5b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3425adf6-74c9-459c-a7ec-63f4afa731dc">
+      <statement statement-id="cm-3.1_stmt.a" uuid="0855d2fa-356b-435b-a04e-12aada76e349">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.b" uuid="0a276b23-361a-4a93-a9be-4dc2b96c0af2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bfe49488-a638-4e68-9eb7-451ab39e7242">
+      <statement statement-id="cm-3.1_stmt.b" uuid="812c5303-1bd3-4794-ba84-f6bf9bb9f5f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.c" uuid="9f0ad820-f2b5-4a69-8304-0d31c83d5c30">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e6055264-6004-4c5b-93cb-158315cd4ae4">
+      <statement statement-id="cm-3.1_stmt.c" uuid="83258362-64bf-4362-afa2-fa541e454503">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.d" uuid="45f49caa-4567-4999-97f0-b2e0158a01a2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c646b68e-c445-4048-afbc-fce5e5c97353">
+      <statement statement-id="cm-3.1_stmt.d" uuid="37e63182-7890-4c1f-adf3-00e03d96e1b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.e" uuid="faf0ca8c-200e-48df-b8fd-82a87a3136b3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="91133bcd-2187-4b80-868b-43fce6118759">
+      <statement statement-id="cm-3.1_stmt.e" uuid="cc734199-b493-4799-873f-c4d44dc48adc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.f" uuid="8d35be76-5e80-455e-920f-0b777129a9a2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="65141bf2-bf0e-4006-8e6c-c91a42d2f38d">
+      <statement statement-id="cm-3.1_stmt.f" uuid="7fcf0209-fae3-423f-9ea9-12e168ee68c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bf16688-f81c-44a6-ae81-ba3153c49be3" control-id="cm-3.2">
+    <implemented-requirement uuid="360515f6-eb64-47c3-a145-b097584ca54e" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="fccd3437-c7a8-4179-8e91-914c396908ea">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0524b339-7241-4222-9c2b-621c2716e4fe">
+      <statement statement-id="cm-3.2_stmt" uuid="09950964-49d4-4d30-a657-1728d3553b34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b6ff0eb-a189-408c-ae89-c574a54e46c4" control-id="cm-3.4">
+    <implemented-requirement uuid="017040b9-362c-4bf4-8084-5d4b3cf5949f" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="07fbee76-dc6a-4330-9105-0907c228b4a3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="883590b3-5606-487a-bc79-beb5fadbaf5d">
+      <statement statement-id="cm-3.4_stmt" uuid="58bfc707-8cd5-4c94-a7d6-2d65a80fba40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53fd9caa-55fe-411f-82a7-0a9d2471cf3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The requirement for an information security representative to be
 a member of the organization-defined configuration change
@@ -3061,20 +3061,20 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d69f597-1814-4740-ba5b-8819c1564f3c" control-id="cm-3.6">
+    <implemented-requirement uuid="8f0003bf-10bf-4017-8ee5-9b28abff5f26" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="19a7f636-d2cf-4d6d-ba30-49c79091b138">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="65554eb9-c8d7-48a1-bc5b-fe72b3082431">
+      <statement statement-id="cm-3.6_stmt" uuid="fe711496-7764-4c5f-9011-e138f18e1a50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81428e2c-aa63-42f6-93fd-254657a93f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="739bd4a3-907d-4b5e-9f67-62809536b7ec" control-id="cm-4">
+    <implemented-requirement uuid="c466f2a9-5044-4f6a-923a-a22d2c787b37" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="ed158e8a-01d1-44bf-9bc5-e3cf63d25a98">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8e513f64-34f6-4309-b6a6-f6319e3aadef">
+      <statement statement-id="cm-4_stmt" uuid="fd2632e7-3b6a-42db-99c7-2a933d3e73a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dcbfc6f-0506-47c9-88ff-91088ccd1d3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -3082,10 +3082,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b2a6949-aab2-4abe-b03b-92c2d19d2258" control-id="cm-4.1">
+    <implemented-requirement uuid="7c2bcabe-23c5-4a3a-93e8-0b71d960bb80" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="7b1bfa5b-563d-475f-ab14-cf3ea667cc33">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b4fa79be-83a6-4fa5-b4a1-9680f9d34843">
+      <statement statement-id="cm-4.1_stmt" uuid="b98b50c7-350c-4a1f-a26b-3ae7b7b8c562">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7fce7e2-1671-4a04-ab64-75a2b6fcc918">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization analyzing changes to the information system in a separate test environment
 before implementation in an operational environment, looking for security impacts due to
@@ -3095,10 +3095,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="747544c4-6649-4d27-85c0-202ab83740f2" control-id="cm-5">
+    <implemented-requirement uuid="7fdd2e49-89fc-4941-b917-40d11d51b291" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="05676f6f-0d5b-4a51-83f1-0b730e658783">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5c7dbd45-830a-4507-aed2-748c0f43fe07">
+      <statement statement-id="cm-5_stmt" uuid="1c596853-5a4a-494b-bcae-2a0fa049d3d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7aa613fd-e3df-4cd8-844c-c8093620a9e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3107,10 +3107,10 @@ https://issues.redhat.com/browse/ACM-358</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a818fb4-01bf-41dc-8c01-f2c02e6d0bfe" control-id="cm-5.1">
+    <implemented-requirement uuid="474b021f-49dc-4f88-86ae-c1ec9ed81999" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="9ab4e84e-0f05-4215-b4b0-944fe10ff360">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="90580261-ada8-47ca-8d95-f6982c04b446">
+      <statement statement-id="cm-5.1_stmt" uuid="32b3c908-b112-43b4-8755-3c84cebc7b3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe98536-e0c9-4f84-a52a-236459ef6aba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3119,10 +3119,10 @@ https://issues.redhat.com/browse/ACM-359</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0bdd09b-3c88-49e6-b5be-56a3a2871bfa" control-id="cm-5.2">
+    <implemented-requirement uuid="ea21072f-c00f-4a5d-a15d-a270a0c61b2f" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="6afd166f-82ad-46df-8a0b-c64669799b87">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ea4fa8ac-fdcc-46cc-854c-cb71dadab961">
+      <statement statement-id="cm-5.2_stmt" uuid="f05cf582-0842-4bba-ac28-75345efb7de2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c706059-b08c-4f41-8f8d-e9ae3ceb2156">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3131,10 +3131,10 @@ https://issues.redhat.com/browse/ACM-360</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ec33b65-7b70-44b8-902b-94ea4a5d9d41" control-id="cm-5.3">
+    <implemented-requirement uuid="9c35d698-950e-4531-8803-f69b143805a2" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="b8b4677e-d06d-486d-a58f-1fc2becfbe0c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="61dd7e09-428a-48a9-b613-d6df3fccdffd">
+      <statement statement-id="cm-5.3_stmt" uuid="67f855ac-0d58-42cb-84c4-b7fab0d6ac15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a4932db-bad9-4b03-8efc-27cb1a5fde5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3143,27 +3143,27 @@ https://issues.redhat.com/browse/ACM-361</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a66a2a6-37f1-4f98-a126-1c0140e67758" control-id="cm-5.5">
+    <implemented-requirement uuid="206cfe8d-425a-44ff-b112-eacc2e05ed4d" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="b031d00c-cedf-412b-b9af-e578cf8106f2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="83d1e6f7-5d0c-484b-a91d-51ac1fae3845">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3e6e07d0-c7a4-47c8-860b-af5d080580e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81428e2c-aa63-42f6-93fd-254657a93f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="a0c38c63-e739-400e-aa18-6192f4892b4f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b210c4a5-e618-40d8-a083-cf0b1a3927f3">
+      <statement statement-id="cm-5.5_stmt.b" uuid="82c24edb-c194-4658-be04-61d5a7ef794b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5994e866-a0cb-486f-96c0-806f6f558c82" control-id="cm-6">
+    <implemented-requirement uuid="4211401c-63bc-48ca-be02-d58c081cf1cd" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="6fc9c5eb-4327-4c16-9649-8b870b75ef99">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7376cb4a-1f7f-4e14-b738-b738f61d4929">
+      <statement statement-id="cm-6_stmt.a" uuid="7923dc4b-0415-4bf6-aa37-b3f8f61fa18d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3171,8 +3171,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="854a9b1d-e4d0-492a-94fc-1ffc79132654">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9e1c2fb5-dcd3-456b-91ff-168cefe4679f">
+      <statement statement-id="cm-6_stmt.b" uuid="be4fee0d-706b-4133-bd8a-7a0465a2b3d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3180,8 +3180,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="9be09eef-a9af-46a7-bf0b-32b8e1ec8438">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cb6c536d-d53c-45c2-9f60-a1cd5ad97b8e">
+      <statement statement-id="cm-6_stmt.c" uuid="a8d60edf-af95-40b5-a21d-b1b354c8c8e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3189,8 +3189,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="45783ee3-c1a7-4f59-b41b-20dd3fab056f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="813b0262-429e-474a-b7aa-f196c4c221a8">
+      <statement statement-id="cm-6_stmt.d" uuid="7576c408-1315-4f8a-9728-018dfb256f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3199,10 +3199,10 @@ https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3de4b717-957e-43ac-b81a-3b2c0367e68f" control-id="cm-6.1">
+    <implemented-requirement uuid="96fc4f30-6d34-4bb7-ba96-5a4cecb50999" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="071b203f-ac6d-4cf0-9dfe-a4bbfd310f7d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="67e5ec91-5a93-4c3a-b291-a2be103b748b">
+      <statement statement-id="cm-6.1_stmt" uuid="9e373a84-b243-44f3-b704-f74d7e0a283c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed93fac-217c-4d62-b645-2b398d12f945">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3211,20 +3211,20 @@ https://issues.redhat.com/browse/ACM-366</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9294d1a3-1262-4c4d-8942-d47190f7845c" control-id="cm-6.2">
+    <implemented-requirement uuid="a0727c77-2e26-40c8-bf8b-dbda9f6104d6" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="7e01dade-a386-492e-b605-89548374326b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e67c48a-fa5f-4a72-810d-25f1ae9284af">
+      <statement statement-id="cm-6.2_stmt" uuid="c0a10642-5392-4c33-ba0d-6f2a09611dcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9eb9a357-2334-4c9c-9020-ca16aa86b909" control-id="cm-7">
+    <implemented-requirement uuid="b4c719a6-2dd9-460d-95cc-d441e140740c" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="57c121d4-e97e-4d82-abed-01213d7bfbe3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0c815cb7-fdd8-411d-a1e3-f665a7ef8671">
+      <statement statement-id="cm-7_stmt.a" uuid="1da9a8db-41f9-49e4-ae38-6822a89fa077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3232,8 +3232,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="603dc4d6-191c-4355-93ee-ba961a74c136">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ac81b699-e28a-4760-adc0-3610a02a8640">
+      <statement statement-id="cm-7_stmt.b" uuid="28cb523a-0175-44c2-972e-cbb34e905615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3242,10 +3242,10 @@ https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3255e164-91c5-406f-bd0f-4d5e416f98d8" control-id="cm-7.1">
+    <implemented-requirement uuid="1eb8e85e-d77d-4b52-8056-c92d4cde2e75" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="3f37602a-2502-4d5d-970f-d452c870d89b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8e88172f-4726-42c3-be4e-45f0370f6b99">
+      <statement statement-id="cm-7.1_stmt.a" uuid="cef486bb-3ad8-4023-8b7e-c1bcd2b80824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ff4da6d-0aa9-4c97-8645-52f997a136e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing the information system per organization-defined frequency to
 identify unnecessary and/or nonsecure functions, ports, protocols, and services is
@@ -3253,8 +3253,8 @@ an organizational process/procedure outside the scope of Red Hat Advanced Cluste
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="a37c22e2-dcb2-4322-8655-6ebe7d5768ff">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="48ecabd8-f515-4b5b-b171-0106566ec4ae">
+      <statement statement-id="cm-7.1_stmt.b" uuid="b555d7ae-73f6-4a3a-a013-8f23296e6d1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbe5722e-0a9d-433b-86da-610c2175f8c9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization disabling organization-defined functions, ports, protocols, and services
 within the information system deemed to be unnecessary and/or nonsecure is
@@ -3263,10 +3263,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3e45882-345d-4c0a-8e4a-6839ae528dcf" control-id="cm-7.2">
+    <implemented-requirement uuid="e344609c-61c2-4054-bab6-2c0663fb95fc" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="9384d644-9739-40d5-8779-2b684c451179">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="53a738c2-8ffa-46bb-8d23-43518167bc23">
+      <statement statement-id="cm-7.2_stmt" uuid="809e7c7b-3277-41fb-9233-3639738bd864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="97405f6c-4ff8-464d-8aaf-7b5f88712aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3275,10 +3275,10 @@ https://issues.redhat.com/browse/ACM-368</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81913956-4cb3-4e1d-a84f-745db95d2bc6" control-id="cm-7.5">
+    <implemented-requirement uuid="d92fabfd-8644-42d2-ac4d-6bbbe39b0df1" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="21c30815-3e29-4c08-96cd-8a61d8fe0a41">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6d30938f-3884-4f3f-b555-17b225802117">
+      <statement statement-id="cm-7.5_stmt.a" uuid="35e3c77c-1244-460d-970a-a43b5774881f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ce7ff33-77bf-472f-8f86-0431dbe19b99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for identifying organization-defined software programs
 authorized to execute on the information system.
@@ -3288,8 +3288,8 @@ to provide authorized software support in allowing authorized applications from
 running on the cluster and in a container through allow listing methods.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="8c603728-32bf-47d9-8dd6-19c384f62c64">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3bbb73ee-93b3-48ca-bb4f-1b22b71e66a8">
+      <statement statement-id="cm-7.5_stmt.b" uuid="02866c42-5125-4eae-8ca3-1f6ecb689511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec0f9591-6a43-4237-b61c-a7aeb4c202a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for employing an allow-all, deny-by-exception policy to allow
 the execution of unauthorized software programs on the information system.
@@ -3299,18 +3299,18 @@ to provide authorized software support in allowing authorized applications from
 running on the cluster and in a container through allow listing methods.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="fe31a1de-fcbf-4f85-a53b-37f6471df990">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="01fe8b3c-b5fa-4220-88cb-b171b77aadb3">
+      <statement statement-id="cm-7.5_stmt.c" uuid="95252faa-256c-4113-9ed2-d9437668739e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46f3dac3-8610-46df-a19e-93db96a65cdf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for reviewing and updating the list of authorized software
 programs per an organization-defined frequency.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbf095ce-44af-4807-a6bb-d0cdbe0f7615" control-id="cm-8">
+    <implemented-requirement uuid="b8130d75-ef47-4fd6-88de-d3de4c957d55" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="86b7d5ba-05a9-4e3f-95f2-8e7ec455d1a5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cf451aca-c830-4433-8c4d-f2a8dd7924fc">
+      <statement statement-id="cm-8_stmt.a" uuid="4b7997c4-b95c-4da6-b56d-328df955facd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3318,8 +3318,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="1264da2d-2142-425d-9258-5ec5d5cbb6d3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f7a042bc-2af1-475a-84b7-bd37dec1968b">
+      <statement statement-id="cm-8_stmt.b" uuid="e13c5af3-18a5-4196-9749-c50c638c94d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3328,10 +3328,10 @@ https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91582eba-872d-46ab-91e2-662c9af54003" control-id="cm-8.1">
+    <implemented-requirement uuid="9fe36fbf-f7f2-42b4-9d2d-389f0f796e9b" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="25fca63b-41f7-47be-b2ba-ced961cc2a34">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fda8ae3f-ad12-4706-9be9-779f0f0042c4">
+      <statement statement-id="cm-8.1_stmt" uuid="2302c565-4ac2-4bd8-82ac-35841670fde6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f87ffde9-a4ba-472d-8283-9c918606a35c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -3343,10 +3343,10 @@ the Operator Lifecycle Manager (OLM) operator.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a33c21ac-b2dc-4cfd-81c2-2d323b3e924f" control-id="cm-8.2">
+    <implemented-requirement uuid="b3f6e03c-ffa1-4abf-b41a-3b3f401f3ea8" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="784446e0-8faf-4b5b-ba34-90bd3e9f2e3a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3442b6e1-1343-4cab-85f3-c879b091b431">
+      <statement statement-id="cm-8.2_stmt" uuid="e9b75ec6-d410-430c-843d-55a26faded60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c969130-39f9-4685-817e-865f53ab7149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for employing automated mechanisms to help maintain an
 up-to-date, complete, accurate, and readily available inventory of information system
@@ -3358,18 +3358,18 @@ the Operator Lifecycle Manager (OLM) operator.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52029250-0ec6-4b19-95a4-0f53aca55c12" control-id="cm-8.3">
+    <implemented-requirement uuid="b1a4fb12-f627-4e35-8547-689a4f1f0ade" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="1af13d3f-cf4d-4d94-95ee-63f7cd1c8dd4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="34450484-b493-4948-a695-2513487d4827">
+      <statement statement-id="cm-8.3_stmt.a" uuid="085de839-f1b8-4149-8c61-97229df41658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58fc2fb1-9eef-43c0-8520-ae9eab6f2f2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for employing automated mechanisms per organization-defined
 frequency to detect the presence of unauthorized hardware, software, and firmware
 components within the information system.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="cb49e841-5ecd-45ad-b76c-c1169aafc256">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a3d736b0-657d-4807-8c7e-a0a0b7621f39">
+      <statement statement-id="cm-8.3_stmt.b" uuid="c12bb9e0-d4cf-4da0-b7fb-c4641c152f3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c619c8d9-7502-45e2-b2e0-213f7121f772">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for taking the following actions when unauthorized
 components are detected:
@@ -3379,10 +3379,10 @@ components are detected:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0eaec8d5-6f06-4ba6-8cc0-4193303839b6" control-id="cm-8.4">
+    <implemented-requirement uuid="d9c9c127-d6d8-4cf2-809b-30010a2bbdb9" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="bf934139-839e-44e8-a72d-0a751069b308">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="388c4f12-ae17-4342-8da7-a04de02ccafd">
+      <statement statement-id="cm-8.4_stmt" uuid="51316e66-4d49-4d59-bf23-fef7068611f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="796b05d3-757e-4095-8fbf-16e0b89aee3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include in the information system
 component inventory information, a means for identifying
@@ -3392,10 +3392,10 @@ of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abb39db8-8b1c-4e3b-8d76-fd95ace93801" control-id="cm-8.5">
+    <implemented-requirement uuid="3bb1d332-05d6-4735-9fcf-28e24573cb73" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="c34f3cda-5c01-4f08-bc2e-e92c96d44111">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="75f02f58-4bb6-47ef-9c91-f0fed057b27f">
+      <statement statement-id="cm-8.5_stmt" uuid="f401ed70-e67b-4d53-ab5b-4db95b45623f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d6be519-fb3f-4566-8036-c3ffb0bc3f40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3404,41 +3404,41 @@ inventories is outside the scope of Red Hat Advanced Cluster Management configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed79cf03-ed8b-4811-bff1-9b464c04d39c" control-id="cm-9">
+    <implemented-requirement uuid="0acf0ab9-64c8-4cce-93f6-398147c7822c" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="8890e9b8-03a9-4253-987a-c3d1d9b127ab">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="85cddeec-4ce5-4552-8ab2-e658fe821246">
+      <statement statement-id="cm-9_stmt.a" uuid="2699f6ad-fda5-4efc-9972-b75232ca1f52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="39bba9c8-d726-4645-ace0-d81da17ab41d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e7c08888-ad11-4ff8-84d5-426a22cb63c3">
+      <statement statement-id="cm-9_stmt.b" uuid="974d06f4-3038-4099-9964-6a277153baad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="c2a95bcb-f1e2-4497-a61e-df89b826e4b8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b0f14c07-3382-46cb-8a3c-ca9948294937">
+      <statement statement-id="cm-9_stmt.c" uuid="c302619e-cb73-4e2f-87f9-a5cd5eada43c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="65f21912-23bf-4774-b378-f480f4b5f42f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2f0ad59f-d9a9-400b-98a8-39b37c9f5809">
+      <statement statement-id="cm-9_stmt.d" uuid="66a8875c-21f7-4ea3-839c-78b7430e54dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffe9c20f-fff9-48cc-838a-ec150b99baf6" control-id="cm-10">
+    <implemented-requirement uuid="d2ed696b-72fe-4c1e-a30e-6e0b4dd715dc" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="b624f7fe-4c5f-45d6-a6d4-4e0f600cd00a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d254156b-9026-4eb7-a347-95ef35bdb3c4">
+      <statement statement-id="cm-10_stmt.a" uuid="c204f5be-2ae0-4e05-8073-f7a8f059fa95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3446,8 +3446,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="b0570e54-2ce5-43cc-80ef-5de523bd53eb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aed2d3cd-156e-49e7-a167-a391cea40d86">
+      <statement statement-id="cm-10_stmt.b" uuid="0d44fe12-5465-48b5-bc36-ca6c8b6b90ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3455,8 +3455,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="37fe993b-2e50-4466-a143-571036fdc87f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6fe396ac-8399-4df3-98c7-7d2e3ece1164">
+      <statement statement-id="cm-10_stmt.c" uuid="5a6b0389-ea77-4714-9d3e-df2a16349d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c0c71e4-b352-4edf-9457-d61b459c03a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -3466,20 +3466,20 @@ of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d1f6f5e-d497-4ae2-aad4-15ebb42b1107" control-id="cm-10.1">
+    <implemented-requirement uuid="7fae52bc-7ac0-41c6-9e39-16df109935ad" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="c4460aca-e239-4501-a4ff-950b917c7d74">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ac5d0d6d-9d5e-492e-b0e8-1eda8aad6d62">
+      <statement statement-id="cm-10.1_stmt" uuid="b1ec6f62-6086-41f9-b45b-d097b6837dca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76b3e3d6-0eb5-4d4b-abe7-59ff3fe5eb3e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ff96f1e-8307-4b0b-bc3d-cfe7ec2201ea" control-id="cm-11">
+    <implemented-requirement uuid="f0a92b60-8313-455d-b277-ad4aee766be4" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="445ab4a0-d8f6-4a06-af49-6550296eea4b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="29f95458-99e8-4bc1-98e3-c7a0435f251c">
+      <statement statement-id="cm-11_stmt.a" uuid="8943b6ab-a43a-446e-9f27-4101bcbb7a8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3487,8 +3487,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="9539ab36-b4bb-4706-bb82-927774b49bb9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1f6ad085-2e93-4272-8b01-eba774aaa890">
+      <statement statement-id="cm-11_stmt.b" uuid="4a42ee86-9eea-454f-ba92-9007a155c8d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3496,8 +3496,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="6ae94000-200e-4a9f-89a6-159943ffd34a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="91cb6a78-d692-492d-9d62-66e6364e17cd">
+      <statement statement-id="cm-11_stmt.c" uuid="072b5c4c-0b3c-460a-a682-9ceff1672f00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3506,10 +3506,10 @@ https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78c4cf9e-ad3b-4d1a-957b-4b0254aa48f0" control-id="cm-11.1">
+    <implemented-requirement uuid="fa9f94a7-3546-4770-819f-5472538dfac3" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="94e3e2f2-ccfb-49bf-905d-9ecfc4761552">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c4b12cb0-0871-4154-b7bd-d5027e5138b3">
+      <statement statement-id="cm-11.1_stmt" uuid="955bc28a-9aec-49aa-908a-87ba8bd26fa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723f1204-cc35-44d0-9766-eea8a572a16e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system alerting organization-defined personnel or roles when the
 unauthorized installation of software is detected is outside the scope of Red Hat Advanced
@@ -3518,17 +3518,17 @@ OpenShift and/or third-party products.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c4cd727-91a1-49c5-9a68-1204e10c88d4" control-id="cp-1">
+    <implemented-requirement uuid="5d89307c-fcba-42e8-a63c-7321194df6e1" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="2a48e811-c011-478b-b348-758048a7cdbd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="72e9f539-28d2-486e-abab-fd974bc7a594">
+      <statement statement-id="cp-1_stmt.a" uuid="1bf1c075-f91f-4e45-8630-64c74b536c9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="0875aad1-6ca8-4171-ac3f-dfd896e50eb6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="da74c37d-3a72-471e-8934-f78d3a8a8d58">
+      <statement statement-id="cp-1_stmt.b" uuid="fdc67e19-0880-459a-9c0a-8e7d819f9981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c68ccf8-7f70-482d-a507-7df58cddbd66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3536,55 +3536,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2501953c-1409-4e1a-a6c8-20c306c1324c" control-id="cp-2">
+    <implemented-requirement uuid="11c62a0f-f3c4-4e2c-abb4-adf83b38a3fd" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="c1551976-9679-48f4-b5a2-d18ab69d54a2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1b514667-ef77-4e6d-8273-bd79dcdfee91">
+      <statement statement-id="cp-2_stmt.a" uuid="a84d8f70-d8b4-4f6a-85e5-4b07593f1470">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="c2ca2251-1701-4124-8dbf-0a7c3f6e5a08">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c582955c-dc7e-4e38-a5e2-dd48903bbfb4">
+      <statement statement-id="cp-2_stmt.b" uuid="e18ca0c2-6176-4438-8caf-fee362ffeee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="849bf386-2a30-4d64-9583-39030ec78388">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="eb5a778e-712d-4120-a9cd-9991dd5e2505">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bf937850-e197-4211-a7ec-e60ad8a0c4c5">
+      <statement statement-id="cp-2_stmt.c" uuid="b6f9e6e9-f6f1-4174-8eab-d7748772bca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e898768-5605-432d-b28c-df65f38fc1ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="98521abc-bcbb-4273-b902-efe7808542dc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c9805f84-7983-4e70-9d2c-8fb5f8b80ea3">
+      <statement statement-id="cp-2_stmt.d" uuid="434ce3b2-0158-40a4-b8d9-bf42c632739f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1740afb5-c728-496c-a5b0-ec2baa4fec28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="df8298ff-1c91-46e7-8e98-540240e73fa9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d5ea81c0-8e62-4f23-bf5c-bbbb0550d206">
+      <statement statement-id="cp-2_stmt.e" uuid="34788329-aa5c-411e-a1b9-b7ca0efb4c73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f230f99c-b3e4-4d24-b559-1da764fec833">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="99482fbd-f0e1-4954-8004-ad6e87b9bb75">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5b833042-59c6-49ac-ae61-2ad531407d81">
+      <statement statement-id="cp-2_stmt.f" uuid="85109794-b537-4232-b40c-a3845c065b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c18bc9c4-74bf-4870-a918-18c8527a7649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="6c799d86-4d64-451c-ab2c-e81bde7fd399">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c91a35b4-97ec-47c1-a3ba-442584678f52">
+      <statement statement-id="cp-2_stmt.g" uuid="035392f4-c3ed-42ec-bc2b-de34fa140b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="397a9793-a389-47c6-b6e7-395dbb57b613">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3592,10 +3592,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8187e5d8-68ac-4cf3-a26e-a000133f6dc2" control-id="cp-2.1">
+    <implemented-requirement uuid="76831693-481c-4cee-891a-297941e7c6ea" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="31bdb297-91fc-4fb5-b58e-6c3329bc2c2d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="55b48e32-9c97-4e41-a934-d9caa6c527ad">
+      <statement statement-id="cp-2.1_stmt" uuid="7b1452fe-e16f-4007-887a-4e521b570561">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="409fb1e3-9c83-462c-acf9-2cfd90e8c49e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Advanced Cluster Management
@@ -3604,10 +3604,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3889d273-fec9-4a6a-a02d-208cc8d67714" control-id="cp-2.2">
+    <implemented-requirement uuid="48f42b75-b4d7-4533-aa88-4d8106319a5e" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="0458f710-0e47-4563-aaf5-f527c0075353">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="757ffd4c-fc5d-46cc-93ba-c5699ec39f56">
+      <statement statement-id="cp-2.2_stmt" uuid="1ce6a377-4f80-47fb-9f98-1ccb1e547ff3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="353e3e92-ef37-48d9-a9d8-86864628c36b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -3617,10 +3617,10 @@ https://issues.redhat.com/browse/ACM-373</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96083b87-c78c-4e9b-8d33-dfb8e887e782" control-id="cp-2.3">
+    <implemented-requirement uuid="e1421c7a-01bd-4604-ac0f-73cccfe36ff3" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="df05d7ae-4b8f-44f7-9f51-ee8cf01109fb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="47c2ec16-f29f-4a50-bc17-66c66b7ed901">
+      <statement statement-id="cp-2.3_stmt" uuid="fd162305-bad6-4974-afba-5bd750961fc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a134b77-9c44-4623-a092-1daf98fb7f81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3629,10 +3629,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1904d85d-31a3-464e-af69-dd9be82dd7a9" control-id="cp-2.4">
+    <implemented-requirement uuid="ed2fa624-2628-451e-be29-3553176f12ec" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="c2b82e39-8515-433c-acb7-518c47840fc1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b4e56465-8e93-43a2-8547-8f95ede9946c">
+      <statement statement-id="cp-2.4_stmt" uuid="8e953238-b2b4-4d65-a5ec-819e1ba2d576">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f130b5c4-ffe7-4824-99d3-1611a1865b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of all missions and business
 functions within an organization-defined time period of contingency
@@ -3641,10 +3641,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12c53abd-d514-4cea-8662-36b65819a779" control-id="cp-2.5">
+    <implemented-requirement uuid="3ef659e4-4d35-4137-901c-0209a7e9791d" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="79bd444a-3c9a-467a-9520-befb5a28aa50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bf38115c-2492-4d80-9dde-76b34c1093f6">
+      <statement statement-id="cp-2.5_stmt" uuid="62316552-c21f-4a10-9ef0-49a37196f1dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa9516a5-b243-4c8b-a5f7-3dfaa69b5737">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the continuance of essential missions and business
 functions with little or no loss of operational continuity and
@@ -3654,20 +3654,20 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed68f1d1-81ab-4dda-81a7-843fed780da8" control-id="cp-2.8">
+    <implemented-requirement uuid="9c322598-1051-4c4e-aa07-91df1930c819" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="fc705aab-442b-4482-b565-b728925d173e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2707ebe1-680f-4533-9c54-7c3cf9f60794">
+      <statement statement-id="cp-2.8_stmt" uuid="57ce58f8-b40f-4258-9d2c-d5c650b7d491">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cb80157-b3bd-432b-bf36-92ed62e60d6f" control-id="cp-3">
+    <implemented-requirement uuid="d7726a10-26e1-40f1-b3df-d3cc2fbdc12e" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="eb7f60e7-10bc-4511-bbea-81be3d2166ef">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="45f4eba5-16c0-41fc-b2c5-05cde5495f19">
+      <statement statement-id="cp-3_stmt.a" uuid="43e18881-4cda-49eb-981d-5565ad5cf5f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b68b2d-f9ad-4603-a627-c390d6207f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3675,8 +3675,8 @@ time period of assuming a contingency role or responsibility is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="b06ef9e6-530d-4de6-8713-cb8eaedc8619">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="33276e8f-bd08-4ddf-8047-1fdf76d23507">
+      <statement statement-id="cp-3_stmt.b" uuid="61cdce07-2078-4888-a636-0efc0ec77b98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4ee3bc0-f404-4c27-8321-75ba15125726">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3684,8 +3684,8 @@ system changes is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="a9227b13-e7b0-4b63-b6b1-7b722f50c702">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="467a3455-6390-40c6-b2b6-1ce726c64212">
+      <statement statement-id="cp-3_stmt.c" uuid="35a2eb77-eec3-4d12-b4bc-a7a2af6bd0df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78771afd-c818-46ce-b95f-5005d1227925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3694,10 +3694,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d895d24a-2263-4bde-a2d6-126bde44e01e" control-id="cp-3.1">
+    <implemented-requirement uuid="4331346d-3843-4258-b3b1-567dfe2a439a" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="e73bbe1c-de0c-4823-98c4-bb383d8ac659">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5425b8de-02b0-4e94-b0b9-1096f7530f7e">
+      <statement statement-id="cp-3.1_stmt" uuid="93dffb86-5f2e-42ad-9de1-2d7ef6397b56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ebedcc21-4b2a-4c3b-b92b-853f0e24cbe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into contingency training to
 facilitate effective response by personnel in crisis
@@ -3706,10 +3706,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0448e240-91c1-43d5-b70d-c448f9156c4c" control-id="cp-4">
+    <implemented-requirement uuid="1fa0d7ae-5369-4255-ad14-0cf27e6553f1" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="52f06ecd-4bb7-4da1-8b52-ae5e1c4bea10">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="44aa59e8-0a73-46e5-bcdf-36f135d15b3b">
+      <statement statement-id="cp-4_stmt.a" uuid="dfbb243f-8b6f-4ff1-9ecb-5e6c92fa29bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c19e5d23-30d2-412a-869f-936c964e9aa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3718,25 +3718,25 @@ readiness to execute the plan is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="f00e26ed-cd29-4514-adc5-6502d92efb2c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d5adbbf5-42cc-419d-9e3e-fb6e06042079">
+      <statement statement-id="cp-4_stmt.b" uuid="23e54280-9fc0-4e6a-b638-a9101ab658ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="735b0a4c-85ff-4a56-a37a-1d98bee952e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="d05bc1da-f2bb-4968-ba65-0feff852430b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="750adad4-5dd8-46bf-8812-692bfa2ee5cc">
+      <statement statement-id="cp-4_stmt.c" uuid="93f8964e-ade9-4166-b97f-eea1360ad93c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="594d0868-fb2a-4f85-b5ea-4bb04dcc00af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b045b780-5ff0-48c9-81ad-8e41365843c4" control-id="cp-4.1">
+    <implemented-requirement uuid="12575e08-268a-4053-a44e-eaeadbba9e51" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="54967b6f-9f11-45b9-955a-4f1e40fa544d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4f97f71f-e744-43cb-8565-5e264f4dd3f5">
+      <statement statement-id="cp-4.1_stmt" uuid="672427c9-1dec-466e-ae09-97c04936193f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57021a96-c3e7-409f-8168-aac348dc14ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3744,10 +3744,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c57adc50-68ea-4154-a576-e57460e8224a" control-id="cp-4.2">
+    <implemented-requirement uuid="09e25fe8-a1b6-407c-a9b5-7539ba13c80b" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="755b3746-6880-4890-9806-d624fd309846">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1c47d35f-bf70-4c05-b76b-ec9f131373bb">
+      <statement statement-id="cp-4.2_stmt.a" uuid="db9fc41a-cf74-46a7-b16f-104d46cac15d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a710718d-c89d-43b9-b014-22dafd416e2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to familiarize contingency personnel with the
@@ -3755,8 +3755,8 @@ facility and available resources is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="ee255c0f-7e62-4bd4-8dfc-d6beb522403d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7c6a2255-85b0-40a4-bde4-62a4e15478ce">
+      <statement statement-id="cp-4.2_stmt.b" uuid="baafcc09-853e-489c-b8da-fcef6c6f0e85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a663a68-fb69-472c-b133-4a70d46fb779">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to evaluate the capabilities of the alternate
@@ -3765,10 +3765,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5901023-3cba-4b98-9d18-6c7c19c9fbfb" control-id="cp-6">
+    <implemented-requirement uuid="32d4c240-6b73-40c3-8e1f-2371bf2cd16c" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="f3b3fd20-0294-4b04-88d6-71d05108b34b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bc2bf3d1-76d0-4878-8362-9fe90e8d4d34">
+      <statement statement-id="cp-6_stmt.a" uuid="62deccc3-3c15-40e0-b92e-b2d35af21899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b8aeaeb-7920-49e4-a075-9bbe51eab52c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3776,8 +3776,8 @@ of information system backup information is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="dc2b5014-cd96-431d-8927-58e35a525d76">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2049d658-6230-484f-ad13-825c0d6a060b">
+      <statement statement-id="cp-6_stmt.b" uuid="59d52f4f-a39e-4a18-993c-17aa03205ed6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33264ae2-bd6c-40b0-8f71-da948db1a710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3785,10 +3785,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="122202dc-fcb7-4842-8a9a-822d12af44a1" control-id="cp-6.1">
+    <implemented-requirement uuid="88217ea5-874e-466e-813a-93ab0b2aa49f" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="2461067e-325c-416c-8967-1cb659fb63ba">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c70fc330-f126-42cf-88ab-d91d32a28487">
+      <statement statement-id="cp-6.1_stmt" uuid="20584f5e-78ce-4c75-adad-02c80d123efa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2575d1fe-aa7f-40f7-ac96-4edb911f947a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3797,20 +3797,20 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1867132a-6667-4f33-96f8-b50b35e8d3e8" control-id="cp-6.2">
+    <implemented-requirement uuid="192472b5-1a56-45b0-b0eb-0d119c8b7e30" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="f2e6c495-0ba9-4d7d-8482-9c34c051961e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="967a790c-95a2-4ae5-bfed-baa520880585">
+      <statement statement-id="cp-6.2_stmt" uuid="e23fcc2a-d47e-4090-8959-f603fafb4c44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3286d59-9415-4ea9-ade7-28d7d3258a90" control-id="cp-6.3">
+    <implemented-requirement uuid="ea6cfde7-446b-458d-85b9-0ef1e928055a" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="6f496d96-8456-4ec7-8967-359e27f6e7c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fc11759e-472e-4286-8e37-834669541dc5">
+      <statement statement-id="cp-6.3_stmt" uuid="dee4cd32-d0b8-432d-8392-c99e47a06dfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c5a5077-53af-4e4c-bef7-dc28b6a55b0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3819,17 +3819,17 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f48c7378-a564-4baf-9fa4-e3dd8662fbe5" control-id="cp-7">
+    <implemented-requirement uuid="7dca179b-5858-4e27-a86e-4a3111c8ee00" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="88b2db63-0cb7-41e1-9829-fa8b77ed7eed">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ea8e7660-b2af-4dad-aa3a-3340bf43873c">
+      <statement statement-id="cp-7_stmt.a" uuid="72673866-9001-4557-9a2d-c5b7d2ff9771">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="7eeb6f3d-75c1-4be3-82b6-777a97956613">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="50d74e4d-e482-40f0-8781-830f0e698e5e">
+      <statement statement-id="cp-7_stmt.b" uuid="937a0b02-31aa-4850-9045-abfab49f0554">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="684ef428-96df-4911-a28e-3fe0da611e04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3839,18 +3839,18 @@ organizational control outside the configuration of Red Hat Advanced Cluster Man
 Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="7ff7cf38-a3d2-4194-bb4a-ff82c9c958bd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4f0ae435-6f61-4184-b18f-1c6533060d78">
+      <statement statement-id="cp-7_stmt.c" uuid="44457aac-178e-455e-b05d-20e96d062c18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="357d587a-33ee-45f0-837d-84b292c5d175" control-id="cp-7.1">
+    <implemented-requirement uuid="5bac4361-75cc-47f6-92f3-857de3e4e31d" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="5ea96d7f-19bb-4268-b3db-2840b6100f7e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e862d223-190a-40dc-89ad-3f924a3930db">
+      <statement statement-id="cp-7.1_stmt" uuid="ecd6c7d7-4cad-4af3-b82f-c418e26fe910">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5938fe8f-6218-4412-9de9-e85c41c6f6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3859,10 +3859,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="461a2193-90f9-4512-888b-620e5716d199" control-id="cp-7.2">
+    <implemented-requirement uuid="1dd09133-c120-4e89-9dfb-1853498bb535" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="b6930e13-c938-4e44-8bc1-c8f6fc2b7f1a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="854ec316-f2d4-45a9-8b1c-0a7e9978242a">
+      <statement statement-id="cp-7.2_stmt" uuid="cd68be50-cb1a-4e44-acf0-87aee57d13b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d71aad49-c607-4bb1-be8a-7358ebffb596">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3872,10 +3872,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="249ea99f-eba3-4752-a4b7-bebd4084672e" control-id="cp-7.3">
+    <implemented-requirement uuid="d987f837-e8e9-4bb8-8249-9678aa579b1d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="fe7d9e33-276d-46e9-aa29-0710672c1b40">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9eb3d0e0-4832-4aa6-a663-b3873738cdaf">
+      <statement statement-id="cp-7.3_stmt" uuid="e691926f-43ab-453d-8bae-77912e7180f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26ddeac3-0a15-4039-a1d5-406d9c8f709e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3884,30 +3884,30 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf7d1a58-9a70-457b-9997-f967d5d17230" control-id="cp-7.4">
+    <implemented-requirement uuid="9938df3e-bb69-4cfc-a5d2-90525427d65c" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="c3f6a032-f0db-465e-875b-3d56a0cf03ab">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d2cfdc96-33ad-4d97-bb31-8cf96c718d8c">
+      <statement statement-id="cp-7.4_stmt" uuid="427c6f9a-3932-4395-8fba-c6b0f9981e8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db8c9b24-f1e5-4eb6-87cb-20fdafa960c8" control-id="cp-8">
+    <implemented-requirement uuid="68ab531a-2f09-4e04-9ee8-d88dd9db911d" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="cd97daac-b4f7-4763-8689-9aa59673621f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d3b7af8d-b716-4c83-9599-8f86c130c549">
+      <statement statement-id="cp-8_stmt" uuid="47bc43c6-56fb-4c11-a2d3-06912f98043e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a21ef46e-67bc-4c3d-806a-1dc80e1fb28a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67800303-10fc-4006-8834-f84efe301085" control-id="cp-8.1">
+    <implemented-requirement uuid="1b74fcb7-c19a-44a6-928f-284a5bec110b" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="d901b3f1-8020-4585-9a62-5eb37286e6b5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="83e4af10-59c2-4a4b-944d-4e8d3fa3fb10">
+      <statement statement-id="cp-8.1_stmt.a" uuid="f290cce3-91be-4f8a-8567-d08fb200f5c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39887fe4-9c3a-4817-ae8b-f759d9dc32bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3916,8 +3916,8 @@ time objectives) is outside the scope of Red Hat Advanced Cluster Management for
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="c7166695-9977-494b-abf4-16f9ee417582">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="296ecd62-44a5-4b18-89b6-10d92c22f2e7">
+      <statement statement-id="cp-8.1_stmt.b" uuid="542ba68e-4407-4aa8-909c-bde5099ab5e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="803113d2-952a-41dd-9f92-1313bd741c18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3927,10 +3927,10 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="444d1e40-16d3-4e54-a051-7e8a99d90702" control-id="cp-8.2">
+    <implemented-requirement uuid="4eabc6d5-e9f9-42cb-aabf-84f982d25b15" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="e3a659e4-afd3-4bde-9bc6-44f65479426a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1eb155e5-cf46-4c09-aa9a-cd6b75bc708f">
+      <statement statement-id="cp-8.2_stmt" uuid="9844759c-bc36-4676-aa67-3586ce5ee6b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="509d23bb-d5e7-4d92-a2b3-4808d8242118">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3939,10 +3939,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a395a0aa-84a7-4434-9836-a967bf2fdc72" control-id="cp-8.3">
+    <implemented-requirement uuid="f6346834-9c3c-4c25-977c-221e051762dd" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="6af60187-52a9-47b4-811e-ae55d8d346de">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="484daeb4-81d0-4a22-8d7f-71dc05e4a46a">
+      <statement statement-id="cp-8.3_stmt" uuid="a8173313-ee4d-4b8a-b6be-014f721f7975">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60a95159-081b-47a6-8e1e-299249fded35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services from providers
 that are separated from primary service providers to reduce
@@ -3951,26 +3951,26 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77147553-5bc0-49fa-86e1-3e0c65c65cd9" control-id="cp-8.4">
+    <implemented-requirement uuid="bc3cae0b-70b6-4741-a10c-86baa87671bc" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt.a" uuid="b783aa2d-4e03-45af-aff5-5b53faf20a37">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="74b077a7-9316-4295-946c-3dd32c4d269f">
+      <statement statement-id="cp-8.4_stmt.a" uuid="f7fedc88-ea7b-4976-a51e-b5822610be08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb9fee77-ee53-4b11-b6c9-40197b00748f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring primary and alternate telecommunications service
 providers to have contingency plans is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.b" uuid="06ac9182-c160-4fa2-8369-f5552cab3fc4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aa3be6ea-0c0f-4cb1-a0f0-5078e966e1bc">
+      <statement statement-id="cp-8.4_stmt.b" uuid="ab3a427a-9629-455d-a8c8-5fae7926d9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="234e7317-7a32-4874-99bf-bae4feb407f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing provider contingency plans to ensure that the plans
 meet organizational contingecny requirements is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.c" uuid="3fbfcd66-93d4-4627-bd02-d0da19e619a0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="50bbfdee-76a3-4b30-90ad-44f0abf442a7">
+      <statement statement-id="cp-8.4_stmt.c" uuid="40b787a1-fa87-4af0-a042-d9f7a353a46f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d384ba6-195b-42f5-b24e-afb5fe95136e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining evidence of contingency testing/training by providers
 at an organization-defined frequency is outside the plannedscope
@@ -3978,10 +3978,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c509094-875a-40a9-904a-b91899d166ea" control-id="cp-9">
+    <implemented-requirement uuid="fec472c4-1589-4e1d-8a69-3ca9d061a9f8" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="5b52b6ea-bbcb-4961-9cb4-dbff64177b06">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1ff17ae9-c1e5-46c4-ab2a-31a17f9949ad">
+      <statement statement-id="cp-9_stmt.a" uuid="db2f5394-8ff0-4521-bbea-025b27b87ca5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21491395-89e7-468f-a092-40db18acd64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3997,8 +3997,8 @@ a centralized identity provider is an organizational control outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="0212932b-4f87-4b1d-8f62-c9cf31f6c640">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="86e1ef50-32ff-4417-b216-057238e3e15b">
+      <statement statement-id="cp-9_stmt.b" uuid="fd4db9c4-afcb-442a-a405-e71ceda7c02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4bd1f00-0443-4329-b52c-e9c1b8f1c1b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -4014,8 +4014,8 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="efdaf379-c865-4c7c-a34a-3d9234641a46">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8d51da80-f229-4794-b8dd-82f7a18c1478">
+      <statement statement-id="cp-9_stmt.c" uuid="45309e62-9dc2-4f5a-b2da-2e6544d065de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98cbd01d-34f7-4052-ba01-45667bf85f9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -4026,8 +4026,8 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="bf6f4afc-26d5-4151-8356-4913f96e2705">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c46d2c3d-cd7b-463e-9c65-c53443cdc380">
+      <statement statement-id="cp-9_stmt.d" uuid="9ad6beca-4b76-4ad1-9e69-d865051bc5a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2239660-ea6d-4404-99ac-d8705981d473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -4043,10 +4043,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53ccfe22-6c91-4e59-a3f9-eb7c72e3b723" control-id="cp-9.1">
+    <implemented-requirement uuid="cfb4a2f0-ece1-4b69-9410-9b9ae76ac701" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="3c98329b-0b37-4607-ad1c-8a1860603905">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b7c19d13-d103-4524-80bd-612423c2633f">
+      <statement statement-id="cp-9.1_stmt" uuid="70710f1e-3008-4f12-abda-05de087517fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2258e8d5-e2f7-419c-affd-8cc39dec7d3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -4054,10 +4054,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f38585f9-3bcf-4483-95bf-545bea991e06" control-id="cp-9.2">
+    <implemented-requirement uuid="373d6f66-f849-4cae-b19c-4f3c6783d858" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="b1e19ea2-ac5f-424d-b82e-2c7e39cb8ed1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="97d756c2-dc4e-4ac0-9076-f81e30ada29a">
+      <statement statement-id="cp-9.2_stmt" uuid="65dbc01c-425d-4533-b009-5753eef8ecde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c5303dae-fc42-4b66-b2d0-eca7728642ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization using a sample of backup information in the restoration of selected
 information system functions as part of contingency plan testing is an organizational
@@ -4066,10 +4066,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ff7d0a0-2581-470b-8f09-ee4fecbe5f9c" control-id="cp-9.3">
+    <implemented-requirement uuid="a48c0fa9-7454-4929-8bbf-dfc2ad8d9b96" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="3b2886ed-42a5-4bac-8648-6f46095b28c5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d5614d98-7e79-433c-b869-c2c4589c15e9">
+      <statement statement-id="cp-9.3_stmt" uuid="5e5931eb-e295-43fb-ba48-df4d9a18425b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="feb28f0b-ca1f-4f4d-9d28-d8e247fa0105">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -4079,20 +4079,20 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af43e37b-1f95-4c14-92f8-a539893b7d97" control-id="cp-9.5">
+    <implemented-requirement uuid="f4576c03-85ac-4922-9da2-f54b79f33b57" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="d7c79e7d-e920-4f9b-a4f8-54b30d16029d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7b788a17-341c-4130-9a28-62bcd63c6e79">
+      <statement statement-id="cp-9.5_stmt" uuid="623e17f5-70e7-4604-848a-e11cd19b46e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aadbf19-1bc5-4c06-86cc-f3485a8ce682" control-id="cp-10">
+    <implemented-requirement uuid="2e3283e1-329e-4162-bf29-d4e3126e42e6" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="7f864ec5-a9bb-4761-86bb-b04e4f3e3370">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="061ec7a5-0803-43e8-a41c-4e7622142b97">
+      <statement statement-id="cp-10_stmt" uuid="c1b5e152-3add-4732-88c3-5df00b1d4d7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2df5ba56-c93c-4b4e-9691-bfc0ace314c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Advanced Cluster Management for Kubernetes environment. A successful control
@@ -4101,38 +4101,38 @@ Management for Kubernetes environment.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5335d2b9-8e05-4cc9-8065-11e8be4f12a3" control-id="cp-10.2">
+    <implemented-requirement uuid="3c3c63d2-8a5c-47a5-98ce-f4fbbe4f20e8" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="0f70fbb8-3e75-49a2-b156-6eae65275410">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c421a014-03ea-486d-93f7-39ff0d6baabb">
+      <statement statement-id="cp-10.2_stmt" uuid="1b464d3f-2cce-46ad-a410-7deac057195a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70c2e825-ecca-4beb-98c4-bb6c3608d1bb" control-id="cp-10.4">
+    <implemented-requirement uuid="0f7d8c42-6e60-4184-9de5-582d3b319d4b" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="70d10291-82fd-4d1d-8f87-75b5895c27e6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b845b889-5822-42a8-a3b2-dce40062805b">
+      <statement statement-id="cp-10.4_stmt" uuid="aa252d34-c6ef-4e7d-9666-e67617cb4dfe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56b15b1e-bdba-44e1-8464-bfc773a9f5c7" control-id="ia-1">
+    <implemented-requirement uuid="36fc9605-761a-4aa5-aa4a-fd84c82053fc" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="baadd63e-0a39-4b2b-80a1-785792bacd7b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e1cd2668-6be5-44af-860b-b0ed139742d5">
+      <statement statement-id="ia-1_stmt.a" uuid="cf609d09-28bc-4a20-97e1-d98ca638d155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393d5912-7a1b-4110-8ad3-fc49b152819c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.1" uuid="deb2021e-49d7-4da8-920f-0738cb47fbcf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3d6ee198-a858-40f7-b428-fb4841554547">
+      <statement statement-id="ia-1_stmt.a.1" uuid="789a9860-a58c-45ea-b3a8-313fa0e13136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edba927a-c814-49fe-8c04-ff0c10424628">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An identification and authentication policy that addresses purpose, scope, roles,
 responsibilities, management commitment, coordination among organizational entities,
@@ -4140,8 +4140,8 @@ and compliance is an organizational control outside the scope of Red Hat Advance
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.2" uuid="191f34fa-6f26-4244-9d06-8c4443cb1b8f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0ec4aaa8-ebfd-49e0-9d07-b1f930abefa8">
+      <statement statement-id="ia-1_stmt.a.2" uuid="8ab56ad8-0bd4-49cc-893f-e209dc583aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="748fc141-4383-4293-bba9-cf7826741c15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the identification and authentication
 policy and associated identification and authentication controls
@@ -4149,24 +4149,24 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="2d4f08bf-b49c-4433-ab2b-e2db50626fc1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cb04a4f8-a81a-44e0-af11-32323eb2f764">
+      <statement statement-id="ia-1_stmt.b" uuid="26b903e8-b266-4924-b37a-8f0861172a9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f9cb66a-f50e-4bb7-ab29-7b634d4309d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.1" uuid="cf4aed23-05cc-4fa1-89d4-41ee1d4ebdac">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5b6ada84-61d8-4951-88f7-aad614794534">
+      <statement statement-id="ia-1_stmt.b.1" uuid="eda88c29-1ff5-458c-8b80-a417b8228841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4abe27-7c28-40f8-b37b-0bd096de234d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication policy is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.2" uuid="d9ec8559-f54b-434f-b73e-891b6822d095">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ffb58cba-c221-45e3-a19d-7aac0f56389e">
+      <statement statement-id="ia-1_stmt.b.2" uuid="ec20ebe0-88c2-4cc6-96c1-5b38b97d9968">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c07e8de5-a0e9-47c9-a078-1c50109032ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -4174,10 +4174,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fa645ce-2bc8-47ef-822a-0a45b2cd7210" control-id="ia-2">
+    <implemented-requirement uuid="6a4e724f-263f-43f3-9729-9c8ea63514cb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="c9169ccd-1f24-40ee-b39c-353b02cf254b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="03f2f5e1-44e6-42b9-9417-0f20f56288be">
+      <statement statement-id="ia-2_stmt" uuid="162c972c-1af8-4c4e-b17c-349af061b17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4188,10 +4188,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b7a528f-d4ec-4d74-b72b-01c2089d9e3a" control-id="ia-2.1">
+    <implemented-requirement uuid="3c240960-c351-40a6-b2a4-a1e32a79afd1" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="af72649c-b448-481a-9c50-4bc273ae563e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bce8efa1-c222-4bf7-9435-40fa9a92404f">
+      <statement statement-id="ia-2.1_stmt" uuid="e18e8632-5d36-4387-8b08-fb985282ab8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4202,10 +4202,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf41f1e4-e77c-4099-ab9b-471850fb381f" control-id="ia-2.2">
+    <implemented-requirement uuid="c932829a-e011-4891-87a1-0eec3d4aec19" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="2e0bfb26-96ec-4e8f-96e6-fe6703e1995d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="20df977e-4717-470d-b308-5db44d2bfc3b">
+      <statement statement-id="ia-2.2_stmt" uuid="8ff22189-d8d1-43cc-afb9-7742620205b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4216,10 +4216,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b37046a5-63b0-4fcd-a2ba-82096cad6d16" control-id="ia-2.3">
+    <implemented-requirement uuid="641e39d6-276f-4f4a-85b0-0c0738574b10" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="33bde980-430b-4fd3-b86e-b3052c667b65">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="58f51490-64ab-4da8-bf55-1110ec190b1c">
+      <statement statement-id="ia-2.3_stmt" uuid="f48e8ea9-20a2-4637-b7cd-e345d3663976">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4230,10 +4230,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89d63203-bfd9-4fb3-9426-109493eaa7de" control-id="ia-2.4">
+    <implemented-requirement uuid="9e77fe9c-a59a-4f6c-8a1c-faabd8ca702a" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="7d929c0f-f0ef-4e27-9741-dc0e931c4a4b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="458ffa6f-f2c8-4fc8-9634-a1679efd5989">
+      <statement statement-id="ia-2.4_stmt" uuid="903278b1-d3e6-466f-be02-e73170fdd3ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4244,10 +4244,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="678f75b4-4549-4617-8aa1-b933ba592f5c" control-id="ia-2.5">
+    <implemented-requirement uuid="ca68cc56-407d-4504-aac2-6cd5f0045191" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="c6753e98-c5f3-41e8-997d-5ccda6338e2f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e86c1479-759f-496c-ba66-52d5fa5af7c5">
+      <statement statement-id="ia-2.5_stmt" uuid="fbc3df07-a142-42fa-b039-d5b43cd4b5c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4258,10 +4258,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02d61770-affb-4e29-8d8c-d0bb17f58a28" control-id="ia-2.8">
+    <implemented-requirement uuid="b68ea6b1-f488-4173-85b2-3da985f97e73" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="c9797b0d-b2f9-4c7a-b0d2-39828de18109">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="be113d15-05f2-49be-9d49-afc6cfe49b4e">
+      <statement statement-id="ia-2.8_stmt" uuid="18245bab-c3fe-4457-ac7a-68f7fcb4b39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4272,10 +4272,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f2330dd-4b12-4df0-9314-948c475227bc" control-id="ia-2.9">
+    <implemented-requirement uuid="b7fe823d-b680-41c6-b91f-511c325aa5ed" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="7ad3ee6d-cafe-40b4-810e-20649eaf2563">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9c74e062-a29f-4802-a504-f8e6ba355374">
+      <statement statement-id="ia-2.9_stmt" uuid="c1a84450-3a1a-45a8-b31a-1a08e71200c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4286,10 +4286,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79a036b5-70c4-414e-b6c0-ec040edd29e6" control-id="ia-2.11">
+    <implemented-requirement uuid="71c2233a-671c-4607-b95a-f0bc869d6405" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="535adc6e-6367-4f78-88f2-4a449ce122ba">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="de0239ce-291f-46a3-9097-0d1f3d9f2ac8">
+      <statement statement-id="ia-2.11_stmt" uuid="5a253ee2-4463-4b3c-8fb4-b31274886fee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4300,10 +4300,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="852f2ce3-20b6-4e07-8337-85cbc216ab5a" control-id="ia-2.12">
+    <implemented-requirement uuid="4501f960-57c6-4dad-81f0-d60c4c694d6c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="67807a82-d258-40b4-aa46-10cfd1cd7943">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="481c4799-5627-4c0b-ad8c-0e48bbf5dbf7">
+      <statement statement-id="ia-2.12_stmt" uuid="204fce8d-b288-418d-806a-cb177bf47091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4314,19 +4314,19 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="343cb000-c3df-4fac-afed-5de1f9ee2052" control-id="ia-3">
+    <implemented-requirement uuid="23e22f3c-9aa0-4cbf-9ad1-823f9dcf2926" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="5b653525-7762-4180-bda4-712bcfb295d4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="233f5f16-dbc7-48ba-a1f9-165da9128a45">
+      <statement statement-id="ia-3_stmt" uuid="b0106689-c877-4dd2-b7fb-48be934113bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4094f41b-39e5-4be9-a5c0-2b03948cd290">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="030180cf-7f15-44e9-813a-124cbc12e92f" control-id="ia-4">
+    <implemented-requirement uuid="3b7e2336-a2fc-4c93-abff-cfe316af78ca" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="4003c976-3c8a-4123-a1aa-4566ab5b2891">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="24b39f42-99fc-4178-9acf-492c059b32f2">
+      <statement statement-id="ia-4_stmt.a" uuid="956405cf-6586-4af5-83d0-ca267a6d897f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc183fe8-bb35-4cc4-8727-634f92deb444">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
@@ -4334,8 +4334,8 @@ requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="496ca4e8-328e-49c9-b520-482ad76e1cef">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="41d67f20-0ca5-425e-b7ee-e62cb25a09c9">
+      <statement statement-id="ia-4_stmt.b" uuid="49d43cd4-1e4e-475a-92a4-88ae451ab482">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2230bb0b-2181-41ee-8168-57e5e9754791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4349,8 +4349,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="3c266949-2f6c-4d40-bd3b-e1dd82820e9e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0da93efc-0c23-4540-9573-0087058e2dff">
+      <statement statement-id="ia-4_stmt.c" uuid="a99ba3ee-7060-4ee7-9cac-e8dcb1e35f5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16e13bdb-c71b-41be-b43f-d677d7fbef35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4364,8 +4364,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="ac87f901-0973-40b5-a961-101676bc1eb7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aba1e2b8-50fc-48b8-a962-0abade29e4ef">
+      <statement statement-id="ia-4_stmt.d" uuid="bd53f8e0-2baa-490d-b35f-cfd55fe18014">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f1be769-82de-492d-8cf4-b3e0f08d2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4379,8 +4379,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="2f9effa6-1a0b-4a18-8dd4-b6cbcbef638a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="133af6e5-5b1a-4217-8e23-3ea93364b882">
+      <statement statement-id="ia-4_stmt.e" uuid="f395857f-0985-4aa5-80f1-08859ab23603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fb2e15b-d2df-4392-bf93-095644224c53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4395,10 +4395,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6f0d482-ab7b-4601-b01d-869ef3f0aace" control-id="ia-4.4">
+    <implemented-requirement uuid="c78aec61-a021-4d55-bbfe-958672079e87" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="751306c4-e5d2-4c84-9357-3fc1aeac7dfb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="57f827f7-3551-4c08-b171-4ac05e5a1044">
+      <statement statement-id="ia-4.4_stmt" uuid="e97a8371-46e3-478c-bebb-9f56b8004e10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f8031f0-f9be-45e7-b1c3-bddedbad2dbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization manages individual identifiers by uniquely identifying
 each individual as an organization-defined characteristic identifying individual status
@@ -4407,10 +4407,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b17025b-caca-432c-b6b9-f3b3f8afcea8" control-id="ia-5">
+    <implemented-requirement uuid="265bbbe5-6012-4f0b-98f3-ac0f0d0caabb" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="aa623754-43b6-41ef-8c4d-24256c85255a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d94ff3a0-7240-466a-9115-e22f8606e21c">
+      <statement statement-id="ia-5_stmt.a" uuid="0eb4ddac-916b-4bbd-a20a-8048259facc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13d72afa-d441-4373-8afd-67699887a6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -4419,8 +4419,8 @@ outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="147a203b-a123-4884-abcf-fd281eb797e4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c0b80d61-a2d9-4909-be98-aac3fb3a2ef5">
+      <statement statement-id="ia-5_stmt.b" uuid="2342220c-0d99-48d2-b27d-7f8c11acd128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2e3e436-8413-4ff8-8dc3-390795606ce5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4434,8 +4434,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="4fb7b3f2-af9c-43cf-aff5-b9bfa54a3c91">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5ec9d057-91bc-4ee9-bf0b-56adb43889fa">
+      <statement statement-id="ia-5_stmt.c" uuid="c05a851b-49e9-473c-9fd3-b2f9d747468d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab69c0d4-d7f0-4b2f-9765-59abe70b49c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4449,8 +4449,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="6c7b7d91-afb6-4e73-903b-f055ed405ea1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4968b777-ee2c-48dd-ba0a-55b91adb6419">
+      <statement statement-id="ia-5_stmt.d" uuid="9e482f09-b15e-4f27-900a-115b03c2ada5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb468c08-e46b-4a87-90d7-1a74a4f9b2c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -4465,16 +4465,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="13f6d1c9-e8dd-43a4-acc9-5f0d96ec0b26">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8e71a0e4-0774-48d5-9301-8915cb9678fd">
+      <statement statement-id="ia-5_stmt.e" uuid="2e7a4efa-6dc2-466f-87f3-2bdadaa24503">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86ca812-e136-48d6-8e5b-bf1c0dd4fdfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="0d4453c7-192b-464c-80fd-c44d4134cd55">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a2794876-74e4-42b4-9a8e-841e79ada45a">
+      <statement statement-id="ia-5_stmt.f" uuid="54e797f3-6ccf-495a-b007-55422183d904">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87585da0-88d9-4846-bd0a-5474bc47b4c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4488,8 +4488,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="27784da3-b4d8-4e84-a090-43c1034269b5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8ef9a680-3c95-4510-9d5e-399b365de9b6">
+      <statement statement-id="ia-5_stmt.g" uuid="96667bec-cb90-4b27-b4d4-b688f8f5548c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2b0d11d-4985-4ae8-867f-246e2e38b3f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4503,8 +4503,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="876047dc-67ac-4560-a064-e3b9bba8d5c6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="73b8096c-278d-426e-996b-55ef33b32966">
+      <statement statement-id="ia-5_stmt.h" uuid="566c4239-0ba8-4637-9a1b-0e367a33b808">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45f712dc-0a01-4159-90c9-1645587ffc6e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4518,16 +4518,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="071d74fc-3086-4e36-b78e-1fb989c8d0f3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ebb1ee62-13bc-4e0b-bfee-5fa92f37f351">
+      <statement statement-id="ia-5_stmt.i" uuid="2aa2e02f-3e59-4431-a53a-6cc4928d33b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b590118c-ff62-4109-ac1e-af0d7f72200a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="415c6e68-636b-45b4-8a74-9596c4d02f58">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7ac38259-d8e2-4402-bb88-8a728221db22">
+      <statement statement-id="ia-5_stmt.j" uuid="2e55020b-a7e2-46bb-8718-650c6fa84427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cac92e2c-d40c-40b6-98f8-387d4166365f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -4542,10 +4542,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b74bfac-78f3-4725-a4b2-0dab36582c42" control-id="ia-5.1">
+    <implemented-requirement uuid="843cd7f7-3c91-468c-8133-8154d72fd572" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="dfc0b44c-dba1-4ed3-906c-fb6f30d1f4e3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="270455d0-d742-46a6-8fb4-6e25f129bbd2">
+      <statement statement-id="ia-5.1_stmt.a" uuid="b36b57f1-0da7-4b49-9dc4-3090d542e914">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e277b16b-df3a-4d18-b9ac-3e358b0a27f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -4560,8 +4560,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="e70f3a02-761b-4549-9253-f3d07eb80bf9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7585e637-a9b5-400a-ade0-258da1b73401">
+      <statement statement-id="ia-5.1_stmt.b" uuid="05a4aa2e-3727-40e9-bbfa-b42196a24986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="749a8823-7ea0-454d-805c-5f14111f539a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of Red Hat Advanced Cluster Management
@@ -4575,8 +4575,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="a1fd413a-7baa-43b1-82e4-6fc8d7379840">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af740cd1-623f-46db-bd1d-593f05adcabd">
+      <statement statement-id="ia-5.1_stmt.c" uuid="675e2c54-d959-44c1-a159-3eb07b727a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147fade7-a31c-46bf-9458-87b74cc33323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of Red Hat Advanced Cluster Management
@@ -4590,8 +4590,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="b9e02bbf-59bc-4c96-b358-8b8db304745a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="067c086d-ee0f-41d3-a09f-ae334fb9c7f4">
+      <statement statement-id="ia-5.1_stmt.d" uuid="ab6f04ac-c266-425d-a68d-2b6125259dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff725e3c-9cab-4d6f-86d1-89512be1db88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of Red Hat Advanced Cluster Management
@@ -4605,8 +4605,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="074cd6dc-5f6a-410d-bd9a-9070d932539f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cbd36769-af7d-4c2b-9ee6-cb09a0e31915">
+      <statement statement-id="ia-5.1_stmt.e" uuid="da41ab94-07c2-4138-8286-633977639ff3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fdcbfc-cd31-4062-9075-c3649ced9f7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of Red Hat Advanced Cluster Management
@@ -4620,8 +4620,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="d1b25c33-b1cc-461d-b4f3-4107d8b8f8f6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f49c9b8f-62d1-422b-9ddb-2fae6a5f3597">
+      <statement statement-id="ia-5.1_stmt.f" uuid="b16315b7-ff09-4cf8-b46b-4ebc4827c3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43f8ae77-bbff-45d1-9a26-2c46568196e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of Red Hat Advanced Cluster Management
@@ -4636,10 +4636,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0b27f9f-4e07-467c-af85-673c060532d7" control-id="ia-5.2">
+    <implemented-requirement uuid="5d7b02e4-5421-4b3d-82ec-e9901d226d72" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="3f6a650d-326b-48c3-be27-e962dff1a1ea">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="771f3ad7-2de5-42b4-ad19-b0323d55e7d7">
+      <statement statement-id="ia-5.2_stmt.a" uuid="d5459896-f2be-4d27-9558-994e1061291e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4649,8 +4649,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="c3786c6e-c439-45fb-8e2d-53f52628dd9d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dc97afee-dea4-4d5d-82d7-4245c19490eb">
+      <statement statement-id="ia-5.2_stmt.b" uuid="0839b2c4-4a2d-4b6d-897d-44ea9aefdb1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4660,8 +4660,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="a469f8d9-e133-4369-9e2c-24a12f508806">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d516764a-caf2-40aa-a65e-69be7c0dfc2a">
+      <statement statement-id="ia-5.2_stmt.c" uuid="ae70c50d-43aa-4494-b675-14f4a2aa8363">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4671,8 +4671,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="1ebaab7e-0ee5-4271-9795-08815ecc9fb4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d33ced55-ff4e-40cb-b752-d0d6c35a6ea1">
+      <statement statement-id="ia-5.2_stmt.d" uuid="77ad8082-0c4d-4c62-a426-51e42bba90f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4683,10 +4683,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95495877-a7d4-4a43-afec-55b68c54668e" control-id="ia-5.3">
+    <implemented-requirement uuid="75470eb5-ee40-49e6-bc7c-edb902adfc09" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="1208221b-6590-476b-8711-537b84b97c98">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a0d53e8e-4858-4e62-8653-372079c75633">
+      <statement statement-id="ia-5.3_stmt" uuid="886abe09-c4bc-47c5-ba3b-972e0036aa3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bbb90a3b-f770-4bba-b0e2-8dcb718f63be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4697,10 +4697,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75350376-4ed7-4be4-8282-7aa9a815409f" control-id="ia-5.4">
+    <implemented-requirement uuid="95a864b9-bcf8-42ac-a31c-68fc921e0c01" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="8cba56c6-cac3-464b-94cd-84cfcacf3b5e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5bf5b50d-963d-41d2-9bb4-592e4453ce54">
+      <statement statement-id="ia-5.4_stmt" uuid="0f1f6ee1-b000-4338-8e76-68220026357f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4711,10 +4711,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37a1217a-813b-47a5-8b89-79b730b38599" control-id="ia-5.6">
+    <implemented-requirement uuid="b59d07fd-2af2-4fa0-9a4d-5f1b7d5f0d83" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="b9af8752-109c-4fe4-9968-49ec36c67c57">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="29ddcd58-04cf-42da-96e1-649d015b10fe">
+      <statement statement-id="ia-5.6_stmt" uuid="fa3f5314-e96b-48ae-b625-5ffe2a2b6c9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76659440-64c4-4e73-818d-f60d84062eb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization protects authenticators commensurate with the security
 category of the information to which use of the authenticator permits access
@@ -4723,10 +4723,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4053855d-0f93-4923-a56b-ac9cf0cac03e" control-id="ia-5.7">
+    <implemented-requirement uuid="8520b60a-a92f-479a-8325-e3f6822d94cf" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="65068e40-e2fa-47e3-96d5-685e8ad41b72">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ac73a1a3-2b7d-41b3-9a8a-9d34e4390e1a">
+      <statement statement-id="ia-5.7_stmt" uuid="8afbe54b-4d3f-43b5-82ed-72ae6e71f49a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4737,10 +4737,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad484c50-1ecb-4911-a656-c905d476e44d" control-id="ia-5.8">
+    <implemented-requirement uuid="c8527c8e-bd3c-400f-894c-56a78eb211e2" control-id="ia-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.8_stmt" uuid="cea13384-0b44-4731-9021-a74f831d0d2d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e9b95138-a28f-4721-b14c-9c95f22d88e6">
+      <statement statement-id="ia-5.8_stmt" uuid="07fa4d59-0915-4506-a15f-7cf5c0e2960c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d93358c0-04ce-41e5-b70a-fb10fbafef18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational implementation of organization-defined security
 safeguards to manage the risk of compromise due to individuals having
@@ -4749,10 +4749,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be98b3cb-e76b-4584-8e90-5b3b7d1ce9df" control-id="ia-5.11">
+    <implemented-requirement uuid="0ef7576f-e66e-44ec-8b1b-71fad3011062" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="3c3a5ede-d523-4faf-ab63-2ec0318630ce">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="118779fb-e581-4cc2-9d61-925a8e82e20f">
+      <statement statement-id="ia-5.11_stmt" uuid="8283a521-2085-4088-8db4-ad9d30e7c0bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1076d1db-258f-4a24-8819-8a454d268091">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -4760,29 +4760,29 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1154522-ca9e-4b75-b0b9-65fac8a4fc91" control-id="ia-5.13">
+    <implemented-requirement uuid="bd0e6db4-cef1-410b-b56f-0736e715bc9a" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="b097aa8b-3313-409d-8b13-627e37d968cc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8f98eb7e-fc6c-4c99-b2a7-27f9178badd6">
+      <statement statement-id="ia-5.13_stmt" uuid="ebf8160a-5ac4-4922-b3bd-b798f563f73f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="27cf107d-7d44-4480-bfdb-bb943b1c780b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d184d25-52f3-4b9b-9e7c-10fa48a65319" control-id="ia-6">
+    <implemented-requirement uuid="584d5061-9946-4ade-9e7a-b7c9fc24fcf9" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="2a8b6ed7-cbc7-429b-ab67-0fef444936d2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6efe05d1-f096-4d5a-9ee2-5fb1130c443a">
+      <statement statement-id="ia-6_stmt" uuid="19ea4177-7de6-4e00-a9e1-390db0e1cc84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffa2f7af-7974-4fb2-b968-8f27f77cd7ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Advanced Cluster Management for Kubernetes session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98084a74-bbe1-40dc-9f50-0b6ab4ee2273" control-id="ia-7">
+    <implemented-requirement uuid="7b05aab3-651e-4c16-aee9-5f5cb58513b9" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="65e72d4d-c652-4e10-a812-b34bf2e39041">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1a6909a9-7ad5-4c5f-816b-8525e7cfa950">
+      <statement statement-id="ia-7_stmt" uuid="b33fcaa7-f0ce-49e1-a782-d5311d91ec4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4793,10 +4793,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1ef7080-8bb2-4e46-912a-a3e0cbb4686d" control-id="ia-8">
+    <implemented-requirement uuid="15dd3aa2-0356-4f5d-8200-d30f8256d773" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="9f10d732-9234-45af-8002-9dde57e4e968">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d9166520-087b-480f-a7bd-0952624b10a1">
+      <statement statement-id="ia-8_stmt" uuid="384de7fa-27c4-4f40-a6a2-6cf58c00a1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4807,10 +4807,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5a9f616-1f6c-409b-97f3-2e97ccf6f62d" control-id="ia-8.1">
+    <implemented-requirement uuid="922dcaf1-78dd-4dc9-9a7a-fc83d03cd39d" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="7a794b82-d6af-4a8a-be60-fb558ee55178">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1fb92a4b-fbce-40e4-8c48-24f23e58f42a">
+      <statement statement-id="ia-8.1_stmt" uuid="2b939949-8825-4a80-8ba9-dc6f5241d760">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4821,10 +4821,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea1c3101-c6f8-4ef9-9f51-e1a7b4c396a1" control-id="ia-8.2">
+    <implemented-requirement uuid="582b2033-a58b-440a-bb7b-842a64c8e6ab" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="f9cc122a-8b85-4659-afb0-17eb73c3b362">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d1a99487-c343-4ff0-a382-87d21ce09c7b">
+      <statement statement-id="ia-8.2_stmt" uuid="cb36cefd-7292-48a0-8850-aff4e257b77d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4835,10 +4835,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce9ec9e8-74f7-4fd2-9f6d-7912c28d05b2" control-id="ia-8.3">
+    <implemented-requirement uuid="246f5842-7f1e-49d0-a393-d6aee19949a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="03b020b2-c9bd-408d-9f4d-4391c502d69d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e4fa190c-e411-4aac-8395-9bd8714d3c0b">
+      <statement statement-id="ia-8.3_stmt" uuid="f32e9b5b-4cbd-46bb-a794-d9cf1a55c8cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4849,10 +4849,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ccaa321-8463-4f1e-9f0c-f0e01067341f" control-id="ia-8.4">
+    <implemented-requirement uuid="903874b7-4e6c-4a85-928b-6d9a96084e0b" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="d23d3bf2-a8ed-4ca5-93fe-775c2a9f132e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e91bb818-36eb-4416-9a5e-b3cd67416298">
+      <statement statement-id="ia-8.4_stmt" uuid="055f41bc-d4f2-4c99-b487-8ac2a3e1e401">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4863,10 +4863,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2618e328-c7de-4ee3-aa6c-03543f2f30fa" control-id="ir-1">
+    <implemented-requirement uuid="e9254f4c-c4e8-418f-bd54-3412a87ddb77" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="0045c6c9-8ec7-4c42-a30f-26a10a196670">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="97eaa5ae-6a03-494c-bdeb-9edd03e80e89">
+      <statement statement-id="ir-1_stmt.a" uuid="2e19fb0a-b243-4978-b25e-a6dbdd4cb2b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c15b72c-d254-49a5-92c0-55715caf39c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles of incident response policies and procedures is an
@@ -4874,8 +4874,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="1d329490-1afe-464c-b6a3-0e5edbc4d8f9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ab75c838-9db9-47ad-afac-7fd14278bc4b">
+      <statement statement-id="ir-1_stmt.a.1" uuid="4c891716-7c1b-44e5-9b2a-57b135457102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f612b7e1-3d6a-4556-8aaf-e7f2d977b4bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles an incident response policy that addresses purpose,
@@ -4885,8 +4885,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="1322be92-a5ae-4779-865a-7c28c2e7512b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="73081bfb-4963-4435-bbd5-4853029b3f19">
+      <statement statement-id="ir-1_stmt.a.2" uuid="b0a371b6-f0ae-495f-a1eb-2e735999acfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a042372f-1c80-4116-adb6-fda1b41ec201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles procedures to facilitate the implementation of the
@@ -4895,16 +4895,16 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="737e2cc4-abec-4985-a1ee-6de2ce12c448">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7b8d2fae-aa24-4964-8c9a-5928854a4910">
+      <statement statement-id="ir-1_stmt.b" uuid="edd9c3eb-d4e3-4df4-8722-bb310cd34222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3b3f0a9-17e3-460c-8777-c47f43a9dd74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating incident response policy and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="a111a765-3a1a-4dd5-8ffc-e0ebe437a05b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c3a93e6b-96da-41fb-9629-770b2f45e27a">
+      <statement statement-id="ir-1_stmt.b.1" uuid="39db6397-b221-422b-81ef-53daa7817782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7fda435-0b22-4225-aa3d-5c11d7eb2b0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response policy on an
 organzation-defined frequency is an organizational control outside the
@@ -4912,8 +4912,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="91b73bab-f4d8-46e8-933a-96eb5a6d00bc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="08b3f494-8064-4f9b-ba94-4dd1d35fe0ba">
+      <statement statement-id="ir-1_stmt.b.2" uuid="36560876-f8de-4ffa-8d36-af3c67f649c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de30e301-2ced-49e8-9acd-6bc32d3ac131">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response procedures on an
 organization-defined frequency is an organizational control outside the
@@ -4922,10 +4922,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc01b05d-7ec8-4121-b8b1-bc59e975e421" control-id="ir-2">
+    <implemented-requirement uuid="a15791af-da74-408d-8450-fdabec814d43" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="d456a6ed-207c-45b9-a3f5-2e9f9958a503">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d1e98687-1300-417e-ba8b-fddc1736515d">
+      <statement statement-id="ir-2_stmt.a" uuid="d0ea58f3-d80e-4734-aec8-dbc72e2dbc20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eafdb258-f903-4d7e-ba22-9e608d95ecb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities within an
@@ -4934,8 +4934,8 @@ or responsibility is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="796d9f72-49ca-47f4-8509-e833370150f5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3b3f7b24-f3bd-4bdd-bd2d-b071f2939977">
+      <statement statement-id="ir-2_stmt.b" uuid="7a3fc29a-b3e6-4ba1-969b-4d919175c9e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709f8fbc-2302-4992-ac8c-8735d21a7224">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities when required by
@@ -4944,8 +4944,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="f2fbee08-f2cf-4a1c-aee8-82b6128a25ff">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4ae048ea-7959-452c-9a98-999982a381be">
+      <statement statement-id="ir-2_stmt.c" uuid="1c37f0f9-5821-44e5-a513-d090941546e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cea18629-49b6-4cce-8db2-0cf050b88697">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities on a TBD time
@@ -4954,10 +4954,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59520987-905f-4af0-aa39-8a9ecb5b92ed" control-id="ir-2.1">
+    <implemented-requirement uuid="13fc97d3-d081-4a4e-84a4-878661ab3bba" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="a5080ac3-38fa-4608-a5d7-37f6443e255f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6c52c165-c94a-48c4-9cbe-c8212a3f26e4">
+      <statement statement-id="ir-2.1_stmt" uuid="6c334895-3e9b-427d-9d63-bbdf08b6ab49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="509f3ffa-73ce-4894-8148-8a32e656febe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into incident response training to
 facilitate effective response by personnel in crisis situations is an
@@ -4966,10 +4966,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="708e7658-28a7-4593-b485-6b8142879601" control-id="ir-2.2">
+    <implemented-requirement uuid="e3607d04-43ec-4f68-813f-386fcf445213" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="da26a5ac-ad14-498e-b660-ec0e7b77cfb3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="60d27ac1-5cce-4c31-afb3-15924f6da2c6">
+      <statement statement-id="ir-2.2_stmt" uuid="ccac7fd2-33bb-4693-a5e4-af26146f30a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae3d5b00-c555-4332-81a2-7ae3e9b7d2f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to provide a more thorough and realistic
 incident response training environment is an organizational control
@@ -4978,10 +4978,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87db73e2-259d-452a-bda4-2090c450073d" control-id="ir-3">
+    <implemented-requirement uuid="5fe91210-3ad7-4b59-b11e-4b50f1b8f556" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="d42e3969-fe24-4a76-bf4e-45f93a3a6fb1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b34faec4-4578-485c-8c15-4b6238132d33">
+      <statement statement-id="ir-3_stmt" uuid="19edf186-549c-4bf8-8965-5045bfa4a58e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10f32706-e44f-49be-8b7a-695b071a6235">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the incident response capability for the information system on
 an organization-defined frequency using organization-defined tests to
@@ -4991,10 +4991,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00a49c3d-c5de-4a07-b579-52b6487641f7" control-id="ir-3.2">
+    <implemented-requirement uuid="fd32563b-889b-4e7c-82d3-39bef4a0e873" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="86a23bff-4455-447b-a01b-bc4561eadcbe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="446b94b1-a89e-4993-ae20-f3d48805c7e1">
+      <statement statement-id="ir-3.2_stmt" uuid="994526cd-4483-43fc-8908-637aab69cf62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23179ad5-4db8-4be7-b47e-a05edbd02d7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating incident response testing with organizational elements
 responsible for related plans is an organizational control outside the
@@ -5003,10 +5003,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15ff6edb-a0c6-4087-89ff-798d948bad8d" control-id="ir-4">
+    <implemented-requirement uuid="265c7809-fc7e-4390-b429-9780daa3bda7" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="2c08891b-9081-4605-b007-51a84842f5a7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fb1a8bd0-7a34-46c8-86d2-f65ba3d1b368">
+      <statement statement-id="ir-4_stmt.a" uuid="6de145d9-7b86-4d6a-aee3-c1c7e7803aab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19a22a0b-bddf-4faa-8ea9-be2b0974f2bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing an incident handling capability for security incidents that
 includes preparation, detection and analysis, containment, eradication,
@@ -5014,16 +5014,16 @@ and recovery is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="58dbc36a-e21d-4363-a385-ee70ffe67dfc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3248a192-8239-4741-af97-29e5596a9707">
+      <statement statement-id="ir-4_stmt.b" uuid="293ce7b1-ff84-4d9c-b8df-803e4aeedc76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c1d81b1-e794-4734-8733-0a934a977389">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating incident handling activities with contingency planning
 activities is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="8f976dd5-c2dd-4461-8935-dad91ecd47d6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="830e8b13-69e2-4c7c-8020-597c652a2792">
+      <statement statement-id="ir-4_stmt.c" uuid="0a6e430e-4502-48d8-994b-538997e10a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe23a19c-6c01-41c3-929f-7c8fe05e7724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating lessons learned from ongoing incident handling activities
 into incident response procedures, training, and testing, and implements
@@ -5033,10 +5033,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a08888da-eb8a-4d8d-bd7a-932329353364" control-id="ir-4.1">
+    <implemented-requirement uuid="84e95595-1884-4a1a-809b-22f6e1189e64" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="86f119dc-7238-435a-9de5-cb8175da6e5d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fdd8d97d-c639-4e4d-a178-5abb4631dc54">
+      <statement statement-id="ir-4.1_stmt" uuid="6b82ce3b-6930-4529-84c7-95d15ed03051">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fac86649-d5ec-4e81-a6b5-366c12292299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to support the incident handling process
 is an organizational control outside the scope of Red Hat Advanced
@@ -5044,10 +5044,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23730806-8c8c-4416-b9dc-3a717d3691c6" control-id="ir-4.2">
+    <implemented-requirement uuid="8696d069-c453-4e0a-8676-4c6a5f77c238" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="2ab053f5-431a-4c1e-b3e3-dab243c2a43b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1ae56234-5da2-4e10-9292-030b53daa405">
+      <statement statement-id="ir-4.2_stmt" uuid="7de0fbe8-37b9-44f6-bea0-53b501513196">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80f5b5a5-18ec-4f49-ba4b-d41152a137ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including dynamic reconfiguration of organization-defined information
 system components as part of the incident response capability is an
@@ -5056,10 +5056,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49d181c8-289a-4602-9b6e-e18f0234d9bb" control-id="ir-4.3">
+    <implemented-requirement uuid="292234aa-b72e-4086-9ac5-230841c7fcb6" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="8ef5ba43-ed39-4896-b526-e76d703b17c5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="40265910-e452-40ec-a984-7815b7bbd484">
+      <statement statement-id="ir-4.3_stmt" uuid="3dc8e79e-d2fb-4158-8838-3139df738ec3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cdca44a6-4f4d-4123-8790-b8a318626c75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organization-defined classes of incidents and
 organization-defined actions to take in response to classes of incidents
@@ -5069,10 +5069,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5393051-87f6-4365-afcb-86001a7eda5d" control-id="ir-4.4">
+    <implemented-requirement uuid="171bbf81-2b5e-43f8-a5f1-469621e79c6f" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="07fbb726-128f-4756-98a2-16006a0bbb4b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8e685877-6fa3-4800-8211-2adda272b725">
+      <statement statement-id="ir-4.4_stmt" uuid="a6d27015-47ec-4941-9ea1-551b9dfc4317">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="126735ba-2d8a-41be-a96e-7c959c0f5f25">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Correlating incident information and individual incident responses to
 achieve an organization-wide perspective on incident awareness and
@@ -5081,10 +5081,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="068f2ea3-0331-44dc-9d40-4aa5d4ee6bfa" control-id="ir-4.6">
+    <implemented-requirement uuid="f60ce563-86a7-4176-9c0c-d007360172c9" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="f1532058-676a-42f5-9ca2-44ac03a73f68">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8a3c4c11-45e4-4490-809e-b15d0cb5c9de">
+      <statement statement-id="ir-4.6_stmt" uuid="0a9681f2-2a6e-4cbe-8e8b-c38d3cf84590">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6cbf815e-47d3-4dc7-99cc-b525ccb04ba8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing incident handling capability for insider threats is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -5092,10 +5092,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f08f51d2-dd10-40b6-9f6d-7e084555ce99" control-id="ir-4.8">
+    <implemented-requirement uuid="27590865-a28a-4f1a-8aab-f55b0aeba34b" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="440e810b-accf-413c-8368-d8e4ae7f2572">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="87e48ff1-9f3e-49e8-8162-c6f4aeb0f2e8">
+      <statement statement-id="ir-4.8_stmt" uuid="8f8b0749-3b4b-466e-a42a-26eb054ac91d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9a7d3b9-1adc-4232-b632-15d6384505a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating with organization-defined external organizations to
 correlate and share organization-defined incident information to achieve
@@ -5106,10 +5106,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2dfff0a3-8832-4ab0-8dbc-45961217b304" control-id="ir-5">
+    <implemented-requirement uuid="f0383d76-28c0-45e7-8319-4e58a63abf89" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="489b71d8-79a6-4db3-82db-02cfc0c28930">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d1bfbb89-ebc3-4395-8550-f8ca63a46fa4">
+      <statement statement-id="ir-5_stmt" uuid="d79d2e79-08a0-4132-bb51-6640123337a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f419747-33f9-4dcd-b671-a38a0487db60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking and documenting information system security incidents is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -5117,10 +5117,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a036a42-99e3-4a74-af54-742bb6ae8405" control-id="ir-5.1">
+    <implemented-requirement uuid="ccf8a912-4404-4eed-8112-9abbdeb9c4e3" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="5c6e3a50-20f1-4909-afce-cd9d73adb16d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9adb7e5a-908e-4a78-9941-ebc9f244d686">
+      <statement statement-id="ir-5.1_stmt" uuid="87c8b3f9-5179-4912-886b-cb981e3f124b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e7a3317-a218-414d-ab49-89010500f349">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to assist in the tracking of security
 incidents and in the collection and analysis of incident information is
@@ -5129,10 +5129,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4627c0e5-8541-4c8a-bd45-d267e9315a41" control-id="ir-6">
+    <implemented-requirement uuid="15b4e51e-95e6-444c-91c2-38df890f012a" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="f21bfc8d-daa3-4258-bf01-6cd468d08aa1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2ccc7afc-2307-469a-afba-96def4b72d12">
+      <statement statement-id="ir-6_stmt.a" uuid="35dfa24e-455a-44a2-88b0-fc4b2bdc0b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9724fc04-f64e-463c-aa7c-cb4cd7ef23e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring personnel to report suspected security incidents to the
 organizational incident response capability within an
@@ -5141,8 +5141,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="71e79d4d-aca9-4248-9a5b-7460c5210426">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8f7bf535-ad2b-42bf-bc0a-44f472218127">
+      <statement statement-id="ir-6_stmt.b" uuid="6d39bf4d-93f3-4d29-ae7b-4776103b9584">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ad30abe-b363-4997-a990-56bd4b0d2a46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting security incident information to organization-defined
 authorities is an organizational control outside the scope of Red Hat
@@ -5150,10 +5150,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09fa0ea9-eda2-4052-9060-720950772829" control-id="ir-6.1">
+    <implemented-requirement uuid="4e07f6d1-b043-4cc6-8279-a7881a860bb2" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="5207e6d0-3348-429f-9b28-4aa354d7fdd1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2a0b89f1-39f0-4ba2-ba0b-604e73f5ed5a">
+      <statement statement-id="ir-6.1_stmt" uuid="596ae1fc-3c86-4899-94a2-9297c2000dc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="27c17396-6e7d-421e-af32-651ab113be30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to assist in the reporting of security
 incidents is an organizational control outside the scope of Red Hat
@@ -5161,10 +5161,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5af4b6a2-03bb-4ac9-91b0-686494873cd2" control-id="ir-7">
+    <implemented-requirement uuid="ae856240-505a-4b8d-8c8b-6d9c6a2f9b77" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="2bba7e26-a24b-4323-8b5f-d5d7b83a9d61">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3d79a62d-e2bb-4700-9d3b-9f3d46d76382">
+      <statement statement-id="ir-7_stmt" uuid="b84e786e-ffdd-4e75-a08a-a3756bd47da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab5b2742-c274-4906-9724-73db577f414a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing an incident response support resource, integral to the
 organizational incident response capability that offers advice and
@@ -5175,10 +5175,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="590dc1ba-d1b2-458a-938c-2c5da31bf753" control-id="ir-7.1">
+    <implemented-requirement uuid="51be95e1-e369-4baa-ae88-e321e0e8f2e0" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="41d8dde1-7ef2-44ea-9e4d-9446501a1a10">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c9239625-cbbf-4226-a2f8-7aa910df5f6a">
+      <statement statement-id="ir-7.1_stmt" uuid="9c23e1af-4162-4013-a7be-058da770e376">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c31820af-03e7-496f-95fd-9bd9db8c25ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to increase the availability of incident
 response-related information and support is an organizational control
@@ -5187,10 +5187,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc364e44-a662-4692-b4ba-f9b671c3260a" control-id="ir-7.2">
+    <implemented-requirement uuid="05a3a6d1-2f0b-4619-9d5a-cd5a6f84fef2" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="e7775906-700e-49a2-8fa7-b639ef896ec7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cf0f1e5b-4379-486c-b8fc-2403e18459da">
+      <statement statement-id="ir-7.2_stmt.a" uuid="dec6579e-7924-4804-9d24-0199baec3fa5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ae0414b-c1a5-418d-bcfc-ec1803f5a452">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a direct, cooperative relationship between its incident
 response capability and external providers of information system
@@ -5198,8 +5198,8 @@ protection capability is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="c5d3874c-f8db-44db-8927-43b4a6373f86">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0ce72d84-c7ae-4371-b6ef-f04acf19c809">
+      <statement statement-id="ir-7.2_stmt.b" uuid="d82c321b-c221-4df4-994b-efd49e6a2a1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b6eeafa-e5e6-4aa0-9d08-af8a45033d3b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organizational incident response team members to the
 external providers is an organizational control outside the scope of Red
@@ -5207,18 +5207,18 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b7ee897-1247-4b04-a1c6-2925cd31fda6" control-id="ir-8">
+    <implemented-requirement uuid="49acd465-9d15-4a96-8f07-ba73e146c21c" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="69b30998-4cee-45ef-b647-bc8518c522c0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="33158fd8-17d1-4184-abf1-8a8497a13c81">
+      <statement statement-id="ir-8_stmt.a" uuid="f8965741-5603-49e3-af65-1d659f54ce7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9c2255d-be43-4916-b2a1-2ec4545adaf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development of an incident response plan is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="9abb97f8-060b-4ec2-a92a-db430b6772d1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="90eb4143-61ae-45a9-816c-a6a6ab996df8">
+      <statement statement-id="ir-8_stmt.a.1" uuid="6a896184-1927-4bad-aa83-85d46f80e335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e97bf89b-5b19-4be2-89c5-71e395ca99c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides the organization with
 a roadmap for implementing its incident response capability is an
@@ -5226,8 +5226,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="1fada392-d7a2-42f7-b9d3-5962af0983c0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c0080921-0132-4403-bac5-e0d204f8411d">
+      <statement statement-id="ir-8_stmt.a.2" uuid="bfed941e-cd44-4c6c-9ede-3cbb9c0cf335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35f4b1c0-c930-4494-9e1d-10b5cc502a2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that describes the structure and
 organization of the incident response capability is an organizational
@@ -5235,8 +5235,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="c19a3780-90df-4bb2-8048-cc9f774361b4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6935eeb7-68f4-4dfc-a4fc-68e4b3fb1b8d">
+      <statement statement-id="ir-8_stmt.a.3" uuid="995382ba-a9d1-4436-ab78-cdc74c7b869c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa50678c-feac-45b8-9d04-c5b15e42ea8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides a high-level approach
 for how the incident response capability fits into the overall
@@ -5244,8 +5244,8 @@ organization is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="2e9109a5-e02c-4243-a266-dfcde95358fa">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="322e4e04-3af9-4728-96e0-cad6a6d4b627">
+      <statement statement-id="ir-8_stmt.a.4" uuid="5f3a186f-2239-4197-94e6-881c17aadd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d268ee8d-5af1-44a1-82e8-e229f663e4cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that meets the unique requirements
 of the organization, which relate to mission, size, structure, and
@@ -5253,16 +5253,16 @@ functions is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="874301fa-1ea3-4fdc-a01e-7613111b7361">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dd7e5dda-e13c-45b0-aac9-a62f685dba09">
+      <statement statement-id="ir-8_stmt.a.5" uuid="a04aac7a-4837-4615-a218-ba5036fe90d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a376441-33f6-42ba-b42d-573d7d61f23b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines reportable incidents
 is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="dd241420-232c-41ce-a977-cd6d8bfe3a40">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b47317fc-e1cb-4ad7-b554-ddf258282533">
+      <statement statement-id="ir-8_stmt.a.6" uuid="42df1525-94f7-4f76-a393-7f54353468f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea7560b7-39dd-49ba-9db7-7c0db486421b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides metrics for measuring
 the incident response capability within the organization is an
@@ -5270,8 +5270,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="ca86bb52-5139-4dd3-90a0-fa64abb1938f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d36243e4-6a52-4b34-aece-48cb55f34616">
+      <statement statement-id="ir-8_stmt.a.7" uuid="a41628b2-c5e2-4a61-bd79-b673113ecdc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b644290c-37dd-4108-bbbf-7d7fce8c7896">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines the resources and
 management support needed to effectively maintain and mature an incident
@@ -5279,8 +5279,8 @@ response capability is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="dcae3c17-e4a6-4560-a54e-c885f20189d8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="80a1f962-a94f-4aba-833c-e75e5e898aa6">
+      <statement statement-id="ir-8_stmt.a.8" uuid="dd7a765e-6f70-47ea-8bfa-6f08f1d7ace4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdef4f08-aa76-4a99-aaf7-054945ac0d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that is reviewed and approved by
 organization-defined personnel or roles is an organizational control
@@ -5288,8 +5288,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="f1427800-4397-4521-a710-acf3ba8ce127">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="26fa957c-272e-424f-9487-60a6eb1ed26b">
+      <statement statement-id="ir-8_stmt.b" uuid="c6e28213-ecfd-4592-8a64-8e7504cbb040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9d8235-d089-4c09-b019-7406facd972f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distributing copies of the incident response plan to
 organization-defined incident response personnel and organizational
@@ -5297,16 +5297,16 @@ elements is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="80386cdd-0ab2-4eea-9d19-109a79ddcb6a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f652451e-8577-481d-b779-1862f8b655ce">
+      <statement statement-id="ir-8_stmt.c" uuid="27d959fb-0e24-4369-99c2-52ce1811a973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d850403-75e5-4b1b-b494-d70b03c03b40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the incident response plan on an organization-defined
 frequency is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="22dac154-bd38-48e9-8a28-e0c107accef2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="676ec2b0-7264-4434-9ee9-a35e09bdeba3">
+      <statement statement-id="ir-8_stmt.d" uuid="6585a985-8ab0-4b01-82f8-c8c294e9d4ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0b9823c-fff1-4de3-bdb6-59a79905784a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating he incident response plan to address system/organizational
 changes or problems encountered during plan implementation, execution,
@@ -5314,8 +5314,8 @@ or testing is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="b3b09c80-1bb7-4cb3-8f7b-73ae95d4565d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c7753e31-69c3-4101-be7d-51ae13e57972">
+      <statement statement-id="ir-8_stmt.e" uuid="6f9441f0-de94-439f-8988-4042e6827f16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befbacf0-182f-4f92-8e7b-23c4d64331bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Communicating incident response plan changes to organization-defined
 incident response personnel and organizational elements is an
@@ -5323,8 +5323,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="011687ea-680c-470a-8282-db31a8702aa1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="041319d7-1e51-4145-8e6f-28d275370382">
+      <statement statement-id="ir-8_stmt.f" uuid="50f96740-c6e7-4edd-a0c3-1b20022f457e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6749410e-7c77-400a-9447-cc1b7ab43744">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the incident response plan from unauthorized disclosure and
 modification is an organizational control outside the scope of Red Hat
@@ -5332,10 +5332,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a33eca12-d6db-4889-8037-e28da5dfb6ba" control-id="ir-9">
+    <implemented-requirement uuid="98b98827-0cf7-403d-be20-13b2aa21e684" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="410060f3-a077-4905-aa67-be4796ac45a8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ebca437a-aa6e-48b5-b150-b084298647d4">
+      <statement statement-id="ir-9_stmt.a" uuid="60d227bc-31c8-4afb-929d-ae4192e47146">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b421293e-ee50-4a6b-91e4-158fa3744172">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by identifying the specific information
 involved in the information system contamination is an organizational
@@ -5343,8 +5343,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="28e720ec-dcf7-4906-88ef-ce412ef6f822">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1787050b-8887-490e-a26e-32e1606f5bda">
+      <statement statement-id="ir-9_stmt.b" uuid="55aa3c25-b7c9-4e4d-97bb-a566887a2b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d55fc4bb-4596-4334-83d8-320cb93449c9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by alerting organization-defined
 personnel or roles of the information spill using a method of
@@ -5353,8 +5353,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="455a41a3-ef21-4420-b5ea-059e10b1b0ac">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="860db0a9-3c04-4ed4-8bf5-4edff14e677c">
+      <statement statement-id="ir-9_stmt.c" uuid="cbadfff8-7d76-4d87-aee3-4ad745601930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0898d7e-b63e-4fa2-ad9c-86a45f3ea4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by isolating the contaminated
 information system or system component is an organizational control
@@ -5362,8 +5362,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="86360e8e-9888-4b3a-8e17-9ae0eb0d76bc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3184572c-28c3-4f23-b8f5-3f68d9c6f543">
+      <statement statement-id="ir-9_stmt.d" uuid="b2d5dd70-0e8e-4439-bf8e-250f7f516bc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bfa0460-18b4-4c21-a1a6-1f1ee454e13f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by eradicating the information from the
 contaminated information system or component is an organizational
@@ -5371,8 +5371,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="16429a19-1025-4cbe-a9f3-b468650972b6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e8f8932e-c59f-42a5-bb05-84c760943676">
+      <statement statement-id="ir-9_stmt.e" uuid="49d9240d-a8d6-4a80-9b78-d5834c271fba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04020748-d4ce-42c4-82f8-f8de764e9732">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by identifying other information
 systems or system components that may have been subsequently
@@ -5380,8 +5380,8 @@ contaminated is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="f453f17f-e4ae-4ff2-91ff-82bcc62d327d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ba4487b3-83d7-4b08-bd84-c07508af1da9">
+      <statement statement-id="ir-9_stmt.f" uuid="24199734-1f3c-4565-af76-40991b3b95e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87d1ad3a-83b8-4de2-bc7d-4ef82d028dc5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by performing other
 organization-defined actions is an organizational control outside the
@@ -5390,10 +5390,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8da9be77-7b78-4ab8-96c1-9999e7cc72a8" control-id="ir-9.1">
+    <implemented-requirement uuid="abebdf7c-86f6-42fb-b3af-a66fffeb2f62" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="063dac5b-2b4f-4e3e-a997-80fd32f631a4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f988fd69-b760-4071-a6fe-46b3f7dcc88b">
+      <statement statement-id="ir-9.1_stmt" uuid="661ab6b4-9978-47ba-b6d6-ebedd98eba88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8644d696-55b0-423c-a449-826f8485de22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning organization-defined personnel or roles with responsibility
 for responding to information spills is an organizational control
@@ -5402,10 +5402,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3491e1ab-207e-4476-aa4b-5632aef32167" control-id="ir-9.2">
+    <implemented-requirement uuid="9d631431-12bf-469c-9285-e2db3fc49bd6" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="482d4581-c2cb-4b9e-896a-eef2cca512fc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4979cd6d-7679-4cfe-b430-089629233543">
+      <statement statement-id="ir-9.2_stmt" uuid="568d3a79-504e-4ff4-9c58-23fa53b3d557">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38d5838d-0dee-4dda-949c-7c4f1f723d37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing information spillage response training organization-defined
 frequency is an organizational control outside the scope of Red Hat
@@ -5413,10 +5413,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0530a454-ebc0-47c1-9452-45d911678a6c" control-id="ir-9.3">
+    <implemented-requirement uuid="519efcc8-6a50-4127-bba2-1b89b88399d5" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="629cf1bf-bc7b-430c-bbb1-885e0bea03d3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="164f52ad-fac4-46e0-9276-f63e428609ef">
+      <statement statement-id="ir-9.3_stmt" uuid="ea197bce-ee86-4494-a3f2-526ca19424a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a37c4a9-030a-4426-9034-cf7f74ad912f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined procedures to ensure that
 organizational personnel impacted by information spills can continue to
@@ -5426,10 +5426,10 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c7c116f-0c64-4a4a-a86c-1cf1f63f22e6" control-id="ir-9.4">
+    <implemented-requirement uuid="d60aa74a-b75d-4be7-9c37-53a8315a467a" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="e2afce24-ffd3-418c-bdae-f1564154c945">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="271fd6f5-a22c-40a7-bd5c-06ad45acb60f">
+      <statement statement-id="ir-9.4_stmt" uuid="d3cdc512-8275-495e-a45d-ba9262e8cee2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f1bf98b-54a7-4867-9a8e-959f80ec9709">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing organization-defined security safeguards for personnel exposed
 to information not within assigned access authorizations is an
@@ -5438,18 +5438,18 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d772da35-decd-48cd-90b3-48dce8ee6d8f" control-id="ma-1">
+    <implemented-requirement uuid="68253bf9-1ed6-4f5a-acd8-c5e98a2fc249" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="6efcd34b-d625-44dc-87f2-0fae40b979cb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f5d8c8bf-9774-4a8a-b0f0-419203357e22">
+      <statement statement-id="ma-1_stmt.a" uuid="3ca0fcfb-f14f-44c6-a572-bd4c7f32c310">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f846a086-263b-4370-892d-c68491d0cb41">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating to organization-defined personnel or roles
 system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.1" uuid="8c9e4a6a-4dee-421b-b034-fc7fd1d7bb63">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e10873e-f935-48ff-85fe-daca0e2f98b7">
+      <statement statement-id="ma-1_stmt.a.1" uuid="f6fda425-2406-4e85-b70e-3944456f3beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e3d7f8d-e593-4cac-b880-3507a5d1f387">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A system maintenance policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance
@@ -5457,31 +5457,31 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.2" uuid="3e8537ed-9e13-4f07-99ec-6759e7b9ad4e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6ae8f207-7dea-4aa7-8e0d-1ccc59a255ee">
+      <statement statement-id="ma-1_stmt.a.2" uuid="f1982d96-04ac-490c-ac02-bc368cee4f66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="d012d5c3-b5f8-4ca7-b630-1ef403a7104e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8dcc8ac5-fc2a-40ce-99d5-becdf16edde6">
+      <statement statement-id="ma-1_stmt.b" uuid="0a2f3d72-f568-4e80-8084-3395f2230ef2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bab8b16-6740-483a-8871-adf6413e9677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.1" uuid="a674d4c5-6326-4ff5-9d08-d3f181f0300d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="140a0273-ba4c-46dd-98b6-5f79a8d4fbe2">
+      <statement statement-id="ma-1_stmt.b.1" uuid="f56a278e-dad4-43fe-ad86-2cf5e6cff1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e461e8a-ef48-4750-8679-909287d16598">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy per an organization-defined frequency
 is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.2" uuid="ee06378b-0d2d-4a1b-8169-37d8f13590a9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a16b00d1-5a01-4c22-b45f-efc38acf890a">
+      <statement statement-id="ma-1_stmt.b.2" uuid="4b62389b-a32e-42b3-8576-acd9c0aff016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3252c66-90f0-4b1c-953a-3142eba06e77">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance procedures per an organization-defined frequency
 is an organizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -5489,10 +5489,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="041941da-72e6-4106-93e9-16d9238a01dc" control-id="ma-2">
+    <implemented-requirement uuid="d0521ab2-47f8-4c54-b9a4-ebb7e6fc728c" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="c47aef59-83f8-4cec-be39-978e02f98403">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="41a98e3e-6a13-457d-bfc4-cb58c82e640d">
+      <statement statement-id="ma-2_stmt.a" uuid="bc734b9b-0490-4393-88a5-09b06ba33b61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a5ff649-d883-4d1e-a467-9e321e2d4d0c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Scheduling, performing, documenting, and reviewing records of maintenance and repairs
 on information system components in accordance with manufacturer or vendor specifications
@@ -5500,8 +5500,8 @@ and/or organizational requirements is an organizational control outside the scop
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="e73cedee-e208-4868-82ee-fbde0fa20cbe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="33aa6078-6fde-44c2-8303-c996bb0ed432">
+      <statement statement-id="ma-2_stmt.b" uuid="d1cac324-6b4a-4c23-863b-dfe5232dd176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b722d8bc-31e6-4be2-b4a4-9f6e0cd15408">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approveing and monitoring all maintenance activities, whether performed on site or
 remotely and whether the equipment is serviced on site or removed to another location
@@ -5509,8 +5509,8 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="d46c9eed-a31c-421e-abd9-75913ba92921">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="74ba6720-fa95-421f-a05d-2b648bbd12f1">
+      <statement statement-id="ma-2_stmt.c" uuid="7a207c63-3cc7-4821-9596-a4b41a662023">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed6a4e6b-a9bc-4146-9134-466a89b59741">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that organization-defined personnel or roles explicitly approve the removal
 of the information system or system components from organizational facilities for
@@ -5518,8 +5518,8 @@ off-site maintenance or repairs is an organizational control outside the scope o
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="eb8e65f5-3933-4035-8661-85abaf295bfc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7a13ae30-1d6d-4be7-a50a-c0364c735109">
+      <statement statement-id="ma-2_stmt.d" uuid="ef69704b-a3d8-462b-bbe9-12af2107ccb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ed82a90-b826-4aeb-8b9d-91820b3a5734">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Sanitizing equipment to remove all information from associated media prior to removal
 from organizational facilities for off-site maintenance or repairs
@@ -5527,16 +5527,16 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="0cff90d0-6213-47b2-a636-4db91d53224d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d0c6e62c-01ec-45c9-b1a8-6adc1be23d26">
+      <statement statement-id="ma-2_stmt.e" uuid="4b99101f-ed9b-4f60-b2b4-6137650183a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee78984e-c60a-4a96-9949-7f60acf14d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking all potentially impacted security controls to verify that the controls are still
 functioning properly following maintenance or repair actions is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="dbd246d8-9537-412e-8134-599095613984">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="27542853-8301-4c3f-93a4-42122282146f">
+      <statement statement-id="ma-2_stmt.f" uuid="c17656a2-3255-4d50-bee0-a64d02c2908b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75b29e40-c2f3-477e-b645-ff552864f6b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including organization-defined maintenance-related information in organizational maintenance records
 is an organizational control outside the scope of
@@ -5544,18 +5544,18 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43fffac2-819a-4b6f-80fb-eb94167f4c94" control-id="ma-2.2">
+    <implemented-requirement uuid="71801c60-38ef-493f-a05c-42e78086178e" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="3384dbe9-6e84-450e-8e06-550d12064cb0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ae0c683c-3f75-4f37-b1c2-5bacc62a8e12">
+      <statement statement-id="ma-2.2_stmt.a" uuid="4c8a1bfb-5356-4967-8841-44cda302ad2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5edd87c9-3a93-4271-aec6-4c0918dcfed9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to schedule, conduct, and document
 maintenance and repairs reflects organizational procedures/policies and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="3a3e2da5-5973-45ca-8d13-734d691f7d85">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="10dc2c57-f592-4b01-8f7b-45ffdf5d31fb">
+      <statement statement-id="ma-2.2_stmt.b" uuid="cf73a382-036e-459f-8590-5f83a16ff545">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a058ee44-d49e-4256-a503-65af79f570b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Producing up-to date, accurate, and complete records of all
 maintenance and repair actions requested, scheduled, in process, and completed
@@ -5564,10 +5564,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ec5e4a1-60ab-475a-a33d-93dc3c6fa699" control-id="ma-3">
+    <implemented-requirement uuid="5b7ca057-e202-4aec-bca6-8e1990d2ae37" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="c051b611-be00-4edc-9a44-38de2128314a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="83249ba6-a076-4562-bd18-5f4d504205dd">
+      <statement statement-id="ma-3_stmt" uuid="db3dbe53-8d00-463f-874f-414cce113a3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6d20b73-12aa-4c9f-b574-8e6c68764fb7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization approveing, controlling, and monitoring information system maintenance tools
 is an orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -5575,10 +5575,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b8cd03a-e69a-4170-9550-00ebd919b393" control-id="ma-3.1">
+    <implemented-requirement uuid="d79dfc91-8495-49c8-a3e4-ba1bcbd32aa2" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="2c23051e-c97b-454a-9849-fd78a92cb22a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a680823a-50ae-437f-b169-95af1c435844">
+      <statement statement-id="ma-3.1_stmt" uuid="49bfdbf8-fdd2-4832-8dcf-9289a33bf93e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="353ae4dc-1b52-45f6-a800-dd3681ceab70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization inspecting the maintenance tools carried into a facility
 by maintenance personnel for improper or unauthorized modifications is an
@@ -5586,10 +5586,10 @@ orgnaizational control outside the scope of Red Hat Advanced Cluster Management 
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47dcf5fd-c663-4472-b75b-2365ec167a9d" control-id="ma-3.2">
+    <implemented-requirement uuid="cbdc8ca6-4a4a-4523-b872-fcf2aa981ecc" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="ea55eff9-39bb-4cbf-97d5-c3a222fb214b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2cc11bba-a1b2-4036-a0da-ef9afa9505e9">
+      <statement statement-id="ma-3.2_stmt" uuid="c288bb45-0823-42f6-8b7e-a0752854eb76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7518b57-5c36-45d7-9fb7-665748b1bfd2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -5597,10 +5597,10 @@ system is outside the scope of Red Hat Advanced Cluster Management for Kubernete
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e579e223-36f1-43cc-a953-6c3f69a99188" control-id="ma-3.3">
+    <implemented-requirement uuid="574548e6-09a5-415c-ad07-f8e1b3cb7ef6" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="9dd84da3-5ec8-4a51-81cf-5f371f9d7ef1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7a10a2df-3a65-479b-8518-f9ce2e083785">
+      <statement statement-id="ma-3.3_stmt.a" uuid="c6f0bab4-b3de-4823-9fe0-c9281f74b817">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49e28527-4a01-4fac-8017-97020217f2b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -5608,24 +5608,24 @@ information contained on the equipment is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="0a9361bd-d76a-46fe-8312-5c5d411274e4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f4c43ea0-25aa-4775-aab1-c0c6ee9f7464">
+      <statement statement-id="ma-3.3_stmt.b" uuid="e684f3e5-4490-4332-bb89-2b27f45edfd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b26e073-bdf9-4805-9b73-008a169701fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="b7f12b51-cb6e-4512-a500-9fe814118665">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f527474f-3d43-4ca7-963b-63f440a61b0f">
+      <statement statement-id="ma-3.3_stmt.c" uuid="981191c3-0955-4bd3-b4c7-83ecb80ffc69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4a3e7cc-8783-40d9-8335-7a37a0412db4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
 facility is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="63c02a7d-10d2-461d-9982-037d7f12a572">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="098704d2-79c0-4764-bceb-8717d3433c26">
+      <statement statement-id="ma-3.3_stmt.d" uuid="cd39c45e-c1fb-47e7-bffe-6783f778a3d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf64b687-a3a9-4671-b1dc-155461eb82ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -5635,25 +5635,25 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75a07f67-b9a5-4436-93b1-d5159e2024b7" control-id="ma-4">
+    <implemented-requirement uuid="ee08bf70-ba34-4996-882b-d3dffbde4407" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="23134f3d-450e-4163-84b8-24f1940d0e4d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="78c3809e-452e-43bb-9828-74985ec75f60">
+      <statement statement-id="ma-4_stmt.a" uuid="eaf394c6-d6bf-4a30-888f-89b5e0c84c00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e991af1-6b2c-42d8-8073-794564765dac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="8f6b0be0-56f8-49c1-aaf8-bb40157b6227">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="23158c81-419f-424d-b34f-176d609ffe82">
+      <statement statement-id="ma-4_stmt.b" uuid="341e27c3-1473-4701-9e46-f6ea142e7911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bf896e2-fb2f-41a7-a919-56de5f20e98a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="5c695e9c-a15f-4cda-9ba2-aece33e50fe1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="efb9ea4e-7d02-46f4-919d-be75c289a92e">
+      <statement statement-id="ma-4_stmt.c" uuid="7c948163-c39b-4a03-8be5-9371269b0fc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a4a4496-4701-4b07-a53d-7c8bc683c411">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for authentication management.
@@ -5663,15 +5663,15 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="97f6d0aa-3cf2-48c6-a10d-057a3df13cf0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1e6543e5-be20-4fa2-9f21-63782e005f5d">
+      <statement statement-id="ma-4_stmt.d" uuid="34cfca8e-60e9-480f-a3fe-b9fe80c948cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9aa9e088-f7a8-44ff-9b10-81842f8f02af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="b97b721d-b3bd-4044-a592-a922122e24d0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1d0ce157-d872-44b4-9e64-9f7e30e07283">
+      <statement statement-id="ma-4_stmt.e" uuid="b171c76d-5876-48a5-833b-544ca7fc02ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08c2886-6ec5-466a-b1bc-29a30be73431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for session management.
@@ -5681,10 +5681,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dedf9ad5-1ee4-49fa-83d7-27ab5a4a890f" control-id="ma-4.2">
+    <implemented-requirement uuid="ead10857-a33d-49d1-bc56-50dc27385779" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="29743392-77f7-4831-bc19-a36b37169b2a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f42674db-4a5e-43dd-a703-b416527d81ef">
+      <statement statement-id="ma-4.2_stmt" uuid="8f138674-4e31-430f-a4e9-8721ab6ee6d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f459ef2e-51bc-4fd3-8e14-4625f48214f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization documenting in the security plan for the information system,
 the policies and procedures for the establishment and use of nonlocal maintenance
@@ -5693,17 +5693,17 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aebf9489-6847-4a92-abab-5a46d68f7a9b" control-id="ma-4.3">
+    <implemented-requirement uuid="4d3ed811-f0c8-4440-bfbf-98ba04e247fe" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="a6013de3-f967-4bd2-a459-d66baa386fbc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="54fca5ab-7a65-4adc-95ab-66ca4e5a71c1">
+      <statement statement-id="ma-4.3_stmt.a" uuid="8e0c4670-84b7-4d1a-be9c-aa9c8875d294">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="01afe2a7-b279-4d30-bc4a-0d89fcc3291c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e1fbd221-8a8a-4dd1-8aa1-22dcdc80becd">
+      <statement statement-id="ma-4.3_stmt.b" uuid="6a0879d9-fa5e-4e44-9323-0effe6ca9564">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b907118a-ee29-43e9-a6a0-fe297afb8ffd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removing the component to be serviced from the information system prior
 to nonlocal maintenance or diagnostic services, sanitizes the component
@@ -5715,35 +5715,35 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76b39f78-d08f-4396-895b-c34e5fbbbc8d" control-id="ma-4.6">
+    <implemented-requirement uuid="93aab12d-4769-4d89-92bc-4a4a02b77c8b" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="02a99a83-eda2-49ab-8d01-30e649c05982">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0221aa27-aac2-4b13-86c0-5680406eeddc">
+      <statement statement-id="ma-4.6_stmt" uuid="a22a6e94-0e12-47f5-9f07-eec50bac38e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="27cf107d-7d44-4480-bfdb-bb943b1c780b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a6866bf-c305-4ca9-88bd-461ed798de75" control-id="ma-5">
+    <implemented-requirement uuid="87aea603-cd1d-4f8f-bdba-d48f5344411c" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="6cc9c1a7-b3f3-4e91-8edb-5c6521acb275">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="555dc556-bba3-42e8-bd43-3d3d9b6f68f3">
+      <statement statement-id="ma-5_stmt.a" uuid="0e5e0116-5d08-442b-b42c-5bd8a7f6fdff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7a30174-580e-4087-9026-06b18bc07a76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="833ba901-e3d6-4aed-a018-2e7d5df75078">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a571c73c-a0ba-4bda-9603-396d1cc8f67d">
+      <statement statement-id="ma-5_stmt.b" uuid="9772139d-fd4c-418a-b7bb-1eb86d96c0b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e903203a-181e-4244-bbd9-00f6b730e88e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="5b22a0c6-1049-4802-9f7f-e438e0c9d3ea">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9bc0f46d-b7bf-4a9d-b2be-c257546d26aa">
+      <statement statement-id="ma-5_stmt.c" uuid="c183f370-501b-4f89-b541-8c349f2603f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd516f90-7eb6-43a6-a738-333a08f568cb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5753,18 +5753,18 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2df15424-5a34-40ca-aae4-b26c2382704a" control-id="ma-5.1">
+    <implemented-requirement uuid="6bd19e15-5977-4371-b020-0a1b73e4ee77" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="f7d4231a-b300-4f2c-8da3-599d3e25d2df">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="410a2c65-e11d-40e5-a52a-7fcf77bd5c51">
+      <statement statement-id="ma-5.1_stmt.a" uuid="6efc75bd-1995-4956-a7a6-f8b9441ca917">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf26008a-ffba-4bbf-91a4-4a841edecce7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
 citizens is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="ef62099f-684e-4361-890f-48fbaaa1bbe0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="eb11ae2c-f908-490e-b1dd-c024865dbbb4">
+      <statement statement-id="ma-5.1_stmt.b" uuid="f13ae1d9-6cef-4f5b-b42d-3e9b7fc55d64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3601f91b-d1db-4661-b309-affd6a7b63a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5773,10 +5773,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb3b5be6-92c2-4d9a-9428-97ab7f76c5d1" control-id="ma-6">
+    <implemented-requirement uuid="92524567-89f1-420e-a36d-8a0f9e70e4e2" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="9979028d-79d0-4126-ab97-a26f4b3fcc1d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c75d91d5-4899-432d-96d3-dcabdfc89ecb">
+      <statement statement-id="ma-6_stmt" uuid="13c5c4a9-5cd8-41b6-a32e-7d53ae01fd09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="525e2023-ea02-4cb1-b4c0-35a6e6a4d05b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization obtaining maintenance support and/or spare parts for
 organization-defined information system components within an organization-defined
@@ -5785,18 +5785,18 @@ of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2c5fd39-f55a-47cd-8c52-38aaab18ad70" control-id="mp-1">
+    <implemented-requirement uuid="aba94ad6-68f5-4410-b77d-4442e659c869" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="f54cc610-ef07-424e-b274-0ee14a52aa7a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4a901618-6221-4c33-ae04-22269cdfa31b">
+      <statement statement-id="mp-1_stmt.a" uuid="ae70b746-73d5-4cc1-b7d9-1c1425c563f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="fb5ebd1b-b48b-4c10-950b-b024a43c3c43">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d55a6393-da1c-4b46-97c9-27b650008025">
+      <statement statement-id="mp-1_stmt.b" uuid="9001b1b1-b946-4cbc-93aa-85d0e80b47c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5804,28 +5804,28 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32b280ac-3419-478e-bf13-e1938408a8ad" control-id="mp-2">
+    <implemented-requirement uuid="91730106-aecb-4b7f-97ae-54f8584ee6f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="aa83efee-f524-4cc5-80c6-33b9745ab20b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f8cbf1e8-e70e-4c25-b7ab-607f5cbfbb5a">
+      <statement statement-id="mp-2_stmt" uuid="eea31d1c-5a73-400d-afc9-be65544ec06b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c0cd5f9-db7d-4559-b2d0-8f3f2e7c01a8" control-id="mp-3">
+    <implemented-requirement uuid="9fb37b43-b174-4dc9-abed-cc660919b431" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="040adf11-296f-41c0-abe8-da39a2889ba7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5906c1e0-43a2-44a5-bd0a-577d7d837bbe">
+      <statement statement-id="mp-3_stmt.a" uuid="983f3fed-b8db-4b99-93d6-089028b950f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="f6674d26-9545-46cc-8ceb-327ea9ffff1c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d284b805-271a-4819-b919-41f8f31c59a5">
+      <statement statement-id="mp-3_stmt.b" uuid="7c06c13e-7049-41d2-8414-f7a3f49d662e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5833,18 +5833,18 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95cc7a50-f360-483d-ac36-ae6795f70a1f" control-id="mp-4">
+    <implemented-requirement uuid="e050ffab-48e6-474e-8aa7-743c0cae9ad0" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="0301f900-11df-42dc-bb43-c6b339f739b9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f899c400-f334-4c42-8486-8b0e4af87c0d">
+      <statement statement-id="mp-4_stmt.a" uuid="7a9dd7c8-e574-4881-aeb3-8526a42ca723">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="42a4144c-c3bf-4920-90bf-06652d8a72c2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d52e67c8-8a53-496f-8086-4c2e08761f6a">
+      <statement statement-id="mp-4_stmt.b" uuid="5012554b-48ca-4f6b-bf11-392e650a6f35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5852,34 +5852,34 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63b036ee-3755-4002-9968-5ebc51e3c6e2" control-id="mp-5">
+    <implemented-requirement uuid="5293ef06-ef10-4915-9a6b-7398fa6b52fa" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="8d3da49e-e6be-4cc0-a2f8-d4cb1465c2f9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4eb0f5f1-c98b-4043-ae79-9b5dc0479539">
+      <statement statement-id="mp-5_stmt.a" uuid="e2da40e4-96a2-4de8-86bb-9d8e550a162a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="3c63a0e7-a989-4fe0-8cfa-4ab2a4038381">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="38d7e839-12cf-442e-ae0a-d7299e8b2db4">
+      <statement statement-id="mp-5_stmt.b" uuid="f102e259-62c0-4b9b-852d-7c2a921a6fa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="cd66f399-ed22-41cb-8284-91370a0c3118">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="123bf5f3-9e30-4409-807a-b13ed0e15705">
+      <statement statement-id="mp-5_stmt.c" uuid="fd03c663-a259-4f0a-8ae1-71451a685f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="b4ec0879-a7e9-41d3-97f7-8a83542dd299">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8e6c70a5-344c-4c16-854d-b2bdbe8ceb84">
+      <statement statement-id="mp-5_stmt.d" uuid="e32304c6-ae95-44d8-aa24-7857f127c7d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5887,28 +5887,28 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="669bfaf2-d8c2-4a4e-9bbe-767966142a98" control-id="mp-5.4">
+    <implemented-requirement uuid="a10582c8-3aa5-42aa-95a1-b114422aabad" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="76342899-3752-43fb-a1c7-6b3d2b4e7d09">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d97da36c-9c3f-4395-a1da-652b842f24ed">
+      <statement statement-id="mp-5.4_stmt" uuid="f1c47367-a2aa-4ba0-9e87-b0c8eabe8923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a01f7381-e179-47e9-a0e9-9fb62127836d" control-id="mp-6">
+    <implemented-requirement uuid="e6cb05be-04da-42b8-bc61-e73a3184da68" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="7a336a42-f90f-4614-8184-bf0ac51f31f7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3d9e6ca5-156c-4b00-9e4b-a6ae451a0b29">
+      <statement statement-id="mp-6_stmt.a" uuid="7704ff74-71f0-4992-bb95-0fc05c1b457c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="608d4cc9-982f-4d57-9850-39d92feee7ca">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9cceedad-0673-4f8f-a80d-938b3798cf2b">
+      <statement statement-id="mp-6_stmt.b" uuid="4b4b52f2-28fb-4b50-b6e2-63aa0383bfaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5916,40 +5916,40 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0021b1a3-53b7-4ecb-bb30-195a00da3d9e" control-id="mp-6.1">
+    <implemented-requirement uuid="efb40e08-8ad9-4f14-afd0-32b41dc7f7d4" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="22de01e0-de1e-4e93-803a-80c9df119f8f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1a992a96-374b-4c73-b28c-73e9124d69b3">
+      <statement statement-id="mp-6.1_stmt" uuid="2713f4d7-b30d-48e9-9922-c98e9a987b3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ac0f0c7-67ba-452f-aa22-a3054af89bd7" control-id="mp-6.2">
+    <implemented-requirement uuid="19d5b1ef-4a99-4221-8802-ca284585ca11" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="86acb471-5d5a-46f7-b8e6-371912357b56">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8d225648-7121-4f2f-8600-793676a07f6b">
+      <statement statement-id="mp-6.2_stmt" uuid="b7efa870-c614-45c0-beb5-2f516baebb4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89dfa6d5-7353-4551-bacf-89d63e31eb21" control-id="mp-6.3">
+    <implemented-requirement uuid="d2f32d4d-3bd0-47ce-9730-6e0da7b6762d" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="9d54e692-088e-4e25-832b-7d2efb5b2e23">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="79f0386a-cf11-4276-a85c-e9b29a03a110">
+      <statement statement-id="mp-6.3_stmt" uuid="c82a6316-9fa7-446f-a338-03a86b60c282">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72c0c9ef-e26c-4e01-b47a-7b1b1289adc7" control-id="mp-7">
+    <implemented-requirement uuid="76b89418-dd30-47b0-b610-232d0779620a" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="6e2bf490-539d-44d9-b0fd-9bf7655eb3be">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="13c04ab1-698b-4581-ac1c-9c2b30e8fbf7">
+      <statement statement-id="mp-7_stmt" uuid="c9cb4913-199e-4777-9977-90b733398721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12bd854e-d12b-466e-9a25-c3588d772f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -5957,20 +5957,20 @@ Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c54f05a-aeb4-4597-99c2-bbc351f80ea0" control-id="mp-7.1">
+    <implemented-requirement uuid="05cb6921-4efe-4157-9da7-01bb4dbee1dc" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="f185ca80-56ed-4aaa-b98c-25d0b067ec57">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f4a847eb-8fb0-48dd-a23e-43f168c0641b">
+      <statement statement-id="mp-7.1_stmt" uuid="198189b2-294d-48ec-8eb3-c82910a87333">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63d2f642-b053-4b37-97a9-f0e63ed1a25d" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="2807e1ed-cd6c-4faa-bc77-15e43202d38e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="792e606c-3bcc-4c7f-a5c4-0320851273c7">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5979,8 +5979,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="979d9224-ad03-456a-8389-97d88a947e1e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fcced927-0f74-4f67-b98d-cb1eaeb60635">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5990,10 +5990,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d58d6d16-6f07-4feb-a844-47acab4fe385" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="7e681b90-b6bb-43a2-8cad-77ded3e39e50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1a780932-b64c-4d94-9f52-c0d2c26cd9a6">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -6003,8 +6003,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="0b68f185-fb34-4304-85c9-44b0b01741f4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9a4e1a9c-5e7f-4c79-a9da-a4a4044ef969">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -6012,8 +6012,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="42860824-a63f-4f01-ad56-3ef84859d6cd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="102b9bdc-99dc-4325-84f3-1e90e540b0fb">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -6022,8 +6022,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="dcbd0ab8-4387-46c1-a9eb-1277a71318b0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="06bab72d-11f2-48ac-b729-e9d9a941333c">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -6032,10 +6032,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8b2ab59-af84-48ba-a18e-11406823827b" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="a5b4867b-3df4-4180-ae56-2d96b582a2c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6ec159e2-182c-4142-a202-6cf539652127">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -6044,8 +6044,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="e47f2472-9f76-4cf5-a3a3-6397577a606f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="106827cf-8b58-463a-81f5-7389f661f80a">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -6053,8 +6053,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="26b4eda1-3d06-4757-9011-202805e5f576">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5c29579f-3b2c-4ea2-97c4-a6963c8622ff">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -6063,8 +6063,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="a2720187-f567-409b-906f-af4851424dda">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1611b3a1-d564-4a41-ba98-27218d5eecfc">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -6073,8 +6073,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="f049a5b8-382b-4b2a-ade8-c23ccea0e9d9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="61f723a5-56f7-40d6-9b47-e6457276bbcb">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -6082,8 +6082,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="f1b2cdbd-6d6c-42c4-88ba-8c4b4203f4b8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f1619eea-95bc-40cb-ae70-1a4817e8fee0">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -6092,8 +6092,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="2fc49298-7680-4e2f-92fd-ae8aebeb43cf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c1d85e2f-42b6-45b6-8b13-ac2fb6604353">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -6103,10 +6103,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c8950d9-450c-4a33-8157-b566ea241f74" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="8e693b93-0774-4c37-9a00-da01d9b78320">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="05e1e401-79cd-4b92-b1e3-6a522adbf159">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -6117,10 +6117,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6846eb87-dc9e-4209-a0df-aa5e5b1a3531" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="22561ec1-58cf-4fb3-9f95-ba094f2596ad">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="00e1572e-6060-4245-9fe1-db28d4d862a4">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -6131,10 +6131,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89b8654f-f41e-4dc8-9608-4c0f3ef5ee65" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="4bec72ec-e9f2-4866-a882-abff95e3a240">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3bdfbab9-db34-4e9e-9fb2-6b16aab4fb74">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -6144,10 +6144,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a04047f0-462b-45fc-9428-84c8c1b912d7" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="6badb8a3-18d4-490b-98a7-cbb30c1fbfcc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d35887ec-1f3e-430b-b08c-ba386bd802ae">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -6156,8 +6156,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="c4a62a48-f441-4492-b13e-f66de474fa80">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c2f8430a-badf-4d36-90c4-82a7b77a58c9">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -6167,8 +6167,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="7db7178d-75ea-4d80-a2e0-95cf27bcf177">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b5fb2813-cbc2-45a1-8dd7-88a016bea1c2">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -6178,10 +6178,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d217367d-0ac8-4eb6-a90e-09e46fa4a1c7" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="cc4c117d-7114-475b-89a2-a7f0747b0455">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ef545ddc-8f6f-4ffd-94c8-6360dc4f4224">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -6190,293 +6190,250 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08c5851b-27f2-477f-9168-523df8702da3" control-id="pe-6.4">
+    <implemented-requirement uuid="ee849f67-c412-42ae-a035-a472b4324f6f" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="113e1c51-f148-4126-bd44-0d5690ca35f6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="61304746-b1fa-4d5f-ac24-3573b357eb31">
+      <statement statement-id="pe-6.4_stmt" uuid="f01f44cd-126b-4ae4-818b-96964de0c8f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ee26458-6dfd-40e4-ae3b-817945f7aa14" control-id="pe-8">
+    <implemented-requirement uuid="be5e63d0-4c48-419f-b1eb-56e1eeb86002" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="c111bb44-d17f-42c8-b4e1-e3b9ad3578e6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ae2240af-96c2-46fc-93ea-0cce70d0688d">
+      <statement statement-id="pe-8_stmt.a" uuid="60ece47a-8333-4136-bcee-0734c6bc9c01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="6f1b43b0-4f74-42c9-a0f1-4b265748668f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c8c776fb-3b1a-47da-8e9d-dd9e49a553a1">
+      <statement statement-id="pe-8_stmt.b" uuid="280068ab-db1d-4d72-ae0a-03fafc30cdbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a98a49ce-d13a-4599-9679-74723f771548" control-id="pe-8.1">
+    <implemented-requirement uuid="13e7f3d6-b09f-452a-971a-7c371dcb1793" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="491a4e65-665d-46e2-96f3-e3149490328f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="effc809e-496e-433e-81b4-d990fe83ff81">
+      <statement statement-id="pe-8.1_stmt" uuid="a439451b-0693-4723-b463-b9d60d2dea0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf32bd89-4594-4512-86dc-7051ee265e7f" control-id="pe-9">
+    <implemented-requirement uuid="64951ba3-a1d6-4493-92b9-62998bedb132" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="50727249-e8c2-4bfd-8a49-a73eccf9180f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="002fe91d-7930-4476-b61f-4d649c6b9f2e">
+      <statement statement-id="pe-9_stmt" uuid="3c5750f5-ddfb-461f-b02f-7558992d0b63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cabe9b86-1d55-4be7-942e-1a2110361681" control-id="pe-10">
+    <implemented-requirement uuid="e3e97c41-4934-4351-9a72-f6544b0f29b3" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="939a1028-66ad-4f07-86b4-8fe90d13a1a6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4bbbe6d4-12cb-48ec-83be-a1ee3eb6eb8f">
+      <statement statement-id="pe-10_stmt.a" uuid="2fca9a05-980e-48b1-937d-8af177cf21b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="8deb3b41-79bc-493d-a817-3fdd2fc22a0f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="85ca79cd-213a-43f6-9d7f-19f5275adc00">
+      <statement statement-id="pe-10_stmt.b" uuid="1a3e16fb-1780-4316-9faa-16c6b8cfa596">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="6e4833d4-2e15-41f0-94f7-b1c477565a27">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7dc6cd8c-946b-42ca-9455-3d1a77e36128">
+      <statement statement-id="pe-10_stmt.c" uuid="2d3c89a8-5364-4d1d-80cb-11a8b0bf4470">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e64a707e-831a-4a48-acec-23cb3d3c0928" control-id="pe-11">
+    <implemented-requirement uuid="a6501d1e-c89b-49b0-aa76-246a01a3f399" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="07bc1187-99c6-4c2a-acce-d37f708d5d35">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1166adb4-3f22-467e-aa97-7936b20c9efc">
+      <statement statement-id="pe-11_stmt" uuid="6d26de0c-897e-4246-920a-94dcba8abb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4355c69-c047-457e-a39a-894f1dbbf942" control-id="pe-11.1">
+    <implemented-requirement uuid="bae0cdfb-84c6-4a84-a715-7710a04903d1" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="47818a6c-d58b-47fb-8245-07296563b430">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aa251c9c-c913-4141-bbac-acc5ffbbead6">
+      <statement statement-id="pe-11.1_stmt" uuid="40881c94-1868-4a2c-bb65-762fa629f13a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17ef15e0-c243-426d-9c68-ef03ba032745" control-id="pe-12">
+    <implemented-requirement uuid="027e9b57-2ee6-41e4-ad65-395483a08ede" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="41fa233f-b718-47ce-95b6-53ea8a7a3a7f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c1830351-ce03-4d8c-aaf8-d7325ebc4435">
+      <statement statement-id="pe-12_stmt" uuid="c0ee43af-659b-4222-a478-e26cf0209bd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4818cec-e089-4229-a0e4-9894ab31bf78" control-id="pe-13">
+    <implemented-requirement uuid="d2fc0a14-167b-4f40-8abd-16cb25ac7510" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="3d6e2191-6ba8-48a2-85fc-1bfdc9cb22ee">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af184f7c-b1bd-40fa-b6ea-b203a3077c4e">
+      <statement statement-id="pe-13_stmt" uuid="9c74e7b7-f0cd-4d18-8e72-9fb8bc120388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1b90734-6206-4b96-8aa0-38b6a3d3de7d" control-id="pe-13.1">
+    <implemented-requirement uuid="188ee57b-7c2b-48d7-8f06-d97c16f8026b" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="ffedecb2-76ba-4d7f-953e-904b8aeac494">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="518b3340-07e3-49b9-a4cb-9acacded2c99">
+      <statement statement-id="pe-13.1_stmt" uuid="58ed2621-6b57-4cc1-b8c5-ad440e3b76cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0fdbb59-2fdb-4018-a9ea-71d5f6a9192e" control-id="pe-13.2">
+    <implemented-requirement uuid="d7af410e-bbd5-4309-9ed3-52811d7d0a35" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="6d686b45-3856-4584-82b1-7197f1c8cb1a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b8e30cd5-6967-43dd-8d11-92de532ff5e0">
+      <statement statement-id="pe-13.2_stmt" uuid="54a5c536-db79-472b-9ec5-3b57ffea5125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b81c3f7f-df9f-4e90-91cc-41f9f41967eb" control-id="pe-13.3">
+    <implemented-requirement uuid="5e77bdfe-feb4-40eb-8540-9cacaa1b4761" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="ca011dfc-ba2e-45fc-ae25-a35d61e20fd7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="27875e01-fb04-44d9-9072-7814cffc6b0f">
+      <statement statement-id="pe-13.3_stmt" uuid="768bde08-904c-43be-9c7f-38ebb398f2dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75843996-8377-43e7-b35f-ab4721956796" control-id="pe-14">
+    <implemented-requirement uuid="c3247981-3141-4ca8-a197-66f96605c590" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="b42d1cbb-7621-402d-87b0-8fdec57a37c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9b41d323-89db-4ed3-807b-c0b9cbe93eca">
+      <statement statement-id="pe-14_stmt.a" uuid="da5e7fe4-059b-4812-8978-9ff93635078b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="4e1a673e-fc1b-40d4-834e-258ed496b5d8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d395c828-36e1-4974-8bb8-5f75cdcf9436">
+      <statement statement-id="pe-14_stmt.b" uuid="627443aa-6e05-457c-902c-be03161932de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdcae36f-e286-4094-897a-998334369911" control-id="pe-14.2">
+    <implemented-requirement uuid="049ef29a-95e2-4fdc-add2-e4c5acf8ba69" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="498c4c6c-25b1-48bd-b9d8-76de5f3216e4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d9a8746e-a3d4-459b-949c-d8c4739ca3ed">
+      <statement statement-id="pe-14.2_stmt" uuid="430af539-e9c1-4ec8-a54f-c6b6fc8aba87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d95a632-015b-4bd8-9df1-728cb7742c3d" control-id="pe-15">
+    <implemented-requirement uuid="e8adb6df-d83e-4c34-ab6d-ab53861166de" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="7210dc49-82b3-411e-9866-4acf791fc88b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="180fe36d-a67b-4f5a-b8dd-817bdc81c5cd">
+      <statement statement-id="pe-15_stmt" uuid="645c4bc3-9242-4439-a386-eedc593005dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c71afe5f-3e9e-4d29-9c99-7e910d2ed9bd" control-id="pe-15.1">
+    <implemented-requirement uuid="1cd5dbd7-af94-49a4-9540-27560ecb2428" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="9f6fb0a2-fe59-4695-808f-b862dfe28dfe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="66897d8d-dfe3-4602-b1b7-ac075b262688">
+      <statement statement-id="pe-15.1_stmt" uuid="65603282-7b67-4d1f-9612-97fb76a031e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecff040e-3192-4008-ae91-1bc33e7ba00d" control-id="pe-16">
+    <implemented-requirement uuid="21865d6e-01d9-4469-9a76-d11a53eeb03c" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="9a4caecd-bd23-4a52-9a5d-bf83f7472e8b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f068abe1-4adc-4633-9eaf-b18651f7b054">
+      <statement statement-id="pe-16_stmt" uuid="34f1d089-badb-4e0a-a76d-443fa1f19144">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5491c1c4-456f-4639-8a64-3b1f8f38b0f4" control-id="pe-17">
+    <implemented-requirement uuid="8e1c4b1b-ee67-4f39-aab0-44d256e218f2" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="a6a0ba05-79b2-4656-ad9e-8abf7a926388">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="196e4061-92d3-40be-a278-ff38765deb1f">
+      <statement statement-id="pe-17_stmt.a" uuid="edb010d7-e83e-46e2-8387-b8c87262fbd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="65660221-f1c5-467e-b8a3-c8bc1883474d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2acdb3b4-343c-464e-9141-0cc59d17c2f0">
+      <statement statement-id="pe-17_stmt.b" uuid="42b6a63c-ce3e-442c-aaf8-7f8ec2e1ea0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="e5026219-0b7d-4af1-bdb5-71c9043c19c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ed0c4c35-cbbd-460a-8142-22b46292be0f">
+      <statement statement-id="pe-17_stmt.c" uuid="10e34321-922d-498a-81cd-93c63c185229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfe875f3-a963-4243-815d-17c9a47d0765" control-id="pe-18">
+    <implemented-requirement uuid="c44231d1-926b-4ad8-9447-121e0db8a713" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="37cf8460-727d-4c72-82eb-7a45334a1cc2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1d172d9f-5f3e-44aa-9db2-f28008437d8d">
+      <statement statement-id="pe-18_stmt" uuid="216bee58-f771-4be3-ab10-b155e14ca939">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72f6fcc2-c259-47b5-a052-9deef363fb90" control-id="pl-1">
+    <implemented-requirement uuid="84980f61-ea2a-4dd1-9376-298aa584f387" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="3ba583ef-1c8a-4df3-b936-397499c50153">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8ed98e15-f567-411b-9de3-77f45cbcdbef">
+      <statement statement-id="pl-1_stmt.a" uuid="382f60d8-c7d8-4ea8-b887-3746baf8da24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="cdca2fff-3474-4f69-845d-4306142f58f2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7ed4da50-2a90-44cb-bf50-61c18ab52167">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="a1c6ea8d-976d-4438-b4d8-b51fcaf15a09" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="77999c47-7f89-4cd9-8939-edbbd8772abd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="61cb1392-6a69-4803-a9e9-43bf19b650da">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="a06e9d99-ba64-47de-81f2-e3a2303a2541">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0e8cc26d-19a7-40dc-9a75-66032f348308">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="7d936aba-2de1-494b-a6a3-950be084dd69">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1de85503-ff3f-4c65-8330-d688274253d0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="7cba6b27-ac3b-4f1c-ba18-fa73db27c788">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="20e0c950-d9bd-4f31-bf8f-37e29a0092ca">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="b4e08b23-1d1b-4aec-b4d2-7f620c2c5d21">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="37924530-3c63-4b21-b833-233843ec8ffe">
+      <statement statement-id="pl-1_stmt.b" uuid="baf019f2-5a26-4574-8b82-0084892b0836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -6484,10 +6441,53 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a673e97-d23a-4665-b375-0ee6c8d98411" control-id="pl-2.3">
+    <implemented-requirement uuid="b7012c99-7d97-4f34-8277-eebb08ad86d1" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="ed00f5db-2484-422d-bbae-fbfdb5a3ef0a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="63ce9c71-fbea-40e6-b11d-d71da2c03d84">
+      <statement statement-id="pl-2_stmt.a" uuid="8dca9505-1b6b-4ebc-bac1-1ed8021b7135">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="2fd6dab7-6837-44c7-bd51-a09128aba62e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d365ff4c-2321-4d03-b06d-2ff79db0d98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="3dcf454a-b8e0-468e-a875-949b94198f9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="a26940da-320e-4b28-b787-fe450c114570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ba4c0c42-c439-47f4-9a47-da0bbe193a31" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="6e9f7be6-ee75-48d8-b03a-909f181c8c2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -6495,34 +6495,34 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c3a2f7b-3849-49da-b315-f0a98ff4fa0e" control-id="pl-4">
+    <implemented-requirement uuid="cea646c8-94e0-4d09-a03b-bbd07071a4a6" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="3b0df00b-cf6c-42c5-9735-f33f0d401b19">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6f87a021-55f3-4598-8a66-8c04aa2889ad">
+      <statement statement-id="pl-4_stmt.a" uuid="880a0c86-f8b5-41d1-b61d-612794c15e5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="6c1e4e7f-a79e-457e-9da9-64783eacb2ef">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a26e1605-4ff9-4a89-a8f9-727aa3f7d44a">
+      <statement statement-id="pl-4_stmt.b" uuid="b4352941-8475-48e3-b6bb-b4937fdfdec9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="70dc1eb0-4285-4e59-8bd1-b46b6a671b40">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e842c06b-4fee-4ae0-84ec-f0c5b07d2260">
+      <statement statement-id="pl-4_stmt.c" uuid="ba9a5420-9b61-4fda-9a3e-6402d4e2751c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="6588a437-1e06-4dc7-a9c2-46d23728cb4e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f327f0cb-6a79-4726-bfb4-9afffc25cac7">
+      <statement statement-id="pl-4_stmt.d" uuid="1f709031-5728-48b0-b2d4-3457e63abf85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -6530,10 +6530,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af3fbb84-0360-4838-824b-2d2446316d89" control-id="pl-4.1">
+    <implemented-requirement uuid="5ee6af21-f5f7-4800-bb79-b8fadb0c9e04" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="2b6b36ca-c447-42b8-addb-09865afe6cfc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8b3af1d3-f88e-41ce-95df-474a3badada3">
+      <statement statement-id="pl-4.1_stmt" uuid="f5955a29-94f8-460b-a54c-e81940669b85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -6541,26 +6541,26 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fdc3805-5994-484c-aa3f-ec49cc254eed" control-id="pl-8">
+    <implemented-requirement uuid="71f516b3-5b86-4bad-a821-3c904d5d712a" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="083b79f5-d267-4616-9b33-feedf9d58b4e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dd9bd34f-afb1-4723-b7ae-0f9a5e6143cb">
+      <statement statement-id="pl-8_stmt.a" uuid="d205c3cb-453f-4a05-936e-7692a784f8a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="b9435590-4f5c-4633-85f2-c62f8d60dcbe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="32fcd03a-aeba-48f4-a6f1-21bf3ba9286f">
+      <statement statement-id="pl-8_stmt.b" uuid="fea79ea1-083d-492e-8a11-ac40132bb69a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="24c3ced6-9fa0-4794-a2f0-e1a1e4a64aa6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7a6c705d-2c16-404c-b9bb-6f9338717afa">
+      <statement statement-id="pl-8_stmt.c" uuid="29ceaa21-6f9f-4be7-bf5a-61356d2855b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -6568,10 +6568,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38866a3b-91dc-42c2-b0b0-da44f62e3cc8" control-id="ps-1">
+    <implemented-requirement uuid="0509732b-28ff-4dce-8534-4a8d553e31cf" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="6fcd35d8-cb62-4b0f-ad29-45f9f218f5ae">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c60af18c-fba4-45b1-b6c2-ac2ba90edb3c">
+      <statement statement-id="ps-1_stmt.a" uuid="8e69a681-7d8c-4c33-8fc1-09c277a7be63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6579,8 +6579,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="448d4b3b-8f18-499f-a14b-9c26b0261381">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="34e83a73-66bb-4016-9e10-d6c6349602ae">
+      <statement statement-id="ps-1_stmt.a.1" uuid="08da0a83-64e2-4d6a-bbe3-4b8639dbe4b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6588,8 +6588,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="4c477adb-103e-4dfe-af9d-bad618baf870">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="278bc18b-a4e5-4680-bac3-998838b5cf2d">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9086085f-9d70-467a-ab6e-a8c7971fc63f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6597,8 +6597,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="815a4cc3-5a6e-480e-95ff-f1f50f946d70">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e09d00c6-314a-4525-aaee-29ec927b78f5">
+      <statement statement-id="ps-1_stmt.b" uuid="d66da28b-8336-4182-87bd-83210fbd8a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cae01e9c-41dd-49da-bc48-41712538a5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -6606,8 +6606,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="05c8f67b-7bfd-4c7c-9a8c-345465811b9f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="43e57710-eb2a-48df-b12a-efca8a565208">
+      <statement statement-id="ps-1_stmt.b.1" uuid="a4c57ab6-c597-4bf2-a004-175baea1e318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6615,8 +6615,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="a93d4ce2-6f03-42b0-be07-51820d531528">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="77fd2be4-45be-4771-9aa1-d69d4bd4c93c">
+      <statement statement-id="ps-1_stmt.b.2" uuid="025d26bb-f914-46f3-89fa-5e193f0cb358">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6625,18 +6625,18 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11520777-2a75-400e-9228-46230189940d" control-id="ps-2">
+    <implemented-requirement uuid="87c32fdb-ceea-43e8-8e1b-c66a7cb24bd7" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="f23db213-990c-4aec-b97e-6c786dc9888e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="452e891f-381d-4b3f-a38f-8bb3f6e3d31b">
+      <statement statement-id="ps-2_stmt.a" uuid="d1ea0e64-8187-4df7-95a0-267fd3f13c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a53b3b50-3dab-4be8-a8fc-e1957dc68954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="aa37f493-84a7-418b-a201-e7d6743c000c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c48eaa5a-ef47-4bea-8571-10364d46f906">
+      <statement statement-id="ps-2_stmt.b" uuid="87a70bf1-bb3e-4225-ad9e-d884e7e43e34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c1603b6-e20d-4245-8cca-589dae4ea801">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -6644,8 +6644,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="1b11d0a5-b3b8-4b18-99c1-47d331205a3d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="957b848c-0a27-4060-96d1-b82405c24fe6">
+      <statement statement-id="ps-2_stmt.c" uuid="f54131c2-6d5c-4b74-b75a-e146a00e040d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b22c353e-755b-4530-baba-c62897c0596f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -6654,10 +6654,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18c5f53f-1fed-4b5a-a813-809e50fda67d" control-id="ps-3">
+    <implemented-requirement uuid="7e38a1d2-2160-48f4-944c-318362f4f233" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="19e201ea-39be-4ef7-9169-1e89d8aafb07">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f73d0714-4ff6-403b-aef8-82ac560a4aa9">
+      <statement statement-id="ps-3_stmt.a" uuid="8ef2de60-c9fc-4743-9abc-bc839c975948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43bf671-6676-410e-9ec7-ab761cf5dd0d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -6665,8 +6665,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="8412c9ef-6467-4119-be05-6d659fdfd648">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3883be5c-3d4a-4360-97bb-a3385c926a3c">
+      <statement statement-id="ps-3_stmt.b" uuid="4c0c480a-e013-43a0-bbbb-7457cf4ba5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4c2e15b-a2f8-4057-8132-53326f3f25ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -6677,10 +6677,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="baeb9dba-1ebe-400a-8b5b-adff6516124d" control-id="ps-3.3">
+    <implemented-requirement uuid="dd80c2c1-fcf5-47f3-a2a7-7786ca02b264" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="2b03212e-4b65-40ac-a68c-cc8e5b320a94">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4cb59b73-2419-4377-a7fb-6c33460acb9a">
+      <statement statement-id="ps-3.3_stmt.a" uuid="5357a4a4-af97-43b5-acf4-60ea83594215">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdf2024a-f885-4f05-94b4-246a58c4ac89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6690,8 +6690,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="6b754c74-777b-46e3-8e6c-7cff004e3828">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f5dd39b3-1a1f-4b53-b614-bf9e348d7e1b">
+      <statement statement-id="ps-3.3_stmt.b" uuid="d8cbd206-c7b6-4a81-82cd-0c25c586e079">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1af432e5-34ab-4653-96fa-b3d2434062ef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6702,10 +6702,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="389e6741-9ce7-4719-93f9-bf4258fe77b9" control-id="ps-4">
+    <implemented-requirement uuid="93d688d1-a188-4a6c-857b-5ff45ff8bd5a" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="4603e5d6-401f-4996-84f1-f29cddd949a3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="84b6e352-9497-4654-aeac-a834f582cda2">
+      <statement statement-id="ps-4_stmt.a" uuid="e8799de5-2c0e-44ed-b148-013e542d59b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33aeb54e-0472-45e8-89ec-ffd517fb4c90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -6714,8 +6714,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="f2a5674d-ae4f-4f83-80ac-99b993212995">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="490b0ccf-284c-4c33-a04c-22c9919b3648">
+      <statement statement-id="ps-4_stmt.b" uuid="9034e4f7-d40a-4dab-9e94-aee7ea990d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42366338-6bf5-413f-af17-1ba8bd0c9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -6724,8 +6724,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="3267ef9d-46a4-4381-9c72-6610a185405a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5fe6cede-69fc-41b1-a3ae-142d3d8bb3d0">
+      <statement statement-id="ps-4_stmt.c" uuid="b0106692-4c65-404a-aefe-774beadb5ab4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60b612-5b36-4216-b8fb-69e2b64a9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -6734,8 +6734,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="d352c2aa-d6fd-4b1b-8154-75bffde3bfba">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dc56b981-296b-4e09-9232-42059b09d6ba">
+      <statement statement-id="ps-4_stmt.d" uuid="a3a2bef0-9f94-4af3-ab52-fc4c4bd892f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3fecd8e-b4bd-4147-8b74-8c3b6faa2410">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -6744,8 +6744,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="69e24c3d-8b04-42c6-b0ec-d2b72165fe75">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="35723fe6-e000-4793-9153-c026b34f1be2">
+      <statement statement-id="ps-4_stmt.e" uuid="d1b7e6c8-a309-4603-bf7d-172dd9858328">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8598f4-dcae-4101-be62-59f0c60d27c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -6754,8 +6754,8 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="0cd3e4ed-f124-4b25-87b0-9856813ed98d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e37052c5-594a-4c6a-a540-96e6d41596c3">
+      <statement statement-id="ps-4_stmt.f" uuid="d9f86f5c-41ba-4235-bfa4-ee491660feab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e3fa770-31ec-412b-85e4-c42df7ec69d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -6765,10 +6765,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a09e493-38e0-44d8-b6b6-15e81943ff52" control-id="ps-4.2">
+    <implemented-requirement uuid="1d588a49-0d1d-4b90-b84a-5758f2ee8baf" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="0e9a5427-190d-4e5d-9dc4-1e584a48640f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ce3e6c30-e2fd-441c-b37c-fbb5a560d904">
+      <statement statement-id="ps-4.2_stmt" uuid="c5a36482-f37c-4c76-8407-b3008d54c749">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2a25526-7f8f-4e40-abbb-a4378e3add7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -6778,10 +6778,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f955bc9a-1576-42d1-95b9-3b2645549389" control-id="ps-5">
+    <implemented-requirement uuid="530189ae-e0b0-4489-817e-68545a85fcb8" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="b260a9f5-36a0-4010-aaa4-14fe70558109">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="df6c7efa-64f2-4373-acba-5d10e5f199a3">
+      <statement statement-id="ps-5_stmt.a" uuid="d60d9065-eed8-454a-b65e-387181feb780">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efe56d04-e15d-4bd6-b15a-0fec2acee727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -6791,8 +6791,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="41cc10c0-6198-4d85-b7c8-d5cfadc3b772">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="36eda307-9209-47f6-aaa7-2d9a40b5291b">
+      <statement statement-id="ps-5_stmt.b" uuid="b1c33cfc-5b1a-4c4a-9a1f-1b326d12b8bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="815501c8-e770-45c5-8421-cd2c1d2e1719">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -6801,8 +6801,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="557ffc97-92c7-4404-8b07-db2e545b5280">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="27193f48-33b7-436b-8035-d419e4041a0f">
+      <statement statement-id="ps-5_stmt.c" uuid="6ef767a9-8e24-4146-a8ba-a16178901e3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ef830a-c8b9-48d2-9f2f-22ffcbe98ccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6810,8 +6810,8 @@ or transfer are outside the scope of Red Hat Advanced Cluster Management for Kub
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="c70c4f51-da1e-4b65-a564-17b3beb92702">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d96cfaa8-4615-450d-8907-48c6896047e0">
+      <statement statement-id="ps-5_stmt.d" uuid="8fa717b1-6194-46de-b1c1-8e9efa7d9024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58a7d968-8b64-442c-8cf8-6a1fb6f14c8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6820,10 +6820,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b3e70eb-1e70-48db-8a2d-8aec2f22c639" control-id="ps-6">
+    <implemented-requirement uuid="55212855-6b55-4446-894f-e8075367debf" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="05e9eae8-98eb-4065-afdb-e4cf3f160f2b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="390dbf2e-ee4f-48f3-864b-35742b6cb09c">
+      <statement statement-id="ps-6_stmt.a" uuid="c0824464-d4c6-4217-9591-66c4979c214a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a87dde3-52c9-4aa1-b88a-5bf8a6716ff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -6831,8 +6831,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="68d464f4-2e3f-46bf-bcbc-5545904079cf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="223c7c2a-7022-4dd4-bce4-cee3d354e51a">
+      <statement statement-id="ps-6_stmt.b" uuid="5f685e28-9d6a-471d-938e-237e539dc978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a00138-2407-4695-b3e6-59fe0dc8f35c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -6840,8 +6840,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="c9a779a9-ea66-4743-b13e-6439a4a8abb7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="39545195-705c-4320-8fbb-04182d6a851e">
+      <statement statement-id="ps-6_stmt.c" uuid="be530178-263c-466a-9967-db94f8582011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6849,8 +6849,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="ccdb8c88-e8d9-4bf8-933f-51106036697a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9d181a53-d6e1-48cf-9294-504be4b4aa7d">
+      <statement statement-id="ps-6_stmt.c.1" uuid="a8f518ca-e021-4e41-a0e8-5b044f14a24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6858,8 +6858,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="67f7598c-18a9-4a88-a05d-09884c6ce12e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="02dc7d95-e0d6-4ec6-8e3d-e647c493bafb">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d966152f-c1d4-4295-8eb6-fadbc32edbfb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6868,10 +6868,10 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25fbddf0-5204-41f6-a06a-1d33b392c5e1" control-id="ps-7">
+    <implemented-requirement uuid="9e92f0ba-f452-431a-85a5-a74cd7c4bc96" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="0704bed7-df78-4cca-9719-d0578efea907">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c280172b-db9c-4c8b-b389-12952483e72e">
+      <statement statement-id="ps-7_stmt.a" uuid="947bc933-387a-4d5d-bc1d-548d44c0489e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d1193a2-7742-4c6b-b661-478eb2347bfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -6879,8 +6879,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="07f964fc-3989-41f3-a00a-1be2fcaea6c5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="489a16dc-3254-4ffd-ae14-b07383c15364">
+      <statement statement-id="ps-7_stmt.b" uuid="24b5dacf-7696-4efe-944c-6489e7ef86e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59e0633-2918-44a3-903e-4506e838ebcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -6888,16 +6888,16 @@ the organization are outside the scope of Red Hat Advanced Cluster Management fo
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="10f032f2-9352-4f77-81c5-7fc869786a5e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="467925b2-581c-4a2d-933f-b41ca7d9a37b">
+      <statement statement-id="ps-7_stmt.c" uuid="e5009a10-28cc-4309-9c3c-f7aa4fa88e19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c862fe2-ab9f-4e92-b685-7e9769b97ddc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="ba855c9a-1f9a-4740-a287-7667257ae54c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6481eb46-08c5-4b7e-bc18-0159ec2b49af">
+      <statement statement-id="ps-7_stmt.d" uuid="19524cc9-a1eb-4861-b73b-e596ec70eef4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5db9d0c1-73ad-4604-a0b5-124b1b0813d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -6908,8 +6908,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="19b193be-d10c-4d4a-930d-e8bcf0d69896">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="88f699b2-7248-4929-8a18-d12e46e4eb85">
+      <statement statement-id="ps-7_stmt.e" uuid="28eae6f7-79a1-481b-9044-61e2d75e108e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0fcff48-98f4-4c4e-894b-17089205806d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -6917,10 +6917,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fdbfaf0-b682-4d06-b3e9-128edf489ace" control-id="ps-8">
+    <implemented-requirement uuid="51daba9a-e441-4a8a-9788-d76c1c1587c4" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="a156eb58-f033-4e05-a9bd-a369a0649f93">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d889c009-3bf5-409a-b59e-35d33811c5d9">
+      <statement statement-id="ps-8_stmt.a" uuid="ae4c7e89-a6d2-4b61-8b0e-aabde6f59a4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0149ee0b-e7e3-4293-b9cb-889fbde710ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -6928,8 +6928,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="c9faf568-543e-4f43-862e-83e50db1c3a1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5d2c3471-2377-4d28-a25c-9308dd471bcf">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -6939,10 +6939,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9df714de-2acd-4493-b9d7-2b52c5172670" control-id="ra-1">
+    <implemented-requirement uuid="6216d434-a474-42af-a2be-87332323c39e" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="3a1f119d-f6e9-4f77-b5b2-677be0b14aa7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c2fef9a6-66f4-4a4a-b190-a6db7a7ab516">
+      <statement statement-id="ra-1_stmt.a" uuid="ba9a3d0a-1b84-474c-8589-1e19f8f59c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6950,8 +6950,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="892ef7d4-2df9-47fd-8b1c-e0f0b273ef5a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="19193588-44a3-4a8f-9902-34191158d96e">
+      <statement statement-id="ra-1_stmt.a.1" uuid="e8073210-6722-4f57-ba87-e52147b2afd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6959,8 +6959,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="65f51c20-2c21-427c-be2c-1091d8335743">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cea52166-5f46-4fe6-90e0-28295cd91fd9">
+      <statement statement-id="ra-1_stmt.a.2" uuid="cca51aed-cfbf-44cc-9053-c1d1f769ad2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6968,24 +6968,24 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="8bd4c5f8-358f-4bfb-9402-5745e7c7573d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="af61e9c2-3021-4022-b206-e79a1775bc97">
+      <statement statement-id="ra-1_stmt.b" uuid="41fcfe11-8e26-454f-8590-a33e35c48c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="93219409-d096-42f6-9045-7440e4a4f8a1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="25d1a89b-6c0d-4329-8822-d5671ebf2c97">
+      <statement statement-id="ra-1_stmt.b.1" uuid="6abad903-8168-4c9a-8415-b68e057853c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="92e9e144-cfda-4b37-9647-77587c1366f1">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bb80a161-ef70-40a7-ad30-18de39e73249">
+      <statement statement-id="ra-1_stmt.b.2" uuid="fc8da6e0-499d-4016-a8f8-fd4a5fc3c2c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6993,10 +6993,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c4dbdbc-7127-46b0-842b-644182bc4f36" control-id="ra-2">
+    <implemented-requirement uuid="5c418f41-5b8c-41e4-8aeb-04b1da9a75b1" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="60789286-f201-4fb8-a78f-5d961867263d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d0f51384-4529-48b0-9014-b962bbe9079f">
+      <statement statement-id="ra-2_stmt.a" uuid="29b82483-d484-4ae1-9bda-11410dc737ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b8ec53-c18d-49e9-8dfb-f9cdff739bba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -7005,8 +7005,8 @@ guidance, are outside the scope of Red Hat Advanced Cluster Management for Kuber
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="f02ae82d-cdd5-477e-aa5b-ca4c68040863">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5bcc8440-c762-4b00-87fc-e47c199bcfb2">
+      <statement statement-id="ra-2_stmt.b" uuid="d1ec18fb-30ba-4d31-8f13-2d53c896008f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8e73384-e452-4de5-8f4e-3904534bbd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -7014,8 +7014,8 @@ the information system are outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="e26fe468-27cc-4377-8a41-850c2e1db56b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4c0101d7-de28-4438-b508-94903a5d35f5">
+      <statement statement-id="ra-2_stmt.c" uuid="41bf5a9c-a005-4633-a11a-548dc6388d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bd08efa-7eda-4b5c-90bf-4212008e6d51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -7024,10 +7024,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c8a9321-a4f1-4917-94c4-fa98894f1d19" control-id="ra-3">
+    <implemented-requirement uuid="15b53a72-3910-4d35-a0a6-194aaa66d734" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="2ac24c4b-cdf5-4d1e-9cac-a18ab143aafb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="00ccf7b9-e194-4069-a044-511b1630d5f2">
+      <statement statement-id="ra-3_stmt.a" uuid="c158bdd6-f9d4-4807-ae30-105f4dbad6d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9e600a5-e75d-45be-a1b0-e134cc6ad299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -7037,8 +7037,8 @@ transmits, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="aa2f0e7c-fdd4-46f0-8e65-a56e25e78b15">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4934a0f4-9790-463e-b006-fb56e250438d">
+      <statement statement-id="ra-3_stmt.b" uuid="6d5266e5-0cf6-41a6-a5e5-19dc40a4104d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08a69f48-635e-4c35-9c57-abef65f44bac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -7046,24 +7046,24 @@ documents, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="570631c4-9fd3-4f5e-a205-d3422125d27c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b1b21250-35b0-4e42-9db4-0642506ac3ec">
+      <statement statement-id="ra-3_stmt.c" uuid="3a949ca5-03dd-4da1-abf3-4964fb2f19dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e0ed2c-75a5-4b3e-85fe-af7dd3c33564">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="198f0fc5-b1fb-4568-92ed-2d8fb565bd28">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e7f6f88a-f2b0-41ea-af9c-e93b0c1d40e4">
+      <statement statement-id="ra-3_stmt.d" uuid="800d36e2-ebdc-4451-8b7a-b55a5d1521e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b31c816-14ea-442d-8c78-f53fefe80486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="2a4da8dc-c4b9-4f98-a96b-50ec2cdbf26e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2545e6b6-6470-4f3a-b948-146fd11dfedd">
+      <statement statement-id="ra-3_stmt.e" uuid="666156ef-f85b-470d-aaf7-cf1a21d1f049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b4f59-53aa-4734-9668-258952461f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -7074,17 +7074,17 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="811d8832-912b-4dff-8cda-7d96cfbe0d13" control-id="ra-5">
+    <implemented-requirement uuid="be9e3ae6-ee6b-4aa5-8d4c-c1d3b608406b" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="8dcf7b24-97ef-4cd7-9e2e-170691f8b79e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e98043d-3fde-45e6-a665-fb4d7b3da7a9">
+      <statement statement-id="ra-5_stmt.a" uuid="dccb79ef-09ee-4efb-939a-24bc0487e826">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="9ef78252-00e5-4c45-86bc-307e7e7bc827">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1396851b-4600-43cd-84ac-0b92e9587c6b">
+      <statement statement-id="ra-5_stmt.b" uuid="a99daa29-24eb-4b9c-8f88-042f70a8ac2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8e77ad9-cca6-42d8-bffe-2f62a993929e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing vulnerability scanning tools and techniques that facilitate
 interoperability among tools and automate parts of the vulnerability management process by
@@ -7099,16 +7099,16 @@ Documentation on how to create a security policy can be viewed at:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="76ebfe8a-bac5-4910-a8f1-e8f780e6d78c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="332b3db4-bc73-4b75-8321-f2e3969a62bc">
+      <statement statement-id="ra-5_stmt.c" uuid="900fe8d3-5443-4c5b-95a3-c19be1492b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38c9ad0f-841e-4ea9-b823-df5705054e7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization analyzing vulnerability scan reports and results from security control
 assessments reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="9433c669-0f74-4291-9f2e-1fe9ba5f9192">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8104940e-1869-43ca-9c1a-3f0537c31adc">
+      <statement statement-id="ra-5_stmt.d" uuid="1efab40a-9b23-4e20-8ea5-804c56098eb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce90a18b-e7b0-46a1-bea5-e49a4ee539ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization remediating legitimate vulnerabilities organization-defined response
 times in accordance with an organizational assessment of risk reflects organizational
@@ -7122,8 +7122,8 @@ via a security policy. Documentation on how to create a security policy can be v
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="3856bfcc-21d8-4c70-bab5-6dfa38ef9a54">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1657a4d4-c25e-4378-a70d-0d28e561038a">
+      <statement statement-id="ra-5_stmt.e" uuid="37330ba6-07dc-4b51-8247-6cefa0718e1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9991d966-780d-4c2e-ac15-992b1775832a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -7134,10 +7134,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03f6bd7d-b99d-496a-b45f-a5079b17ab9a" control-id="ra-5.1">
+    <implemented-requirement uuid="b91bb912-26df-4bc5-a3ba-9a7a3f3cc9be" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="f277024f-bc33-427f-bcc7-8709460201ff">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="519fa925-c88a-4f59-80ea-5ee0d5cfdd9b">
+      <statement statement-id="ra-5.1_stmt" uuid="d7217a8b-c3d1-4c98-b71f-14bf8270f9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ccdc896-ee97-4175-a453-b287e3acbb8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization determining what information about the information system is discoverable
 by adversaries and subsequently takes organization-defined corrective actions against
@@ -7146,30 +7146,30 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3d0f3e5-8436-4bb0-88af-d25f073f0525" control-id="ra-5.2">
+    <implemented-requirement uuid="c6949a3c-43fb-4149-b748-fd3fc0fb31f1" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="e766c5e7-2b1c-4e5a-acf4-23e5d7b822f5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ed425a0d-5a1d-4f88-ae71-f15f0da38efa">
+      <statement statement-id="ra-5.2_stmt" uuid="30f80a77-17ec-4eac-9c5c-c9beb9de6e72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64989f8b-bbfd-499b-8fba-862ec6ca2426" control-id="ra-5.3">
+    <implemented-requirement uuid="1f68bff4-c369-44e2-9c46-d446299c2bb3" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="48c87d48-3a87-4e16-9560-ba9bce1519ac">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="44d58fa5-2434-46ad-975e-3928931644aa">
+      <statement statement-id="ra-5.3_stmt" uuid="b7c13b29-ed36-47cb-93fc-d90c28f1555e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="180c6d15-a51b-41a8-bec2-4391ff3f2e0c" control-id="ra-5.4">
+    <implemented-requirement uuid="5155f1c8-5bfa-44e0-9629-4e254e21f91e" control-id="ra-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.4_stmt" uuid="ae588f42-f82c-4ab4-92e4-842ed1285801">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6c4cf3d8-b7cc-451e-9da9-b39beb60f72b">
+      <statement statement-id="ra-5.4_stmt" uuid="f4fe56ce-5cb5-483e-b995-529e8f6c1f80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ccdc896-ee97-4175-a453-b287e3acbb8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization determining what information about the information system is discoverable
 by adversaries and subsequently takes organization-defined corrective actions against
@@ -7178,10 +7178,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af10e170-43f4-4f29-87d1-b4324a3cc4d1" control-id="ra-5.5">
+    <implemented-requirement uuid="50a2816c-9bb6-4852-b778-5a03733ed359" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="537a4644-259e-4f31-9db3-67ab5fb0eed2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="be3858a3-342f-4175-bd23-2e06fb54c1c9">
+      <statement statement-id="ra-5.5_stmt" uuid="97aaba5d-c60d-4e2d-b70d-c933884a873b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1700163-85db-4331-8fe1-7a7558eb110e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system implementing privileged access authorization to
 organization-identified information system components for selected organization-defined
@@ -7193,10 +7193,10 @@ layer to provide and implement privileged access.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9de99ace-8295-44bb-a0a5-89eed8e55f5d" control-id="ra-5.6">
+    <implemented-requirement uuid="20626d10-0b34-4ccb-aacb-b4a870726812" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="992a796a-928d-4849-8b90-789ba40b283d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b9c775bb-80cb-433d-be07-baec44d79291">
+      <statement statement-id="ra-5.6_stmt" uuid="209a6a02-16c0-468e-bb8f-dce319fbf58c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79fa25c0-40af-4bb4-8492-d2f0c50a1a9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing automated mechanisms to compare the results of vulnerability
 scans over time to determine trends in information system vulnerabilities is an
@@ -7205,10 +7205,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e63c7d5-edcc-4229-97ab-a2f879f9f3bd" control-id="ra-5.8">
+    <implemented-requirement uuid="4e055e52-d501-44f2-a717-138634b1c54b" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="e71c530e-f742-4b34-9560-9f774de3742d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8cbda2ff-640f-4ba1-9c1e-31aa720c1e70">
+      <statement statement-id="ra-5.8_stmt" uuid="2884be7a-4f0d-41d6-b00f-61f82e1b41d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="601da591-f584-4f91-83d7-ac2205cf1e83">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -7217,10 +7217,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="263e499b-f503-4b77-bc76-e523217ee551" control-id="ra-5.10">
+    <implemented-requirement uuid="3b6c5f4c-15ea-4501-8797-1ffcc5e853e2" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="39ca7a9d-e9c6-4946-b612-4b6745cd68d9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="65f0b547-a773-4749-adec-5e1494e4e283">
+      <statement statement-id="ra-5.10_stmt" uuid="ddb8cc4c-559a-4ecd-9dc7-dc1588eeb0df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad32f683-fa60-43ce-9376-33f089071373">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to correlate the output from vulnerability
 scanning tools to determine the presence of
@@ -7229,10 +7229,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c67884b9-ae69-4653-8aab-d0d1a8b5d64b" control-id="sa-1">
+    <implemented-requirement uuid="bef6edc6-6d64-47dd-8489-9a6e27d991c2" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="0c25d954-d3b7-4195-9ca4-68795b7ec62d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ac073485-0d5f-4ee9-bf7d-4db6d9d4ad39">
+      <statement statement-id="sa-1_stmt.a" uuid="028f5a03-49c2-4b53-a7cb-1785af084ad6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7240,8 +7240,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="582c8890-3c3a-4427-9712-c17433cdf3d7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8b3bd870-228e-45c0-b0ad-1198d8bc9c89">
+      <statement statement-id="sa-1_stmt.a.1" uuid="19b9b625-8a58-40a1-9e80-83cddeae90b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7249,8 +7249,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="f5632127-86e8-470a-ac7f-c8d5a8708e25">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d8b97ab6-57bf-4c5a-82b0-e4e398ffb2b7">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2797b025-1caf-4640-b133-b5e5762e2982">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7258,8 +7258,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="abae8324-2677-4e98-9f47-e6981cec9ed0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="26b75333-47af-486c-aca1-c133d55f2b68">
+      <statement statement-id="sa-1_stmt.b" uuid="d89d6bd3-82ec-4645-9fbf-fb91ecf0d243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7267,8 +7267,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="e80eb06f-73b8-465f-b8e5-46eea52c7d2c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a865c137-4e21-4407-87f9-4e19d9408e3e">
+      <statement statement-id="sa-1_stmt.b.1" uuid="c38432aa-2db4-4d9f-8b38-599675772d61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7276,8 +7276,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="498e53f8-0744-4b35-bc28-8e9f116465ca">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3b10ea9b-2b3d-40ee-8deb-be2564c47916">
+      <statement statement-id="sa-1_stmt.b.2" uuid="16876a68-d462-4e48-b51b-467eea24dab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7286,10 +7286,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d845797-f346-4671-8394-61d06067d0d4" control-id="sa-2">
+    <implemented-requirement uuid="6964c443-11d8-4230-8f68-28dd5588b94c" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="87db024d-9f69-4361-a119-3de20d599d55">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a0cf9e38-12f8-40f4-a937-5f7e5b348994">
+      <statement statement-id="sa-2_stmt.a" uuid="2e505351-afb0-46ec-829b-870b2fe94a7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d4b9c05-7564-44a9-aca9-fe352166d044">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -7297,8 +7297,8 @@ mission/business process planning are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="9bc67c74-b2d5-4912-8b09-72e7bffc62d8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b6a5b122-debc-42e9-9a13-777559678972">
+      <statement statement-id="sa-2_stmt.b" uuid="f8220ce3-ac39-4864-83f6-f270da1edf1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fc173ed-aac2-473c-80a3-14d8ca2254cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -7307,8 +7307,8 @@ process are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="7a25560f-4ebb-4117-aa69-777f2a7b3b20">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5be93857-2af8-4822-97a4-13d80110b64c">
+      <statement statement-id="sa-2_stmt.c" uuid="59308e73-1cc8-454a-af7f-74ef44846a9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d123c3-667e-4146-bf92-e0f3cd02938b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -7317,10 +7317,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c50e05b4-ba52-48c1-ae3a-c4b0f96d9983" control-id="sa-3">
+    <implemented-requirement uuid="499e5123-bce7-45ee-afd3-a841fc3c8b48" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="3bcca8a4-e6ed-426e-a211-39574f186e7d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="681919f5-4342-4698-a3b1-c8e15262424d">
+      <statement statement-id="sa-3_stmt.a" uuid="302872d8-fd9d-4cf2-82a0-7e28293d6287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce685a8-c7a8-40d5-bffb-a711ad980341">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -7328,8 +7328,8 @@ information security considerations are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="095eea1d-8c7c-4e9a-a52d-612735970501">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0ef5d7e4-049e-4e5f-9a1a-a7036862c00a">
+      <statement statement-id="sa-3_stmt.b" uuid="de1b1699-b5ca-4cc6-87f4-7897cf852320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb2cea8e-397e-4dc3-a732-f4ea8cc16dd3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development life cycle
@@ -7337,16 +7337,16 @@ are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="56dada32-bc9c-4a4f-a53a-46545bceb28e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c6525a91-d34e-4b49-a386-e052abf7fd67">
+      <statement statement-id="sa-3_stmt.c" uuid="2050dd81-a765-4f5c-862a-6a9f35db0df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8283839f-f8b4-4736-8ed0-acad14cd7419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="07959d7f-a062-4775-8548-b6410eb7ab9c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="59cc6273-e904-4edd-b25e-9cda7a4c82ee">
+      <statement statement-id="sa-3_stmt.d" uuid="c8b2952a-7d4b-4096-872c-d5056996ffab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bdaaf3-c06a-4ead-9455-181fc42ab80a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -7355,42 +7355,42 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46518a1b-6f3d-4b4c-99b5-5f39557dc0a1" control-id="sa-4">
+    <implemented-requirement uuid="13e16672-ab35-4283-b047-0ddfae0a55fe" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="f9ca15cb-722d-4234-ac61-46a2012d6294">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f77367c4-4969-4730-beaa-411007b52907">
+      <statement statement-id="sa-4_stmt.a" uuid="739264ec-e883-4320-8ec7-5254f35496b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="195535e5-eff2-4172-8801-5e8a786a670a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="5749bae2-79f5-488a-bc8e-37aaa319e14c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b5eedf67-7b2c-46b0-b80d-f083b11cbf80">
+      <statement statement-id="sa-4_stmt.b" uuid="9e4076e4-39dd-404c-bd0f-e6d62c71c87e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce554d87-8848-4201-bcbf-a5a3deb85d2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="a227b046-8447-4b96-9087-40604699dd17">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2800ab33-51a9-491e-bb4d-db8d3eba0d6d">
+      <statement statement-id="sa-4_stmt.c" uuid="d4f5a970-6c0e-486e-bb78-97e25c18eefa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7e96d96-886f-4a58-b249-fc5ceb5d3acb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="540cac26-e518-4471-9f03-e468141665e4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="21779c8e-3501-4bf8-8bf3-2daaa0194096">
+      <statement statement-id="sa-4_stmt.d" uuid="85d4555e-30c6-4760-b264-7532f915aee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="916f3e52-34a3-445b-9b72-d122deb0afd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="9ba19776-77d4-4bfa-a494-1ca7c51da552">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a99512d1-2278-490d-9066-dbd26f436cac">
+      <statement statement-id="sa-4_stmt.e" uuid="1655e4cb-492b-4bd3-9089-808252d01ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d76a02c8-d32b-4ce3-a42a-e90a15373882">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts are outside the
@@ -7398,8 +7398,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="2e559c70-7dd9-4b95-8b43-ff9eb7c150d6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="efc14947-4e20-4c11-98d7-12345b44f67a">
+      <statement statement-id="sa-4_stmt.f" uuid="1eda4fcd-e205-498b-8423-b9957105e1ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a9cc39f-3256-4309-b8de-7d81b133ebf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -7407,8 +7407,8 @@ intended to operate in acqusition contracts are outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="9cb9d36a-fb20-4fac-bb36-03369fc95b8f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e8df9a0-3d06-43f6-adca-b00d67a1ffe0">
+      <statement statement-id="sa-4_stmt.g" uuid="ef890e3b-8c9f-4c7b-b5a8-b8e58ca7133a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72b142ea-c5ba-4f92-9019-96802ebb8ab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in acqusition
 contracts are outside the scope of Red Hat Advanced Cluster Management
@@ -7416,30 +7416,30 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2124766a-c7dd-452b-9330-cb26de982b82" control-id="sa-4.1">
+    <implemented-requirement uuid="7321ca74-e148-474e-94f8-a04964c037fb" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="5840f904-495f-4ffa-8bf3-2855225a2863">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ff877bea-92bc-4210-902a-f40231542263">
+      <statement statement-id="sa-4.1_stmt" uuid="209afdb1-0dac-4e0f-b926-4d48ebfda0c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="396a34f2-b59d-4622-aaa7-317ddb07a610">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Official documentation is needed
 and is currently being worked.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1220bf44-57f2-4717-9cce-d054755bc115" control-id="sa-4.2">
+    <implemented-requirement uuid="3af98ccd-bcb3-4ec4-9ab5-f615bac80918" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="c7e3f4f1-d582-4e76-abf7-a7c063102afc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a4c4a972-926c-49c1-b88f-c48a3e413ed5">
+      <statement statement-id="sa-4.2_stmt" uuid="2d9c3962-f6cd-4ffc-8e4e-c3243a618897">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="396a34f2-b59d-4622-aaa7-317ddb07a610">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Official documentation is needed
 and is currently being worked.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd98ea80-4cde-456d-ade6-685e2037a5c5" control-id="sa-4.8">
+    <implemented-requirement uuid="295d7c7e-344a-4e07-bd3c-ad0317bf6ad5" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="46833808-72b5-45ba-968a-646fa6bf71ce">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7d1b4a46-8fa5-4063-876f-7792721ac20a">
+      <statement statement-id="sa-4.8_stmt" uuid="e7c6a491-2819-43b3-a2e5-1ff9f28377f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79d192da-1b65-4775-9d6e-edfc880fcb97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -7449,10 +7449,10 @@ https://issues.redhat.com/browse/ACM-455</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8f00ba9-13cf-42f9-ab94-aeff60e937b3" control-id="sa-4.9">
+    <implemented-requirement uuid="a7b398aa-7c24-4d88-8c0d-6cc942cb6d7c" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="85ee0c89-c46e-48ad-8bed-ae55cec457f8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e5294428-5c80-4b74-93ad-ad219b4877cb">
+      <statement statement-id="sa-4.9_stmt" uuid="8bbd2217-aa27-4acd-a9a3-cb000706c911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ab34981-0568-4c3e-be31-4775bb96c832">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -7462,10 +7462,10 @@ https://issues.redhat.com/browse/ACM-377</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de78582b-1781-411a-8d93-55b1f5011337" control-id="sa-4.10">
+    <implemented-requirement uuid="a196beaf-b45c-4b19-8e7f-624f1e5c3339" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="88d9ccb8-55a8-4d0a-8085-5e6fdec73397">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7d2e4be9-9d47-4ddd-9b78-7d2de358eff2">
+      <statement statement-id="sa-4.10_stmt" uuid="41eb5975-a78e-430f-bcb5-abb0606affc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7473,90 +7473,90 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8afa7a8d-22ce-4893-b75e-a2c550a93a39" control-id="sa-5">
+    <implemented-requirement uuid="f822cd1b-379a-4c7b-ad53-f1e217a85b04" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="39ec1a4b-5bbd-4d4a-bcb6-b2110fbdb310">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="15c3c7b4-4ce4-44fa-86d7-ce9333468f06">
+      <statement statement-id="sa-5_stmt.a" uuid="b9f58e21-0fd2-4c7b-b4aa-f12cb4ea7309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="f84d838a-9f20-46a4-9ece-e82730d9f2b0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="767d8633-c742-4680-b132-12a5339b073a">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5678be5a-2a7e-46ba-93e8-de0b2f9e96f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="50d8669c-df39-412f-9968-b877d5fc293f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e1dc5fba-cafd-4acf-aeea-542c239c9e26">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e301d484-e461-46a6-b65f-302944eeff34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="065f755c-dff0-4f8b-b41d-6734ae4578c0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fb4adc21-b66c-4a22-b868-0650026dd448">
+      <statement statement-id="sa-5_stmt.a.3" uuid="4b02dc91-2d21-455f-a6c9-095af0426668">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="847745b7-e2f4-48ad-9155-2671d5250c2c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7facb503-babf-4ac3-9560-9bfad968003d">
+      <statement statement-id="sa-5_stmt.b" uuid="16150061-93ad-48ca-a3bb-2d3c4da717fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="b84ebd71-8f4a-496b-801e-1d0fe2c95d1a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2e40e37f-bc96-4030-a2bd-303a6b9cd357">
+      <statement statement-id="sa-5_stmt.b.1" uuid="953f7b0b-89c7-4dad-9cef-3b651e3a402c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="be758859-4fe4-4191-9b1c-543d48cb3511">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="43051aa4-c2bc-4422-ae39-0885754daffc">
+      <statement statement-id="sa-5_stmt.b.2" uuid="3cab31bc-a5ab-4408-b629-7447386c8035">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="375f4d04-762f-4af5-86f4-5bdffe48421d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="accff102-1a5a-4e5c-87bb-b298211465ab">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2c38c229-d3a1-4a76-b42e-d2ef311f4e15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="781db275-53f3-471f-9472-821f3b6814c5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2d9e37e8-0b4b-428b-a420-d4e6a0726f17">
+      <statement statement-id="sa-5_stmt.c" uuid="c7bbf9bd-1f61-4dc4-8ee2-f0f3b230081b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="f7e9026a-d9d9-49a6-af71-a55bdeeeed63">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7f21f13e-edbe-4dee-8a5c-f4e390ad420e">
+      <statement statement-id="sa-5_stmt.d" uuid="e87a5f39-1929-43af-85fb-1ff5fd949fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="f0aefe72-865d-48b6-aae1-2d56c65717c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fd587230-f09d-463f-992c-951859d5abed">
+      <statement statement-id="sa-5_stmt.e" uuid="7cad6c74-4815-4ba7-94b0-dfae69599372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7564,10 +7564,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22d9dd24-ee6b-4ad4-8b77-8d6885475b9d" control-id="sa-8">
+    <implemented-requirement uuid="8c7e85b9-da64-4a6f-8ee7-c868643947d2" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="5970664d-bef4-4eb0-b0bf-e0fed3b46cb2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f2eee68c-6cdd-4032-a29f-7d6853de7d93">
+      <statement statement-id="sa-8_stmt" uuid="330eb71f-a093-4fbf-adff-60bd30b13dec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7575,26 +7575,26 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a57e004d-770c-48a5-a6c3-6abd7b260d0d" control-id="sa-9">
+    <implemented-requirement uuid="661d2ffc-26a5-4c69-b185-ff60e64b76d2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="250b7bf6-de94-4a4c-9a80-cf2af5ebf13a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="462267a1-3e2f-43e2-be47-abd4a1ccbb7b">
+      <statement statement-id="sa-9_stmt.a" uuid="5f542c78-8954-48e3-818d-25b5d1ae6d82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="118992ab-09c6-4c07-8869-49f12769b70b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b28e337a-1731-4b06-b132-53e018c8ac15">
+      <statement statement-id="sa-9_stmt.b" uuid="8cb867c1-31f2-4862-946c-378dd8307496">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="83ba7aec-652a-4884-9b27-1842f3d65bea">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ed1d1a5a-dbc6-4cfb-a74b-e18bfca1d123">
+      <statement statement-id="sa-9_stmt.c" uuid="a7025379-d99a-4313-aaa0-ad70d2e34718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7602,18 +7602,18 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6964ab3-def8-46df-99d6-1188cb6bfa66" control-id="sa-9.1">
+    <implemented-requirement uuid="d374372a-c466-4530-b2df-cfe59d66e943" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="3a65d92d-ed7e-4d83-96bc-e505950b4076">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="77ab5ae9-3685-4ce3-bf6c-981635fded67">
+      <statement statement-id="sa-9.1_stmt.a" uuid="a13cf2d6-1e4f-4d6c-a246-5539b67d3d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="6646892a-e7d4-4cbb-a09d-7896239d7517">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="69922b12-cdd1-4810-b177-3b5712ae5d17">
+      <statement statement-id="sa-9.1_stmt.b" uuid="f79f60ba-031e-4b6f-a533-244df1db8001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7621,10 +7621,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6dbde981-8ffb-4a7d-895c-f80bc1dc73cd" control-id="sa-9.2">
+    <implemented-requirement uuid="05cca186-4c93-4554-b38a-cb0455cac705" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="e3842ac3-3d78-4f64-84c5-d9dcc323e534">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0b9ba7d5-0197-4934-9574-8d07de61ceca">
+      <statement statement-id="sa-9.2_stmt" uuid="e6e126af-e9ae-4ff8-a97f-410c9d6ca2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7632,10 +7632,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03b08bc1-4592-49ff-96b0-0beb60e163ec" control-id="sa-9.4">
+    <implemented-requirement uuid="2b246686-ca40-4e18-8a90-0ab9d8241c26" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="a908ce4f-75c8-4d99-96e7-256fe9e19c16">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="92ac1800-64d7-49c4-8a7d-d1c12c930b46">
+      <statement statement-id="sa-9.4_stmt" uuid="f23f3eb6-2991-470d-bbfe-0e04cada3f50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7643,10 +7643,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e08eedcf-2fd7-4e34-a281-2761b67969f0" control-id="sa-9.5">
+    <implemented-requirement uuid="39c0c307-c6cc-489f-b3b1-e8fab2aabf04" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="abe16851-dbcc-4f82-a888-9654cba14202">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="714ecd81-f00e-408b-a24a-89847c5d6694">
+      <statement statement-id="sa-9.5_stmt" uuid="55f4568c-cd0c-44f9-abf9-e77ace1e5a71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7654,10 +7654,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c743ecb-fe87-4cd1-9063-8807b2f6cd35" control-id="sa-10">
+    <implemented-requirement uuid="7cbf2bd9-a9eb-40af-b1e0-a1585a7a4bca" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="0cb6d9cb-60bf-4bd5-b4c5-61a18644808e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="1f6b1380-7042-40c2-917a-0061f62448b7">
+      <statement statement-id="sa-10_stmt.a" uuid="fd9e8657-5a44-45f4-ab60-93aaab932264">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="088b458a-7d1f-4ed0-8d97-62d27cf13c5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -7665,8 +7665,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="43ac6372-e2a7-4c55-8b41-68885d39ebef">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6477f54e-349b-4905-b242-0b67b7af03df">
+      <statement statement-id="sa-10_stmt.b" uuid="46568e54-403e-4201-9a03-6fe10dd5ccff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cdd8f10-0af9-4344-b12c-fca87995ad08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -7674,8 +7674,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="0956f178-5084-418e-9584-e4d322b5fc3e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a92e5132-e9a9-481c-8d87-cde5127552d2">
+      <statement statement-id="sa-10_stmt.c" uuid="b59f2c8f-a5aa-4444-9931-76f6979b7575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b02aec24-7c7c-44f1-84b0-dec1cf004fab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -7683,8 +7683,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="a922aeea-6805-46e6-9c0f-de7ac26eb3a9">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9c24e2f6-06e1-4f22-b19f-0ad5e7e22ad8">
+      <statement statement-id="sa-10_stmt.d" uuid="5057677b-e07c-42de-a498-e47de857c621">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bd4914a-69ad-4e12-886c-71a3999dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -7692,8 +7692,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="288507d5-57af-4500-a95b-45d217b0e058">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="65b5f3d6-bf05-4530-bece-fe0b40fa3a5e">
+      <statement statement-id="sa-10_stmt.e" uuid="a4af5b56-db83-48c0-9e07-ee41c95827e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abad8380-8fa7-4f57-bd9d-8fa81ad7e349">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -7702,10 +7702,10 @@ https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88ce4bd2-5730-43d6-a67a-864575b3858d" control-id="sa-10.1">
+    <implemented-requirement uuid="7e811e3c-bc47-4f24-b66f-9a08fb53fc60" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="7092c685-383c-493a-af05-685a5ac686cf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b4ab8270-fffb-4e2e-9afa-98370ac44f6d">
+      <statement statement-id="sa-10.1_stmt" uuid="4c7fdda1-0519-49dd-9c12-b944c6d0553a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7713,10 +7713,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee336313-2c01-4c50-8dc0-a8b8e9c0915a" control-id="sa-11">
+    <implemented-requirement uuid="4ba90207-b468-4f32-8ca2-ab7a72426bb4" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="cf01e189-6110-4016-9683-edea0b347ace">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="62634e1b-0492-4e22-a6de-09d54c329b8d">
+      <statement statement-id="sa-11_stmt.a" uuid="126b3d5b-7f8f-4d48-8ee7-89a1acd113db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78869988-a5b4-42b2-aaa5-6f9d6c1f8fb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -7724,8 +7724,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="69fa255b-1a52-4a39-8183-77a9dcdd2be5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b176d555-07e5-4a1e-83c6-2c6dd715a878">
+      <statement statement-id="sa-11_stmt.b" uuid="f70ac29e-3b5b-4a9e-93c1-128a941c32b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa0f19a7-52ad-40b8-8ebe-75ae3ddca053">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -7733,8 +7733,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="29fdaaf2-3ba9-439d-8b9a-e7061e99205d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="699fd792-afe8-4aee-bdbf-3578f7efba38">
+      <statement statement-id="sa-11_stmt.c" uuid="2b88980e-09bc-4ec4-ac6f-5ec1cff4324b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04309885-08c4-431f-9715-4483a8d4700d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -7742,8 +7742,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="82d1539a-d68e-4e32-93ee-a592ae16b83d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2cae036a-f3bd-4228-9633-b9d2c279f010">
+      <statement statement-id="sa-11_stmt.d" uuid="e09cedf6-d5c6-4312-9dd6-f9af55e3f857">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fb3eeb2-af52-4205-ba3c-8b021a4039ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -7751,8 +7751,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="2682b619-b420-401e-8844-ac77ce6a7f7a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f79c3c4f-2854-4c4d-9d75-82e3e82ccf2f">
+      <statement statement-id="sa-11_stmt.e" uuid="844d2ca3-7f60-4eeb-a114-f85a0893694f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dc70364-a195-45e9-a3dd-6fd90aa3d069">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7761,10 +7761,10 @@ https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5719637-543f-4aaf-9162-2443c5fb4e4a" control-id="sa-11.1">
+    <implemented-requirement uuid="1688c6c8-e006-4864-b472-f2107ad16193" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="c245ad41-8317-43b0-86e8-dc2fdf58f64d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="aed141c5-276d-40c0-9ac1-c7cd029fe991">
+      <statement statement-id="sa-11.1_stmt" uuid="688c07be-68f8-4067-a0ab-853e5f5cabd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2611b8a-495c-40ec-a6fa-5b0e1a65ce2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -7774,10 +7774,10 @@ https://issues.redhat.com/browse/ACM-459</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a8583c0-a9e2-41a3-9f62-005f1acbc8a7" control-id="sa-11.2">
+    <implemented-requirement uuid="631e878f-0cde-4d74-8e2b-ac56c1ff1605" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="69586d2f-b6f1-4878-b565-122fc14a6acc">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9271b048-9426-4a39-adb0-97d4b62756aa">
+      <statement statement-id="sa-11.2_stmt" uuid="b9a3c176-c156-4b7e-af54-b446cc227cf3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d8a7757e-bd17-47f8-9d8d-b83628ccfa5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7786,10 +7786,10 @@ https://issues.redhat.com/browse/ACM-460</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="253a2e12-9460-4f2a-a0a1-fb88c5c85c30" control-id="sa-11.8">
+    <implemented-requirement uuid="b456393a-a4f3-405f-aaeb-8b4ca8c73c4f" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="df9011a0-173d-42d8-b6ef-ec9b25ded7ff">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="43a5d484-2f58-4614-880a-da71d4bf353f">
+      <statement statement-id="sa-11.8_stmt" uuid="3f6b4669-9832-41ad-939e-8187217d66a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="926f69f0-f998-46da-87bd-ce533f93f463">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -7799,10 +7799,10 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f2de983-33ad-415b-9542-2be403182c95" control-id="sa-12">
+    <implemented-requirement uuid="72ada5e9-6cab-4d70-b4f7-394d38e211e6" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="b9ed9914-48c7-4bdf-a87f-25e7e5d8d8f4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="94dc89cf-89e4-45f0-a631-c02232232a40">
+      <statement statement-id="sa-12_stmt" uuid="be09f38a-98eb-4bbe-bd7d-b8a0b1ac9ead">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05d30f08-26ee-4210-aa0f-5055c6661d57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-12 is planned. Progress
 can be tracked at:
@@ -7811,10 +7811,10 @@ https://issues.redhat.com/browse/ACM-406</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="410aad10-c939-4add-acad-591698631d18" control-id="sa-15">
+    <implemented-requirement uuid="e10bebc3-3d91-48fc-bef8-658e61379b36" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="b03ba3cb-7434-454d-96a2-c169437c7205">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d5897feb-102e-44a5-8b78-01de3ca26f94">
+      <statement statement-id="sa-15_stmt.a" uuid="8f3d8c38-e16e-4d8f-abed-ea26df0cd3c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b8b9243-4fa5-47c3-b0f7-e1754521fca2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a) is planned. Progress
 can be tracked at:
@@ -7822,8 +7822,8 @@ can be tracked at:
 https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.1" uuid="5f7463b9-5aff-4095-942c-bddac349adfe">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b122ae6f-9dd5-4270-9207-4ea41ac913a4">
+      <statement statement-id="sa-15_stmt.a.1" uuid="f61653c9-e9ca-4986-ad4b-564a7f4271f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff6d6a5b-f6e3-4eab-9a04-4e4c889c218f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(1) is planned. Progress
 can be tracked at:
@@ -7831,8 +7831,8 @@ can be tracked at:
 https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.2" uuid="567b2c5a-03c4-4a73-9c4f-6b96f4cfa411">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="49de0452-b69b-40d3-a313-8fa6b269837b">
+      <statement statement-id="sa-15_stmt.a.2" uuid="c6d3d76f-8681-4d50-ace6-5308ba8a4e13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8b2bbf8f-2108-44f3-aa21-e0869769c6ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(2) is planned. Progress
 can be tracked at:
@@ -7840,8 +7840,8 @@ can be tracked at:
 https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.3" uuid="9c4303b7-3ac9-4752-ad3c-a151e229bf29">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="42e517c2-2b77-46ca-8778-80ecb280a204">
+      <statement statement-id="sa-15_stmt.a.3" uuid="cfb18848-08ea-41fb-9a0d-a4f137133d44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1a2d021-97ac-488a-83db-62c68132175d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(3) is planned. Progress
 can be tracked at:
@@ -7849,8 +7849,8 @@ can be tracked at:
 https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.4" uuid="7e95c298-295b-4712-a897-99c583b0d94b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="13d16b6b-eeb7-462e-805c-1e34914aed8a">
+      <statement statement-id="sa-15_stmt.a.4" uuid="e6076c1b-b94d-4c45-9b9b-a763fec4fa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6269a8b1-5f3e-4e7e-89b6-d22bf343aafb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(4) is planned. Progress
 can be tracked at:
@@ -7858,8 +7858,8 @@ can be tracked at:
 https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="cf481976-10f5-49f4-b834-c30b91f29a83">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="721af5be-7d6d-4a61-b636-dd20dd56ad1f">
+      <statement statement-id="sa-15_stmt.b" uuid="6956d3e7-1658-4c03-89b8-6030f7775f49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f0dc4d0-f504-4d2e-8e84-674255e3f1f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(b) is planned. Progress
 can be tracked at:
@@ -7868,10 +7868,10 @@ https://issues.redhat.com/browse/TBD</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="106c67cc-979d-4c4f-9790-98b69e0f8de6" control-id="sa-16">
+    <implemented-requirement uuid="80558024-119b-4d3c-a4ca-1d9b123d1993" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="d4c726a9-1e31-41c6-8bb4-76767f73a645">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e89abc74-64e2-4eda-8b73-29363cdce921">
+      <statement statement-id="sa-16_stmt" uuid="db538c68-aa9d-4e6e-8c99-b0e3dd1cc9a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -7879,10 +7879,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e14ea20d-ce8c-41b9-bd47-6848cd0ae620" control-id="sa-17">
+    <implemented-requirement uuid="247769d1-0b58-451c-9a1a-411e8bb0a1e6" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="6d8fbcd5-af65-4015-b13a-46c5dabee36f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="84991fd3-3002-4147-b713-a2c60c846575">
+      <statement statement-id="sa-17_stmt.a" uuid="b5297ac1-af95-468d-aff4-08548366bdff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bf0378c-14ea-43a9-b4ff-b08b20a367ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(a) is planned. Progress
 can be tracked at:
@@ -7890,8 +7890,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-383</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="c07c977e-c533-4103-904e-43be4ed71ff8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="33aa8b49-a400-4164-9714-9140aac6b126">
+      <statement statement-id="sa-17_stmt.b" uuid="3c6095d2-0010-4e6a-98ce-bf3f3c826fd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f239e915-255e-442f-a852-6443a04de25a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(b) is planned. Progress
 can be tracked at:
@@ -7899,8 +7899,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-383</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.c" uuid="c7dd5c89-2888-4447-a097-d80acc8db56b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="353cc412-593b-4130-a607-1c2ee921fd03">
+      <statement statement-id="sa-17_stmt.c" uuid="98e59339-4084-40c0-a1be-7de2f9dee2de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a336b6f1-bf76-4211-9522-feaad5d0bd92">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(c) is planned. Progress
 can be tracked at:
@@ -7909,55 +7909,55 @@ https://issues.redhat.com/browse/ACM-383</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a9b7168-a849-442f-a63c-29b6e67698d7" control-id="sc-1">
+    <implemented-requirement uuid="063e4e11-4214-4e9a-a375-4796714c910b" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="595efb68-72f6-4dad-810c-ef54e632140b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e60b7253-f7ac-4db6-a638-fe6b47b505e7">
+      <statement statement-id="sc-1_stmt.a" uuid="a12a93f1-5b0b-4786-aa28-143f30eb38d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.1" uuid="3cf94d68-8c2c-405f-9eca-951345e1879e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ba9f0938-81f3-47f7-b428-eb5fd38b11fd">
+      <statement statement-id="sc-1_stmt.a.1" uuid="45a41e0c-33f5-42c9-beb9-74f9f76e5038">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.2" uuid="90d1b7e6-091a-45c4-99db-2af4e0e3c7e5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="55fa21bc-4e5d-403a-b946-4cddb5ca6d6e">
+      <statement statement-id="sc-1_stmt.a.2" uuid="e7cf378c-c4c8-4a51-91e2-dde7481422aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="6140c477-76b7-4a1b-b160-f7449d749e74">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9e2f098b-f214-4190-97f7-e8b724dfd362">
+      <statement statement-id="sc-1_stmt.b" uuid="11034f66-c864-479c-9204-78d1cc94bf09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.1" uuid="412571bb-db84-4ea4-ae23-18f18dbab3fd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5404b0ca-ea59-464a-a748-5bd9f85e2dcf">
+      <statement statement-id="sc-1_stmt.b.1" uuid="af7bc38e-b9c7-43e2-8eed-e0196d0fa0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.2" uuid="81e5ad9d-d562-4cd6-a7a3-3326d76996f6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0b91b162-73b8-40ea-a66f-bced40a1b63c">
+      <statement statement-id="sc-1_stmt.b.2" uuid="254e5f5f-0634-4de1-b144-7021e0e88822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af47a842-26f5-4b09-88aa-d2477e876e64" control-id="sc-2">
+    <implemented-requirement uuid="059e4c90-bd86-4140-bf09-2d97a146ec61" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="287062e5-6675-461a-85a5-a5f5f1ed76bb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="470e148b-18ab-462f-b89e-c88cde49bbaf">
+      <statement statement-id="sc-2_stmt" uuid="36052b94-cf92-4613-a11f-cd2f24b72a52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ceb6221c-0fff-4bc4-bb3b-4b812d3e884d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -7966,20 +7966,20 @@ and management functionality access is separated.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b878137-9343-4053-a101-029d8b0c598d" control-id="sc-3">
+    <implemented-requirement uuid="691dd453-eff1-42f8-9216-8ae466af1c75" control-id="sc-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-3_stmt" uuid="67c0c478-0f4a-4c1b-9b2c-fa0338df8ac8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="77830841-ff44-476f-81c9-b4b7f1e44f37">
+      <statement statement-id="sc-3_stmt" uuid="c1be3faf-0da4-4cc7-94d9-149933901346">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6583cca-aae6-4c56-a80f-c63b54983643" control-id="sc-4">
+    <implemented-requirement uuid="2dfcfe4c-f6a9-499d-bb43-75cd582bdd9b" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="4bf58101-bdfc-48d1-a223-f024cdfade53">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="86c462cb-6894-4a86-85e7-846f65b9ce53">
+      <statement statement-id="sc-4_stmt" uuid="8b093930-76e7-4b8e-8f0c-9bec74a320bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10d1ee8e-592b-46d5-9ef1-b1c0e098d576">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -7994,10 +7994,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="931a70fc-6729-42a3-91c9-d974c7147316" control-id="sc-5">
+    <implemented-requirement uuid="5b576bcb-c919-40fd-bb67-5821d10a7345" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="c9c49064-b529-4bd3-849f-3147cb95a8af">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e9fd0357-a0ae-4cdc-942d-ab18d85d46ec">
+      <statement statement-id="sc-5_stmt" uuid="e548b1c4-6c2d-4cfe-bb0e-38075f414e38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2b1b6a-92b3-4d83-aca4-3e0256656908">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8006,10 +8006,10 @@ https://issues.redhat.com/browse/ACM-384</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00634275-0fc7-4204-9ab3-89d2ff336453" control-id="sc-6">
+    <implemented-requirement uuid="eaaa0023-3b4d-47a2-b4eb-563d4b1e4864" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="bc3bf59d-369d-4bd0-8773-ce91d62cfd31">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ac5b0fee-6b73-49d4-b7fd-25673110fb75">
+      <statement statement-id="sc-6_stmt" uuid="65c95447-d9f2-43c8-89d8-e28dcb5b2293">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad52e261-46a9-4e0b-8d8f-4b805a9cd3aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes provides by default
 resource allocation.
@@ -8021,10 +8021,10 @@ https://issues.redhat.com/browse/ACM-491</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3db1c622-1444-4650-add4-6d50d8fbba35" control-id="sc-7">
+    <implemented-requirement uuid="56f23e97-1252-4185-aaff-741dcf403498" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="e1d3b2ac-203e-465b-b562-08bdd6d624c5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4fa9dc6f-afed-4f40-b10f-2937db010951">
+      <statement statement-id="sc-7_stmt.a" uuid="13502385-9466-448b-9d7e-fc2841c74e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de4b5a8f-71f7-41e8-a400-6ed93c1e6851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring and controlling communications at the external boundary of
 the system and at key internal boundaries within the system is outside
@@ -8032,8 +8032,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="63919d11-ff24-4a79-92eb-9555e34a1aa6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e46a54ab-3225-4e18-ae7e-6a0f494138cb">
+      <statement statement-id="sc-7_stmt.b" uuid="87f66c85-c155-43f5-87dd-579923be77bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23fbdb9b-c426-4f48-a8cf-4b13cde82e04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing subnetworks for publicly accessible system components that
 are either physically or logically separated from internal
@@ -8041,8 +8041,8 @@ organizational networks is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="9394cca0-9a1a-470a-968f-a916ed5e9bdb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b8156973-60bd-499e-8ae3-5622ea37011f">
+      <statement statement-id="sc-7_stmt.c" uuid="67a90d86-423a-4b5d-ac1a-13bec42b5b4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1301a0a-a911-43d5-86f8-94058c539d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Connecting to external networks or information systems only through
 managed interfaces consisting of boundary protection devices arranged in
@@ -8052,10 +8052,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74f04255-4198-4a00-ba46-190d5d24bbd0" control-id="sc-7.3">
+    <implemented-requirement uuid="615a5a86-f1fd-44b2-b001-ebf3fcbc9f2c" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="5f1bd6da-6638-4709-a604-f15da2322ee5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a05035e1-c20f-4cc3-b7be-ac4e9e2ef501">
+      <statement statement-id="sc-7.3_stmt" uuid="ba9923da-e4dd-43b2-a873-91b818bb5f66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5b6b357-2cd2-494e-a99c-23ceb5a7779f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -8068,10 +8068,10 @@ https://issues.redhat.com/browse/ACM-385</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62b28d3e-2732-41c2-b22c-c11201f3b729" control-id="sc-7.4">
+    <implemented-requirement uuid="a882084f-2782-44f6-b805-2d45a77f29df" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="44180aab-16d5-42d2-8bc8-130c765a526c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3ea729a9-1795-47a8-af34-8a43f782e6de">
+      <statement statement-id="sc-7.4_stmt.a" uuid="0cb84731-f9a9-43f0-b0f9-6a75c4ab103b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7edac91c-20b7-40b4-aa71-16ee1b3d8e53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication
 service is addressed at the network infrastructure layer and is an
@@ -8079,8 +8079,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="ab4e79f3-12ed-4ff1-92d7-206088dec926">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7bd846d4-3892-4bf9-b598-4c83d6204f44">
+      <statement statement-id="sc-7.4_stmt.b" uuid="49f59666-aa21-47f8-b72d-2b4e9a7c7af0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38feef40-0d21-467c-ab25-d63893b608a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside
@@ -8089,8 +8089,8 @@ configuration and is typically handled at the network infrastructure
 layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="63c208d6-c494-4320-8afc-323b9d94c017">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="684cdd94-9987-4763-9627-76269b9c062f">
+      <statement statement-id="sc-7.4_stmt.c" uuid="5f95f49f-c3d1-4a69-a6d5-4722a0338cd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c1d1a6a-3294-4e7b-b40a-dea74e2d7579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being
 transmitted across each interface is an organizational control outside
@@ -8099,8 +8099,8 @@ configuration and is typically handled at the network infrastructure
 layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="b4a67a73-f0ae-435a-a053-1d7de4a8d7a8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7875cbb7-b4d3-4322-bba0-0466e870e20f">
+      <statement statement-id="sc-7.4_stmt.d" uuid="e9e71658-9af3-472e-bc42-cf64626b39cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21595205-efd2-44c0-9df9-ebccd2bd217b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational
@@ -8109,8 +8109,8 @@ Kubernetes configuration and is typically handled at the network
 infrastructure layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="098e8238-1a69-4497-a8f7-fdd0cf23e01f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5d4ddda5-ea0f-4688-b8f4-ce9c20675b1f">
+      <statement statement-id="sc-7.4_stmt.e" uuid="e9160e3e-343d-44b5-b2a2-07f4b21b474b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4434ce6c-364a-40f7-9d18-d19fa4e19025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally
 defined frequency and removing exceptions that are no longer supported
@@ -8121,10 +8121,10 @@ layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b95d28f-8fff-4105-accf-b66a63f4ec71" control-id="sc-7.5">
+    <implemented-requirement uuid="0374f80b-0d74-4552-ab33-2d898fe4543c" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="102e2440-a419-494d-937d-3c71de3abc5b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="48c59870-6c80-4dc9-a700-18ed7bbae43b">
+      <statement statement-id="sc-7.5_stmt" uuid="0c412dca-b9bf-4c7b-a5b1-c65064bf205c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ae14af3-0e7a-4075-b379-fec38e0351d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -8137,10 +8137,10 @@ https://issues.redhat.com/browse/CMP-424</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="593cea31-1d7e-43ca-8df3-d72129d8a8fb" control-id="sc-7.7">
+    <implemented-requirement uuid="2721a473-4275-4b19-b59d-65c6e1d2c535" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="c1b1ae59-83c7-420e-84ba-433c90deade7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bba48da8-b5da-4f9b-9460-5d9bd3cfdb86">
+      <statement statement-id="sc-7.7_stmt" uuid="cd8b0cd6-b2fb-410d-b73e-042bfe844c97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b8b8e6b-b7cb-4a1c-9659-f9deac17394c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In conjunction with a remote device, prventing the device from
 simultaneously establishing non-remote connections with the system and
@@ -8150,10 +8150,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2663f6a2-b8c5-4553-9342-74d9ffb20416" control-id="sc-7.8">
+    <implemented-requirement uuid="5327d9dc-5d39-47f8-aa8b-97c65f5bac9a" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="cb98ff00-0994-41b1-89b5-299ad755fa16">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a0e88ce5-60be-4ce5-a557-01d130a06953">
+      <statement statement-id="sc-7.8_stmt" uuid="b457520d-3ba8-49fe-9713-59a0435e2438">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c15c0d95-db47-45db-8fab-2334a0e079bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Routing organization-defined internal communications traffic to
 organization-defined external networks through authenticated proxy
@@ -8162,10 +8162,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6bc7a41-7f9a-4dbf-92e5-e60f58e2ae8e" control-id="sc-7.10">
+    <implemented-requirement uuid="f8f43230-eecf-4860-81be-f10ef7240f24" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="4599b356-147c-4f55-b649-46dea2efb152">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a8a7750b-3a5c-4452-b2ee-56e8fc844a36">
+      <statement statement-id="sc-7.10_stmt" uuid="8dd24d44-c14b-4616-b27a-60e378c71915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c57d69ef-4473-4549-a72b-0b1c5bb3d9e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized exfiltration of information across managed
 interfaces is outside the scope of Red Hat Advanced Cluster Management
@@ -8173,10 +8173,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fea88c61-19e5-4890-949f-93aaba172928" control-id="sc-7.12">
+    <implemented-requirement uuid="a53cb130-af00-4ecf-9fcb-42b5b3a284d7" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="bff213ab-f780-43e8-a6af-236a54ba9ab7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b3dd3229-3a70-4afa-9978-436b89407423">
+      <statement statement-id="sc-7.12_stmt" uuid="3d02f023-2c4f-43f8-a0c1-4de86f884706">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d29edd9-111b-4a3b-b9c4-6bf8e2e0cfb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined host-based boundary protection
 mechanisms at organization-defined information system components is
@@ -8185,10 +8185,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85e43a9e-d150-4ba2-bbd7-dea231d97fab" control-id="sc-7.13">
+    <implemented-requirement uuid="9c1ac441-82b0-4da6-9fb9-cf8ce288a719" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="51cbdfea-0a69-42db-bd9f-84487e2b8a68">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="450a094b-cf87-4589-bc9f-315094d7a95c">
+      <statement statement-id="sc-7.13_stmt" uuid="cbf60374-942c-4837-b9bb-dd1f1f3f7f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f40708a-e612-483f-b517-e43f329e0aef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Isolating organization-defined information security tools, mechanisms,
 and support components from other internal information system components
@@ -8198,10 +8198,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed746e7e-e94e-4119-987b-b674bd10fc73" control-id="sc-7.18">
+    <implemented-requirement uuid="4f45c786-a981-4163-a62e-b611986c2fc1" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="92afd02d-ba68-469c-b66f-d28179e63a21">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a1d3b28a-c3ff-4c31-a7b0-1d8c2eab34b7">
+      <statement statement-id="sc-7.18_stmt" uuid="c1a3c1d6-1ce9-4576-a5c8-d64cd5dfddaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c792010c-269f-4dcf-b31c-c50a716923e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Failing securely in the event of an operational failure of a boundary
 protection device is outside the scope of Red Hat Advanced Cluster
@@ -8209,10 +8209,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="701c39d4-440f-4d39-a903-2dddff6cc0ea" control-id="sc-7.20">
+    <implemented-requirement uuid="fc2a32ef-0f7e-4b87-b0d8-63536bb56073" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="667a5819-75cf-4986-a3be-a4937121454d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="adf7bf58-99c1-4e0b-91a4-a47d70047a98">
+      <statement statement-id="sc-7.20_stmt" uuid="af94f083-7203-4e5f-8592-8b8861393c09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04cb34ea-6caa-45d0-a451-354cc2e066aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the capability to dynamically isolate/segregate
 organization-defined information system components from other components
@@ -8221,10 +8221,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acecf271-659f-4abb-80c5-c9183b5e0bc9" control-id="sc-7.21">
+    <implemented-requirement uuid="8c4198d3-c241-469e-825d-2cff67fac80f" control-id="sc-7.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.21_stmt" uuid="75b0bee0-7adf-4cbf-9ca6-728afba7f0e5">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5460b62b-dcef-4086-98e5-73c70429c517">
+      <statement statement-id="sc-7.21_stmt" uuid="e81c30fb-b52e-4aed-b531-986690eb07ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="265165b3-eec0-4574-8412-2255edb8b61a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing boundary protection mechanisms to separate
 organization-defined information system components supporting
@@ -8234,10 +8234,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c320d031-3474-445f-b5dd-9fce20cb9a1c" control-id="sc-8">
+    <implemented-requirement uuid="76a8a755-ff71-492b-80d8-3ffaef117e3c" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="a0f4c306-9989-4dc4-a8ec-1fde9240a1f3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="140847af-0dd6-4d58-bb1c-490ba5935233">
+      <statement statement-id="sc-8_stmt" uuid="b3d27a6f-fd58-4a8d-8807-863eb3e77e79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84e096c7-b33a-4e05-a3c1-eb9baf19b49f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -8249,10 +8249,10 @@ https://issues.redhat.com/browse/ACM-386</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea34cf54-2de5-45de-8966-12eed64c6513" control-id="sc-8.1">
+    <implemented-requirement uuid="82f2ac7f-81ce-47fd-989f-ecd8a1527f06" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="132bd5a9-b858-4437-a380-cdfe927a56ce">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7d4fb339-c723-4846-9cd3-dbaafb794973">
+      <statement statement-id="sc-8.1_stmt" uuid="939e04d4-0206-4eb7-ab21-50098faa8523">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d6aca3a-8a0d-46dc-a215-fb60ab74be7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing cryptographic mechanisms during transmission unless
 otherwise protected by organization-defined alternative physical
@@ -8261,10 +8261,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbda0b69-6fa2-4be3-af5e-c5ca18e362ef" control-id="sc-10">
+    <implemented-requirement uuid="c5e04792-80e3-47d1-bdce-638bb888ab02" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="e752c0e3-ee91-4b0b-b13e-dc145a552ad4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e9af7284-576c-4db0-b4ca-e25b4bb16a61">
+      <statement statement-id="sc-10_stmt" uuid="abe54df5-bf79-4a71-b90c-009432798a35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e66c2b0-387f-44da-8064-74d9c8673208">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -8273,10 +8273,10 @@ means on how this is established.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fbcde20-3741-47d9-852d-5e7d815469e6" control-id="sc-12">
+    <implemented-requirement uuid="f4a51580-1504-444f-8cb6-eca35566cd21" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="0d848dde-39ab-4709-9960-05ca22b0b4be">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="fc006b42-3c84-40c4-8132-f3248e4fd49b">
+      <statement statement-id="sc-12_stmt" uuid="01a81a53-f306-4a28-b642-fd8e42b313a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed54e6a1-6659-41a3-bfeb-bab90f16b829">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and manages cryptographic keys for required cryptography
 employed within the information system in accordance with
@@ -8286,10 +8286,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5a2d3cc-b72e-453b-9dc8-7bb4044f8901" control-id="sc-12.1">
+    <implemented-requirement uuid="3e3c795a-d9fd-4022-8c3b-01383f396f5c" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="587d4677-e2bf-4bd6-94fb-69581da7789a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="394fa552-3b26-475a-82e7-f43110178445">
+      <statement statement-id="sc-12.1_stmt" uuid="d10503ea-39f2-487c-9e2d-15dce590d096">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d638e33-cb9e-496b-9ddc-c7ac20c285aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining availability of information in the event of the loss of
 cryptographic keys by users is outside the scope of Red Hat Advanced
@@ -8297,10 +8297,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79d57a30-2b2a-4486-8530-2356ca27fefe" control-id="sc-12.2">
+    <implemented-requirement uuid="48e0f6c7-bd57-4ea2-a463-7a376c429c4c" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="e732ecd0-6ccb-49b2-9e18-b634c17d6887">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a4231095-c1f1-46fb-8a2d-498c4e755cab">
+      <statement statement-id="sc-12.2_stmt" uuid="8e9624b0-0547-47bc-bea7-02ef42bdac01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa96f4d-60e9-47a5-8488-04b648ca158f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Producing, controlling, and distributing symmetric cryptographic keys
 using NIST FIPS-compliant or NSA-approved key management technology and
@@ -8309,10 +8309,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a974aef1-5006-40bf-a0cc-51cb5cbc2cc8" control-id="sc-12.3">
+    <implemented-requirement uuid="3a9eca27-4398-4781-86cd-0aec0a4fbac9" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="54add051-60ae-4545-84ed-0f158502dc4e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d9d239af-efe3-4964-878c-f3a6dbb51236">
+      <statement statement-id="sc-12.3_stmt" uuid="ff8137ad-b4cc-4ff1-8901-ba3a90e3e5ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95ed6489-1734-438d-b0a4-392b344c8792">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Producing, controlling, and distributing asymmetric cryptographic keys
 using NSA-approved key management technology and processes is outside
@@ -8321,10 +8321,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51ad65ea-ae77-432c-a467-b6dabccc239a" control-id="sc-13">
+    <implemented-requirement uuid="3fd47604-a913-403b-bb68-ccd137bfa211" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="2def6a5f-a3f6-4ff2-9fb1-97fcc14e4055">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d67ab995-9d6a-456e-95f5-d1207b555ecc">
+      <statement statement-id="sc-13_stmt" uuid="5f71cac8-d81c-4210-81cc-56f35b49cf0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9015bd23-0bf4-4d39-86d7-b1372a363320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined cryptographic uses and type of
 cryptography required for each use in accordance with applicable federal
@@ -8334,10 +8334,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acbfb425-1a34-485b-8bda-7ee0bf6c56ef" control-id="sc-15">
+    <implemented-requirement uuid="60c39bf5-9dd5-4a4f-9d65-86b4ba78a77b" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="489467bd-aa0f-4aef-afcc-16038e7208c2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="585cc3a1-03d4-494e-8847-544f045d99ad">
+      <statement statement-id="sc-15_stmt.a" uuid="c17cc0dd-de75-4336-b4ea-b5ac72074452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -8345,8 +8345,8 @@ not applicable because Red Hat Advanced Cluster Management for
 Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="d75d0a48-4d97-4a35-a404-8122022fff8a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f2c0348a-1ea1-4f31-8fcd-e7c5eb420a77">
+      <statement statement-id="sc-15_stmt.b" uuid="82026196-8890-49df-811a-e0c6edb6bedb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -8355,10 +8355,10 @@ Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83a877c2-54e7-421a-8f8b-075e82e4afc6" control-id="sc-17">
+    <implemented-requirement uuid="adaf211f-cea1-4950-9f0c-fc4a92d4e5bd" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="16a00285-6c89-4920-9924-4b47c655fee6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f4f846ff-c2fa-48d3-b4c0-9c96f552d790">
+      <statement statement-id="sc-17_stmt" uuid="f2e84a5b-21e8-45ed-b978-6f20c4fa4be4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2da496cb-e8b3-4222-8990-f4fc3cd51aa2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -8367,10 +8367,10 @@ https://issues.redhat.com/browse/ACM-387</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="373211a1-a039-4b17-9c22-db60b9f66b32" control-id="sc-18">
+    <implemented-requirement uuid="b1529437-35a7-4899-a9e8-34c10a2e639c" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="8235e233-a7cd-4723-8509-864920ab7766">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3246334d-164b-4dd6-8151-ad1517393d24">
+      <statement statement-id="sc-18_stmt.a" uuid="7670ab9c-52d1-49f4-87cc-9516c4126d85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -8378,8 +8378,8 @@ planned. Progress can be tracked via:
 https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="fb9d98dd-6996-44af-ae29-aeb69eadfe7f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="52757e31-d5f4-4007-a31a-eda1a69d976f">
+      <statement statement-id="sc-18_stmt.b" uuid="41c8ab76-2048-4d02-8f51-4576ce47c200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -8387,8 +8387,8 @@ planned. Progress can be tracked via:
 https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="58679988-0c44-403a-acbf-775981caf816">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="20ac9141-6b9f-4f55-ad3f-da1f08c60078">
+      <statement statement-id="sc-18_stmt.c" uuid="39b64d86-886d-483e-8de2-423feb732958">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -8397,18 +8397,18 @@ https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5935eabf-dbfe-4276-8ae7-55a2410c3a9e" control-id="sc-19">
+    <implemented-requirement uuid="8883a25b-61d0-434c-9bbe-e948f9a773d5" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="bde39631-b816-4c38-a2c2-7049718c3f8b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="64898a26-d2cc-44c0-b121-aab2d167ccb9">
+      <statement statement-id="sc-19_stmt.a" uuid="5797fb17-4fd2-47a8-9915-2fee3956c60c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7a2647d-4a45-47c8-8fab-e3d58a5a98b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management
 for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="4ecdb9b2-8e34-4478-81aa-2c2d2462a16b">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f0f9fbcd-e8d2-4bd0-86e6-8912c2881c3d">
+      <statement statement-id="sc-19_stmt.b" uuid="ff2c71bb-f02b-42f2-a9ae-e63fb1f3cef1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7a2647d-4a45-47c8-8fab-e3d58a5a98b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management
@@ -8416,10 +8416,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f05850e-a27f-480d-be69-e3ccd5a6488a" control-id="sc-20">
+    <implemented-requirement uuid="23dd3257-e41c-46b7-b50f-224e0ece8433" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="c611e1fb-9996-4251-add1-5d93cd86a377">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d02346d8-a3f1-41f0-ae43-16f1b0a83da2">
+      <statement statement-id="sc-20_stmt.a" uuid="74b46734-23e3-40a1-86f4-e151498e8daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b06f186-06b1-4420-84c3-5562c998e3ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing additional data origin authentication and integrity
 verification artifacts along with the authoritative name resolution data
@@ -8431,8 +8431,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="8d9b7993-d386-4e1d-ae30-921c9bda1eb7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7fd54138-bd1d-4e8e-9f76-8378e47a7e0f">
+      <statement statement-id="sc-20_stmt.b" uuid="584e9542-8ea8-49d1-b9ed-4061ffb3e388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04c15b7f-aaf5-4aad-9468-3ec78c5f0d68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the means to indicate the security status of child zones and
 (if the child supports secure resolution services) to enable
@@ -8445,10 +8445,10 @@ for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5562dabc-8066-4d2b-8a1d-600d94b63dbf" control-id="sc-21">
+    <implemented-requirement uuid="284c92b1-ee3d-4f5e-934d-f4e46f765513" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="9458bcc2-802b-4257-a805-38fce66a0632">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b6234b34-5275-470e-aacb-3126990bfe7c">
+      <statement statement-id="sc-21_stmt" uuid="1237c951-198d-425c-bbf0-3f7cb2c85b11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d804e87-282d-46fd-b73c-7c83cb92348e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requesting and performs data origin authentication and data integrity
 verification on the name/address resolution responses the system
@@ -8457,10 +8457,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="641815a9-ca33-444b-bff4-ce4ba4b9c7b4" control-id="sc-22">
+    <implemented-requirement uuid="a1fd2e32-64d0-46f8-a9d2-089b11bd5cb1" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="36f5832b-14a3-40d5-9280-9e07f222e1f2">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="38b8e317-3528-4f44-b0b4-d2c82359e0fe">
+      <statement statement-id="sc-22_stmt" uuid="68ca8a26-b035-470b-a730-35e3f5212d29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcd37744-2fde-4ebb-8cd1-6cbd7ce478b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Collectively providing name/address resolution service for an
 organization are fault-tolerant and implement internal/external role
@@ -8469,10 +8469,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dde65984-8238-441f-bb22-b3aa08475176" control-id="sc-23">
+    <implemented-requirement uuid="86e0c946-574f-481c-87c7-c7bd81e996a6" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="1566f5af-1c4f-4bdd-9a09-478d3d32394e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="907daa8c-902e-4095-96c2-1184f98ab5c0">
+      <statement statement-id="sc-23_stmt" uuid="7464d79e-1b64-4f76-9fbc-5c4919f35900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee83d187-f7c6-4afd-91c2-4eb3aa554c65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -8488,10 +8488,10 @@ https://issues.redhat.com/browse/ACM-407</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="462d022b-9774-42d9-aa93-a66fef1636ef" control-id="sc-23.1">
+    <implemented-requirement uuid="e3673180-7896-4dd3-aa43-79c852b3836c" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="5a16877c-7273-401d-8f97-dbbb9ae66e29">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3c4c9709-cfe4-4a85-bf40-58bb89ec7aa7">
+      <statement statement-id="sc-23.1_stmt" uuid="deec09b4-5f1e-4eb6-a080-ecf4e070f3aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c13e3721-0965-4890-b4a7-bb79d7682bf1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Invalidating session identifiers upon user logout or other session
 termination is outside the scope of Red Hat Advanced Cluster Management
@@ -8499,10 +8499,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a1fbb5e-f3af-4add-8350-08f6ccf223bb" control-id="sc-24">
+    <implemented-requirement uuid="41238acb-ab4f-45a7-9c2d-3aa4d741db00" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="0e84561c-7f13-4387-8a2e-e82317c12bae">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5be484e3-b00e-4209-98f8-453ae7c31150">
+      <statement statement-id="sc-24_stmt" uuid="f944f322-5878-4914-a87d-a53330ae10eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="170b8582-e361-47d9-940d-39f08917ce2f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8511,10 +8511,10 @@ https://issues.redhat.com/browse/ACM-389</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="897ad53b-8cf3-4cab-a9b4-9d244e3ee2f4" control-id="sc-28">
+    <implemented-requirement uuid="61eac231-50f1-4024-9218-d9e72ee28960" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="99edfd82-67f6-4c1a-ac03-0b1de04e69d0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a33400ff-52e3-4722-9868-ce6390e17711">
+      <statement statement-id="sc-28_stmt" uuid="82300480-58d9-4dbd-af4f-40c0c33db823">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8f00c6a-2844-4a15-9a2c-640757a6145d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality or integrity of organization-defined
 information at rest is outside the scope of Red Hat Advanced Cluster
@@ -8522,10 +8522,10 @@ Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="138b454e-0a66-482f-8091-3292f0c553be" control-id="sc-28.1">
+    <implemented-requirement uuid="5b2102c1-6120-4713-ae07-93d4294e8a6c" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="e10f05a7-3df0-406f-b823-bcb8e5dbab09">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ad6696ae-5c7c-4d85-a1fb-cd55e4546950">
+      <statement statement-id="sc-28.1_stmt" uuid="b480bace-0ade-4d36-afa6-fc45be3099e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96252d26-9075-4864-9b3a-9d44b90d1345">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -8535,10 +8535,10 @@ transport.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="979380eb-bad3-41e4-b938-fb6e79e1288c" control-id="sc-39">
+    <implemented-requirement uuid="06047ebf-250e-4bc2-8889-294df634a49c" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="df81463f-4703-4c50-b358-135e21fa772f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="6a1fa54b-1bd6-4b78-9f61-50faa0667ac3">
+      <statement statement-id="sc-39_stmt" uuid="45056cf1-b025-4ef6-857b-25e11139281a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="905ec3ac-6de3-40b5-abfa-45041060bccd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining a separate execution domain for each executing process is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -8546,55 +8546,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f8e9909-3032-4a32-beeb-5b22a00ac4f0" control-id="si-1">
+    <implemented-requirement uuid="1ac57cb5-e0eb-49d1-8ae6-31169fd834b4" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="83d50071-7a1a-4025-8c2b-a98eda7dd679">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f6b3599d-ecc5-4a32-a161-9df5105f6402">
+      <statement statement-id="si-1_stmt.a" uuid="e9254d38-f6e2-41ff-aad0-6e9e07d1c09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="e5af0db3-1b62-494b-955c-ea8a7629f2a8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f4051398-624c-4c10-a2b4-f15461c84a54">
+      <statement statement-id="si-1_stmt.a.1" uuid="3e00a5d5-ce55-45f6-8aac-56a15fb5d9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="051b5dcb-9ee7-42d2-b2e6-7b0146148590">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f263ca68-3837-4945-9588-6c184170e268">
+      <statement statement-id="si-1_stmt.a.2" uuid="c7d2bf00-f2d1-42b0-92ad-eb30eb27d02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="db0c4164-4308-423b-9e5c-4975b1c6996d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3c5c4579-88f2-4981-9468-0ff42db6c1f0">
+      <statement statement-id="si-1_stmt.b" uuid="24f5c308-d85d-437d-9246-e67792f05101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="a6b30e06-a185-43ff-8f4e-f6f67984868e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f7c2ba20-0426-4e85-acf0-a4f4737c8a68">
+      <statement statement-id="si-1_stmt.b.1" uuid="7f50bdcb-e683-423b-8ec4-c40a04d2f4ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="fe8a3716-cf5b-437e-b0b2-d4b0e883105c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2433d1c8-c6c9-4adf-9e12-9e14542e9f94">
+      <statement statement-id="si-1_stmt.b.2" uuid="f590ce87-15aa-4188-badb-1c64dc28365f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41f12639-4de7-4a8f-9222-85ecbd0d8609" control-id="si-2">
+    <implemented-requirement uuid="ba0844fb-4f55-4ccb-9350-65001c226036" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="cb4c6008-e182-4ddb-ab4c-13e04b1733e4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="2c5b37d1-480f-453d-ad5f-f1c5cf56e535">
+      <statement statement-id="si-2_stmt.a" uuid="8fe5873f-4410-4b49-b0a1-39acae3c6973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d82e347-ad53-4671-b12a-7fa613597f98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Advanced Cluster Management
 for Kubernetes deployment for flaws, reporting on those flaws, and correcting them. A
@@ -8603,8 +8603,8 @@ discovered and remediated, as well as tools that are used to assist in detection
 remediation.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="c54c3180-41d7-404c-9cd5-52d40e767625">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9bd9424c-f859-47af-9f9f-ae97bc7f1109">
+      <statement statement-id="si-2_stmt.b" uuid="376ff04a-f459-444f-aca7-68c33bc958b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54df072f-e685-4337-8829-049d63b612e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Advanced Cluster Management for
 Kubernetes updates related to flaw remediation prior to installation. A successful control
@@ -8612,25 +8612,25 @@ response will discuss the testing process (e.g. the nature of the test environme
 types of testing performed, the tools in testing, etc.).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="eb4d859e-f55b-42cb-b99e-3e9a7ea18500">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5d50c5ef-8ba8-4d42-b402-7e1ecd338f34">
+      <statement statement-id="si-2_stmt.c" uuid="f3546051-4f29-4055-8e73-2bc44e58c533">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="4fac5d40-1331-4191-8672-1e34011c119e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c6c324ac-c824-4938-90bf-937afb6a0724">
+      <statement statement-id="si-2_stmt.d" uuid="6b511da2-09d7-44b2-a2e3-8c2a07b01922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b9e4349-6011-4bf6-8dab-3ae2101a2838" control-id="si-2.1">
+    <implemented-requirement uuid="6b8870e2-1d5f-4d95-a333-33510b339c3a" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="d369965b-f63e-4170-8c90-b4fd9cda3a18">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="cc3164d2-3c0f-4fb4-8971-a52639f711f7">
+      <statement statement-id="si-2.1_stmt" uuid="5658710b-79bc-4bb4-b796-30d8312b748d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44c49a90-081d-4cc9-90a6-ea53d8ccb76f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization centrally managing the flaw remediation processes is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -8642,10 +8642,10 @@ remediation.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a722b513-e110-42a0-a1d0-ca4a33dd5fd0" control-id="si-2.2">
+    <implemented-requirement uuid="e11aee77-2dde-4d21-81e2-f08972504493" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="bda23116-a120-4bda-8d4f-2f245b95eddd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="49c5ba81-7564-4032-83a9-ec78ba7ee56f">
+      <statement statement-id="si-2.2_stmt" uuid="183255ab-7418-4705-9a34-ea3d032f6ffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80a45e58-0de6-429a-b7f1-aac42d1b1351">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms per an
 organizational-defined frequency to determine the state of information system components
@@ -8661,10 +8661,10 @@ remediation.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b05c08f8-1d66-4834-903f-ea8a35f9c1ff" control-id="si-2.3">
+    <implemented-requirement uuid="b76323ea-cbcc-4fdb-82bc-237f53c61852" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="f410d8ae-49f9-446f-a5ef-71bc25e6177a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9d499c64-41d0-4542-a2ea-0210aaae6e0d">
+      <statement statement-id="si-2.3_stmt.a" uuid="b78b08f8-f505-4781-8609-e69e5d0908e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f027844-481b-4e3a-9503-758b2b4d49f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -8674,8 +8674,8 @@ remediation using timestamps and calculates the time elapsed
 difference.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="7e71ba9f-72ce-4301-94a7-d6ed9497ed38">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f641c1d1-32d8-455b-8092-b40a941b42ab">
+      <statement statement-id="si-2.3_stmt.b" uuid="04ea7b38-be21-40c3-a9e2-34dfe3656c43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5efc2319-b920-4bb3-8f63-c96f7afe6e7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -8686,10 +8686,10 @@ customer defined period after a flaws discovery.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7dd16301-933f-40a3-98f9-970b055d4844" control-id="si-3">
+    <implemented-requirement uuid="c4c53f67-ef6a-46b6-af85-f8628d279672" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="7fb49849-dcee-4c5d-920a-2e7c87565e8c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="de40438e-0207-4af7-bd34-e10ce4885ed9">
+      <statement statement-id="si-3_stmt.a" uuid="c9a78034-edec-4d05-bd0c-63e1d22f5549">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad7e803-63d3-428c-897b-f3e6c876d05e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious code protection at
 information system entry, and exit points to detect and eradicate malicious code. A
@@ -8699,8 +8699,8 @@ scripts). In regards to Red Hat Advanced Cluster Management for Kubernetes, this
 generally through the use of third party tools.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="e0eec87a-a1c7-4bc0-a3c1-323ffea9e0de">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3f234b85-97d9-45f5-b261-09ca74dcb07f">
+      <statement statement-id="si-3_stmt.b" uuid="9e354838-03da-492b-9122-03257ea75bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="210a2511-c79d-417a-9918-37a176cef03a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -8708,15 +8708,15 @@ management policy and procedures is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="877e02e7-3bb8-4f70-88a9-818d8986c5bb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="743356db-cd44-490c-8fdf-dfa1de52bb4e">
+      <statement statement-id="si-3_stmt.c" uuid="18d03ef9-86d5-48b3-ab0e-42b0f75db078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2caa1d9-ef0f-467a-b427-cda36c3c95bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="6a2d5b33-781f-40c2-9c54-a8d741e847e6">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ec68b38e-9b2c-49d0-8d54-7bd6121a31c4">
+      <statement statement-id="si-3_stmt.c.1" uuid="b84429c3-26de-4de0-8205-aebee6408335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42a678a9-b637-471c-8b9c-b022ad140114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -8725,8 +8725,8 @@ security policy is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="8e45bd6a-c9b5-43d7-be22-312e98e87b0e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="28391865-8469-4655-bf5a-4908317d4d98">
+      <statement statement-id="si-3_stmt.c.2" uuid="be7da617-432e-438a-afc1-d74bd9291a7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723d2a9f-9964-4c4d-8df2-d0904f80d4f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an
@@ -8734,8 +8734,8 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="1eb42dba-1ffc-4102-9d0a-537bc2aaa2cf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f61f13cd-a6f5-4bb2-9303-98b908bfa6ab">
+      <statement statement-id="si-3_stmt.d" uuid="427c4401-59c6-4c80-b8f3-2448c94585f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4d4652d-b87f-4963-ab15-232536b7d509">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an
@@ -8744,10 +8744,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a36bee0-9fc7-4c21-b8ff-3917f67ce981" control-id="si-3.1">
+    <implemented-requirement uuid="cc1129cc-aefa-4012-89e5-1acef7b0d53a" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="e9c6b8cc-f75b-4f26-98ca-a8351458d97d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="67eae072-78a9-465f-a80d-cb29821e3667">
+      <statement statement-id="si-3.1_stmt" uuid="f9f6e5cf-08e3-4a67-8af0-7b28703f8a5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00658baf-6614-48de-b4ef-2422d0e0b1d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -8757,10 +8757,10 @@ protection mechanism is centered in one location.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2cd04c9-fa6c-4fe2-bb89-35324db28a12" control-id="si-3.2">
+    <implemented-requirement uuid="25d410dc-01f7-4446-bba6-47347f365abc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="507704fe-309b-483a-a981-2e22389b6e57">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7b1b06f9-903f-4deb-9811-934143d5d1b7">
+      <statement statement-id="si-3.2_stmt" uuid="222ec5c0-526b-42c0-8ad2-ee599fb2a9d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ab0afd2-1a93-4315-be52-14c1dd0fd34c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -8770,10 +8770,10 @@ mechanisms definitions are configured to be updated automatically.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13f0c4ff-b8fd-4d10-bd6b-c09a73ff9077" control-id="si-3.7">
+    <implemented-requirement uuid="43e85563-c3d6-4a65-817c-37eef06356ee" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="62ea4c14-f2c6-4047-a76d-c19d46df7900">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d8bd7142-3f14-46dd-a300-9cfadeb76b0e">
+      <statement statement-id="si-3.7_stmt" uuid="87741b84-52d4-4ab7-92aa-ee49d3e50eb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ae9636-4fcb-4810-b789-4bdd780cb24c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -8785,24 +8785,24 @@ do not yet exist.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39e87ef5-fc64-48e7-abf9-acdb23b2dffa" control-id="si-4">
+    <implemented-requirement uuid="b77472be-ee4b-4cc6-a1f1-76fee3f8749d" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="a593d854-da71-4113-9968-e5bad1b3b900">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="07451b7c-6632-4e55-92c4-71f576c0dc29">
+      <statement statement-id="si-4_stmt.a" uuid="e06f9d1c-ebe0-496d-8603-066fa2b282f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="0fe09581-f8f0-40b8-8dfc-8c79d6a7cb5a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dd5e8bfe-0dd5-4909-88c5-43e7d8227fdd">
+      <statement statement-id="si-4_stmt.a.1" uuid="c5488e87-5971-47c5-84e7-b10a62142a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="f584b97f-e804-4830-98fc-d53e5fc861c4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="63dbfc12-3c95-45db-a916-b90ed758a8a6">
+      <statement statement-id="si-4_stmt.a.2" uuid="4ba6ecd1-1581-4cad-965d-3bb5040ffd58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="201402b4-6cb9-4705-ab64-3be7e6f0bad7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
@@ -8810,8 +8810,8 @@ Kubernetes configuration. Functionality to meet this control can be provided by 
 party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="3f23a942-c8ac-486d-9f04-14efa89e30e7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="dd286f26-d18c-49f3-81ce-2921a77bc779">
+      <statement statement-id="si-4_stmt.b" uuid="30ba8a4b-7359-4609-a0a4-50da18a179ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="839816c6-ec65-4e84-afd9-398166749d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope of Red Hat Advanced
@@ -8819,16 +8819,16 @@ Cluster Management for Kubernetes configuration. Functionality to meet this cont
 provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="bc3b65e9-41b8-4250-8c0a-e4974e14d04f">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="57b5d2f3-344a-4681-a7b3-882c200a3482">
+      <statement statement-id="si-4_stmt.c" uuid="0cd49d2f-114c-4414-944c-faddf2e30fc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="370fd0b3-f1a9-4e99-9133-431c67d824dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration. Functionality to meet this
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="56f0378e-406d-4366-b667-84fb9798c016">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ba7b352d-7fd5-4e5d-92f2-b571a2e20190">
+      <statement statement-id="si-4_stmt.c.1" uuid="077aadd6-ed2f-4f7d-b6a2-7c067cedac63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23939e4e-ab8e-46ef-aeee-f23facfdf1ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect
 organization-determined essential information is an organizational control outside the
@@ -8836,8 +8836,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="82d66872-c5fc-4c4d-b388-e12577805cca">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8c08a433-939d-455a-b2fa-eb9d55b08fc1">
+      <statement statement-id="si-4_stmt.c.2" uuid="268e71da-855c-4f6d-849d-a4f0958b0884">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0efbfba9-8414-4e18-ae9d-27b0c6324809">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types
 of transactions of interest to the organization is an organizational control outside the
@@ -8845,8 +8845,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="72eb4a8c-6b58-4b04-ac3b-bdfae9473e23">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="a09c5251-ab4c-43f7-aac8-891e9386781c">
+      <statement statement-id="si-4_stmt.d" uuid="ca1cfc9e-26bb-4cc7-9555-01e010b5b1b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0249159-9b9f-4fd1-83ee-3234a37ae777">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of Red Hat
@@ -8854,32 +8854,32 @@ Advanced Cluster Management for Kubernetes configuration. Functionality to meet 
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="a8963a34-c31d-4483-8011-278adb28cc95">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d76c60cc-3bbf-46fd-8802-d20df974d267">
+      <statement statement-id="si-4_stmt.e" uuid="40798e3b-3e4c-4c93-8b60-f0208c2461d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="05a09be8-4b15-4777-85fd-b79f8f21d387">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="565779cc-c2f7-4ea6-974a-fe15a3c0797e">
+      <statement statement-id="si-4_stmt.f" uuid="8adc244d-9602-4c86-a355-3aaee407d3f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="63f30923-1344-4427-8b2a-48ae2f5ae348">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="097cc4ad-9a26-47f8-9d97-faa9141a9149">
+      <statement statement-id="si-4_stmt.g" uuid="52c9cdad-4eee-4f34-a375-7b2bf80f656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb0f361c-8731-41e7-a483-d2bda3654ca9" control-id="si-4.1">
+    <implemented-requirement uuid="ffd3bfb4-78e9-450d-965f-96856862f408" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="053e0936-d44a-42a2-a6e1-14865e2013b4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="e9101ece-8503-4727-8a16-d822d0494555">
+      <statement statement-id="si-4.1_stmt" uuid="16afa9b2-20e3-4ba1-bcd2-8098cc67cf64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75f50e55-c553-45db-bb8c-30361e73d6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection tools into the Red Hat
 Advanced Cluster Management for Kubernetes environment, and documenting how this capability
@@ -8889,10 +8889,10 @@ intrusion detection systems.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdf5eada-7133-4ad2-87d1-41d6a74157f7" control-id="si-4.2">
+    <implemented-requirement uuid="c31976d1-1871-421b-8e96-69220dab9a1e" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="d0f4f662-36e7-4972-b5d2-d162a11934ac">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="49d32813-837d-4932-a11d-1322279e004c">
+      <statement statement-id="si-4.2_stmt" uuid="c7e73141-2c8f-4676-89e5-070980b98710">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d64a6302-9767-4def-a28a-5c4adce87eb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -8905,10 +8905,10 @@ analysis of events.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c995af5d-7afe-450e-b783-1743cc3e9e02" control-id="si-4.4">
+    <implemented-requirement uuid="a0f9e3fc-0011-4b97-992c-3921c5775276" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="ddabb9ee-0447-490e-b30e-1424af761806">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="706b4b22-5075-4b86-aee8-a8de0e6401db">
+      <statement statement-id="si-4.4_stmt" uuid="ce5ff580-45da-48aa-bcb3-9069b7aa1ae5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29ed9044-d16e-4a98-92d8-975eb8efa59d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -8919,10 +8919,10 @@ not, how network traffic is continuously monitored.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fd88ffa-a64f-4739-abed-349d82d88542" control-id="si-4.5">
+    <implemented-requirement uuid="aa6078a3-0537-4df2-aea6-19f07d576df9" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="63b28d09-91f0-4ece-8569-a7c458881932">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="302113b4-f3b1-40e6-9a3e-b41021d95cd4">
+      <statement statement-id="si-4.5_stmt" uuid="f8ba4da5-bf97-4f88-adc9-9a33152faa79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a945f5d-16d7-4dae-a509-4bd705f164a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -8933,30 +8933,30 @@ the notification.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d65d76b-f452-460e-a4e9-9b65c6145fb8" control-id="si-4.11">
+    <implemented-requirement uuid="63aeafb0-812d-4467-b703-28e07f1f6637" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="50f42305-6438-48ab-8396-6b10f1642174">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="14cdff76-d573-4780-9e10-862c221b06b7">
+      <statement statement-id="si-4.11_stmt" uuid="03157a0b-9e23-43c9-be22-7504eb1fac93">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ee266a9-bf9a-430c-986c-0055552e4ebd" control-id="si-4.14">
+    <implemented-requirement uuid="b905cef1-dbb1-48fb-a2dc-3bbce0ccb46e" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="866c81d7-8070-4e17-b52e-e216ef2893c3">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="784b0162-9141-4abc-a9d7-ae7fb4cd2fc5">
+      <statement statement-id="si-4.14_stmt" uuid="5dabb2d8-b6be-40bd-a302-fbc631b4fef1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="348ac440-2934-46a4-93a3-1d4eab3ff590">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes infrastructure does not have wireless
 capabilities.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bdfc8ca-9424-4991-8add-90ec93736731" control-id="si-4.16">
+    <implemented-requirement uuid="6e9e4e24-e18e-4d4f-89d0-58241619c30b" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="353b6831-f516-46a3-aff1-b14af4511109">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="8c3d7e0a-49e1-43b5-96b8-e848f8deee86">
+      <statement statement-id="si-4.16_stmt" uuid="74d9bf36-b9ba-4314-abbe-c8e488027922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31a90a61-6e68-45f2-ae8d-38329d2b5957">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating information from
 monitoring tools, for multiple system components. This is frequently accomplished with
@@ -8966,10 +8966,10 @@ OpenShift layer or a third party product.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eefe2443-ce7b-4035-bdc6-ae8da9b97dcf" control-id="si-4.18">
+    <implemented-requirement uuid="576f27d3-0ecb-419e-8cd5-68bc465b050a" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="932129b5-3e1a-4eb2-82f3-b9d8f2ec90c7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="17e68e88-2f98-4723-b30d-74dee7fc9ba8">
+      <statement statement-id="si-4.18_stmt" uuid="06768a7d-67fe-440a-ab2d-054a2e7b9692">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12907633-0c10-46c8-9ee4-241015acab9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization analyzing outbound communications traffic at the external boundary of the
 information system (i.e., system perimeter) and at interior points within the system (e.g.,
@@ -8979,20 +8979,20 @@ responsiblity of the underlying OpenShift layer or a third party product.</p></r
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24ebc05e-2cf0-4fd6-84a3-db69603c037f" control-id="si-4.19">
+    <implemented-requirement uuid="4fd661c1-5021-473a-a547-8ef93cdd3293" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="f13c04a6-026e-4084-b8a3-ac49668449d4">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9c30901f-98bc-46a9-bdb7-7f28d046bada">
+      <statement statement-id="si-4.19_stmt" uuid="8a580d4f-d8c7-4706-a1a4-d71ad3e45d82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e3466f0-e461-47a7-b509-9506976fc3b5" control-id="si-4.20">
+    <implemented-requirement uuid="5074e2c2-9d22-4924-b321-aaaf9b573d63" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="a33feacd-4beb-4cf5-8d45-662bf2fc2d8c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="4b8ecfd5-6240-4320-876f-5aadc0097842">
+      <statement statement-id="si-4.20_stmt" uuid="c9f4b831-be5c-4009-9469-49bf74488a00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5f87ebf-c640-4adf-918e-dd2cfadd3061">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization implementing additional monitoring of privileged users is outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration and is the
@@ -9000,20 +9000,20 @@ responsiblity of the underlying OpenShift layer or a third party product.</p></r
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6bacabe-9482-48cb-88f2-89de6a6ad6e4" control-id="si-4.22">
+    <implemented-requirement uuid="55624926-450a-4678-a6c2-7bfa1cf67f9e" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="8fc95f71-c002-4fc5-aff8-c594cb0e4b6a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bb6c68c0-2f47-482c-bf3b-0f92d0212c0c">
+      <statement statement-id="si-4.22_stmt" uuid="8b29f8ae-0f86-43ad-8856-3879e0ba0076">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="920db5e6-b60b-4d13-adeb-c402ac9cfd8e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system detecting network services that have not been authorized or approved
 by authorization or approval processes and audits or alerts organization-defined personnel</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5731c427-523d-4415-9da3-a8dca9dcee69" control-id="si-4.23">
+    <implemented-requirement uuid="afb5860c-50b3-444e-a2e3-08dd642fcc0e" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="f6028594-2875-49d8-a4de-4ffea2518d80">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="791175a4-6f35-40b3-8a62-27a836bc41b2">
+      <statement statement-id="si-4.23_stmt" uuid="43e85834-a3ce-4203-a851-f9e56c595598">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9a25e07-6617-4bf8-9474-a63300b8407e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring mechanisms which is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
@@ -9021,10 +9021,10 @@ is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfddf5c8-6baf-4521-a246-9e6f88e05b90" control-id="si-4.24">
+    <implemented-requirement uuid="cad3c92d-241f-4eb2-b8c5-7e29edd07f8f" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="67e2a3b3-6512-413a-a495-1f6b72f2d62a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="0c95e637-180e-44a8-91b0-4d989357cc58">
+      <statement statement-id="si-4.24_stmt" uuid="36eb53e1-f8f2-4635-ba8a-674ec8575db7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e74635f9-6d31-4158-8803-42493064d905">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system discovering, collecting, distributing, and uses indicators of
 compromise is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -9032,10 +9032,10 @@ configuration and is the responsiblity of the underlying OpenShift layer.</p></r
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0d0a16f-c5e0-49f5-96db-826c98f7f16f" control-id="si-5">
+    <implemented-requirement uuid="481d74f3-9023-4094-878d-88853a0e4a08" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="167468bb-8ca9-47fe-b34d-ebcfb5c4c471">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="09f69cc1-0bcf-4bea-9451-125b44523226">
+      <statement statement-id="si-5_stmt.a" uuid="a92b6b92-db21-47e7-ac94-6997c9d82245">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c0f4359-ac0a-46be-84f6-5db0aa230901">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an organizational
@@ -9048,16 +9048,16 @@ Hat specific products can be accomplished following the following documentation:
 https://access.redhat.com/security/updates/advisory</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="d9bca554-a654-48d1-accf-e9b1e9e97e47">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="487135a5-1603-46cf-9d09-ad027e823eda">
+      <statement statement-id="si-5_stmt.b" uuid="38658151-0557-406c-93de-a0a33b31ca75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c81518b-42bc-47eb-87e1-ecbd3b59996e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization generating internal security alerts, advisories, and directives as deemed
 necessary is an organizational procedures/policies outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="6ec8298f-7133-4a6b-8b91-c55f6bb87b5d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="f474b20a-b8b0-475c-861b-6858e1427b9d">
+      <statement statement-id="si-5_stmt.c" uuid="61adc42a-b045-4ab4-9041-2f6349f10343">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc7940a6-7fec-4aad-b086-5e8792390249">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined personnel
 or roles, organization-defined elements within the organization, organization-defined
@@ -9065,8 +9065,8 @@ external organizations are organizational procedures/policies outside the scope 
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="111eacc3-8c89-4391-82d5-9e6f33a85669">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="59805ffd-e1b9-4bd5-9f2c-8989a52fee8c">
+      <statement statement-id="si-5_stmt.d" uuid="b69855b2-331c-4eb5-9cd5-1fee573661f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c96147-de3d-4927-b91f-70aef285a171">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -9075,20 +9075,20 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ff5a162-dc5e-469a-94fb-c8059333c892" control-id="si-5.1">
+    <implemented-requirement uuid="35edbac0-26a5-4a3a-9ac2-626467cf3633" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="449f4be0-fe0f-460d-8100-4a176b1c9d50">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="edcbc857-8e19-4401-a52c-fedd4f7ce092">
+      <statement statement-id="si-5.1_stmt" uuid="ff55245c-cceb-42b6-82c1-b345a900c4c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c58ff256-cb79-4a31-9d12-5141f3576b5a" control-id="si-6">
+    <implemented-requirement uuid="e789018f-9aa3-4578-a2d0-bcfdad5ed8fd" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="303e48f4-3dd9-407e-a559-19b3484404c0">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="c4feb544-9375-4924-ad1e-4461072386fd">
+      <statement statement-id="si-6_stmt.a" uuid="a96e2d51-4254-4af9-935e-832019c57447">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4564a29-cdb2-4912-bf3d-a30d174bc75d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -9097,8 +9097,8 @@ security functions deemed necessary to verify, as well as the means
 for testing the correct operation and resolving any issues found.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="66f402d0-9671-4e5d-b6e6-22f9f8d92310">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="ee557c4b-c9d5-419e-a3e8-544014b8e08a">
+      <statement statement-id="si-6_stmt.b" uuid="c0fe2cf2-fa37-4cda-9071-1c74d8467c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4be5c4cf-a5c1-4fd4-8c6f-337797193d62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -9108,8 +9108,8 @@ rationale for selection of the specific frequency and circumstances
 of security function verification.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="7b307d43-0600-4a3f-8e89-3433a0e97a6d">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="10a99487-615c-4f48-a6ea-4ed981cfd1f9">
+      <statement statement-id="si-6_stmt.c" uuid="8a98bff7-b0e7-4a69-b224-dfa650a70213">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befdfd8e-f236-4a0a-b767-d7239209650f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -9117,8 +9117,8 @@ will need to outline the personnel or roles selected (to include
 system administrators and security personnel as required by FedRAMP).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="6020e2b6-d7ab-41ca-b38a-b64f885f9ce7">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="50a21304-9db3-48f4-9f9b-cfcbd3ad9a07">
+      <statement statement-id="si-6_stmt.d" uuid="a24e40cd-5934-48c2-8a05-4ad2b17db488">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab599b72-785f-486e-8436-d1efdb42643a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -9129,10 +9129,10 @@ actions.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65167232-c0b5-4d42-9226-15c57fe3b164" control-id="si-7">
+    <implemented-requirement uuid="7b0f9b85-31fd-442a-8e3a-991b9c495d85" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7_stmt" uuid="47e8a6e1-733e-4aa0-a4bd-901d87ab516c">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="88b2e05f-f121-43a8-ae64-e742ab6c2822">
+      <statement statement-id="si-7_stmt" uuid="439ed4fb-b18e-48d4-bcf1-f8e4a6d168c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1eff74f2-3641-4150-b9ca-e391f4f73fce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -9141,10 +9141,10 @@ the integrity-checking mechanisms these tools employ.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e95c2455-4a25-4862-97aa-6224dd7460fe" control-id="si-7.1">
+    <implemented-requirement uuid="c3ed22dc-a6ed-4d4e-9265-c1f1413d205b" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="d88b690d-f404-46e5-ab8c-02bf7ba944ce">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="9c0b3364-5914-493d-8599-30510a8df87a">
+      <statement statement-id="si-7.1_stmt" uuid="0f8ac069-b5e3-4629-ac05-19924c496242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dd3c6ff-0d3f-48be-8c8e-8bebb092b61d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -9155,10 +9155,10 @@ for selecting those criteria.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7907ab49-8bc2-4f4b-a1e7-8c4ceb6bdb94" control-id="si-7.2">
+    <implemented-requirement uuid="2173be2a-efdb-4c04-8a78-b07bcec25efd" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="98edecc7-3df4-435c-9872-a49c5b5d834a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="b08e36ce-ca06-4c5d-a7f2-b23cf0c59774">
+      <statement statement-id="si-7.2_stmt" uuid="45ce6bcf-b81f-4215-a44c-0d1abfd59750">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9dd95628-fb12-4369-8372-ff4f6a800009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing automated tools that provide notification to
 organization-defined personnel or roles upon discovering discrepancies during integrity
@@ -9167,10 +9167,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e11f7b31-5f9a-42c5-9a19-95a1dc0c0547" control-id="si-7.5">
+    <implemented-requirement uuid="b69bd7a6-b33e-45f3-9f8c-6e5b63220d9b" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="936b0b1f-62f7-41ce-b365-b74734328931">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="5bbd035f-2618-407d-8f10-30162b7a523b">
+      <statement statement-id="si-7.5_stmt" uuid="9e813101-8a63-435a-b837-04c95f4ea09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c498b36-a01c-41d7-b9a5-daafe273ccf7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system automatically shutting the information system down, restarting the
 information system, implementing organization-defined security safeguards when integrity
@@ -9179,10 +9179,10 @@ Kubernetes configuration and is the responsiblity of the underlying OpenShift la
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69dac091-b9e2-4402-89c5-f66115f236c2" control-id="si-7.7">
+    <implemented-requirement uuid="9531851a-263d-4d69-a3b4-b14a7165e828" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="71fcc34c-20a8-468f-9082-06903c68e573">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3a44f90b-293e-4c51-bf8c-20583a5022e7">
+      <statement statement-id="si-7.7_stmt" uuid="cffcaa9f-aa52-457f-af9d-1243539d45db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ce820e4-fe1e-4eb9-80a4-b7926317c692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -9193,64 +9193,64 @@ capability is invoked when needed.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0394034-afbd-4cc2-9b9a-5c89ec09362a" control-id="si-7.14">
+    <implemented-requirement uuid="a8fe1b27-6939-4ebe-a4d0-a3be71eb362a" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="fa8cf2f3-35d4-4545-b064-ce4065b058dd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="178c2dac-9238-4536-8e3e-270f0082dcb0">
+      <statement statement-id="si-7.14_stmt.a" uuid="0af46a67-9ec9-4652-bef7-92bb88b01164">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="8d88b325-136f-4eb2-b156-a4dbce52f7d8">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="83e7fc18-5830-4fba-8603-e97e0909047d">
+      <statement statement-id="si-7.14_stmt.b" uuid="21c75073-f84c-44e1-884d-181408e628a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72bd0aa7-8019-4c41-b623-f349ad7d6572" control-id="si-8">
+    <implemented-requirement uuid="1e3c35ca-17eb-489e-a181-896c419bb51f" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="432e6ba8-2196-4ef6-b22c-927b96f9f429">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="3f1a5e73-d651-44cf-ac21-d2a333f33b43">
+      <statement statement-id="si-8_stmt.a" uuid="369f401b-bd4e-4968-9394-e46031c15872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="ddba482a-6088-4756-bf1e-ef00d85e76eb">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="bad12185-696d-4946-af31-2abf4cebfbe2">
+      <statement statement-id="si-8_stmt.b" uuid="25e05593-0d8e-440a-b4f9-0f74f1ca8fd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ceb3565e-d343-4fd2-8cfe-1436d80956f9" control-id="si-8.1">
+    <implemented-requirement uuid="aa300855-c275-4494-90c4-e5612bc78f50" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="6639c7ef-860d-4a7a-9884-d8b127f1306e">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7509ddfc-eb4d-4e6b-a9f0-7880a45c15a5">
+      <statement statement-id="si-8.1_stmt" uuid="6a02e17d-ff0c-4259-b890-2c76e9cbc397">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="783272af-d518-4283-8506-705f2f198a49" control-id="si-8.2">
+    <implemented-requirement uuid="cc7d9720-c210-4c72-a15c-952c494b276c" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="3e225014-750c-444a-b396-3bf46011d990">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="47e29596-4f83-4178-b829-bac13cb2acc1">
+      <statement statement-id="si-8.2_stmt" uuid="4f6fa2f6-a52e-4e95-8631-1faa8e089bf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82494171-a114-4ac2-bf64-500e24fc4b3a" control-id="si-10">
+    <implemented-requirement uuid="e9607c12-c170-43fd-bf41-21e266b84b5c" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="d4e5c7fd-b5e6-48b0-a411-75d6b7469ebf">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7c11baea-62f6-44f3-937c-36dc46721f3f">
+      <statement statement-id="si-10_stmt" uuid="9ef61e9a-c8e8-479c-8d54-f8de2d543839">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bd8abe4-c17d-4fb2-8ffe-1308d874d38b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-10 is planned. Engineering progress can be
 tracked via:
@@ -9259,10 +9259,10 @@ https://issues.redhat.com/browse/ACM-408</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b8881e5-f697-434a-952a-7b5e27940120" control-id="si-11">
+    <implemented-requirement uuid="3690ed91-498f-413f-989f-401d583daa67" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="7e4289a5-9835-472d-bbeb-715aabd5ef9a">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="55a1b0da-7d9e-45a4-b2cb-3458ce83c82d">
+      <statement statement-id="si-11_stmt.a" uuid="9b23aa69-1b7e-4dbb-9851-20f4abf25f52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="865e1508-b7b1-4441-98ee-5926017f013a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system generating error messages that provide information necessary for
 corrective actions without revealing information that could be exploited by adversaries is
@@ -9270,8 +9270,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="4a6ace31-5d1a-4fa6-8fd5-07d8d4fb4673">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="43f68012-f205-45fb-b6a3-0c591b9b2371">
+      <statement statement-id="si-11_stmt.b" uuid="272ef5c4-ac80-4ca7-9805-d316b28a2cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48ad5d86-2a5f-4351-934f-cbe96f6e857c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system revealing error messages only to organization-defined personnel is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
@@ -9279,10 +9279,10 @@ is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf5204ac-b660-4779-9c82-1b39e015df63" control-id="si-12">
+    <implemented-requirement uuid="7205643c-3fde-44cd-89f2-51341494df7b" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-12_stmt" uuid="04a7907a-0cb3-452d-bbac-0d45fafc47cd">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="d2b1db27-e798-4095-99a8-1ab08e388c1b">
+      <statement statement-id="si-12_stmt" uuid="61bd108a-4e6b-4c39-b959-4c294686cc5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="571f3030-adbd-47fb-ae1d-3e65521060c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Advanced Cluster Management for Kubernetes in
@@ -9295,10 +9295,10 @@ are met.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b71723f-0551-4ddd-a1f8-9eeb95d30497" control-id="si-16">
+    <implemented-requirement uuid="a61b9e66-5638-4db3-bcd4-fcc71083a1b5" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="337fbb76-2e44-4a68-a2e3-f0f9a0558e85">
-        <by-component component-uuid="ead1148e-f1ed-4510-8297-43e556adb8b3" uuid="7ccc1bd7-4dfd-4d28-8516-3fe987391471">
+      <statement statement-id="si-16_stmt" uuid="11a543ef-80bd-47a9-b814-d2fd1ffbb3df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe9d115-183d-4519-9da9-7bd79a8b9842">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system implementing organization-defined security safeguards to protect its
 memory from unauthorized code execution is outside the scope of Red Hat Advanced Cluster

--- a/xml/rhacm-fedramp-Low.xml
+++ b/xml/rhacm-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2697ca07-a9af-42c6-ab25-a3c0479ea05f">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b0843546-a0ee-4d17-b766-65284dedeaa1">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.28+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.10+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="53482e31-b018-4586-9e6e-34070a931e77">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="364de3bf-6f67-4fc4-bdfb-57ca54defd1a" control-id="ac-1">
+    <implemented-requirement uuid="446a37a9-8d6e-46ec-bd4a-d588b86fc059" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="64df5557-c6c6-4f9a-bb5e-64d100b47743">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8bcf94f5-f4d9-494f-bff3-4c2f5ff3751f">
+      <statement statement-id="ac-1_stmt.a" uuid="a46fa548-3227-4b5c-9e93-b4551e31bdfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36092e00-4d2c-418b-880b-8666504caae1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination of organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.1" uuid="fd2ac36a-fa78-4ae8-a477-074a5e87ae3c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c13ea87b-619d-4450-b00f-32ec44a426c5">
+      <statement statement-id="ac-1_stmt.a.1" uuid="f0061df9-be8c-426d-9430-6f55ca66a31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="848b0235-1b1a-4fcf-942c-013642a9448e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An access control policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance is an
@@ -503,32 +503,32 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.2" uuid="477e78dd-3e9d-4f43-a909-003bb434d935">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2fb7fa27-26ba-437d-9c69-419dc1788b28">
+      <statement statement-id="ac-1_stmt.a.2" uuid="c8f713b3-3d22-40d0-bec1-0fd90c1d94c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="0617b9af-ae7b-4102-9cdd-3e276c6c0204">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7e89a50d-3656-4ed9-a506-213c55ae36e4">
+      <statement statement-id="ac-1_stmt.b" uuid="51ec5615-5e67-4f8c-94e2-6e1b8ce61aef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a99e9c01-39cc-4093-864f-9a0ea60cdf5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating current access control policies and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.1" uuid="28a6e0a0-6fbe-421c-8191-f12b42ea368d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b8a55631-f475-40b7-bded-927b9c211380">
+      <statement statement-id="ac-1_stmt.b.1" uuid="458d23f0-08aa-4e32-97c6-abd0be9e9bce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0679509e-52fb-4b00-a43b-3ef62a41877a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.2" uuid="10e052dc-742c-4470-b345-1a6e8ddcaaa1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1b49460c-ba46-4b61-8d9f-c015c61af6fd">
+      <statement statement-id="ac-1_stmt.b.2" uuid="a729a20f-9875-4d17-ac07-0c78a62d7653">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3355f100-b665-40a9-ac04-a26e35f125e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -536,32 +536,32 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba75bac9-914b-4af9-a0c8-3d9c2b7c72a9" control-id="ac-2">
+    <implemented-requirement uuid="f48afcad-3715-41c6-abcd-de0aeb8f62c4" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="8d79c90d-eba8-4283-8e83-df451b6ed82f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3f7a6491-8e03-4d36-8f6d-a20192b7fca6">
+      <statement statement-id="ac-2_stmt.a" uuid="071c595b-1c04-45fd-8884-54a98c532e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd99f31e-58f4-4550-8889-f7593dd8fec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying and selecting the following types of information system accounts to
 support organizational missions/business functions is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="db748b5b-e31a-40a3-a459-09bfeb113dbc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="71f2e34b-0393-4873-b7c5-c3c65af2ed7c">
+      <statement statement-id="ac-2_stmt.b" uuid="056e1235-b35d-4b33-9e7d-6f66114715e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0db68032-e217-4080-ba94-6adfd1e97616">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning account managers for information systems is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="6f2c7548-813a-44c1-b6ed-bbe0478cef1b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="51004d08-bacb-4634-b268-a04dc986d57d">
+      <statement statement-id="ac-2_stmt.c" uuid="d4922d23-07c1-4882-b9a9-ae68419ba2c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af87783f-3e43-45ae-a397-c22e28fc4bc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role memberships is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="e2d0480f-75be-4503-85ca-69cbb4eb498c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="388957e1-48ed-4c1c-b659-bab7fc848587">
+      <statement statement-id="ac-2_stmt.d" uuid="e608893e-0645-4161-9404-db3af18049bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d23ed55-db60-4784-9945-229baa1dba09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specifying authorized users of the information system, group and role membership,
 and access authorizations (i.e., privileges) and other attributes (as required) for each
@@ -569,16 +569,16 @@ account is an organizational control outside the scope of Red Hat Advanced Clust
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="9f3d3777-465f-4d76-ad40-d413db2c4b3b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="43181daa-3bdd-42b6-af36-ae82c1981171">
+      <statement statement-id="ac-2_stmt.e" uuid="96007fe4-1aa9-461b-b1c7-f57af74c3bc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3b5f0a1-6cca-46c6-8d74-a4d7af405163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring approvals by the organization-defined personnel or roles for requests to
 create information system accounts is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="f30e2b6c-530e-445a-981f-c0f5baa9c896">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f5b7c1b4-c3f9-4821-aa39-8b67d1f7b266">
+      <statement statement-id="ac-2_stmt.f" uuid="94b4eded-4c6c-4732-9b2b-e1b523bfc2e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb1bba66-5aec-4056-8637-f249f7d9b368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating, enabling, modifying, disabling, and removing information system accounts
 in accordance with the organization-defined procedures or conditions is an organizational
@@ -586,71 +586,71 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="62acf9f7-f727-4834-9aa3-1a43de56d95c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2fca6ff7-58dc-4ae7-b192-6ef8ca6a40d0">
+      <statement statement-id="ac-2_stmt.g" uuid="71d1f487-08fd-4033-adf0-511d6baced01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5813133d-dc14-464f-a80e-a458308b0924">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the use of information system accounts is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="dc5e6f85-a333-4fa5-a3bf-1434c4da0f3d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4583e38f-2674-4f65-81f7-72a0095930da">
+      <statement statement-id="ac-2_stmt.h" uuid="9dfc8529-1ae8-455a-9f16-4ccd2e30b472">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5d5918ea-bff0-4d9f-862b-87eed7745465">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers based on organization policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.1" uuid="6a586b7c-8bb1-4907-bd03-ab8d3b4b8eb3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dcf977a3-af0f-4852-93d3-e32d77ddffb7">
+      <statement statement-id="ac-2_stmt.h.1" uuid="6f3a1a5d-0e5c-4fa5-859a-2c354cbf7bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3bf8a-966d-4ce5-99af-2112ab2db55a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when accounts are no longer required is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.2" uuid="e3722946-8a2b-4676-9224-bd466dc29d33">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9e357b67-91ad-44ff-83ca-d6f2348ee0bb">
+      <statement statement-id="ac-2_stmt.h.2" uuid="5410d25d-7179-4c37-b207-9770f42388ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eefeca77-e7cb-4309-ab70-98e43ee0f21a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when users are terminated or transferred is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.3" uuid="e4c29b9f-9724-43ae-9aa9-7174e246397a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cfc54d16-27c0-4373-99f0-828ce069f3fa">
+      <statement statement-id="ac-2_stmt.h.3" uuid="59a7dfb3-5417-40ca-8b68-fb05f204c519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709fa778-591d-43b1-99f1-57d85da2c984">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when individual information system usage or
 need-to-know changes is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="ef2200fc-08cf-42ff-99bd-06201d471a28">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a50f5640-55f7-41c8-bd63-899614b56853">
+      <statement statement-id="ac-2_stmt.i" uuid="72153925-174b-4b9b-aebd-3c4ee81886ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3deedd5-b309-475d-8c14-2d3c4bd9d324">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on organizational policies is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.1" uuid="b1af10f0-e8c1-4e99-be31-1b23238ca2ff">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ce4056e3-2103-4544-894d-875e22b95e53">
+      <statement statement-id="ac-2_stmt.i.1" uuid="fc866425-422a-458b-b692-66f3ddba4077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bdf2292-5cea-48c9-a97b-03c440bb886d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on a valid access
 authorization is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.2" uuid="397b586a-8a25-46de-a300-0f788131c5b8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b192035d-c025-4c24-82fe-fee570a6a99f">
+      <statement statement-id="ac-2_stmt.i.2" uuid="733525f4-4f43-4c42-b223-c7cda170e955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b59c0b1-9f0f-4807-ae5b-3dc2cfd8f3d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on intended system usage is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.3" uuid="04df0e47-3cc7-4d7a-8238-d927f35db97e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5631da3e-2de9-4dab-9a96-b8aa78f926a4">
+      <statement statement-id="ac-2_stmt.i.3" uuid="39eb2761-3339-46ff-9006-e58ad19cc724">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="063e440e-bf85-4f03-a941-ba604aeecb07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on other attributes as
 required by the organization or associated missions/business functions is an organizational
@@ -658,16 +658,16 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="9180b732-8809-44e1-ad5f-bed289a6955c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="18c0cb5a-3791-45d6-9816-aed21fe4bb11">
+      <statement statement-id="ac-2_stmt.j" uuid="880ba87d-a493-4868-8e58-499d98903b59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29ccfaaa-25ca-486a-a1c7-7f75266738e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing accounts for compliance with account management requirements is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="3106d808-e180-4628-9737-2776dce07f18">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2499c854-2919-41dd-afd7-4132f5845ec5">
+      <statement statement-id="ac-2_stmt.k" uuid="e887fc23-6372-426c-a670-f40a1eee3726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adf77389-1a12-412f-b327-7b6a5a0cb558">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for reissuing shared/group account credentials (if deployed)
 when individuals are removed from the group is an organizational control outside the scope
@@ -675,10 +675,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="801388df-8998-43f0-b7cd-1902b7e9168b" control-id="ac-3">
+    <implemented-requirement uuid="1d94fe0c-7b3f-4b68-9e0c-a2f16f5ad4b2" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="cd794058-9711-44cc-9d53-ce635fae4e12">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="54fd3817-c539-4b0f-8860-312057cdc90d">
+      <statement statement-id="ac-3_stmt" uuid="f9fb34c9-0b6c-4915-91ad-f5ec8476b3f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4a3ed62-15b5-4c8a-b32a-1ae088add7fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing approved authorizations for logical access to information and system resources
 in accordance with applicable access control policies is outside the scope of
@@ -689,10 +689,10 @@ relies on OpenShift for access enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a89e472f-6a97-4bb1-8006-11ce6fcc64d3" control-id="ac-7">
+    <implemented-requirement uuid="9e1db829-fdaa-4194-8af7-a78edf04eba6" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="7e41fa42-3d92-432d-b64b-559bfebe1c74">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="22f48ccc-7a5a-4772-bde7-d00e9de5498f">
+      <statement statement-id="ac-7_stmt.a" uuid="b3e410d3-f272-4815-90b5-03a1d6ee4c39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5e9720c-eebc-40e0-942d-9fb08a7b54ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a limit of an organization-defined number of consecutive
 invalid login attempts by a user during an organization-defined time
@@ -703,8 +703,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="13d135a5-a4df-4908-8b7a-080571b35b3a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="90ee05f5-11c2-460b-9e8b-5b327d015f3d">
+      <statement statement-id="ac-7_stmt.b" uuid="c17db2f7-5064-4071-b4f2-c01afee07259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52cbafe5-5b89-4cfe-aa8b-04f8077546a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically locking the account/node for a defined time period, or
 locking the account/node until released by an administrator, or delaying
@@ -717,10 +717,10 @@ for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69fbef60-159d-46ed-ac56-61ada0f5e1e9" control-id="ac-8">
+    <implemented-requirement uuid="9dca821d-7949-44d6-846b-6c1c3258ca23" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="80d57e80-1f01-419f-b2e2-c42157ad778c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="db7a6274-8a7f-4112-94b3-5d5e52663100">
+      <statement statement-id="ac-8_stmt.a" uuid="3db1117e-7344-4b25-bad6-9fa07294bbe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0939dbe-e45c-4303-a828-f73439cd2cb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -735,8 +735,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="047c5ff9-6c2e-4d08-bc68-42b4f6475a06">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3b2f1087-ecc1-4bb7-bde0-1211a37505f9">
+      <statement statement-id="ac-8_stmt.b" uuid="1e505d13-6d01-4048-bc14-9c124464989a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57fefa6e-7f03-40b3-bf9b-2cd97e8e9287">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -750,8 +750,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="e95c9a46-3aa6-44a3-9f56-9d586e1eab64">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="710a7677-f27a-4590-8579-f7746b75b6f3">
+      <statement statement-id="ac-8_stmt.c" uuid="72c013ea-4aa0-4188-a6df-1a2abd22eb65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2671d163-9697-45bd-bf8c-8da3de9c7630">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -768,8 +768,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="c97bf397-10e2-424d-963a-6e4590f7d1a8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="48492cc5-6c0a-4327-8f64-86c38df148ba">
+      <statement statement-id="ac-8_stmt.c.1" uuid="5e025568-70db-436b-b07a-1263236aeb2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="505b0b2e-9e7e-4ed4-b3fe-8b8f917769f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -781,8 +781,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="782d4ab4-dcc4-4584-869d-4f1f84fb859f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ccbcf082-7b5e-4cf6-86ce-51f697c0a108">
+      <statement statement-id="ac-8_stmt.c.2" uuid="4cc4d223-2e5e-4486-96d3-f09d672416f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f33d5c8e-5121-42ab-a713-f12b260eb0ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -795,8 +795,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="c0e990be-1b01-4c91-ba6b-411647f27cf4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bde22483-f419-4e83-b7a3-a186848cf028">
+      <statement statement-id="ac-8_stmt.c.3" uuid="291f26ac-e5ec-40c7-ba2a-a5c85fe69824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69f46d8e-dfdb-4489-b4a7-5489aa0c8f4a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -811,10 +811,10 @@ https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b21d914-e0a5-4c0a-b6e8-6b4d977ed30b" control-id="ac-14">
+    <implemented-requirement uuid="77a08b50-4be7-4f66-8f4f-84855ef1cc49" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt.a" uuid="44053876-ae1c-4713-8bb4-7fb8de4babf9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="01c32327-7863-4dad-b13b-ee4ab04e700f">
+      <statement statement-id="ac-14_stmt.a" uuid="5629b5ea-36ab-455c-8d73-cf6c88bfa332">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1255ed5a-781e-4085-9ebf-573f7faa1c7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organization-defined user actions that can be performed on
 the information system without identification or authentication
@@ -823,8 +823,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-14_stmt.b" uuid="6089fec6-746d-46c8-a4fd-94c03f140fa7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9e594d44-94ea-406a-a79d-845daa6c2cd2">
+      <statement statement-id="ac-14_stmt.b" uuid="368700cb-708a-4db2-b713-a770859e28d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce50b336-a265-411a-bc40-27ece30bac20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and providing supporting raionale in the security plan for
 the information system, user actions not requiring identification or
@@ -833,10 +833,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="421e64c7-edad-43ae-a16e-7fd50ad7f2d9" control-id="ac-17">
+    <implemented-requirement uuid="7128e417-6249-45af-8571-c712eb28d094" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="2ac76e4b-9fa3-439d-9154-e04d66de6a17">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e883ffb6-94cb-4376-9da6-8a862f83845b">
+      <statement statement-id="ac-17_stmt.a" uuid="68cff69d-2bb8-4591-8f38-62249ae0b657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15acf2ac-db91-4dd0-9b79-e7e64fb6a447">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing nd documenting usage restrictions, configuration/connection
 requirements, and implementation guidance for each type of remote access
@@ -844,8 +844,8 @@ allowed is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="1670c719-c82e-43f8-b8e5-4577f384a84f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4314830d-c508-4a66-9e39-2ea100f20145">
+      <statement statement-id="ac-17_stmt.b" uuid="40ccd22d-b36a-4e0d-8390-e043a4dc09ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81512212-759c-488e-af52-ac47b733dd17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing remote access to the information system prior to allowing
 such connections is an organizational control outside the scope of Red
@@ -853,18 +853,18 @@ Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9077020-774d-460d-93db-d957ac92ebf5" control-id="ac-18">
+    <implemented-requirement uuid="81b0da80-f4cc-4d8e-9e32-03731ed286ce" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="ec173566-4aab-4c1f-9523-7f9c841a4331">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0603404e-c767-4b62-a1a7-ba4f2bfe29aa">
+      <statement statement-id="ac-18_stmt.a" uuid="ac4516ea-59d7-4493-9f0a-360aa160ccac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="706e0ed7-6e8d-4399-8bdc-3284bdc4d24f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless access
 usage restrictions are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="817c3aaf-cc38-4f79-a7c1-90a33bc4ea8e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e20a54f5-14a6-45cd-b45b-77ace44b7d7b">
+      <statement statement-id="ac-18_stmt.b" uuid="0571c9d5-0dc7-4fa2-8fe5-70ddeb67d2bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d4bd5c-e641-4851-81a8-29309766ceb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Advanced Cluster Management for
@@ -872,28 +872,28 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="827f449b-d3c1-4e4a-9c92-fe578ef00bd4" control-id="ac-19">
+    <implemented-requirement uuid="ab1ce503-1654-45eb-88e7-f92f730772f4" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="ed0ae21c-b011-404b-b2ed-0ac574396a3f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3dce77db-6b81-4b3b-a196-3a6c3a972da3">
+      <statement statement-id="ac-19_stmt.a" uuid="01754353-65da-42c5-a2ba-a8fbb18820bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aabd43cd-5bb9-47d2-9b2f-f270d6af778e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="c840413e-046e-4610-af67-6b999b85d948">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4c7e984b-1c25-4bc4-aaef-3f75989a84b8">
+      <statement statement-id="ac-19_stmt.b" uuid="ddf9d051-c971-4d22-8dd4-1a4bf09571b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0007f9d-320c-4743-92e6-918f64f1605e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e824e6c-4ad4-4ce0-8347-1292f8e71ec9" control-id="ac-20">
+    <implemented-requirement uuid="21f8c09b-b7fc-46d0-9ab8-c90adab0f1ac" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="81c2badb-f10a-4790-b4b3-b5387a5d4d96">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a497adaa-d832-4472-b22b-f0b31e13d931">
+      <statement statement-id="ac-20_stmt.a" uuid="e95daffc-210d-4201-b395-9d40aaaf8f2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d7a03b-2e25-4575-b1c4-9c3d3634b60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for
 accessing the information system from external information systems is
@@ -901,8 +901,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="9c1cce48-ee5f-4fe7-9572-033c9093a966">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2a03ed79-a620-4441-8f77-ea61f588c024">
+      <statement statement-id="ac-20_stmt.b" uuid="f4553ed7-066b-4f8f-bc8d-87ccf77e5546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3e2dcd3-f967-4d44-982b-9a17aa45ef34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for the
 processing, storage, or transmission of organization-controlled
@@ -911,10 +911,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49a9440c-562f-4f6d-b61c-2999e25760b8" control-id="ac-22">
+    <implemented-requirement uuid="675bf8d7-bd6f-4f1f-9e04-44762cc751f3" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="3a19f0e3-3ee2-44de-9b12-beaed5ad65f3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="08e602a1-6ce4-4444-b08c-01b0a36ffacb">
+      <statement statement-id="ac-22_stmt.a" uuid="14806bcc-f83f-4408-922c-53f570a5cf0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2636d175-e8a1-4668-9723-bebf0f555433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -922,16 +922,16 @@ system is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="fec8f21f-e0f9-4c38-86b8-59827145a63d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3ce542c1-2dcd-47e2-a1f5-cb4cf3c7644a">
+      <statement statement-id="ac-22_stmt.b" uuid="ed069c5d-4f75-460c-aa1e-937e618e2d0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d07655f-56af-4e87-bc90-2467e6b3df99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="54e8c815-cd28-43de-a42e-98e44461cfe2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="da82d787-dd0c-4070-b4a1-502b5e603297">
+      <statement statement-id="ac-22_stmt.c" uuid="fa8310c4-487f-4cc1-9e79-e0c0360f2413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72fc5d98-cf5a-4240-b0bd-bdf9d0bfa482">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto the
 publicly accessible information system to ensure that nonpublic
@@ -939,8 +939,8 @@ information is not included is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="b954cafd-1940-4ec6-ae0c-2d62a50b70aa">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="aafdcc95-eaf6-4922-8d4e-534af1535a48">
+      <statement statement-id="ac-22_stmt.d" uuid="c8214e90-c694-4709-a058-085720e7ede6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f4c2c7a-9aa2-4c48-a223-dad78aac1f7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system for
 nonpublic information at an organization-defined frequency and removal
@@ -949,10 +949,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83dc8533-48ca-4a5d-b718-267a910e9496" control-id="at-1">
+    <implemented-requirement uuid="3d53f5ba-0388-464e-9ed2-226cdbaf9b51" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="c6c5bdf6-45f0-4f9f-87a9-697a9f792199">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8e9961ce-ade9-4802-bcd2-9cbf4812d979">
+      <statement statement-id="at-1_stmt.a" uuid="7db712a1-e7a4-40f2-8040-fa0b61ce15de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a2fc15b-b52c-4d67-9db2-82f2b71fbeb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
@@ -960,8 +960,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.1" uuid="79fe36ac-d8a9-4704-a743-f4bee7c9e07a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3be3bef4-3cdf-4899-80c6-2eb8c2c3cc23">
+      <statement statement-id="at-1_stmt.a.1" uuid="c36d15a6-7c20-415f-aec2-db0d8b83ffe8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3624a79a-adf7-4b9a-a6c1-bece2aa3f97a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles a security awareness and
@@ -972,8 +972,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.2" uuid="4ffe2c42-af6c-4473-a4a1-a83ae096c19e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c596751b-d715-4ba0-86bd-45cdade9bbe4">
+      <statement statement-id="at-1_stmt.a.2" uuid="e07b53ed-3179-401d-a4a2-d3fdea6560e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5d8f64c-5e67-4b22-bf59-9d33772a5147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles procedures to facilitate the
@@ -984,8 +984,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="6ad7fa08-ef7f-456a-bd21-e6ea3db05b68">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="aab9ae2f-4f04-4933-951d-e28fcafe2a4a">
+      <statement statement-id="at-1_stmt.b" uuid="f01cc4c9-9890-48b2-930c-1aabdc40f441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a296282-0d22-40c0-a0ae-d7297eff630c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness training policies
 and procedures is an organizational control outside the scope of Red Hat
@@ -994,8 +994,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.1" uuid="5d2151d7-73e8-48a2-aac6-76dbb8d4d624">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="53f6d53a-cc73-4503-95b0-729ba8ea1def">
+      <statement statement-id="at-1_stmt.b.1" uuid="6a893871-b841-4f12-8149-b6894e65aae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="573a8d1d-647c-4672-994d-e1a08cb74495">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 policy on an organization-defined frequency is an organizational control
@@ -1004,8 +1004,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.2" uuid="cd8e642e-60de-4d0c-99c6-b8aca352ce43">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="06997cf0-f70b-4f6e-8789-7b4e114bf388">
+      <statement statement-id="at-1_stmt.b.2" uuid="224d4d2e-cfff-409a-b773-0910fb235c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9659903-f239-41f0-bbc3-f13d2e6d3a01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 procedures on an organization-defined frequency is an organizational
@@ -1015,10 +1015,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a87f979d-b17e-493d-b440-a9a42cc265b9" control-id="at-2">
+    <implemented-requirement uuid="e6ed68bb-0870-4dcb-9b24-17c1ebce64a8" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="b15ecc44-9958-490b-811e-35f2a48771a0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6ab7bd86-393f-4337-9c64-bb970e57f7b0">
+      <statement statement-id="at-2_stmt.a" uuid="8503c131-86bc-4578-a094-8bdda4893fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14ebc016-0547-4d5d-b10d-d315cba099ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) as part of
@@ -1028,8 +1028,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="ed0999a1-78a9-4be0-956a-d3164717b083">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="86144ac6-2bf3-4942-98ea-f9cf9a9ff948">
+      <statement statement-id="at-2_stmt.b" uuid="01cdbb14-ba93-4579-bd0b-1c3cf8b62da0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46d6e9ac-9d48-4d7c-baec-7c7a2083c708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) when required
@@ -1039,8 +1039,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="94c149ab-b90d-489e-992d-a5027eb8bdeb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e608a8a7-a1ee-4a8e-951d-d9cf11bc316a">
+      <statement statement-id="at-2_stmt.c" uuid="da6133dd-b73d-4380-bb5a-861448a188fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="132b46ae-43ce-48f6-a591-be355da2ce1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) on an
@@ -1051,10 +1051,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56f09d01-6ca7-41fc-b6c6-dfe119ee578a" control-id="at-3">
+    <implemented-requirement uuid="a16777d8-142c-4f9a-906d-b955c88bf4a0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="3179d7a8-579a-496f-8298-d013a359404e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1d3c8be6-16a3-4d6c-9aaf-a5abc4566203">
+      <statement statement-id="at-3_stmt.a" uuid="7b4ef1c4-73cb-4b9c-a509-733b33d61428">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb373e0-5af9-4d04-be11-a02bfbef71c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities before authorizing access to the
@@ -1064,8 +1064,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="151fba07-2905-44d7-883f-ee8b7ebaa0a9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="65bcfdbf-bc27-4a85-855d-7ecc45c91aa4">
+      <statement statement-id="at-3_stmt.b" uuid="f6d28bf3-3ac5-4c73-9c71-7230cced8cec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="903135ca-e9e4-493b-a7a6-add2514eebcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities when required by information system
@@ -1074,8 +1074,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="d97184e8-c525-4608-a55f-5cc2b0966015">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0dd8a178-62b8-4155-b2f7-765b01fe46c4">
+      <statement statement-id="at-3_stmt.c" uuid="86749632-bd79-45d4-b60f-9b5fcc96a451">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4aa49d88-350e-43ed-9ee8-dfd4807cdf61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities on an organizational-defined
@@ -1085,10 +1085,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee8fd8aa-d5bf-4106-a136-195d2c19dbcf" control-id="at-4">
+    <implemented-requirement uuid="d8b591f0-19de-4755-ae3e-345052f4cb56" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="8614eca0-244d-4357-8bfa-02388ab0d221">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5cff4b29-800e-4460-94e8-77ebbd7c8ec6">
+      <statement statement-id="at-4_stmt.a" uuid="0087eb27-174e-490b-b0fc-dcf52ce768b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22f347b7-eaef-495f-a58e-700c61644f3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and monitoring individual information system security
 training activities including basic security awareness training and
@@ -1098,8 +1098,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="d7dd992f-fbde-44f7-ae48-a7db5a8ec4cc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d9799e93-bcd6-4958-aeaa-94cbaccf5f4b">
+      <statement statement-id="at-4_stmt.b" uuid="9904e3c3-abb9-4091-8f38-c1bbafa94d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="225f3983-c3eb-4a20-8b70-52480656e170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retaining individual training records for an organization-defined time
 period is an organizational control outside the scope of Red Hat
@@ -1108,10 +1108,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b719092a-a0ea-41f5-a45d-e25860bf025a" control-id="au-1">
+    <implemented-requirement uuid="93522bc6-7b1e-46e0-b2e9-4fc565ab55d1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="13a9dc05-c5cb-4798-b479-819c3f5ecc6e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="64cc69bb-09c5-439c-a16c-85f9d9a4815e">
+      <statement statement-id="au-1_stmt.a" uuid="89ecb81a-977e-453b-aa96-fb6e0cb4b418">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce489d2-2ab4-40a3-8a56-d77d87a28670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Advanced Cluster
@@ -1119,8 +1119,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.1" uuid="195d754d-ff9a-4205-9af9-52eccb49b9e0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="73b2f4f5-9817-4360-bce7-c4b3ae6aeeab">
+      <statement statement-id="au-1_stmt.a.1" uuid="c2e804c1-4b19-42f5-8170-b199f7f06f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="128c9f3f-1bff-4316-98c6-5cb24150cc87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy that addresses purpose, scope, roles, responsibilities,
@@ -1130,8 +1130,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.2" uuid="1283f931-508f-4f29-93ce-429a69730d9c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="330e7a94-e41a-4bb4-8259-4d531f6bd318">
+      <statement statement-id="au-1_stmt.a.2" uuid="fbdb7c26-1ad2-4e01-b276-caefef2baddc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2d115ed-16a4-4dfe-a543-32be43c3d405">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level procedures to facilitate the
 implementation of the audit and accountability policy and
@@ -1141,8 +1141,8 @@ for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="d32597e1-4652-4f40-9c8c-34f1be637e0b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="037a60d2-2cad-4fab-aa3e-b77420053937">
+      <statement statement-id="au-1_stmt.b" uuid="e55963d2-5a06-4ec1-bb13-1bf5f9ae9a96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147568cb-e0e1-4ce7-97d1-3b200534508d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat
@@ -1151,8 +1151,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.1" uuid="c81f7c9d-cad1-44a2-8082-5be57a365d51">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="53d02426-639c-4064-be9f-477f95a10da5">
+      <statement statement-id="au-1_stmt.b.1" uuid="d7166a9b-8fdf-4cf3-8af2-84a77d67636b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e63d95d9-1312-427d-b9f8-0a6704c04dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy per a defined frequency is outside
@@ -1161,8 +1161,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.2" uuid="594f93e0-9465-4936-bf3e-f46ce2eaf699">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="29246790-9efd-45b8-9a4a-37a9484ec77b">
+      <statement statement-id="au-1_stmt.b.2" uuid="8ef977d8-1e69-4b30-a44c-d8f1fc5b5070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e298296-2a66-4578-998f-b5bce664d747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating an organizational-level audit and
 accountability procedures per a defined frequency is outside
@@ -1172,10 +1172,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="285fe38c-f377-402a-8fce-a0924facdb8c" control-id="au-2">
+    <implemented-requirement uuid="b03e41af-2673-4478-b4ef-fabb7dfc78bd" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="f1d09eed-b433-4433-980b-3c135e0a3cf1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="625fe33d-e4d9-4c11-9f23-b73f26b2f732">
+      <statement statement-id="au-2_stmt.a" uuid="1b8b0e5b-da43-45bb-ba31-0b2bb2e19836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1186,8 +1186,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="eb486f8a-ad58-45e6-9e4c-39c51b6bf683">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9778b17a-5b9c-4745-b004-ad38f0e1c6cd">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1195,8 +1195,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="7772834d-a28c-412a-8a49-e06b647e2566">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9982ce81-9ba6-4aa8-8e0a-9cd555eb9c04">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1205,8 +1205,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="f7991ad2-f938-40a9-b28f-5e4d565b4a99">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="71563ee3-b1fd-4412-b892-c1ef669e0480">
+      <statement statement-id="au-2_stmt.d" uuid="21380c65-89e0-46ae-9f7c-c077c3f43f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1218,10 +1218,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="802d862e-ba23-4e19-a09f-e2bd8091b595" control-id="au-3">
+    <implemented-requirement uuid="565157ed-c989-45de-9051-e3e39cdc5baf" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3_stmt" uuid="c7f1f261-9344-42b1-9241-f7cda7d4a54a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="217cedd7-02e6-4ce4-9fd8-c6f4e9a7aab1">
+      <statement statement-id="au-3_stmt" uuid="efd94e80-a7d7-4e59-9d8b-d97f7418a986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1233,10 +1233,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04cc2528-306d-40ba-90f2-9e4ce57ed4da" control-id="au-4">
+    <implemented-requirement uuid="fda69e31-a6eb-4841-8f77-97b9def4c605" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="3b15cb80-723e-4371-89f8-9c95c170c569">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="928d4303-a7a9-421e-9037-bb19cd1e364d">
+      <statement statement-id="au-4_stmt" uuid="621babff-ebe8-45d6-bb9c-8ededcfc5c0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1248,10 +1248,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ece4697-217c-41cc-8b22-e88b8dd5ea28" control-id="au-5">
+    <implemented-requirement uuid="f1968243-07bd-4385-bba0-7104ebd712e0" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="4c9a69ec-797f-434d-b61a-e7ea198e7fed">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ec7ddc70-dcd8-4303-9172-68e6803329ed">
+      <statement statement-id="au-5_stmt.a" uuid="151d383a-efd6-44e0-b745-12d1fc7d6ac1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1262,8 +1262,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="1e452d32-a436-4a4f-8bca-236aaf86e164">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="292d47a4-26fc-4c0b-b923-42f207582878">
+      <statement statement-id="au-5_stmt.b" uuid="a6646919-06bb-478a-bcdb-b2d8386b09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1275,10 +1275,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ca41317-e8fb-42f0-93a0-a8b54ff07ea0" control-id="au-6">
+    <implemented-requirement uuid="f402cea2-a394-465d-a946-c6d65a71f86f" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="e9a71070-21ce-44d4-8e0e-2e6bd6554dbd">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b9362ff3-a422-45ee-a48e-f0777a03de75">
+      <statement statement-id="au-6_stmt.a" uuid="bad96ef8-562a-4ccb-a6dd-0b1bcff62f78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27f022e-887b-4ae9-8345-28848b08f1f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1287,8 +1287,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="4bb1052d-4fd7-43a2-a77a-eec6cfd17309">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bc1bd0ac-974c-46c5-a69c-84e73947f5a6">
+      <statement statement-id="au-6_stmt.b" uuid="b4d9453e-3213-4bd7-b194-30d0da550f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dd55b1d-9d68-43e2-8156-2c1d86cf1a3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1297,10 +1297,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="799f5ec3-0717-44b8-b157-0f959a291a57" control-id="au-8">
+    <implemented-requirement uuid="bc57b069-5a92-4967-af4d-a8b7d562cf0a" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="78b121e5-4a99-498d-a012-929ca4a738f8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f409003f-bf07-42a8-b911-68ba7d348c7f">
+      <statement statement-id="au-8_stmt.a" uuid="2514ddf3-efed-429e-bbbe-4de6676b6a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1310,8 +1310,8 @@ Operator and to the OpenShift cluster and is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="04c868f7-45de-40f4-89ec-433881d00113">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4fe86cc9-f4b9-4790-915d-72ede6ff3187">
+      <statement statement-id="au-8_stmt.b" uuid="0f88897c-bea3-40de-8f58-22ce0807fdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1322,10 +1322,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5896592-684d-40a7-829c-1c6e04946fc1" control-id="au-9">
+    <implemented-requirement uuid="fa8e2aa7-1ffa-4aa6-a9a7-7ffd06c379da" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9_stmt" uuid="8f71008b-3e8c-4232-af83-b484da8c5109">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="54813a83-21b6-4ded-a3de-d4bd5b8b6407">
+      <statement statement-id="au-9_stmt" uuid="0636913e-ee07-4cc2-a565-a356ba89844c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1337,10 +1337,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e907c3b-0271-4348-8c5c-90e4561c1ad8" control-id="au-11">
+    <implemented-requirement uuid="e7bcea13-2029-4aea-8e07-ba3593be0301" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="7569ce20-3a14-493c-b546-ecefce2c8770">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="23b0e695-d125-4f61-ad26-1e5d12747299">
+      <statement statement-id="au-11_stmt" uuid="d7e22308-ca97-42d6-b7b7-39775e6e92e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1352,10 +1352,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55023578-80cd-44f4-9c5b-7177762a3e43" control-id="au-12">
+    <implemented-requirement uuid="6da943ff-8ed1-4a0e-9856-1c6f0d776cf4" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="e6268150-f7aa-4108-b8c6-13e9d424d1f4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="334261a1-a797-4196-8541-2a4969cb2bb4">
+      <statement statement-id="au-12_stmt.a" uuid="e8e03e01-00af-4235-89ef-f45557254e07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1366,8 +1366,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="fa4b4932-2696-4d61-8073-6149a01149ad">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="efc6f309-2c41-47f9-bbe9-e0f39a1ee1e8">
+      <statement statement-id="au-12_stmt.b" uuid="766ed89b-14a8-478c-b140-61e909d67881">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1378,8 +1378,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="b654ba9f-1a3a-4024-93ff-78a97c84f0e5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="df916377-c084-4275-8f24-fdfe9605d3be">
+      <statement statement-id="au-12_stmt.c" uuid="c6e873a5-a73d-4a3e-8264-7b1b0848562d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1391,18 +1391,18 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59f9d123-4155-4af5-9cb0-39165835a9db" control-id="ca-1">
+    <implemented-requirement uuid="01f4c3ba-c968-46bc-8330-f85b6bcc8467" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="d9ef3e51-41fe-4ad6-aad8-6534e70358c6">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7a8d455e-2e31-45ef-bcb1-fa9717b2e714">
+      <statement statement-id="ca-1_stmt.a" uuid="519ae86e-7b1a-4ca9-bed4-cff7f2c53d33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="00842597-8cc1-4c54-8cb7-34509bc8cb61">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b063e39a-33e1-4b91-b9ed-5a32d62372a2">
+      <statement statement-id="ca-1_stmt.b" uuid="2639125c-d328-4613-a73c-3e9c3beae532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1410,34 +1410,34 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration gu
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e58ab10-6c18-48c3-a726-d58216c3dcb4" control-id="ca-2">
+    <implemented-requirement uuid="c672dd8d-a42c-4506-b5c5-aa859ae35fa6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="99c5f57f-7a94-430f-b357-950ff6a2f7d7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9cfc9451-d6e9-418a-8e1f-85b656dbb23c">
+      <statement statement-id="ca-2_stmt.a" uuid="5ad78120-51f6-4cb6-9f11-60323121f058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="4bc89850-8d8b-4c2f-928d-81105b737f6f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="94a2cbbd-4216-448d-a52f-8d459354504b">
+      <statement statement-id="ca-2_stmt.b" uuid="55b6f393-d145-48bf-bb19-b8c5f9152e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="c7a05524-2971-49a5-a76f-dca7a6f3b241">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6eaf15c3-3ef9-4cf0-9e01-150fcd717678">
+      <statement statement-id="ca-2_stmt.c" uuid="a48b116e-64f7-43bf-bfb8-d5400123afc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="05cf46db-df1d-4b83-adda-1b25c316e85c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8bd9a051-76ea-4f02-8583-ce958497af6f">
+      <statement statement-id="ca-2_stmt.d" uuid="32344de1-3c92-4154-951e-ef77e7e0b719">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -1445,10 +1445,10 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cebb09a2-0774-4cdf-ae6e-e687ef5569bd" control-id="ca-2.1">
+    <implemented-requirement uuid="b2a4477a-ef14-4efe-a747-daf74eff8f74" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="01c7b888-ed91-441e-b3a8-010fcb968856">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3245d838-bd42-4bd7-9399-25fcdd6115e1">
+      <statement statement-id="ca-2.1_stmt" uuid="72d3ad7f-82e8-448f-8abf-ef69c5c57aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2c057b-c13b-497d-baf4-043ee1ee1c6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -1456,26 +1456,26 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59f72774-ba22-4c8f-a837-b077a025cf2f" control-id="ca-3">
+    <implemented-requirement uuid="b57f061e-790a-4ea9-aef1-3bdeaae3d6a7" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="1d8ae09a-b114-48c0-9d92-a7bd39a1973c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="95d8e7f7-1890-4c61-a5e8-9de9185da582">
+      <statement statement-id="ca-3_stmt.a" uuid="1ed9d428-4eff-4ed9-9345-c103b6e33df6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="ca61291d-c1bc-415c-bcf8-c5c9fd78647e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d7b0b091-e5d1-4b00-8e2c-b2f9125a379f">
+      <statement statement-id="ca-3_stmt.b" uuid="2625543f-8485-4cce-aadf-f54753f5eff0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="0f5ba83d-4171-431e-b5b7-710c9303992c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="24381164-90eb-491d-8b1c-d030f8ca1be2">
+      <statement statement-id="ca-3_stmt.c" uuid="1a5d17dd-405b-4e8f-8d25-dbef8f40a7cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -1483,10 +1483,10 @@ configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a835d46-3dd6-4f89-b951-410e2f7b76b9" control-id="ca-5">
+    <implemented-requirement uuid="1bd5743e-193f-4be9-b335-a1ac7999bbb4" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="b190169b-3cb5-4f1b-86a0-f883773eca76">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b90f79ef-b6b8-4e27-8105-9994ac36f2c6">
+      <statement statement-id="ca-5_stmt.a" uuid="959605c7-23fd-4050-b5c1-48d5ac034bb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f79d6ae-edfe-441a-b485-8f3c80a8a60d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Advanced Cluster Management for
@@ -1502,8 +1502,8 @@ Management for Kubernetes POA&amp;M, Engineering progress can be tracked at:
 https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="01ba4113-7945-4b8a-9b56-f1cb11598821">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e8835822-f01e-4718-93cc-210c61515469">
+      <statement statement-id="ca-5_stmt.b" uuid="84692ecf-2d34-4137-9dd1-aa808d86317d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="112a979a-cc94-4e65-903c-099daa507bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -1518,34 +1518,34 @@ https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6625043d-3c8f-404b-8656-c49cef9c4e7f" control-id="ca-6">
+    <implemented-requirement uuid="9cac12f1-c86a-48a1-9afb-2b3110154cc6" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="82c0f762-9a10-408b-931d-dd18c8dd813f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="53d7b34c-dcb2-4bb8-8c98-241a50285f4f">
+      <statement statement-id="ca-6_stmt.a" uuid="9bd01460-b742-446b-9268-e6cde83176df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="1da0b9b1-6bd3-4ca5-b716-314fbc15f795">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d383d4ac-a448-4f45-8b5a-a07661e04376">
+      <statement statement-id="ca-6_stmt.b" uuid="fb426be2-214f-4715-9254-482db9f1bc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="797a7481-9c84-49ae-9717-86e86e19c151">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b278d114-91c0-479d-b726-f8cb8265f541">
+      <statement statement-id="ca-6_stmt.c" uuid="9c030712-735c-49b7-801f-b934d6b58413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0386218-70c8-4456-a6be-70f2e54cdac0" control-id="ca-7">
+    <implemented-requirement uuid="6c564476-fae9-49f2-a572-42196d208bbe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="b5917aae-3853-422c-b84e-f94bc45dcea2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="55f9c78d-5695-4561-982a-62918e2ca6ed">
+      <statement statement-id="ca-7_stmt.a" uuid="3283410d-f341-42d7-8822-c01d1690337b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758b258c-4b30-4271-92f4-8e61b4afbda4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -1553,8 +1553,8 @@ monitored is an organizational control outside the scope of Red Hat Advanced Clu
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="e78dd1c5-c657-4a1e-9ffc-c4fedb6c942a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8c4f07b9-b817-4ac3-b0b7-90bd218eb196">
+      <statement statement-id="ca-7_stmt.b" uuid="48871aa8-8b97-4cbe-9e3e-931acd8a9136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15daea3c-f9bf-4a50-b2d4-42ae6bf92ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -1562,40 +1562,40 @@ monitoring and assessment of such monitoring is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="2b7994e7-3266-4018-a4a4-9988440b66a1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="38a217b5-b24b-42a9-8379-b0a30d413708">
+      <statement statement-id="ca-7_stmt.c" uuid="c61aefca-5fb6-4ec0-b86b-8a3c2ae2cf5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="e1d9edc9-4840-4b40-ba8c-fe72b5098e27">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="728055e9-3296-42fd-918f-11ebd8d79ae1">
+      <statement statement-id="ca-7_stmt.d" uuid="fa928e68-9aee-43a7-bf4a-6c6b78cbce0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="676eed7c-a406-4d24-9e87-db4c52097a30">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5a79dfaf-46c8-41b3-a30c-12f68c1ceeec">
+      <statement statement-id="ca-7_stmt.e" uuid="6a25579c-105d-4374-9cb5-d4253403d253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="be49509b-cb79-41ad-811a-27fa7e9c3be7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="98e99162-4f0f-41de-b6e4-c889c706a178">
+      <statement statement-id="ca-7_stmt.f" uuid="a2f92bfc-f9f8-40c7-ab30-00922de2c237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd1e0580-e27c-4e69-91c6-a25f4f1ebfbe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="16e5b577-aa37-4178-a52d-78d59c4eddfa">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8a7e00bc-62c2-4e9d-a8aa-c4f773dc866c">
+      <statement statement-id="ca-7_stmt.g" uuid="909988f3-0b2f-4ed8-a609-43f5e85394ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="defb78fb-f730-4013-87f4-f1eeb599f705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -1604,18 +1604,18 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ef61568-e78c-4889-a7e0-2697482d6ec7" control-id="ca-9">
+    <implemented-requirement uuid="fb8dae49-0d16-4648-b836-94ba226c896a" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="6a93d1c0-b9df-4cc5-abef-40b7549381ab">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="41103598-08ea-4d68-9767-4c8638b40c92">
+      <statement statement-id="ca-9_stmt.a" uuid="3766cc50-8615-4b7b-bb50-d26dffcf813d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30b2b449-8b0e-4aec-8bca-769e02bc9335">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing internal connections of organization-defined information system components
 or classes of components] to the information system is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="76f8cc59-44c9-4677-95f0-851415ad091e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="20b3fd9b-9b02-4508-9571-28c5aaef914a">
+      <statement statement-id="ca-9_stmt.b" uuid="45f6f5ac-2298-4437-ab64-74ffa3b7f354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ed18582-8a10-4c66-bbc4-d598891b6257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting, for each internal connection, the interface characteristics, security
 requirements, and the nature of the information communicated is an organizational control
@@ -1623,18 +1623,18 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="415978e3-c451-4097-9545-456f2071a52d" control-id="cm-1">
+    <implemented-requirement uuid="48bb0d88-da47-4cbc-9d34-bf0ccaed2fad" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="9b5991e6-806d-4597-adaa-97d392a8d8ce">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="161a27f4-fdd3-47c7-b2bb-34a0893b5d20">
+      <statement statement-id="cm-1_stmt.a" uuid="60c79fbc-29d7-4e5a-b683-463c626aad98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f517f39-42dd-4978-b5c0-209b1d8a2ff4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="3111fb6e-8d48-4649-84cf-6e412fe3b695">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="af5f8352-3545-4277-a646-07e4ba82c80c">
+      <statement statement-id="cm-1_stmt.b" uuid="baf16baa-b205-4934-8794-c50d0b74a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1070a7df-1715-4de8-a48e-ed5d829e68c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
@@ -1642,10 +1642,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77b8b055-d8c0-4e5e-af7b-ecbbce494a3f" control-id="cm-2">
+    <implemented-requirement uuid="a1d079dd-398c-4f9c-b11e-3c65e3cd857a" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="f42a4fc6-ee11-4043-9a9e-3c6e92ac74ca">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="93b78b8c-afcc-4f4f-bfe0-f0a3ab021ab4">
+      <statement statement-id="cm-2_stmt" uuid="a9e3b1c4-87e9-45c7-a9d8-90ee1adcc060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dcacec4-2e1f-4a03-975a-494dd6fbf8fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management for Red Hat Advanced Cluster
 Management for Kubernetes (RHACM) is to implement the principles and patterns of GitOps
@@ -1664,10 +1664,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05a7adf9-b2ad-4b62-8e08-44a064767d40" control-id="cm-4">
+    <implemented-requirement uuid="c466f2a9-5044-4f6a-923a-a22d2c787b37" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="904d3126-c681-440d-86ba-d9270f4eab82">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1cfbbcc4-7fc3-4563-a778-6f97d4db53e5">
+      <statement statement-id="cm-4_stmt" uuid="fd2632e7-3b6a-42db-99c7-2a933d3e73a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dcbfc6f-0506-47c9-88ff-91088ccd1d3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -1675,10 +1675,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e2fe952-402f-4c00-b841-ad5c56d93b35" control-id="cm-6">
+    <implemented-requirement uuid="4211401c-63bc-48ca-be02-d58c081cf1cd" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="a2d976f7-f0af-49be-aea8-eb589e17eced">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="27ed2eb8-b250-4c01-ba06-ceabcb5fb2d3">
+      <statement statement-id="cm-6_stmt.a" uuid="7923dc4b-0415-4bf6-aa37-b3f8f61fa18d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1686,8 +1686,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="b69b51cc-445a-4bdb-8bb2-273c47d4ff41">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dd7fde1b-c421-458d-bafd-565cd27031a6">
+      <statement statement-id="cm-6_stmt.b" uuid="be4fee0d-706b-4133-bd8a-7a0465a2b3d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1695,8 +1695,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="aa560592-a757-40d3-af32-c395f0af2d4f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d0193335-35f7-4c66-9d1a-3d359db0ca99">
+      <statement statement-id="cm-6_stmt.c" uuid="a8d60edf-af95-40b5-a21d-b1b354c8c8e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1704,8 +1704,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="bbf5e215-1010-43b3-81c3-c7ddb8be3540">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="20712dad-fde7-4be5-8815-86b7530b6a3a">
+      <statement statement-id="cm-6_stmt.d" uuid="7576c408-1315-4f8a-9728-018dfb256f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1714,10 +1714,10 @@ https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18f8a9d4-26cd-4ca5-a6f5-ef5c8d6d9e96" control-id="cm-7">
+    <implemented-requirement uuid="b4c719a6-2dd9-460d-95cc-d441e140740c" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="ca05d748-c9e9-402b-86f6-46b51f866d88">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ab08344e-b5c1-4f8a-8357-559b3884d855">
+      <statement statement-id="cm-7_stmt.a" uuid="1da9a8db-41f9-49e4-ae38-6822a89fa077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1725,8 +1725,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="09d665f4-d576-4fd3-b0ef-3084f98c5bfe">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="39a05fd6-8fa7-45cb-9424-5345ef46c34f">
+      <statement statement-id="cm-7_stmt.b" uuid="28cb523a-0175-44c2-972e-cbb34e905615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1735,10 +1735,10 @@ https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64842f57-4ddc-40fc-b601-59b626f68738" control-id="cm-8">
+    <implemented-requirement uuid="b8130d75-ef47-4fd6-88de-d3de4c957d55" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="9d49db98-ea71-44d9-ba19-64476784c22e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="56d3b7fd-8162-482a-b431-cf3e263665ee">
+      <statement statement-id="cm-8_stmt.a" uuid="4b7997c4-b95c-4da6-b56d-328df955facd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1746,8 +1746,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="2a58840b-d9a1-4690-9635-402c8e73d48a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2eda9804-d038-47cc-b184-3b5501bdffe7">
+      <statement statement-id="cm-8_stmt.b" uuid="e13c5af3-18a5-4196-9749-c50c638c94d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1756,10 +1756,10 @@ https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6daed30c-4588-4fed-aa97-21e400a92962" control-id="cm-10">
+    <implemented-requirement uuid="d2ed696b-72fe-4c1e-a30e-6e0b4dd715dc" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="d3c40e76-f01a-49c6-b3fe-991ba367ce72">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4b926fba-0c27-4a73-a9a0-300ff979e503">
+      <statement statement-id="cm-10_stmt.a" uuid="c204f5be-2ae0-4e05-8073-f7a8f059fa95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1767,8 +1767,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="341afbff-0128-406a-83f5-853bb7830e46">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e6a0fb33-b396-49cd-ba71-7cf91de3cb42">
+      <statement statement-id="cm-10_stmt.b" uuid="0d44fe12-5465-48b5-bc36-ca6c8b6b90ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1776,8 +1776,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="9c54adbd-0e7c-461a-a34c-581f67e22da2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="709e5224-d68d-493d-90ba-1d3452cd077e">
+      <statement statement-id="cm-10_stmt.c" uuid="5a6b0389-ea77-4714-9d3e-df2a16349d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c0c71e4-b352-4edf-9457-d61b459c03a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -1787,10 +1787,10 @@ of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f31f38c-0792-40fb-bae7-59a539b7f3b4" control-id="cm-11">
+    <implemented-requirement uuid="f0a92b60-8313-455d-b277-ad4aee766be4" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="58e8c6e7-ddab-4dd5-966a-6cd7e34d55d4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="aca16a19-96e6-445c-82f5-fab8e69d4d59">
+      <statement statement-id="cm-11_stmt.a" uuid="8943b6ab-a43a-446e-9f27-4101bcbb7a8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1798,8 +1798,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="d66650c6-82c6-456c-9a0c-1de8565bac86">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="aeb7f62b-6bd9-468b-926b-a456fd2bb4d4">
+      <statement statement-id="cm-11_stmt.b" uuid="4a42ee86-9eea-454f-ba92-9007a155c8d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1807,8 +1807,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="3ae2c578-cca6-4aaa-8ace-b16d3ffd480f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d01b926f-072a-4024-a61b-eec8a88993de">
+      <statement statement-id="cm-11_stmt.c" uuid="072b5c4c-0b3c-460a-a682-9ceff1672f00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1817,17 +1817,17 @@ https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="197aa2c3-e5b6-4e5b-9ba0-15e1df927f30" control-id="cp-1">
+    <implemented-requirement uuid="5d89307c-fcba-42e8-a63c-7321194df6e1" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="2dbb841e-5e21-4b92-b0f4-c7e63c62fb66">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="98e1234d-8625-4e55-b9cc-12a52928aad5">
+      <statement statement-id="cp-1_stmt.a" uuid="1bf1c075-f91f-4e45-8630-64c74b536c9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="55c30eb9-48e2-45ce-b043-e6140f57cff3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9341a681-3d57-4539-aca0-1cfd9edc8868">
+      <statement statement-id="cp-1_stmt.b" uuid="fdc67e19-0880-459a-9c0a-8e7d819f9981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c68ccf8-7f70-482d-a507-7df58cddbd66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -1835,55 +1835,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb6a5e9f-40e4-4400-aff6-13fce774fdef" control-id="cp-2">
+    <implemented-requirement uuid="11c62a0f-f3c4-4e2c-abb4-adf83b38a3fd" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="16e25206-5d9d-453e-bd0d-5bfd94bf107c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b193ed4a-26fe-4ace-9b8c-bc0299e7061a">
+      <statement statement-id="cp-2_stmt.a" uuid="a84d8f70-d8b4-4f6a-85e5-4b07593f1470">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="a4b3bf61-5d43-4b1a-b31b-022a298c8245">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="506bb659-91af-40ef-922b-027e33770aea">
+      <statement statement-id="cp-2_stmt.b" uuid="e18ca0c2-6176-4438-8caf-fee362ffeee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="849bf386-2a30-4d64-9583-39030ec78388">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="036466ca-6f90-44cc-a487-79e690716e2f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f4331ba6-9767-4fd9-b24b-933367ae60a5">
+      <statement statement-id="cp-2_stmt.c" uuid="b6f9e6e9-f6f1-4174-8eab-d7748772bca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e898768-5605-432d-b28c-df65f38fc1ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="e8f5e46b-8826-40db-9af9-9c8c146272c7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dc878c6c-a5be-4a03-89c0-6b8ed8f67a60">
+      <statement statement-id="cp-2_stmt.d" uuid="434ce3b2-0158-40a4-b8d9-bf42c632739f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1740afb5-c728-496c-a5b0-ec2baa4fec28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="97b904e5-89ae-47c7-9152-3404bd536533">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7c1576f0-df4b-4be2-a5e1-341a41bbb24b">
+      <statement statement-id="cp-2_stmt.e" uuid="34788329-aa5c-411e-a1b9-b7ca0efb4c73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f230f99c-b3e4-4d24-b559-1da764fec833">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="6ba6a953-734e-41a9-a189-2ba00155c0df">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5ec2fd2c-891a-4e5a-8a78-ddd2b386648d">
+      <statement statement-id="cp-2_stmt.f" uuid="85109794-b537-4232-b40c-a3845c065b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c18bc9c4-74bf-4870-a918-18c8527a7649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="15c8e863-e7cd-487c-9366-746727e6271b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2930c07f-b2a4-4e0b-9ff8-d6b0a3cb5108">
+      <statement statement-id="cp-2_stmt.g" uuid="035392f4-c3ed-42ec-bc2b-de34fa140b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="397a9793-a389-47c6-b6e7-395dbb57b613">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -1891,10 +1891,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d4f52bd-d6eb-4a17-807b-4ffb962c1ae4" control-id="cp-3">
+    <implemented-requirement uuid="d7726a10-26e1-40f1-b3df-d3cc2fbdc12e" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="630313ee-8ab6-498d-9c36-7c99364c9881">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8c062f08-2bd7-4254-8eed-1cae82e1352a">
+      <statement statement-id="cp-3_stmt.a" uuid="43e18881-4cda-49eb-981d-5565ad5cf5f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b68b2d-f9ad-4603-a627-c390d6207f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -1902,8 +1902,8 @@ time period of assuming a contingency role or responsibility is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="0f97809d-072a-4cb0-8ed2-af1e964613e1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dbdd016c-6838-49cb-bcad-6eb544ba5f5b">
+      <statement statement-id="cp-3_stmt.b" uuid="61cdce07-2078-4888-a636-0efc0ec77b98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4ee3bc0-f404-4c27-8321-75ba15125726">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -1911,8 +1911,8 @@ system changes is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="2294dd1b-78cc-4956-9342-3ceba01e29fe">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a8bcb346-4a6c-4438-94df-7b5433ac0219">
+      <statement statement-id="cp-3_stmt.c" uuid="35a2eb77-eec3-4d12-b4bc-a7a2af6bd0df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78771afd-c818-46ce-b95f-5005d1227925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -1921,10 +1921,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a19f5e9-23fc-45df-b06b-8acfc33192b1" control-id="cp-4">
+    <implemented-requirement uuid="1fa0d7ae-5369-4255-ad14-0cf27e6553f1" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="d1ecb011-67f7-412f-bbaa-cc9400cd9153">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="995c9dec-4af0-42ab-b98d-1618c105474d">
+      <statement statement-id="cp-4_stmt.a" uuid="dfbb243f-8b6f-4ff1-9ecb-5e6c92fa29bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c19e5d23-30d2-412a-869f-936c964e9aa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -1933,25 +1933,25 @@ readiness to execute the plan is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="c65ea41d-7f94-4d7b-9f65-9e8b1d4a5b7d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c6eb31fe-c538-4e5d-8a6f-d7284b46347a">
+      <statement statement-id="cp-4_stmt.b" uuid="23e54280-9fc0-4e6a-b638-a9101ab658ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="735b0a4c-85ff-4a56-a37a-1d98bee952e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="47a4090c-1478-4a5c-8a44-f15c172e67b9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8836ec56-c1a4-486f-b2f3-fa9c5c49fa5a">
+      <statement statement-id="cp-4_stmt.c" uuid="93f8964e-ade9-4166-b97f-eea1360ad93c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="594d0868-fb2a-4f85-b5ea-4bb04dcc00af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0178e093-63b1-4c5a-b205-8c1a01100c4d" control-id="cp-9">
+    <implemented-requirement uuid="fec472c4-1589-4e1d-8a69-3ca9d061a9f8" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="52ce81fd-1bc5-417a-9a4d-b0c53d4f17b7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="afb310fd-04cb-4df6-b918-d5904488e506">
+      <statement statement-id="cp-9_stmt.a" uuid="db2f5394-8ff0-4521-bbea-025b27b87ca5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21491395-89e7-468f-a092-40db18acd64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1967,8 +1967,8 @@ a centralized identity provider is an organizational control outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="62cf2fc5-e861-4d2b-836b-af98cf508eb7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="094a0219-7de2-4af5-b239-a6c9c05d23c3">
+      <statement statement-id="cp-9_stmt.b" uuid="fd4db9c4-afcb-442a-a405-e71ceda7c02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4bd1f00-0443-4329-b52c-e9c1b8f1c1b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1984,8 +1984,8 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="380ac51d-2d81-4f6f-b863-22182150a0f2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6c6e5372-3ea8-4519-ad3a-46f8c3784369">
+      <statement statement-id="cp-9_stmt.c" uuid="45309e62-9dc2-4f5a-b2da-2e6544d065de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98cbd01d-34f7-4052-ba01-45667bf85f9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1996,8 +1996,8 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="58d60b67-a2ed-4277-9bb2-1ec724705db1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="19adc454-6d04-4ef6-80f3-b12318dc2594">
+      <statement statement-id="cp-9_stmt.d" uuid="9ad6beca-4b76-4ad1-9e69-d865051bc5a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2239660-ea6d-4404-99ac-d8705981d473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2013,10 +2013,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67de2993-3cc3-40ea-a151-78ced5747acf" control-id="cp-10">
+    <implemented-requirement uuid="2e3283e1-329e-4162-bf29-d4e3126e42e6" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="a9ffa008-6b53-4e2a-acee-e9c66132d59f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0fd6fa2d-45f6-4c58-b353-e89e25ca822e">
+      <statement statement-id="cp-10_stmt" uuid="c1b5e152-3add-4732-88c3-5df00b1d4d7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2df5ba56-c93c-4b4e-9691-bfc0ace314c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Advanced Cluster Management for Kubernetes environment. A successful control
@@ -2025,18 +2025,18 @@ Management for Kubernetes environment.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a582b3b-c301-475a-9726-faec8fdbf223" control-id="ia-1">
+    <implemented-requirement uuid="36fc9605-761a-4aa5-aa4a-fd84c82053fc" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="3134bb2d-087d-4bbb-8f16-6d2233ba946a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ecaca305-6e52-4efd-900d-14eab5287735">
+      <statement statement-id="ia-1_stmt.a" uuid="cf609d09-28bc-4a20-97e1-d98ca638d155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393d5912-7a1b-4110-8ad3-fc49b152819c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.1" uuid="ea00f685-edc2-4f61-99d1-3e799d643614">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="28377ba2-a47f-488b-8bea-2f8b4761bcae">
+      <statement statement-id="ia-1_stmt.a.1" uuid="789a9860-a58c-45ea-b3a8-313fa0e13136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edba927a-c814-49fe-8c04-ff0c10424628">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An identification and authentication policy that addresses purpose, scope, roles,
 responsibilities, management commitment, coordination among organizational entities,
@@ -2044,8 +2044,8 @@ and compliance is an organizational control outside the scope of Red Hat Advance
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.2" uuid="5f7b6c02-fba4-4824-aaea-f132f40390d4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8c132f61-1bef-4497-b17c-463ddf6a9aa4">
+      <statement statement-id="ia-1_stmt.a.2" uuid="8ab56ad8-0bd4-49cc-893f-e209dc583aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="748fc141-4383-4293-bba9-cf7826741c15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the identification and authentication
 policy and associated identification and authentication controls
@@ -2053,24 +2053,24 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="ef0d2fa3-9383-40bb-8591-f54a96d99f9e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dc07136d-0ec3-43bb-ba65-2688aa90f358">
+      <statement statement-id="ia-1_stmt.b" uuid="26b903e8-b266-4924-b37a-8f0861172a9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f9cb66a-f50e-4bb7-ab29-7b634d4309d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.1" uuid="57052709-34c5-47e1-b8c1-651358f3e690">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="dfff43c5-7005-4a13-8383-14cfbc7a0981">
+      <statement statement-id="ia-1_stmt.b.1" uuid="eda88c29-1ff5-458c-8b80-a417b8228841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4abe27-7c28-40f8-b37b-0bd096de234d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication policy is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.2" uuid="b132a447-ff1b-4ada-94a2-954d235c0eea">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9f4c55f1-70b3-40d4-bd35-9533c03dedb0">
+      <statement statement-id="ia-1_stmt.b.2" uuid="ec20ebe0-88c2-4cc6-96c1-5b38b97d9968">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c07e8de5-a0e9-47c9-a078-1c50109032ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -2078,10 +2078,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9800b0b3-9607-4a08-a750-d65e50624bb1" control-id="ia-2">
+    <implemented-requirement uuid="6a4e724f-263f-43f3-9729-9c8ea63514cb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="82c495bd-fe42-417e-81ec-3ed8f7720a25">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="273c4cd8-4ada-4ceb-953f-a48d0bd42c2e">
+      <statement statement-id="ia-2_stmt" uuid="162c972c-1af8-4c4e-b17c-349af061b17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2092,10 +2092,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d19d9df-3304-4aaa-b061-8778f73a2884" control-id="ia-2.1">
+    <implemented-requirement uuid="3c240960-c351-40a6-b2a4-a1e32a79afd1" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="7ce75ce4-3b53-4478-bef1-82e1662d3d04">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="781611b3-4ece-4459-b002-7301e8c56834">
+      <statement statement-id="ia-2.1_stmt" uuid="e18e8632-5d36-4387-8b08-fb985282ab8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2106,10 +2106,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f17c9a9-97b7-40a0-8ede-a17cc65cf1fd" control-id="ia-2.12">
+    <implemented-requirement uuid="4501f960-57c6-4dad-81f0-d60c4c694d6c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="defa863c-d6fa-44b9-b6dd-67f487a65ecd">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="656f98f1-1957-431a-b58e-4e9575ade7ad">
+      <statement statement-id="ia-2.12_stmt" uuid="204fce8d-b288-418d-806a-cb177bf47091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2120,10 +2120,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25ecb408-6a13-428d-9a42-03577ca36822" control-id="ia-4">
+    <implemented-requirement uuid="3b7e2336-a2fc-4c93-abff-cfe316af78ca" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="b50f3298-f200-43fb-93f3-f684e83595f3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4288b3f9-6b78-4b2f-a211-5a8d4222934e">
+      <statement statement-id="ia-4_stmt.a" uuid="956405cf-6586-4af5-83d0-ca267a6d897f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc183fe8-bb35-4cc4-8727-634f92deb444">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
@@ -2131,8 +2131,8 @@ requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="e88dfdda-eb30-47ff-aa0f-a2512c2d16c0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cece92db-0a9d-4f68-a9a7-058a14c56a60">
+      <statement statement-id="ia-4_stmt.b" uuid="49d43cd4-1e4e-475a-92a4-88ae451ab482">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2230bb0b-2181-41ee-8168-57e5e9754791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2146,8 +2146,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="f7ac2d86-7482-4bc4-8aaa-123fac1eb678">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6e10662d-c10d-4035-9a91-7ba5225fcbe4">
+      <statement statement-id="ia-4_stmt.c" uuid="a99ba3ee-7060-4ee7-9cac-e8dcb1e35f5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16e13bdb-c71b-41be-b43f-d677d7fbef35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2161,8 +2161,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="c9e14657-af9f-4e02-b038-85f3af97ad0c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9356ba50-58d5-4424-988b-2e461a6fa3a1">
+      <statement statement-id="ia-4_stmt.d" uuid="bd53f8e0-2baa-490d-b35f-cfd55fe18014">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f1be769-82de-492d-8cf4-b3e0f08d2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2176,8 +2176,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="54e71a60-f31c-4a0a-bf1a-780d880e5cf2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="35ee5c14-6fef-4442-b594-8727a2639850">
+      <statement statement-id="ia-4_stmt.e" uuid="f395857f-0985-4aa5-80f1-08859ab23603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fb2e15b-d2df-4392-bf93-095644224c53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2192,10 +2192,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19c171e6-2505-4553-a2e6-95d8e6527b70" control-id="ia-5">
+    <implemented-requirement uuid="265bbbe5-6012-4f0b-98f3-ac0f0d0caabb" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="9bde5227-ebfd-4e13-8797-e305a5ef583f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2321e3e3-22da-4104-bf05-5379ca92783b">
+      <statement statement-id="ia-5_stmt.a" uuid="0eb4ddac-916b-4bbd-a20a-8048259facc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13d72afa-d441-4373-8afd-67699887a6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -2204,8 +2204,8 @@ outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="5f1fa984-d427-4ee1-aa9b-ec66e693fa7c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ca2efc4c-7aa1-48bd-9500-1b22f82c34f0">
+      <statement statement-id="ia-5_stmt.b" uuid="2342220c-0d99-48d2-b27d-7f8c11acd128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2e3e436-8413-4ff8-8dc3-390795606ce5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2219,8 +2219,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="e27201a1-c7cf-4122-ad86-7d062a4adf8a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="96e3fc3a-ed64-414a-9e64-914898d37496">
+      <statement statement-id="ia-5_stmt.c" uuid="c05a851b-49e9-473c-9fd3-b2f9d747468d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab69c0d4-d7f0-4b2f-9765-59abe70b49c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2234,8 +2234,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="d7982700-16fe-444d-b1c4-e3f5e48998f6">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c4d1060b-6ece-4ec2-bba8-98d31e1808fd">
+      <statement statement-id="ia-5_stmt.d" uuid="9e482f09-b15e-4f27-900a-115b03c2ada5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb468c08-e46b-4a87-90d7-1a74a4f9b2c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -2250,16 +2250,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="795bcdfe-aa8f-4e9f-a731-5253cc093592">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="eb31ca4e-8f97-4018-95e5-ba4055b0eb41">
+      <statement statement-id="ia-5_stmt.e" uuid="2e7a4efa-6dc2-466f-87f3-2bdadaa24503">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86ca812-e136-48d6-8e5b-bf1c0dd4fdfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="001d368b-014a-4733-a88b-8e2272b71532">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a1c0e74d-bf9f-465f-8edb-0686c0927514">
+      <statement statement-id="ia-5_stmt.f" uuid="54e797f3-6ccf-495a-b007-55422183d904">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87585da0-88d9-4846-bd0a-5474bc47b4c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2273,8 +2273,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="36b2dd64-de46-415d-beca-aa2d5fe2b6f9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="891cb61d-8961-4e6d-a416-fe6634f15d22">
+      <statement statement-id="ia-5_stmt.g" uuid="96667bec-cb90-4b27-b4d4-b688f8f5548c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2b0d11d-4985-4ae8-867f-246e2e38b3f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2288,8 +2288,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="c7d7b2e0-63a4-410a-9bac-4e4013489776">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2b35cbdf-7bd2-418b-9178-37e1a2c6d7d5">
+      <statement statement-id="ia-5_stmt.h" uuid="566c4239-0ba8-4637-9a1b-0e367a33b808">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45f712dc-0a01-4159-90c9-1645587ffc6e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2303,16 +2303,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="5376fa33-5f24-48d7-825d-52df6e956eef">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5348a82f-5b7d-4829-8b51-c0c2fae61d16">
+      <statement statement-id="ia-5_stmt.i" uuid="2aa2e02f-3e59-4431-a53a-6cc4928d33b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b590118c-ff62-4109-ac1e-af0d7f72200a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="41b53c35-2206-4a00-b05a-bf9e83c94894">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="13246134-cf04-441c-a6d7-7ca3f2b26737">
+      <statement statement-id="ia-5_stmt.j" uuid="2e55020b-a7e2-46bb-8718-650c6fa84427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cac92e2c-d40c-40b6-98f8-387d4166365f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -2327,10 +2327,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d28472f-f394-459c-9c56-614e6efb1898" control-id="ia-5.1">
+    <implemented-requirement uuid="843cd7f7-3c91-468c-8133-8154d72fd572" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="dec5c157-0727-4d36-8880-98e6ee5760bc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e299567a-0f76-4ac4-8182-50311b7aa455">
+      <statement statement-id="ia-5.1_stmt.a" uuid="b36b57f1-0da7-4b49-9dc4-3090d542e914">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e277b16b-df3a-4d18-b9ac-3e358b0a27f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -2345,8 +2345,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="2063eb11-77f4-409a-80fa-f8555e4e49ea">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8bc224e5-8b35-48a0-a80a-6cc1a42c0123">
+      <statement statement-id="ia-5.1_stmt.b" uuid="05a4aa2e-3727-40e9-bbfa-b42196a24986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="749a8823-7ea0-454d-805c-5f14111f539a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of Red Hat Advanced Cluster Management
@@ -2360,8 +2360,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="d1c2074b-47ec-474e-afb5-955e696f6955">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9ed890ea-8ce2-4724-9841-13224ec10fb4">
+      <statement statement-id="ia-5.1_stmt.c" uuid="675e2c54-d959-44c1-a159-3eb07b727a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147fade7-a31c-46bf-9458-87b74cc33323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of Red Hat Advanced Cluster Management
@@ -2375,8 +2375,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="50e94e57-b5ec-4a4f-8f3c-c642158d7f04">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9778c113-b2cc-4868-a8ce-ca98a3f5fb5e">
+      <statement statement-id="ia-5.1_stmt.d" uuid="ab6f04ac-c266-425d-a68d-2b6125259dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff725e3c-9cab-4d6f-86d1-89512be1db88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of Red Hat Advanced Cluster Management
@@ -2390,8 +2390,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="5f79c8f4-79ac-4326-bf13-af0b04266b06">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0d7fb67d-a46d-4a6f-b629-c3ce7dff1b50">
+      <statement statement-id="ia-5.1_stmt.e" uuid="da41ab94-07c2-4138-8286-633977639ff3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fdcbfc-cd31-4062-9075-c3649ced9f7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of Red Hat Advanced Cluster Management
@@ -2405,8 +2405,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="b096e18e-4510-410c-acfa-6867e1efe202">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="047cfcee-967e-46cf-a175-8727dfc2a9ee">
+      <statement statement-id="ia-5.1_stmt.f" uuid="b16315b7-ff09-4cf8-b46b-4ebc4827c3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43f8ae77-bbff-45d1-9a26-2c46568196e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of Red Hat Advanced Cluster Management
@@ -2421,10 +2421,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60a9b9e5-32c8-416b-83fd-0f190d87553c" control-id="ia-5.11">
+    <implemented-requirement uuid="0ef7576f-e66e-44ec-8b1b-71fad3011062" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="0de325b0-179c-41d5-8d80-078f3963ebcf">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3629d0f7-00f4-4295-942b-a2f000f4db9c">
+      <statement statement-id="ia-5.11_stmt" uuid="8283a521-2085-4088-8db4-ad9d30e7c0bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1076d1db-258f-4a24-8819-8a454d268091">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -2432,20 +2432,20 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3da09a7-75d3-4b45-b0b9-e8b7b9d2a5ad" control-id="ia-6">
+    <implemented-requirement uuid="584d5061-9946-4ade-9e7a-b7c9fc24fcf9" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="c4611c7b-11e2-449d-a144-e196da862150">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8f0c540d-f7b6-406c-8cc7-1637cb403871">
+      <statement statement-id="ia-6_stmt" uuid="19ea4177-7de6-4e00-a9e1-390db0e1cc84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffa2f7af-7974-4fb2-b968-8f27f77cd7ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Advanced Cluster Management for Kubernetes session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5e5ec10-e915-4008-89e4-045fad59e75b" control-id="ia-7">
+    <implemented-requirement uuid="7b05aab3-651e-4c16-aee9-5f5cb58513b9" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="b054534b-bd33-4e78-95a9-7bb1bc69e363">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ce2eea92-361b-44c4-8e05-af3cdbd4b75c">
+      <statement statement-id="ia-7_stmt" uuid="b33fcaa7-f0ce-49e1-a782-d5311d91ec4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2456,10 +2456,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b68ec393-42ac-4324-ae3f-f3c4957dffb7" control-id="ia-8">
+    <implemented-requirement uuid="15dd3aa2-0356-4f5d-8200-d30f8256d773" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="b031a8d9-2ed8-4d27-b217-3edbda769a84">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2e4cd814-1214-4ac8-8de7-8d6dee0f6e8f">
+      <statement statement-id="ia-8_stmt" uuid="384de7fa-27c4-4f40-a6a2-6cf58c00a1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2470,10 +2470,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d274621-1d24-4143-a52f-9aa1431b6f9b" control-id="ia-8.1">
+    <implemented-requirement uuid="922dcaf1-78dd-4dc9-9a7a-fc83d03cd39d" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="5a849430-ee25-4d69-ac84-2aab97837e7b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="564e7680-f077-4bb3-b430-a0dc536e6b5a">
+      <statement statement-id="ia-8.1_stmt" uuid="2b939949-8825-4a80-8ba9-dc6f5241d760">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2484,10 +2484,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cf427ce-8e5e-4e12-bdd2-00de6416edd3" control-id="ia-8.2">
+    <implemented-requirement uuid="582b2033-a58b-440a-bb7b-842a64c8e6ab" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="b9c0ee2b-7e4c-4e8b-b528-7a8851158235">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="85b8c96a-c5ac-452d-b99f-7122b1f27f1f">
+      <statement statement-id="ia-8.2_stmt" uuid="cb36cefd-7292-48a0-8850-aff4e257b77d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2498,10 +2498,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35cd7f81-d7c4-4c13-a2c1-c9b032b3dcea" control-id="ia-8.3">
+    <implemented-requirement uuid="246f5842-7f1e-49d0-a393-d6aee19949a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="6541f89d-12f8-4da8-aa7e-5c1d043d5488">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ea891dab-fcd1-433c-b787-35d851a20ff1">
+      <statement statement-id="ia-8.3_stmt" uuid="f32e9b5b-4cbd-46bb-a794-d9cf1a55c8cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2512,10 +2512,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4f0645e-87d7-4634-99f1-5151a1ee634f" control-id="ia-8.4">
+    <implemented-requirement uuid="903874b7-4e6c-4a85-928b-6d9a96084e0b" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="f31f0d09-47d8-46b7-b127-c67b3c12629d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="53e7a882-175f-4304-b1a9-53694f65a596">
+      <statement statement-id="ia-8.4_stmt" uuid="055f41bc-d4f2-4c99-b487-8ac2a3e1e401">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -2526,10 +2526,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29b46c3d-c4b3-4ba6-9648-28922b458bfc" control-id="ir-1">
+    <implemented-requirement uuid="e9254f4c-c4e8-418f-bd54-3412a87ddb77" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="69755167-36f7-4d37-8576-1b0a6475a2d8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cddf9c11-56ca-444d-8d44-27eddaea1b4c">
+      <statement statement-id="ir-1_stmt.a" uuid="2e19fb0a-b243-4978-b25e-a6dbdd4cb2b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c15b72c-d254-49a5-92c0-55715caf39c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles of incident response policies and procedures is an
@@ -2537,8 +2537,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="049b24f4-767b-47bb-860e-b82f24818e38">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8af01ae5-9465-47dd-b422-1e0aec7b3c69">
+      <statement statement-id="ir-1_stmt.a.1" uuid="4c891716-7c1b-44e5-9b2a-57b135457102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f612b7e1-3d6a-4556-8aaf-e7f2d977b4bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles an incident response policy that addresses purpose,
@@ -2548,8 +2548,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="68cece2c-75b3-4bec-a068-02fd49feaabd">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="50372da4-31e4-4c55-b4d9-2e80eade243d">
+      <statement statement-id="ir-1_stmt.a.2" uuid="b0a371b6-f0ae-495f-a1eb-2e735999acfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a042372f-1c80-4116-adb6-fda1b41ec201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles procedures to facilitate the implementation of the
@@ -2558,16 +2558,16 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="257ba104-6b64-4e0e-b197-da2b8d04c271">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="72356854-4d89-45e3-b74e-ba05b376a039">
+      <statement statement-id="ir-1_stmt.b" uuid="edd9c3eb-d4e3-4df4-8722-bb310cd34222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3b3f0a9-17e3-460c-8777-c47f43a9dd74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating incident response policy and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="21ead8ee-4dfe-4aa1-98d4-01eab123f817">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3e7d7f98-5d93-4689-9b1c-5cf88e77658a">
+      <statement statement-id="ir-1_stmt.b.1" uuid="39db6397-b221-422b-81ef-53daa7817782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7fda435-0b22-4225-aa3d-5c11d7eb2b0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response policy on an
 organzation-defined frequency is an organizational control outside the
@@ -2575,8 +2575,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="bfcfe73c-4edc-4585-a2cd-08be12df4260">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d5c3fe53-9a5e-43aa-8974-bf30ff18d62c">
+      <statement statement-id="ir-1_stmt.b.2" uuid="36560876-f8de-4ffa-8d36-af3c67f649c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de30e301-2ced-49e8-9acd-6bc32d3ac131">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response procedures on an
 organization-defined frequency is an organizational control outside the
@@ -2585,10 +2585,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b2b6640-144d-4096-869b-bf2e38451baf" control-id="ir-2">
+    <implemented-requirement uuid="a15791af-da74-408d-8450-fdabec814d43" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="fb6d8b87-6b16-4d7b-994f-bb730308cbe1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bf0bbe9e-2d2c-41fa-8ff8-feb4bd40477c">
+      <statement statement-id="ir-2_stmt.a" uuid="d0ea58f3-d80e-4734-aec8-dbc72e2dbc20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eafdb258-f903-4d7e-ba22-9e608d95ecb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities within an
@@ -2597,8 +2597,8 @@ or responsibility is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="eac835c1-d65c-4f9d-9ec8-c5d4a4c51ccb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="69e593f4-13e7-4ac1-abf1-8b711891fa40">
+      <statement statement-id="ir-2_stmt.b" uuid="7a3fc29a-b3e6-4ba1-969b-4d919175c9e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709f8fbc-2302-4992-ac8c-8735d21a7224">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities when required by
@@ -2607,8 +2607,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="92c7dae5-730e-43a6-8c38-a2c1a68e487f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7d65fea6-6c97-4ba7-a979-889e47c00b19">
+      <statement statement-id="ir-2_stmt.c" uuid="1c37f0f9-5821-44e5-a513-d090941546e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cea18629-49b6-4cce-8db2-0cf050b88697">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities on a TBD time
@@ -2617,10 +2617,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42e9dc04-b2d4-4691-972b-bb4a050bbf09" control-id="ir-4">
+    <implemented-requirement uuid="265c7809-fc7e-4390-b429-9780daa3bda7" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="bd2ef1d7-b802-44b0-8edd-119ccabb6e91">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a3d1e8c9-e4ee-4315-9090-b84af17908fd">
+      <statement statement-id="ir-4_stmt.a" uuid="6de145d9-7b86-4d6a-aee3-c1c7e7803aab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19a22a0b-bddf-4faa-8ea9-be2b0974f2bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing an incident handling capability for security incidents that
 includes preparation, detection and analysis, containment, eradication,
@@ -2628,16 +2628,16 @@ and recovery is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="94f3ab4b-8d27-4e23-85db-c4bf8da75e01">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5670c333-5252-4fae-bae0-4d11e2f2c6da">
+      <statement statement-id="ir-4_stmt.b" uuid="293ce7b1-ff84-4d9c-b8df-803e4aeedc76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c1d81b1-e794-4734-8733-0a934a977389">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating incident handling activities with contingency planning
 activities is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="5c42e24b-bf2b-4505-8436-4f49f82472e4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="305e632f-276d-41f5-9f70-b7cc9c6a03ae">
+      <statement statement-id="ir-4_stmt.c" uuid="0a6e430e-4502-48d8-994b-538997e10a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe23a19c-6c01-41c3-929f-7c8fe05e7724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating lessons learned from ongoing incident handling activities
 into incident response procedures, training, and testing, and implements
@@ -2647,10 +2647,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e9fcd5-776a-4389-8422-9d773596ba23" control-id="ir-5">
+    <implemented-requirement uuid="f0383d76-28c0-45e7-8319-4e58a63abf89" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="4bd4b2fc-7032-4cdc-8daf-9ba394bbd7f1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a69c3237-b7ad-4fe7-be2b-9e4499e20f52">
+      <statement statement-id="ir-5_stmt" uuid="d79d2e79-08a0-4132-bb51-6640123337a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f419747-33f9-4dcd-b671-a38a0487db60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking and documenting information system security incidents is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -2658,10 +2658,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3545e2b2-7aa8-40ef-85bd-206ca12616ea" control-id="ir-6">
+    <implemented-requirement uuid="15b4e51e-95e6-444c-91c2-38df890f012a" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="0f4e3930-0a5f-4da5-a177-0176dabaed73">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e91ee691-8a7f-48b2-8f58-abbbb192ab15">
+      <statement statement-id="ir-6_stmt.a" uuid="35dfa24e-455a-44a2-88b0-fc4b2bdc0b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9724fc04-f64e-463c-aa7c-cb4cd7ef23e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring personnel to report suspected security incidents to the
 organizational incident response capability within an
@@ -2670,8 +2670,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="31f7bcfa-d6e1-46f7-bc9b-7a881ce5f790">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9bc34669-94a5-4af3-bf15-4c20bf75f19c">
+      <statement statement-id="ir-6_stmt.b" uuid="6d39bf4d-93f3-4d29-ae7b-4776103b9584">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ad30abe-b363-4997-a990-56bd4b0d2a46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting security incident information to organization-defined
 authorities is an organizational control outside the scope of Red Hat
@@ -2679,10 +2679,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="055abfd4-02cb-4280-b31d-6b0f6aebc60f" control-id="ir-7">
+    <implemented-requirement uuid="ae856240-505a-4b8d-8c8b-6d9c6a2f9b77" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="2b4629d7-4b3e-49f8-9422-fea1559ab595">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c791a5d1-db90-4138-b58e-08148e2e35cb">
+      <statement statement-id="ir-7_stmt" uuid="b84e786e-ffdd-4e75-a08a-a3756bd47da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab5b2742-c274-4906-9724-73db577f414a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing an incident response support resource, integral to the
 organizational incident response capability that offers advice and
@@ -2693,18 +2693,18 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf126d81-c1e8-4b4e-a0d2-f9153a33fd90" control-id="ir-8">
+    <implemented-requirement uuid="49acd465-9d15-4a96-8f07-ba73e146c21c" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="778f4222-8e44-4a2b-89c3-72f81641dde5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="96696dfc-19a4-452e-923f-b8f7e79d7792">
+      <statement statement-id="ir-8_stmt.a" uuid="f8965741-5603-49e3-af65-1d659f54ce7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9c2255d-be43-4916-b2a1-2ec4545adaf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development of an incident response plan is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="e019bc5b-a188-4e53-abe4-1f6f07c49206">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="237a2458-5caa-4462-b5aa-ce14652b45a6">
+      <statement statement-id="ir-8_stmt.a.1" uuid="6a896184-1927-4bad-aa83-85d46f80e335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e97bf89b-5b19-4be2-89c5-71e395ca99c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides the organization with
 a roadmap for implementing its incident response capability is an
@@ -2712,8 +2712,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="390caf38-6bc3-4b82-ad72-58f075bb56f2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="623401f7-d2f0-48a4-a2ed-ec4ba7183a32">
+      <statement statement-id="ir-8_stmt.a.2" uuid="bfed941e-cd44-4c6c-9ede-3cbb9c0cf335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35f4b1c0-c930-4494-9e1d-10b5cc502a2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that describes the structure and
 organization of the incident response capability is an organizational
@@ -2721,8 +2721,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="44247697-730f-4df8-8a50-4285d56e5a65">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="90e6c6c0-9aa4-4b53-987f-f1aed856000d">
+      <statement statement-id="ir-8_stmt.a.3" uuid="995382ba-a9d1-4436-ab78-cdc74c7b869c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa50678c-feac-45b8-9d04-c5b15e42ea8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides a high-level approach
 for how the incident response capability fits into the overall
@@ -2730,8 +2730,8 @@ organization is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="f8b7c0d4-8865-4748-b2e2-542454c2bd3a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="14cd55fa-5297-4f77-9ed1-85c093553d44">
+      <statement statement-id="ir-8_stmt.a.4" uuid="5f3a186f-2239-4197-94e6-881c17aadd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d268ee8d-5af1-44a1-82e8-e229f663e4cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that meets the unique requirements
 of the organization, which relate to mission, size, structure, and
@@ -2739,16 +2739,16 @@ functions is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="60b0aa2e-4360-436d-b86b-5e7ea2d642f7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ed7f0e6e-b3e5-40d8-8316-49bab446420c">
+      <statement statement-id="ir-8_stmt.a.5" uuid="a04aac7a-4837-4615-a218-ba5036fe90d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a376441-33f6-42ba-b42d-573d7d61f23b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines reportable incidents
 is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="33aaf758-d870-45e0-9559-2730244ea07c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2eb26b48-a1d9-4a3f-933b-c82e85eecf7e">
+      <statement statement-id="ir-8_stmt.a.6" uuid="42df1525-94f7-4f76-a393-7f54353468f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea7560b7-39dd-49ba-9db7-7c0db486421b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides metrics for measuring
 the incident response capability within the organization is an
@@ -2756,8 +2756,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="568df1b2-5178-40bb-a0fb-1743b8f49318">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d8be0fb8-ffe4-4cbc-a822-557eb5522c5e">
+      <statement statement-id="ir-8_stmt.a.7" uuid="a41628b2-c5e2-4a61-bd79-b673113ecdc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b644290c-37dd-4108-bbbf-7d7fce8c7896">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines the resources and
 management support needed to effectively maintain and mature an incident
@@ -2765,8 +2765,8 @@ response capability is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="da065cd5-8f85-44d0-95bc-0325cd4a9a1e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="022cc15c-f184-48ae-adf1-cda911e291cf">
+      <statement statement-id="ir-8_stmt.a.8" uuid="dd7a765e-6f70-47ea-8bfa-6f08f1d7ace4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdef4f08-aa76-4a99-aaf7-054945ac0d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that is reviewed and approved by
 organization-defined personnel or roles is an organizational control
@@ -2774,8 +2774,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="442d7aae-5958-44c7-91c9-2b8c29d097b5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b54ba983-0906-422f-9799-ed08c884845e">
+      <statement statement-id="ir-8_stmt.b" uuid="c6e28213-ecfd-4592-8a64-8e7504cbb040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9d8235-d089-4c09-b019-7406facd972f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distributing copies of the incident response plan to
 organization-defined incident response personnel and organizational
@@ -2783,16 +2783,16 @@ elements is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="c3ee7b1e-4dd1-46d8-ba1e-f0de1e4f5003">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ceabfd59-59ec-4f8c-bdb2-e19c57069c68">
+      <statement statement-id="ir-8_stmt.c" uuid="27d959fb-0e24-4369-99c2-52ce1811a973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d850403-75e5-4b1b-b494-d70b03c03b40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the incident response plan on an organization-defined
 frequency is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="cccddec9-1589-4b16-8ad4-4544158e5552">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b6868c08-cdff-4c56-9b7f-2b0bb12e30d6">
+      <statement statement-id="ir-8_stmt.d" uuid="6585a985-8ab0-4b01-82f8-c8c294e9d4ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0b9823c-fff1-4de3-bdb6-59a79905784a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating he incident response plan to address system/organizational
 changes or problems encountered during plan implementation, execution,
@@ -2800,8 +2800,8 @@ or testing is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="2a8dec75-d286-43dc-ab8c-296b9f1704f8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="110c5e04-4af3-41ea-bd4f-225a455bfb05">
+      <statement statement-id="ir-8_stmt.e" uuid="6f9441f0-de94-439f-8988-4042e6827f16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befbacf0-182f-4f92-8e7b-23c4d64331bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Communicating incident response plan changes to organization-defined
 incident response personnel and organizational elements is an
@@ -2809,8 +2809,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="a4313427-353f-444a-a965-188f655dbf60">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bdf9cc87-c04a-44ad-8bae-a4895effe338">
+      <statement statement-id="ir-8_stmt.f" uuid="50f96740-c6e7-4edd-a0c3-1b20022f457e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6749410e-7c77-400a-9447-cc1b7ab43744">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the incident response plan from unauthorized disclosure and
 modification is an organizational control outside the scope of Red Hat
@@ -2818,18 +2818,18 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b5b775f6-c779-41bc-936c-d7c312bc410a" control-id="ma-1">
+    <implemented-requirement uuid="68253bf9-1ed6-4f5a-acd8-c5e98a2fc249" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="f13be77e-2ecb-4c44-9e8c-7eb73631c043">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="00f8d537-c6fb-426b-9b09-5455afcce8a1">
+      <statement statement-id="ma-1_stmt.a" uuid="3ca0fcfb-f14f-44c6-a572-bd4c7f32c310">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f846a086-263b-4370-892d-c68491d0cb41">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating to organization-defined personnel or roles
 system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.1" uuid="d49a1a57-6ddf-4caf-9827-e2482d968976">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c9e39b99-8bf4-4338-b1ed-6810623b46cb">
+      <statement statement-id="ma-1_stmt.a.1" uuid="f6fda425-2406-4e85-b70e-3944456f3beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e3d7f8d-e593-4cac-b880-3507a5d1f387">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A system maintenance policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance
@@ -2837,31 +2837,31 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.2" uuid="dbcd82ae-734e-4f07-8c30-52265eeb52b9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7354067e-f421-40dd-83b5-0ecd83a79669">
+      <statement statement-id="ma-1_stmt.a.2" uuid="f1982d96-04ac-490c-ac02-bc368cee4f66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="74c10b75-3e91-4f50-b496-1e6972eedf3b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="00ad38e5-8412-452b-be7b-cb51afe712ed">
+      <statement statement-id="ma-1_stmt.b" uuid="0a2f3d72-f568-4e80-8084-3395f2230ef2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bab8b16-6740-483a-8871-adf6413e9677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.1" uuid="a05d35dd-9fb9-45a3-8983-93ea17efceed">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ed704d58-40fd-40dd-b114-251bc86a9b2d">
+      <statement statement-id="ma-1_stmt.b.1" uuid="f56a278e-dad4-43fe-ad86-2cf5e6cff1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e461e8a-ef48-4750-8679-909287d16598">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy per an organization-defined frequency
 is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.2" uuid="5ca57053-a346-4767-8216-e6763af2f56e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="714665fb-1c61-46d9-a382-96c37aee791d">
+      <statement statement-id="ma-1_stmt.b.2" uuid="4b62389b-a32e-42b3-8576-acd9c0aff016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3252c66-90f0-4b1c-953a-3142eba06e77">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance procedures per an organization-defined frequency
 is an organizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -2869,10 +2869,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="491e1040-e469-41d4-8adb-628b0e244c70" control-id="ma-2">
+    <implemented-requirement uuid="d0521ab2-47f8-4c54-b9a4-ebb7e6fc728c" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="500163be-6966-4d1f-99a3-cd28759f713f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5efbdea1-978f-4545-b22f-f755f9552d93">
+      <statement statement-id="ma-2_stmt.a" uuid="bc734b9b-0490-4393-88a5-09b06ba33b61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a5ff649-d883-4d1e-a467-9e321e2d4d0c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Scheduling, performing, documenting, and reviewing records of maintenance and repairs
 on information system components in accordance with manufacturer or vendor specifications
@@ -2880,8 +2880,8 @@ and/or organizational requirements is an organizational control outside the scop
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="151c032a-9617-4a60-af25-f1160b13fe7a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="89dbd106-560f-46e3-aec2-016022ae81c2">
+      <statement statement-id="ma-2_stmt.b" uuid="d1cac324-6b4a-4c23-863b-dfe5232dd176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b722d8bc-31e6-4be2-b4a4-9f6e0cd15408">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approveing and monitoring all maintenance activities, whether performed on site or
 remotely and whether the equipment is serviced on site or removed to another location
@@ -2889,8 +2889,8 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="3f612b03-494b-47df-9ef4-563a70a939a1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="718e6424-b94b-4e73-a41a-433000e343f4">
+      <statement statement-id="ma-2_stmt.c" uuid="7a207c63-3cc7-4821-9596-a4b41a662023">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed6a4e6b-a9bc-4146-9134-466a89b59741">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that organization-defined personnel or roles explicitly approve the removal
 of the information system or system components from organizational facilities for
@@ -2898,8 +2898,8 @@ off-site maintenance or repairs is an organizational control outside the scope o
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="5284fc82-70f0-46cd-b453-426e41b0c739">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3a7e1012-a2a2-4723-bf11-e555a7d8644e">
+      <statement statement-id="ma-2_stmt.d" uuid="ef69704b-a3d8-462b-bbe9-12af2107ccb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ed82a90-b826-4aeb-8b9d-91820b3a5734">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Sanitizing equipment to remove all information from associated media prior to removal
 from organizational facilities for off-site maintenance or repairs
@@ -2907,16 +2907,16 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="675af91d-9d72-4c20-962f-cea6bcfefd64">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="12ee811d-d30f-495e-a4c8-ae654c2d8e08">
+      <statement statement-id="ma-2_stmt.e" uuid="4b99101f-ed9b-4f60-b2b4-6137650183a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee78984e-c60a-4a96-9949-7f60acf14d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking all potentially impacted security controls to verify that the controls are still
 functioning properly following maintenance or repair actions is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="5ad4f97f-87b7-47a1-8eb8-dc1c852c6c9c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ba57ec17-3075-447f-849f-9799006aa6ff">
+      <statement statement-id="ma-2_stmt.f" uuid="c17656a2-3255-4d50-bee0-a64d02c2908b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75b29e40-c2f3-477e-b645-ff552864f6b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including organization-defined maintenance-related information in organizational maintenance records
 is an organizational control outside the scope of
@@ -2924,25 +2924,25 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a7d9f0a-1e8f-437f-816d-59a2b470bec9" control-id="ma-4">
+    <implemented-requirement uuid="ee08bf70-ba34-4996-882b-d3dffbde4407" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="74030671-50e9-4d6a-9358-d7c63802bc98">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ceb78a3e-7e45-477c-aacb-2f0a5e194a86">
+      <statement statement-id="ma-4_stmt.a" uuid="eaf394c6-d6bf-4a30-888f-89b5e0c84c00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e991af1-6b2c-42d8-8073-794564765dac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="b551a68c-19ea-49ed-8e1e-14d5c4b237fb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="263f76ce-0581-4bba-9eac-c54b7e2ec9fc">
+      <statement statement-id="ma-4_stmt.b" uuid="341e27c3-1473-4701-9e46-f6ea142e7911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bf896e2-fb2f-41a7-a919-56de5f20e98a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="41e16b31-e140-468c-acc6-9705a783d714">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f626e3d8-4548-4fd5-a789-146848d7445c">
+      <statement statement-id="ma-4_stmt.c" uuid="7c948163-c39b-4a03-8be5-9371269b0fc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a4a4496-4701-4b07-a53d-7c8bc683c411">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for authentication management.
@@ -2952,15 +2952,15 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="8abf1a2d-32c5-4cad-b45b-a84f4288c322">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="11f549a0-babe-4279-b2e0-cd32bf6be429">
+      <statement statement-id="ma-4_stmt.d" uuid="34cfca8e-60e9-480f-a3fe-b9fe80c948cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9aa9e088-f7a8-44ff-9b10-81842f8f02af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="784fe8d8-a2bd-4a27-b485-868f4420deb3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="394830a5-a2b8-4c61-a676-99209fb0533c">
+      <statement statement-id="ma-4_stmt.e" uuid="b171c76d-5876-48a5-833b-544ca7fc02ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08c2886-6ec5-466a-b1bc-29a30be73431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for session management.
@@ -2970,26 +2970,26 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2eb193b-05e0-4ab7-844b-2b27f3c122f0" control-id="ma-5">
+    <implemented-requirement uuid="87aea603-cd1d-4f8f-bdba-d48f5344411c" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="cd6c4b24-eaea-4428-851b-55263b99f277">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3a323f8c-4685-4d5d-871b-f638ddd55db1">
+      <statement statement-id="ma-5_stmt.a" uuid="0e5e0116-5d08-442b-b42c-5bd8a7f6fdff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7a30174-580e-4087-9026-06b18bc07a76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="16eed219-d90c-427f-b51f-99fa80ad8cf9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a16b9967-f8f3-470b-bebf-f216d0ce0a0f">
+      <statement statement-id="ma-5_stmt.b" uuid="9772139d-fd4c-418a-b7bb-1eb86d96c0b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e903203a-181e-4244-bbd9-00f6b730e88e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="ac2d557f-fc30-4fef-9e30-b40eff10722e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="29f17ada-a32d-4ec9-aa52-690ac7457d59">
+      <statement statement-id="ma-5_stmt.c" uuid="c183f370-501b-4f89-b541-8c349f2603f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd516f90-7eb6-43a6-a738-333a08f568cb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -2999,18 +2999,18 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b79f44c8-6685-458b-b8f6-d36c8bbe5bd1" control-id="mp-1">
+    <implemented-requirement uuid="aba94ad6-68f5-4410-b77d-4442e659c869" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="86f1fb52-f2a1-49db-b3e6-410a1261ae5b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9f58c9bf-24a8-42bb-a075-e94bdd8e98e3">
+      <statement statement-id="mp-1_stmt.a" uuid="ae70b746-73d5-4cc1-b7d9-1c1425c563f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="e61b07b1-18a4-41fc-afbf-58173edd02d9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="275a3e5c-1d49-4582-a319-6599d92cbc79">
+      <statement statement-id="mp-1_stmt.b" uuid="9001b1b1-b946-4cbc-93aa-85d0e80b47c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -3018,28 +3018,28 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="807c0006-1ecf-4d62-931f-d846424ff5ea" control-id="mp-2">
+    <implemented-requirement uuid="91730106-aecb-4b7f-97ae-54f8584ee6f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="8ea0926c-a1fe-44a3-8583-b63a4f8b2912">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9a45fee9-b804-4bc8-9efb-761175ea5576">
+      <statement statement-id="mp-2_stmt" uuid="eea31d1c-5a73-400d-afc9-be65544ec06b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb9203cb-9199-4787-b995-ed9c6fbdc040" control-id="mp-6">
+    <implemented-requirement uuid="e6cb05be-04da-42b8-bc61-e73a3184da68" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="34e4ec22-edc9-43fa-a08e-34e7e0093304">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6424c82e-a760-481c-9602-b9428924e233">
+      <statement statement-id="mp-6_stmt.a" uuid="7704ff74-71f0-4992-bb95-0fc05c1b457c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="bf6eda67-1ffc-4d1e-9e2f-48e7a8377d92">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9a4d58db-745b-40e6-846b-49ffcc34ad9a">
+      <statement statement-id="mp-6_stmt.b" uuid="4b4b52f2-28fb-4b50-b6e2-63aa0383bfaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -3047,10 +3047,10 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de4162b4-7a02-4d79-b9f1-c12285e66f98" control-id="mp-7">
+    <implemented-requirement uuid="76b89418-dd30-47b0-b610-232d0779620a" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="11600d60-0c33-47c9-8bdd-ed1a1656790d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b11979ba-b2fb-4f63-a41f-ec7180ab9aae">
+      <statement statement-id="mp-7_stmt" uuid="c9cb4913-199e-4777-9977-90b733398721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12bd854e-d12b-466e-9a25-c3588d772f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -3058,10 +3058,10 @@ Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4548975-206f-4ae1-8ce9-1e0d901429ee" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="c92587ab-b342-44a2-8b1a-6152243be9a6">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="482bd839-d9f8-4dcd-9712-a9d9cc39c87b">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -3070,8 +3070,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="95929ab1-8007-4661-9326-590210939524">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="70ce6588-b881-4ba8-a99d-fee3ca40a8d3">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -3081,10 +3081,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5e37fd2-878f-455e-9af8-96cab0ac2bc4" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="a6e397cb-bad1-4d6d-af7d-81ad0f8704d1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b81f640b-d524-4f79-9deb-90a437e91394">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -3094,8 +3094,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="2ffbb6f3-d132-4199-a650-a82a183ce288">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="107a8edd-eb29-4251-b893-f1f166ab6981">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -3103,8 +3103,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="0f4b23ce-dd10-4930-91af-888b8a13ebd9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5f67651c-59ac-4f0b-9f3d-918768bad0fe">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -3113,8 +3113,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="4384976e-d98b-474f-a49a-ad6335701759">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9446c438-8ffc-4a5b-9221-9cacd5e004c8">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -3123,10 +3123,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f33c0ec6-9f5b-462e-a2a0-3c7677b8e648" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="72fca228-f371-4b3a-b345-18c3da2b5dfe">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a23fc2c6-b665-4210-8306-729d72e106dc">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -3135,8 +3135,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="bf0ca416-5a61-4475-b5b1-e095f226fe2e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ead9433f-4f9b-488e-89b2-3801213f86a9">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -3144,8 +3144,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="9f85e8a3-9344-4e22-839b-9523a4fdbf95">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c45b4fc3-8587-4d98-9bc4-81389a06af31">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -3154,8 +3154,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="b5eb9220-1553-45d2-acbf-2fe75e5e3e21">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a24b7431-6ffd-44b9-aa9c-a6039ca9e4c0">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -3164,8 +3164,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="96d03ce9-7854-4306-b903-c3ea1a18a243">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bdceb7ae-a84f-4932-8d72-1f89d3e149cc">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -3173,8 +3173,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="32b79503-04cd-4254-86f5-89bd567e387b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a6736d48-bfde-4d1b-ac7f-c5d4789c88a5">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -3183,8 +3183,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="63e20927-7cf3-4f38-a832-b63f83c2826f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a68f414c-0cbd-4ab5-8480-1abbc5e9ecef">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -3194,10 +3194,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f93aabe6-8d36-4925-9ccc-0b9bc3b3e5a8" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="b3b800c4-e3a5-4aee-a512-b9506e952627">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0c54e936-1304-479f-b17a-e3a8f05dff68">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -3206,8 +3206,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="17bfd293-3176-4a9e-ab1a-07de746ffa1b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="03f3e30b-d5d5-4398-aa0f-c11ebc7d9cbf">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -3217,8 +3217,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="7204e837-6620-4b03-9e4c-f742992e6414">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9e65a708-f1fb-4378-853c-79f140cb4fbe">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -3228,92 +3228,92 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1322228-876c-4950-adea-d2fef8fdf544" control-id="pe-8">
+    <implemented-requirement uuid="be5e63d0-4c48-419f-b1eb-56e1eeb86002" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="fae1de77-ff50-4a87-a061-849e8f30f6f4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6ef83a97-34ef-49a5-9e05-cdd657a0b996">
+      <statement statement-id="pe-8_stmt.a" uuid="60ece47a-8333-4136-bcee-0734c6bc9c01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="84651579-65d3-4fc1-8fd7-ae7ee654c3c3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d5e5d3bb-ba66-4252-97bb-de6e1e0e1c77">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fc7bf039-9125-4e1f-b114-ca871edbfb4d" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="67ed3ed2-fe31-41f5-92e7-a86d85af4dff">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1dd1eca6-f73b-4d54-98e3-3546ad41a2c0">
+      <statement statement-id="pe-8_stmt.b" uuid="280068ab-db1d-4d72-ae0a-03fafc30cdbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf6a78d2-0397-40f7-9c69-7dfe0ed5cec7" control-id="pe-13">
+    <implemented-requirement uuid="027e9b57-2ee6-41e4-ad65-395483a08ede" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="46a4cf50-163e-4508-8e6b-cbb14f44c7b3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="815e9e0c-01dd-439b-8d72-46cc363d560c">
+      <statement statement-id="pe-12_stmt" uuid="c0ee43af-659b-4222-a478-e26cf0209bd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bfb25eef-f62f-4e48-8f9f-a8107c97322d" control-id="pe-14">
+    <implemented-requirement uuid="d2fc0a14-167b-4f40-8abd-16cb25ac7510" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="2ab95db8-1210-423d-b8ea-5df58802c618">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="31680c2b-a7d1-4786-ab4f-e94518678c5b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="b7c7aa42-e8a1-45a8-b7fa-07369194bd4c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="92218cec-8bab-4786-b3c0-3c1547c531c9">
+      <statement statement-id="pe-13_stmt" uuid="9c74e7b7-f0cd-4d18-8e72-9fb8bc120388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c872248-7de1-4417-b95c-6456728c85c1" control-id="pe-15">
+    <implemented-requirement uuid="c3247981-3141-4ca8-a197-66f96605c590" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="a28fa0f1-88bf-4faa-9657-c8e94a2225e0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4cd817b0-a0f4-428d-8971-ddb34e32bba7">
+      <statement statement-id="pe-14_stmt.a" uuid="da5e7fe4-059b-4812-8978-9ff93635078b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="627443aa-6e05-457c-902c-be03161932de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aabbfe38-4e1a-45b5-8ce5-c7a7210c84df" control-id="pe-16">
+    <implemented-requirement uuid="e8adb6df-d83e-4c34-ab6d-ab53861166de" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="3c76ad23-fb97-440c-ba00-5796e706af55">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d082cc0f-c4a0-4bba-ba6b-98844c74df03">
+      <statement statement-id="pe-15_stmt" uuid="645c4bc3-9242-4439-a386-eedc593005dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e39c755a-069c-4cba-82d8-1baf8ad7208b" control-id="pl-1">
+    <implemented-requirement uuid="21865d6e-01d9-4469-9a76-d11a53eeb03c" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="3e1166cb-c845-471c-97c6-82bbfb3aefb4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="67f52abd-30b3-484d-be91-beac96293bec">
+      <statement statement-id="pe-16_stmt" uuid="34f1d089-badb-4e0a-a76d-443fa1f19144">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="84980f61-ea2a-4dd1-9376-298aa584f387" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt.a" uuid="382f60d8-c7d8-4ea8-b887-3746baf8da24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="b4f9cffe-c16d-42ed-8bc6-388f886f35cc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="daaf9e65-f54a-480c-ac75-8238bb599162">
+      <statement statement-id="pl-1_stmt.b" uuid="baf019f2-5a26-4574-8b82-0084892b0836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -3321,42 +3321,42 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88ee8e01-c9c4-4370-a25a-c69713974654" control-id="pl-2">
+    <implemented-requirement uuid="b7012c99-7d97-4f34-8277-eebb08ad86d1" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="8cd227b8-0054-4cca-9a04-73d98ab124c0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bade1f0c-5996-4c6a-b11a-64016b57e512">
+      <statement statement-id="pl-2_stmt.a" uuid="8dca9505-1b6b-4ebc-bac1-1ed8021b7135">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="a0fa21e6-2a35-4968-bf46-26383923e445">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a1f16183-27f6-4425-856d-6881449a620b">
+      <statement statement-id="pl-2_stmt.b" uuid="2fd6dab7-6837-44c7-bd51-a09128aba62e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="6d3afd62-fa27-4d2a-a232-469734244f0f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4f02133e-a7f2-4ef7-9a06-ab089408cb6c">
+      <statement statement-id="pl-2_stmt.c" uuid="d365ff4c-2321-4d03-b06d-2ff79db0d98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="b47c7561-10c3-4aea-a19b-cc28801670eb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="adbc3d7c-d4b9-44d5-adc1-e0c31780cfe0">
+      <statement statement-id="pl-2_stmt.d" uuid="3dcf454a-b8e0-468e-a875-949b94198f9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="f41db23b-551a-41d8-ac15-d2dc895bde10">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a17ebafd-6e16-4b6f-b1f0-5812b382bf34">
+      <statement statement-id="pl-2_stmt.e" uuid="a26940da-320e-4b28-b787-fe450c114570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -3364,34 +3364,34 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fb2cb4c-b3f7-400c-b6fc-73e0b5e6f2b4" control-id="pl-4">
+    <implemented-requirement uuid="cea646c8-94e0-4d09-a03b-bbd07071a4a6" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="6f069082-ed94-4f72-a811-fecb1aca5233">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9ba324a4-3c32-4ce8-bdc7-363da2ead86b">
+      <statement statement-id="pl-4_stmt.a" uuid="880a0c86-f8b5-41d1-b61d-612794c15e5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="ed7cc530-2bf8-426e-ba08-16cd84875e14">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9b85bf7d-6c33-4051-87f2-cc120afac7ff">
+      <statement statement-id="pl-4_stmt.b" uuid="b4352941-8475-48e3-b6bb-b4937fdfdec9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="0def98a9-565d-43b7-a3d9-c1c1f6fe7f2b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1b5d5250-e4a6-4a36-b3da-04204b6b8c72">
+      <statement statement-id="pl-4_stmt.c" uuid="ba9a5420-9b61-4fda-9a3e-6402d4e2751c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="1e41f629-a85a-4bbb-b567-6a5e87e58de6">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d3f269ca-61e5-4130-a9bc-75547a713135">
+      <statement statement-id="pl-4_stmt.d" uuid="1f709031-5728-48b0-b2d4-3457e63abf85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -3399,10 +3399,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ce08dc0-d478-47c1-a808-29cacd54a2a9" control-id="ps-1">
+    <implemented-requirement uuid="0509732b-28ff-4dce-8534-4a8d553e31cf" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="aa4bf597-42b2-4ce7-bff3-1f55c0122c98">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7f380b80-f51c-4a4c-aa43-d81e1efe1dc2">
+      <statement statement-id="ps-1_stmt.a" uuid="8e69a681-7d8c-4c33-8fc1-09c277a7be63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3410,8 +3410,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="722d98f4-c18a-44e0-9a47-c4a045b5b827">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="70281dd9-a61a-47bd-a8df-d9026e69c843">
+      <statement statement-id="ps-1_stmt.a.1" uuid="08da0a83-64e2-4d6a-bbe3-4b8639dbe4b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3419,8 +3419,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="15dcbbe9-677b-494a-ad8e-77867b3cb485">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7b562c1e-8ca7-4796-83b5-c0d0f1096c17">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9086085f-9d70-467a-ab6e-a8c7971fc63f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3428,8 +3428,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="9574fe1f-dafb-4d2b-86e4-7d53b344a1ea">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ff2a458c-21d6-4b9a-aa9e-9db5d30baa78">
+      <statement statement-id="ps-1_stmt.b" uuid="d66da28b-8336-4182-87bd-83210fbd8a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cae01e9c-41dd-49da-bc48-41712538a5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -3437,8 +3437,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="56332ac6-9352-4704-b399-4111c2dcbb14">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="29aa2abc-3e1b-4496-8e5a-0156e9f6310b">
+      <statement statement-id="ps-1_stmt.b.1" uuid="a4c57ab6-c597-4bf2-a004-175baea1e318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3446,8 +3446,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="d2c6e4bf-c3ba-421e-b972-4685fbdd9882">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="71989754-ce95-4a28-b1d5-09825b34463a">
+      <statement statement-id="ps-1_stmt.b.2" uuid="025d26bb-f914-46f3-89fa-5e193f0cb358">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3456,18 +3456,18 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7a6bad7-cd67-43b8-b209-537117e24bd6" control-id="ps-2">
+    <implemented-requirement uuid="87c32fdb-ceea-43e8-8e1b-c66a7cb24bd7" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="75874b41-3a09-4e0e-8179-913a1aafc2ef">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cf3cf13d-c9c2-4d70-89a2-d232c2fd0cda">
+      <statement statement-id="ps-2_stmt.a" uuid="d1ea0e64-8187-4df7-95a0-267fd3f13c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a53b3b50-3dab-4be8-a8fc-e1957dc68954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="1dfb5551-a607-479b-a8b1-609b211d8434">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="fcddbd00-0c52-4c42-aa32-bf642846b1c8">
+      <statement statement-id="ps-2_stmt.b" uuid="87a70bf1-bb3e-4225-ad9e-d884e7e43e34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c1603b6-e20d-4245-8cca-589dae4ea801">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3475,8 +3475,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="31384e47-beef-4784-8e19-de591252e41b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e465ee50-b353-4ef7-9a09-a165957af87b">
+      <statement statement-id="ps-2_stmt.c" uuid="f54131c2-6d5c-4b74-b75a-e146a00e040d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b22c353e-755b-4530-baba-c62897c0596f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -3485,10 +3485,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2dda9033-2fa6-4e73-bc9b-23be7855969e" control-id="ps-3">
+    <implemented-requirement uuid="7e38a1d2-2160-48f4-944c-318362f4f233" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="b65c556e-73cd-471f-9f95-6f96489fe21d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="478cae32-862c-484b-bd05-7f2e8bac849d">
+      <statement statement-id="ps-3_stmt.a" uuid="8ef2de60-c9fc-4743-9abc-bc839c975948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43bf671-6676-410e-9ec7-ab761cf5dd0d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3496,8 +3496,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="eeb95c82-c7b5-4919-94c5-34f0fc3f5ce7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0f408d9d-d647-460e-b40d-7e21bcaf57e3">
+      <statement statement-id="ps-3_stmt.b" uuid="4c0c480a-e013-43a0-bbbb-7457cf4ba5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4c2e15b-a2f8-4057-8132-53326f3f25ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -3508,10 +3508,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c5754ac-06a5-4bdd-a7b9-d3a08ca92cd8" control-id="ps-4">
+    <implemented-requirement uuid="93d688d1-a188-4a6c-857b-5ff45ff8bd5a" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="140f8cbe-cf54-48b2-b48a-15a2c468b096">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b6a9cc33-a8d3-486a-aacf-a2f91ddc4c08">
+      <statement statement-id="ps-4_stmt.a" uuid="e8799de5-2c0e-44ed-b148-013e542d59b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33aeb54e-0472-45e8-89ec-ffd517fb4c90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -3520,8 +3520,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="fe88ff68-7014-4dd8-a8e6-2bb8497be74d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4831eb6f-8b67-477f-9473-b6bb49d554b1">
+      <statement statement-id="ps-4_stmt.b" uuid="9034e4f7-d40a-4dab-9e94-aee7ea990d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42366338-6bf5-413f-af17-1ba8bd0c9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -3530,8 +3530,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="3d70877c-fa75-4bec-b72a-ddfd01d427c3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6a0d5d34-4f9e-4387-a123-23ee72fba961">
+      <statement statement-id="ps-4_stmt.c" uuid="b0106692-4c65-404a-aefe-774beadb5ab4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60b612-5b36-4216-b8fb-69e2b64a9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -3540,8 +3540,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="46324abc-d0b8-45ff-bb32-21fb67213a54">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4dc90f68-07b3-46a1-9766-02221f57c91e">
+      <statement statement-id="ps-4_stmt.d" uuid="a3a2bef0-9f94-4af3-ab52-fc4c4bd892f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3fecd8e-b4bd-4147-8b74-8c3b6faa2410">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -3550,8 +3550,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="259fe747-f24f-4442-9dcb-5c7ae89d6ae3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7a2af2fe-0c10-4aec-a851-61388c9ceb85">
+      <statement statement-id="ps-4_stmt.e" uuid="d1b7e6c8-a309-4603-bf7d-172dd9858328">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8598f4-dcae-4101-be62-59f0c60d27c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -3560,8 +3560,8 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="a3660663-6fcd-4e63-b634-9e328a422dc5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9327bd09-3023-48ae-bc12-0cecbf9c9cb3">
+      <statement statement-id="ps-4_stmt.f" uuid="d9f86f5c-41ba-4235-bfa4-ee491660feab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e3fa770-31ec-412b-85e4-c42df7ec69d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -3571,10 +3571,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d6970e0-e8b7-4621-b516-54cfaa4c2115" control-id="ps-5">
+    <implemented-requirement uuid="530189ae-e0b0-4489-817e-68545a85fcb8" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="10959307-e883-4b38-905b-c4a07c1129ed">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b29ffa56-03c8-4f0b-baa5-a750499b6a1e">
+      <statement statement-id="ps-5_stmt.a" uuid="d60d9065-eed8-454a-b65e-387181feb780">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efe56d04-e15d-4bd6-b15a-0fec2acee727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -3584,8 +3584,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="6a29bd57-7c47-4b56-8822-7c7200b26612">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ce6c96d8-a8e6-4f38-9146-773815a3677e">
+      <statement statement-id="ps-5_stmt.b" uuid="b1c33cfc-5b1a-4c4a-9a1f-1b326d12b8bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="815501c8-e770-45c5-8421-cd2c1d2e1719">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -3594,8 +3594,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="8a0ff8f3-1fed-43bb-9ecd-3e6f05dc98d1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="928d0bf8-89eb-4a64-a95e-02e1a024685d">
+      <statement statement-id="ps-5_stmt.c" uuid="6ef767a9-8e24-4146-a8ba-a16178901e3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ef830a-c8b9-48d2-9f2f-22ffcbe98ccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -3603,8 +3603,8 @@ or transfer are outside the scope of Red Hat Advanced Cluster Management for Kub
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="20fb4c4d-1957-4edf-b4cc-e1ac40ded1f3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1c1fb686-58ac-40c1-928d-41b7f9327b23">
+      <statement statement-id="ps-5_stmt.d" uuid="8fa717b1-6194-46de-b1c1-8e9efa7d9024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58a7d968-8b64-442c-8cf8-6a1fb6f14c8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -3613,10 +3613,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27aa3afd-8a21-4388-baf0-dc4c1fcb4e50" control-id="ps-6">
+    <implemented-requirement uuid="55212855-6b55-4446-894f-e8075367debf" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="f23399ca-6449-4c95-b309-0e26c73aaa8f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0691e9ca-77ee-4599-a547-7a668f31cb6c">
+      <statement statement-id="ps-6_stmt.a" uuid="c0824464-d4c6-4217-9591-66c4979c214a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a87dde3-52c9-4aa1-b88a-5bf8a6716ff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -3624,8 +3624,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="9f592421-ec5a-45b3-86f6-6a2f39a84feb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="99453177-e45b-40b3-be21-1be18497f735">
+      <statement statement-id="ps-6_stmt.b" uuid="5f685e28-9d6a-471d-938e-237e539dc978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a00138-2407-4695-b3e6-59fe0dc8f35c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -3633,8 +3633,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="3a98f76e-aa6d-4ab0-adbf-4f6c3592146b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c52880a7-1769-4260-8019-b4023763ac5c">
+      <statement statement-id="ps-6_stmt.c" uuid="be530178-263c-466a-9967-db94f8582011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3642,8 +3642,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="1b9a35ec-9826-4248-85fb-cab914140901">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b7cf1d4c-2158-4205-8116-bba5f6bd46be">
+      <statement statement-id="ps-6_stmt.c.1" uuid="a8f518ca-e021-4e41-a0e8-5b044f14a24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3651,8 +3651,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="0a6125c8-b43a-4ad2-817d-01238c45d875">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d2f6e994-12fd-4390-91bd-ba9ea13be454">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d966152f-c1d4-4295-8eb6-fadbc32edbfb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3661,10 +3661,10 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21011a98-8120-43f8-8941-9fb82a1fcf9f" control-id="ps-7">
+    <implemented-requirement uuid="9e92f0ba-f452-431a-85a5-a74cd7c4bc96" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="dcce534f-767a-4450-a545-7fca83cbffa0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="00862f3f-e270-47cd-9863-fc7d4894b1f4">
+      <statement statement-id="ps-7_stmt.a" uuid="947bc933-387a-4d5d-bc1d-548d44c0489e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d1193a2-7742-4c6b-b661-478eb2347bfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -3672,8 +3672,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="7a0ca640-9775-443f-a4fd-1e597828aaa8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="76486bab-1e9c-4248-8bc6-fe67d3d6582f">
+      <statement statement-id="ps-7_stmt.b" uuid="24b5dacf-7696-4efe-944c-6489e7ef86e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59e0633-2918-44a3-903e-4506e838ebcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -3681,16 +3681,16 @@ the organization are outside the scope of Red Hat Advanced Cluster Management fo
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="76f91dea-5fa6-4335-8de5-94add8d1094a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="19f74b24-4534-408e-9abd-51caeb2ed34c">
+      <statement statement-id="ps-7_stmt.c" uuid="e5009a10-28cc-4309-9c3c-f7aa4fa88e19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c862fe2-ab9f-4e92-b685-7e9769b97ddc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="60d65c1c-55d0-4805-a926-f841b4b5324f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1d3a9560-41f6-4a77-9cdc-00957a052f28">
+      <statement statement-id="ps-7_stmt.d" uuid="19524cc9-a1eb-4861-b73b-e596ec70eef4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5db9d0c1-73ad-4604-a0b5-124b1b0813d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -3701,8 +3701,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="874346e5-5d88-47da-b0b0-8a6c098dc084">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c20142d0-ef99-4c5e-b82f-c9c94f0add4f">
+      <statement statement-id="ps-7_stmt.e" uuid="28eae6f7-79a1-481b-9044-61e2d75e108e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0fcff48-98f4-4c4e-894b-17089205806d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -3710,10 +3710,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0ad96eb-184d-4ea5-8290-6135089471a3" control-id="ps-8">
+    <implemented-requirement uuid="51daba9a-e441-4a8a-9788-d76c1c1587c4" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="f7d4f596-e20a-40ab-8936-027ae1f61aad">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="56a62cda-cc88-4b6b-88da-b936fb959b78">
+      <statement statement-id="ps-8_stmt.a" uuid="ae4c7e89-a6d2-4b61-8b0e-aabde6f59a4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0149ee0b-e7e3-4293-b9cb-889fbde710ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -3721,8 +3721,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="ba9c897c-6759-488c-a6b0-d8c25ad9297b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8c0ea1a7-a665-43e5-b50b-df69a5a1a6d2">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -3732,10 +3732,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06815430-e6cc-4d99-8706-8e1508cf222c" control-id="ra-1">
+    <implemented-requirement uuid="6216d434-a474-42af-a2be-87332323c39e" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="45d5c8ea-5d81-42a3-87f8-969ea70d5cdc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ba8805b6-6195-4a94-a55d-3ad47008cae6">
+      <statement statement-id="ra-1_stmt.a" uuid="ba9a3d0a-1b84-474c-8589-1e19f8f59c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3743,8 +3743,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="771e9d0c-43a0-49c0-9695-6b89a8346e41">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="57a4190b-2c3d-4bba-8b31-fdf12d219401">
+      <statement statement-id="ra-1_stmt.a.1" uuid="e8073210-6722-4f57-ba87-e52147b2afd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3752,8 +3752,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="f49f9a82-45f6-4d6a-b27e-e0fcc55e3f5d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ad0ef9ac-4a8e-4d8b-832b-323a93fbc5cf">
+      <statement statement-id="ra-1_stmt.a.2" uuid="cca51aed-cfbf-44cc-9053-c1d1f769ad2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3761,24 +3761,24 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="0fcf58e4-9b92-44d0-8ad0-dad125ceb1b0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d731ee68-b541-40c4-99e9-8c0e142d5f41">
+      <statement statement-id="ra-1_stmt.b" uuid="41fcfe11-8e26-454f-8590-a33e35c48c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="1b221a68-200c-4a52-8dd1-55cc37221a9e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d9370c9e-34f4-424a-96a8-5d7f64884b2d">
+      <statement statement-id="ra-1_stmt.b.1" uuid="6abad903-8168-4c9a-8415-b68e057853c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="64cfd8d3-62b1-4744-93ec-78fecd4c1375">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b97110d6-d543-4381-8ff7-158a6479681e">
+      <statement statement-id="ra-1_stmt.b.2" uuid="fc8da6e0-499d-4016-a8f8-fd4a5fc3c2c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3786,10 +3786,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="697f74de-06d0-4e93-a69d-b4b9a3536af7" control-id="ra-2">
+    <implemented-requirement uuid="5c418f41-5b8c-41e4-8aeb-04b1da9a75b1" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="e362f821-a66d-4c0d-bd04-658a2708f1fb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="040786c0-1419-487c-a031-f73bc4ec5d2d">
+      <statement statement-id="ra-2_stmt.a" uuid="29b82483-d484-4ae1-9bda-11410dc737ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b8ec53-c18d-49e9-8dfb-f9cdff739bba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -3798,8 +3798,8 @@ guidance, are outside the scope of Red Hat Advanced Cluster Management for Kuber
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="0dbf1c4a-5c69-438e-9dd9-dccd857a089f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="419a88fb-2c41-4c61-a8ff-4f5a8fd11000">
+      <statement statement-id="ra-2_stmt.b" uuid="d1ec18fb-30ba-4d31-8f13-2d53c896008f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8e73384-e452-4de5-8f4e-3904534bbd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -3807,8 +3807,8 @@ the information system are outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="caf379ec-aa1f-41c9-a2de-767bb079b097">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="21a8d166-21d3-4907-bbad-4601f28798d1">
+      <statement statement-id="ra-2_stmt.c" uuid="41bf5a9c-a005-4633-a11a-548dc6388d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bd08efa-7eda-4b5c-90bf-4212008e6d51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -3817,10 +3817,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2deae6d2-5116-4045-bf77-911b8b40a722" control-id="ra-3">
+    <implemented-requirement uuid="15b53a72-3910-4d35-a0a6-194aaa66d734" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="56d446d9-af1c-4e22-a927-afa1abcb1e25">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e93542c3-c185-4695-b0f3-844452814c35">
+      <statement statement-id="ra-3_stmt.a" uuid="c158bdd6-f9d4-4807-ae30-105f4dbad6d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9e600a5-e75d-45be-a1b0-e134cc6ad299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -3830,8 +3830,8 @@ transmits, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="99425668-370e-4ca8-9b99-ac8884e9259d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e693e64d-0c3e-45b8-af30-79ccc1b3bfd8">
+      <statement statement-id="ra-3_stmt.b" uuid="6d5266e5-0cf6-41a6-a5e5-19dc40a4104d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08a69f48-635e-4c35-9c57-abef65f44bac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -3839,24 +3839,24 @@ documents, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="85a6d299-c9be-48b1-adf1-6dccaf263974">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a6912e5b-c0a2-4328-bc26-e872748b7c70">
+      <statement statement-id="ra-3_stmt.c" uuid="3a949ca5-03dd-4da1-abf3-4964fb2f19dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e0ed2c-75a5-4b3e-85fe-af7dd3c33564">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="079e0780-d182-4094-b131-cdc1802ecb22">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f8d3091d-2fb4-4a26-90a3-bb64a8035c85">
+      <statement statement-id="ra-3_stmt.d" uuid="800d36e2-ebdc-4451-8b7a-b55a5d1521e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b31c816-14ea-442d-8c78-f53fefe80486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="7e573a10-bc57-452b-93ff-323713f5b471">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="444e4812-21ff-401c-9c53-fbda8cb3f4a2">
+      <statement statement-id="ra-3_stmt.e" uuid="666156ef-f85b-470d-aaf7-cf1a21d1f049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b4f59-53aa-4734-9668-258952461f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -3867,17 +3867,17 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5937a3b1-1f88-4108-aa46-07ad49db90f3" control-id="ra-5">
+    <implemented-requirement uuid="be9e3ae6-ee6b-4aa5-8d4c-c1d3b608406b" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="511cb794-7ccf-4126-aa9c-003892e34a67">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e7d659f9-2ded-4989-b1a2-c0fce82b5088">
+      <statement statement-id="ra-5_stmt.a" uuid="dccb79ef-09ee-4efb-939a-24bc0487e826">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="d901345c-3b03-44a0-abb3-32721954c5de">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="51fbf09e-de42-4634-8b9f-9db2f224750d">
+      <statement statement-id="ra-5_stmt.b" uuid="a99daa29-24eb-4b9c-8f88-042f70a8ac2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8e77ad9-cca6-42d8-bffe-2f62a993929e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing vulnerability scanning tools and techniques that facilitate
 interoperability among tools and automate parts of the vulnerability management process by
@@ -3892,16 +3892,16 @@ Documentation on how to create a security policy can be viewed at:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="1bf3ea25-c8db-4829-b821-1f177c46fc39">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="23e400e5-18d5-467b-b87d-3e35f264c1ee">
+      <statement statement-id="ra-5_stmt.c" uuid="900fe8d3-5443-4c5b-95a3-c19be1492b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38c9ad0f-841e-4ea9-b823-df5705054e7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization analyzing vulnerability scan reports and results from security control
 assessments reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="7a8aa2d3-a9ef-4d68-8370-27f1523da275">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ad270bcb-d6c8-43f6-a884-0277cb6fe51d">
+      <statement statement-id="ra-5_stmt.d" uuid="1efab40a-9b23-4e20-8ea5-804c56098eb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce90a18b-e7b0-46a1-bea5-e49a4ee539ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization remediating legitimate vulnerabilities organization-defined response
 times in accordance with an organizational assessment of risk reflects organizational
@@ -3915,8 +3915,8 @@ via a security policy. Documentation on how to create a security policy can be v
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="c827f13e-756c-4d09-8195-24e3060fd38d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2fcfea7c-ccfd-4586-8527-79e7cee43459">
+      <statement statement-id="ra-5_stmt.e" uuid="37330ba6-07dc-4b51-8247-6cefa0718e1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9991d966-780d-4c2e-ac15-992b1775832a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -3927,10 +3927,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b186faf-bff7-4b40-826e-841af90408e0" control-id="sa-1">
+    <implemented-requirement uuid="bef6edc6-6d64-47dd-8489-9a6e27d991c2" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="d332f059-045c-4c26-b067-3bc86d2c91e0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="313ce9d0-5f65-4839-885d-3b24faf91f8b">
+      <statement statement-id="sa-1_stmt.a" uuid="028f5a03-49c2-4b53-a7cb-1785af084ad6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3938,8 +3938,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="101f58f9-f095-4278-a6cb-dfb7293c4f69">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ffc75fec-2887-48ff-9732-7a9bc507b167">
+      <statement statement-id="sa-1_stmt.a.1" uuid="19b9b625-8a58-40a1-9e80-83cddeae90b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3947,8 +3947,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="b5277321-6169-4bae-92f5-c93d2932f43d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e51b1737-0d31-4bba-8320-b0632a3cdcf4">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2797b025-1caf-4640-b133-b5e5762e2982">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3956,8 +3956,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="e815f49c-d756-495a-991d-8a285f1f190c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1a5214d7-8e21-4f52-9f59-ed27f71cb749">
+      <statement statement-id="sa-1_stmt.b" uuid="d89d6bd3-82ec-4645-9fbf-fb91ecf0d243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3965,8 +3965,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="2bea9627-fb1e-438b-9e55-b3ab310a7c3a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e99db171-7f10-432e-b786-31e24f0105af">
+      <statement statement-id="sa-1_stmt.b.1" uuid="c38432aa-2db4-4d9f-8b38-599675772d61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3974,8 +3974,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="efc94580-6915-4c7a-9c5e-b04db15a021b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="19d729f0-a2f4-49cd-9792-f52e4b53e7bb">
+      <statement statement-id="sa-1_stmt.b.2" uuid="16876a68-d462-4e48-b51b-467eea24dab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3984,10 +3984,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ab5746e-8539-421b-a23c-b8d712b8055e" control-id="sa-2">
+    <implemented-requirement uuid="6964c443-11d8-4230-8f68-28dd5588b94c" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="46a70357-758f-4347-b2c5-37eaf33464b1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="430811bb-d222-4ebc-988b-8f906fa8b2eb">
+      <statement statement-id="sa-2_stmt.a" uuid="2e505351-afb0-46ec-829b-870b2fe94a7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d4b9c05-7564-44a9-aca9-fe352166d044">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -3995,8 +3995,8 @@ mission/business process planning are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="e661b8f8-6e9c-4d1b-bb28-921c2cf9f7d9">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="db0834ce-56e8-4624-8453-4d69a1b110e0">
+      <statement statement-id="sa-2_stmt.b" uuid="f8220ce3-ac39-4864-83f6-f270da1edf1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fc173ed-aac2-473c-80a3-14d8ca2254cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -4005,8 +4005,8 @@ process are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="8913b8bb-9609-48fc-abcd-79e4ae8e525d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7a1a2331-0be8-477e-9d24-e1fd1f25328a">
+      <statement statement-id="sa-2_stmt.c" uuid="59308e73-1cc8-454a-af7f-74ef44846a9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d123c3-667e-4146-bf92-e0f3cd02938b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -4015,10 +4015,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="479bd375-b7a6-4ee9-a339-aed0e73bbe8e" control-id="sa-3">
+    <implemented-requirement uuid="499e5123-bce7-45ee-afd3-a841fc3c8b48" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="3a0f16f1-ce39-422f-af6f-e0ba21ea1363">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="069f4968-678b-4817-b432-68a32bb9b29e">
+      <statement statement-id="sa-3_stmt.a" uuid="302872d8-fd9d-4cf2-82a0-7e28293d6287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce685a8-c7a8-40d5-bffb-a711ad980341">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -4026,8 +4026,8 @@ information security considerations are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="e50b5f73-71a6-4dc3-876c-ce98c99bf644">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="786a6448-c4d7-4ad7-94ab-76d735a147a0">
+      <statement statement-id="sa-3_stmt.b" uuid="de1b1699-b5ca-4cc6-87f4-7897cf852320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb2cea8e-397e-4dc3-a732-f4ea8cc16dd3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development life cycle
@@ -4035,16 +4035,16 @@ are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="b69003ad-8c5c-4fdc-983a-db995a42c262">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7f5316e9-a234-4333-8d6e-06387e0912a7">
+      <statement statement-id="sa-3_stmt.c" uuid="2050dd81-a765-4f5c-862a-6a9f35db0df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8283839f-f8b4-4736-8ed0-acad14cd7419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="74b7a5dc-38f2-490a-bbfb-573080445701">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="82f5de03-180b-4aec-a05c-518a4cdd2564">
+      <statement statement-id="sa-3_stmt.d" uuid="c8b2952a-7d4b-4096-872c-d5056996ffab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bdaaf3-c06a-4ead-9455-181fc42ab80a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -4053,42 +4053,42 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8a358d2-0a52-4003-9c79-6fc2ab12e958" control-id="sa-4">
+    <implemented-requirement uuid="13e16672-ab35-4283-b047-0ddfae0a55fe" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="d32ff8e4-68b6-41e4-8fbf-3ceb8ac00acc">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="93ff07cb-ca19-4f4f-9a21-bc449cd4f747">
+      <statement statement-id="sa-4_stmt.a" uuid="739264ec-e883-4320-8ec7-5254f35496b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="195535e5-eff2-4172-8801-5e8a786a670a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="bad39dc7-069d-42e1-8c53-3e0886a16814">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2f5e9fa9-83fb-43fc-9b42-7c5829af47dc">
+      <statement statement-id="sa-4_stmt.b" uuid="9e4076e4-39dd-404c-bd0f-e6d62c71c87e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce554d87-8848-4201-bcbf-a5a3deb85d2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="289bc4ca-b465-4192-836d-b9be2022b58f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="79e056bf-d33b-4243-aacc-64767c96cdf4">
+      <statement statement-id="sa-4_stmt.c" uuid="d4f5a970-6c0e-486e-bb78-97e25c18eefa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7e96d96-886f-4a58-b249-fc5ceb5d3acb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="f3c10bba-6c29-4cb8-9dd9-9b531255a857">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="14e721eb-c93e-45a7-8bbc-d28fd7bd56fe">
+      <statement statement-id="sa-4_stmt.d" uuid="85d4555e-30c6-4760-b264-7532f915aee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="916f3e52-34a3-445b-9b72-d122deb0afd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="902a8edf-e05e-40d7-a517-14699d77e38f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d88f1657-5f4e-4f81-ae3d-949564f79920">
+      <statement statement-id="sa-4_stmt.e" uuid="1655e4cb-492b-4bd3-9089-808252d01ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d76a02c8-d32b-4ce3-a42a-e90a15373882">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts are outside the
@@ -4096,8 +4096,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="c989729d-ca8c-449d-8bca-fe5cb07ca1ad">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c08182bf-d3a2-4d6e-89f3-fc2e1bb449bf">
+      <statement statement-id="sa-4_stmt.f" uuid="1eda4fcd-e205-498b-8423-b9957105e1ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a9cc39f-3256-4309-b8de-7d81b133ebf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -4105,8 +4105,8 @@ intended to operate in acqusition contracts are outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="89063a80-b3e2-42cd-b1ae-8154be042b6f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="81dcb779-517b-4d8e-9d3f-06270914d3ce">
+      <statement statement-id="sa-4_stmt.g" uuid="ef890e3b-8c9f-4c7b-b5a8-b8e58ca7133a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72b142ea-c5ba-4f92-9019-96802ebb8ab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in acqusition
 contracts are outside the scope of Red Hat Advanced Cluster Management
@@ -4114,90 +4114,90 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83017b33-386c-4e67-a91d-c02c96a26564" control-id="sa-5">
+    <implemented-requirement uuid="f822cd1b-379a-4c7b-ad53-f1e217a85b04" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="68d44839-0c0b-41c1-a48d-a003f7c47fa1">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="25d6e1e4-769c-41cb-8c9a-9cf14d8d9d3e">
+      <statement statement-id="sa-5_stmt.a" uuid="b9f58e21-0fd2-4c7b-b4aa-f12cb4ea7309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="96c9683f-f03d-447a-80db-fede4f194b0f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f77e0a66-391d-433c-9166-9525159a9e32">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5678be5a-2a7e-46ba-93e8-de0b2f9e96f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="0a49f85a-be5e-4f64-ac8a-fad12201ddd0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e8955882-5052-471e-b44f-16b05cbdfe4c">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e301d484-e461-46a6-b65f-302944eeff34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="7f44e374-8b8d-43e9-a25a-0619b2bcda2e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="66b627dc-18d2-485f-a607-025fa546816e">
+      <statement statement-id="sa-5_stmt.a.3" uuid="4b02dc91-2d21-455f-a6c9-095af0426668">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="dfcdc750-ec3f-4146-aa2c-a4a5d63368eb">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bd82a416-4245-45f3-8108-04e8a87deff5">
+      <statement statement-id="sa-5_stmt.b" uuid="16150061-93ad-48ca-a3bb-2d3c4da717fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="4134b888-5726-4e09-a15e-6d41b998ad2c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0dd7dda5-1356-4d95-8b33-23477ffb0158">
+      <statement statement-id="sa-5_stmt.b.1" uuid="953f7b0b-89c7-4dad-9cef-3b651e3a402c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="981db913-c2c1-4833-966d-48607a53352e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="12641989-288b-44bd-a6bd-2dbc4d7edd8b">
+      <statement statement-id="sa-5_stmt.b.2" uuid="3cab31bc-a5ab-4408-b629-7447386c8035">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="c1e01d6e-4556-4453-8431-ae9cef307559">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="5696f507-f353-475b-b720-64baf6f71faa">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2c38c229-d3a1-4a76-b42e-d2ef311f4e15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="c155f830-0e22-4f88-8cc4-e0a49e1314c0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="beef356b-7445-470b-b9a9-fa3af2e798bd">
+      <statement statement-id="sa-5_stmt.c" uuid="c7bbf9bd-1f61-4dc4-8ee2-f0f3b230081b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="c60b7f86-c614-4cfb-8e59-8eb868dcd958">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="02a95c85-3fd5-4db5-9b53-ba56970640ad">
+      <statement statement-id="sa-5_stmt.d" uuid="e87a5f39-1929-43af-85fb-1ff5fd949fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="2dc67afa-e280-493d-8039-c9be0694b670">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cd4951c6-e2fa-40f9-b9c1-1c8689f5cc31">
+      <statement statement-id="sa-5_stmt.e" uuid="7cad6c74-4815-4ba7-94b0-dfae69599372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -4205,26 +4205,26 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf0d9070-6d9a-4c42-a4bf-cb5f9c888bd2" control-id="sa-9">
+    <implemented-requirement uuid="661d2ffc-26a5-4c69-b185-ff60e64b76d2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="630edee4-5d36-44f7-9d54-48f10c2c72c8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1974013d-6ceb-4822-b41d-624279418e54">
+      <statement statement-id="sa-9_stmt.a" uuid="5f542c78-8954-48e3-818d-25b5d1ae6d82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="09b604ea-d87b-4877-8afe-3ea21ce71816">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2d9cc0dd-e49c-4712-994d-66a60dae41fa">
+      <statement statement-id="sa-9_stmt.b" uuid="8cb867c1-31f2-4862-946c-378dd8307496">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="3367d12d-c3e4-48e6-abb6-5eaf09bc2fd8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ffb4e4f5-a766-46b6-914f-f3907c01d794">
+      <statement statement-id="sa-9_stmt.c" uuid="a7025379-d99a-4313-aaa0-ad70d2e34718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -4232,55 +4232,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac92e7fd-c1d3-42dc-b60e-a9c172133edb" control-id="sc-1">
+    <implemented-requirement uuid="063e4e11-4214-4e9a-a375-4796714c910b" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="5169e79a-6118-454d-b38c-c832a8516909">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="55910664-1990-4c83-8453-4e9444290af9">
+      <statement statement-id="sc-1_stmt.a" uuid="a12a93f1-5b0b-4786-aa28-143f30eb38d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.1" uuid="71a44c01-585d-4f92-9590-03c159c97298">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="2fd0eee3-80bb-45a5-b3f5-c49d5cd349eb">
+      <statement statement-id="sc-1_stmt.a.1" uuid="45a41e0c-33f5-42c9-beb9-74f9f76e5038">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.2" uuid="efe72a33-a9c1-4f97-a841-7ddd5b8357f6">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="96d0a1ba-bef0-447b-bd90-05edd0518e6f">
+      <statement statement-id="sc-1_stmt.a.2" uuid="e7cf378c-c4c8-4a51-91e2-dde7481422aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="10ec2921-97aa-4d58-adb5-1d4caeec167f">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="ab61aac0-9a99-4180-bfba-e0442e824621">
+      <statement statement-id="sc-1_stmt.b" uuid="11034f66-c864-479c-9204-78d1cc94bf09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.1" uuid="83f17360-e757-483f-95d4-cf057c94702a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="afe5b929-8f98-4cba-b0b7-fc744390c94d">
+      <statement statement-id="sc-1_stmt.b.1" uuid="af7bc38e-b9c7-43e2-8eed-e0196d0fa0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.2" uuid="94b52129-df5b-4ed5-9a3a-9be22dcef15b">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d9de6575-b6c5-4fb0-b785-70cfd1eb22ec">
+      <statement statement-id="sc-1_stmt.b.2" uuid="254e5f5f-0634-4de1-b144-7021e0e88822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4545bce-590d-4c9e-87b3-26902f4de9a1" control-id="sc-5">
+    <implemented-requirement uuid="5b576bcb-c919-40fd-bb67-5821d10a7345" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="05634a4c-1531-465e-a459-1251f6e9016c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="bdf9ecc2-d293-4dda-b364-49df4f190913">
+      <statement statement-id="sc-5_stmt" uuid="e548b1c4-6c2d-4cfe-bb0e-38075f414e38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2b1b6a-92b3-4d83-aca4-3e0256656908">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4289,10 +4289,10 @@ https://issues.redhat.com/browse/ACM-384</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1953142-0ff7-4010-a133-2b6d15dacd34" control-id="sc-7">
+    <implemented-requirement uuid="56f23e97-1252-4185-aaff-741dcf403498" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="5b6c7357-0c1d-4b81-8c17-5d4465d06e50">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="0427e893-9a6d-4b72-ba84-b8dfeb8f3fa2">
+      <statement statement-id="sc-7_stmt.a" uuid="13502385-9466-448b-9d7e-fc2841c74e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de4b5a8f-71f7-41e8-a400-6ed93c1e6851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring and controlling communications at the external boundary of
 the system and at key internal boundaries within the system is outside
@@ -4300,8 +4300,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="34f1a355-d83a-4bbf-81ce-96536efbf6ff">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="801de8b6-4bc9-4a41-9873-be812a97ee31">
+      <statement statement-id="sc-7_stmt.b" uuid="87f66c85-c155-43f5-87dd-579923be77bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23fbdb9b-c426-4f48-a8cf-4b13cde82e04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing subnetworks for publicly accessible system components that
 are either physically or logically separated from internal
@@ -4309,8 +4309,8 @@ organizational networks is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="65c985d4-0ba8-474b-b67b-ce0e8c44cd24">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="b7a371a8-ee46-4760-9952-b5c5bb937816">
+      <statement statement-id="sc-7_stmt.c" uuid="67a90d86-423a-4b5d-ac1a-13bec42b5b4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1301a0a-a911-43d5-86f8-94058c539d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Connecting to external networks or information systems only through
 managed interfaces consisting of boundary protection devices arranged in
@@ -4320,10 +4320,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea2e42f9-d96e-422e-9d40-d9616f809d90" control-id="sc-12">
+    <implemented-requirement uuid="f4a51580-1504-444f-8cb6-eca35566cd21" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="c04b462a-5bf6-416e-b226-3d9271be469a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c8b54b5f-72b4-4915-9409-f5156734c912">
+      <statement statement-id="sc-12_stmt" uuid="01a81a53-f306-4a28-b642-fd8e42b313a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed54e6a1-6659-41a3-bfeb-bab90f16b829">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and manages cryptographic keys for required cryptography
 employed within the information system in accordance with
@@ -4333,10 +4333,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d07ed73-1924-474e-85fc-2979599d2da3" control-id="sc-13">
+    <implemented-requirement uuid="3fd47604-a913-403b-bb68-ccd137bfa211" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="3f66d491-9214-47bd-8e57-3cea9de095a4">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="20b5bf5b-c6ea-409d-8352-a02ff490df88">
+      <statement statement-id="sc-13_stmt" uuid="5f71cac8-d81c-4210-81cc-56f35b49cf0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9015bd23-0bf4-4d39-86d7-b1372a363320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined cryptographic uses and type of
 cryptography required for each use in accordance with applicable federal
@@ -4346,10 +4346,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10000651-6d3a-4f77-af65-c7e6c06b42d5" control-id="sc-15">
+    <implemented-requirement uuid="60c39bf5-9dd5-4a4f-9d65-86b4ba78a77b" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="da6d44a3-cd86-470c-bbd7-93cdff5387c5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="58cce267-7972-428c-a86d-0020f27e8049">
+      <statement statement-id="sc-15_stmt.a" uuid="c17cc0dd-de75-4336-b4ea-b5ac72074452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -4357,8 +4357,8 @@ not applicable because Red Hat Advanced Cluster Management for
 Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="90efd362-0f35-4238-9495-3cd171959556">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a14bfb2a-c407-46b7-94b7-514dc1b7985f">
+      <statement statement-id="sc-15_stmt.b" uuid="82026196-8890-49df-811a-e0c6edb6bedb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -4367,10 +4367,10 @@ Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae5afb7e-f8fe-447d-807e-fb293c441a62" control-id="sc-20">
+    <implemented-requirement uuid="23dd3257-e41c-46b7-b50f-224e0ece8433" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="eac5c1d8-c26f-494c-8303-120dbec4612c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="71a520e3-db9d-46b4-bb6d-5e4f09208537">
+      <statement statement-id="sc-20_stmt.a" uuid="74b46734-23e3-40a1-86f4-e151498e8daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b06f186-06b1-4420-84c3-5562c998e3ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing additional data origin authentication and integrity
 verification artifacts along with the authoritative name resolution data
@@ -4382,8 +4382,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="47896c0c-5c23-44fa-ad15-0c829c4945cf">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="fce81cdf-a236-4416-8d50-563f876208f4">
+      <statement statement-id="sc-20_stmt.b" uuid="584e9542-8ea8-49d1-b9ed-4061ffb3e388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04c15b7f-aaf5-4aad-9468-3ec78c5f0d68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the means to indicate the security status of child zones and
 (if the child supports secure resolution services) to enable
@@ -4396,10 +4396,10 @@ for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d79b0fb5-b6b1-4ab7-a57f-9c23c843aa8a" control-id="sc-21">
+    <implemented-requirement uuid="284c92b1-ee3d-4f5e-934d-f4e46f765513" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="3ca5bee4-c586-4751-9dc9-4ddb855286f0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c8fe87c4-1702-459b-a9ba-030aff04a08c">
+      <statement statement-id="sc-21_stmt" uuid="1237c951-198d-425c-bbf0-3f7cb2c85b11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d804e87-282d-46fd-b73c-7c83cb92348e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requesting and performs data origin authentication and data integrity
 verification on the name/address resolution responses the system
@@ -4408,10 +4408,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c1269c7-e478-46e8-aa19-d78ed5177ba9" control-id="sc-22">
+    <implemented-requirement uuid="a1fd2e32-64d0-46f8-a9d2-089b11bd5cb1" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="40dfcd35-1834-4a8b-ae8b-f19412a556a2">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="3670112b-b4b6-42ea-b818-0fc18c24d9b4">
+      <statement statement-id="sc-22_stmt" uuid="68ca8a26-b035-470b-a730-35e3f5212d29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcd37744-2fde-4ebb-8cd1-6cbd7ce478b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Collectively providing name/address resolution service for an
 organization are fault-tolerant and implement internal/external role
@@ -4420,10 +4420,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4515e75-1141-48b6-a8a2-ea6188836a5f" control-id="sc-39">
+    <implemented-requirement uuid="06047ebf-250e-4bc2-8889-294df634a49c" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="7d42425a-3a8d-472f-bed4-d1afe1d1b96a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1f71ec10-e1fc-40ef-bfd4-003ccf4fd931">
+      <statement statement-id="sc-39_stmt" uuid="45056cf1-b025-4ef6-857b-25e11139281a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="905ec3ac-6de3-40b5-abfa-45041060bccd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining a separate execution domain for each executing process is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -4431,55 +4431,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a35bad5e-ab3f-44f6-aa5e-2ecbb2fdcdc1" control-id="si-1">
+    <implemented-requirement uuid="1ac57cb5-e0eb-49d1-8ae6-31169fd834b4" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="26daadbb-239d-4014-9c2e-0827323badf7">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="567c13d9-c932-40ef-a67a-6a8ac4d5bd87">
+      <statement statement-id="si-1_stmt.a" uuid="e9254d38-f6e2-41ff-aad0-6e9e07d1c09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="3549cb40-066c-444f-909f-6dc5e8a0bbd0">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1ce2c8c4-6972-41dd-86e8-f5edba36b714">
+      <statement statement-id="si-1_stmt.a.1" uuid="3e00a5d5-ce55-45f6-8aac-56a15fb5d9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="fc1e7ca2-4e6d-49a4-8014-14cfa77cc7b8">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="8059e9fa-5b0f-4952-9db4-f04ab1fe1d20">
+      <statement statement-id="si-1_stmt.a.2" uuid="c7d2bf00-f2d1-42b0-92ad-eb30eb27d02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="87d884c8-800c-4e83-90c7-a0b9047cd67d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="a0f70e36-4bf2-44f9-9666-a8fe1a668b09">
+      <statement statement-id="si-1_stmt.b" uuid="24f5c308-d85d-437d-9246-e67792f05101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="1a7567dd-0116-454e-906d-537bdd78ef98">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="fce68513-fdcb-4ba3-9f2f-34d4c32fddbc">
+      <statement statement-id="si-1_stmt.b.1" uuid="7f50bdcb-e683-423b-8ec4-c40a04d2f4ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="ebd54d3a-0e1c-40cf-8372-84ed5a5fc28d">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="83ee0ff8-e251-41bc-a78a-dc2f88cdce3f">
+      <statement statement-id="si-1_stmt.b.2" uuid="f590ce87-15aa-4188-badb-1c64dc28365f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b114b75e-7fdb-412d-98fa-bd9da22827b9" control-id="si-2">
+    <implemented-requirement uuid="ba0844fb-4f55-4ccb-9350-65001c226036" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="6b7af928-dfe0-4b18-8cff-a001187c3fae">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="10a7dac1-010c-48d8-9186-35b288c8a0bf">
+      <statement statement-id="si-2_stmt.a" uuid="8fe5873f-4410-4b49-b0a1-39acae3c6973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d82e347-ad53-4671-b12a-7fa613597f98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Advanced Cluster Management
 for Kubernetes deployment for flaws, reporting on those flaws, and correcting them. A
@@ -4488,8 +4488,8 @@ discovered and remediated, as well as tools that are used to assist in detection
 remediation.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="9af3a581-6e3f-4054-956f-fa2956676238">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="079d8efc-55fa-421f-bb5a-50ad4ee5af2f">
+      <statement statement-id="si-2_stmt.b" uuid="376ff04a-f459-444f-aca7-68c33bc958b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54df072f-e685-4337-8829-049d63b612e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Advanced Cluster Management for
 Kubernetes updates related to flaw remediation prior to installation. A successful control
@@ -4497,25 +4497,25 @@ response will discuss the testing process (e.g. the nature of the test environme
 types of testing performed, the tools in testing, etc.).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="f1e3aba7-db2d-4aec-b639-aaf2bebc5e3e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="74419e8a-0e34-4fc9-ae7e-61bdbff866e4">
+      <statement statement-id="si-2_stmt.c" uuid="f3546051-4f29-4055-8e73-2bc44e58c533">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="d562bd01-fa75-4a4d-b77f-ced00215774e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="7f31d759-a902-469d-9ecc-07b9cfe465a1">
+      <statement statement-id="si-2_stmt.d" uuid="6b511da2-09d7-44b2-a2e3-8c2a07b01922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbb81289-bf9b-42ef-bf27-fd5e51b42156" control-id="si-3">
+    <implemented-requirement uuid="c4c53f67-ef6a-46b6-af85-f8628d279672" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="85d51f12-258b-4402-ab97-9e30f6ed4e20">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="895163d0-ac1e-4d19-bd2e-46cb797f52dc">
+      <statement statement-id="si-3_stmt.a" uuid="c9a78034-edec-4d05-bd0c-63e1d22f5549">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad7e803-63d3-428c-897b-f3e6c876d05e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious code protection at
 information system entry, and exit points to detect and eradicate malicious code. A
@@ -4525,8 +4525,8 @@ scripts). In regards to Red Hat Advanced Cluster Management for Kubernetes, this
 generally through the use of third party tools.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="fd24684d-aca0-4eec-abdd-a7a0a1ca0f46">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="9249392f-64ff-4ccf-b54b-5fffd978a357">
+      <statement statement-id="si-3_stmt.b" uuid="9e354838-03da-492b-9122-03257ea75bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="210a2511-c79d-417a-9918-37a176cef03a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -4534,15 +4534,15 @@ management policy and procedures is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="7324993d-683f-42e8-ba53-aeb9a2f8b1e3">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cd941979-717a-4b69-8642-0ea665b9fc29">
+      <statement statement-id="si-3_stmt.c" uuid="18d03ef9-86d5-48b3-ab0e-42b0f75db078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2caa1d9-ef0f-467a-b427-cda36c3c95bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="fe343c4f-fffc-43ee-897a-5b2b7b590a9a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="112f306c-6ddd-441e-a0cf-2fde91e73936">
+      <statement statement-id="si-3_stmt.c.1" uuid="b84429c3-26de-4de0-8205-aebee6408335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42a678a9-b637-471c-8b9c-b022ad140114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -4551,8 +4551,8 @@ security policy is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="ce73a992-b9f8-4194-82f9-ccd90ae9dd89">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="94b77a05-f77b-4f53-86a2-d8a29f7db5d9">
+      <statement statement-id="si-3_stmt.c.2" uuid="be7da617-432e-438a-afc1-d74bd9291a7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723d2a9f-9964-4c4d-8df2-d0904f80d4f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an
@@ -4560,8 +4560,8 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="8a453690-b205-45b8-95ea-bd0d2720715e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="cc46ea6d-e4b4-4e18-8bc6-df58b4fc743b">
+      <statement statement-id="si-3_stmt.d" uuid="427c4401-59c6-4c80-b8f3-2448c94585f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4d4652d-b87f-4963-ab15-232536b7d509">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an
@@ -4570,24 +4570,24 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="597f1b70-9b1f-4902-9fca-a29c274728e5" control-id="si-4">
+    <implemented-requirement uuid="b77472be-ee4b-4cc6-a1f1-76fee3f8749d" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="01c2dd7d-8623-4efd-aa2f-91e8bc94cb9e">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="4816c532-0360-457f-ac58-b1da8deae7d1">
+      <statement statement-id="si-4_stmt.a" uuid="e06f9d1c-ebe0-496d-8603-066fa2b282f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="c5620068-e86f-4aae-8207-e19967fa1915">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="f2b409f0-2e6e-4f62-a44c-91a4245548e1">
+      <statement statement-id="si-4_stmt.a.1" uuid="c5488e87-5971-47c5-84e7-b10a62142a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="f8a898db-b666-4812-a4e7-a7f99c53de90">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="370cdc8a-1765-4fa9-9fff-b537e17bbfd9">
+      <statement statement-id="si-4_stmt.a.2" uuid="4ba6ecd1-1581-4cad-965d-3bb5040ffd58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="201402b4-6cb9-4705-ab64-3be7e6f0bad7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
@@ -4595,8 +4595,8 @@ Kubernetes configuration. Functionality to meet this control can be provided by 
 party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="238c4804-ac06-4c48-8ee8-1587f8e72028">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="04e172f9-c77a-465b-8aae-50e84ff6e219">
+      <statement statement-id="si-4_stmt.b" uuid="30ba8a4b-7359-4609-a0a4-50da18a179ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="839816c6-ec65-4e84-afd9-398166749d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope of Red Hat Advanced
@@ -4604,16 +4604,16 @@ Cluster Management for Kubernetes configuration. Functionality to meet this cont
 provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="d8a6f4a1-9c0f-414d-a565-b34370dd1e5a">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="edb5f5a3-32c5-4d08-b421-056b5a2802d6">
+      <statement statement-id="si-4_stmt.c" uuid="0cd49d2f-114c-4414-944c-faddf2e30fc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="370fd0b3-f1a9-4e99-9133-431c67d824dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration. Functionality to meet this
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="48e7a35d-3c9e-44a4-84da-7c6ad7350916">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="335fb36f-bb56-4955-a221-d242a79ac27b">
+      <statement statement-id="si-4_stmt.c.1" uuid="077aadd6-ed2f-4f7d-b6a2-7c067cedac63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23939e4e-ab8e-46ef-aeee-f23facfdf1ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect
 organization-determined essential information is an organizational control outside the
@@ -4621,8 +4621,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="f8cba9ce-4588-406a-ab4a-341fb21d836c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="1c9ed71e-9193-422f-b42b-f84c228fdcae">
+      <statement statement-id="si-4_stmt.c.2" uuid="268e71da-855c-4f6d-849d-a4f0958b0884">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0efbfba9-8414-4e18-ae9d-27b0c6324809">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types
 of transactions of interest to the organization is an organizational control outside the
@@ -4630,8 +4630,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="ea333eee-c860-4d23-a715-ab4f60407072">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="c41b9a70-8f4e-400b-ae34-56ca3278ad49">
+      <statement statement-id="si-4_stmt.d" uuid="ca1cfc9e-26bb-4cc7-9555-01e010b5b1b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0249159-9b9f-4fd1-83ee-3234a37ae777">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of Red Hat
@@ -4639,32 +4639,32 @@ Advanced Cluster Management for Kubernetes configuration. Functionality to meet 
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="7c2909d2-7dcb-4552-9cca-755d9bf7c046">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="6f32bee8-328f-477c-a539-a94cfb05b8c5">
+      <statement statement-id="si-4_stmt.e" uuid="40798e3b-3e4c-4c93-8b60-f0208c2461d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="132e81cc-aad9-4629-8252-6c68a0ebe958">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="e04b5dc3-78fa-4e54-a1b5-25fc9f5933d3">
+      <statement statement-id="si-4_stmt.f" uuid="8adc244d-9602-4c86-a355-3aaee407d3f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="3ba1e65a-5706-40ff-96b4-6cb99acf9138">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="58ed00b6-5800-4a58-93bc-8c564eb44ecf">
+      <statement statement-id="si-4_stmt.g" uuid="52c9cdad-4eee-4f34-a375-7b2bf80f656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb6ecaca-47a2-41e6-8315-8088f238cefa" control-id="si-5">
+    <implemented-requirement uuid="481d74f3-9023-4094-878d-88853a0e4a08" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="003c2aff-6aeb-4c92-ad84-46ade8fba1a5">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="41244730-a956-4502-9980-9592bc7e13b2">
+      <statement statement-id="si-5_stmt.a" uuid="a92b6b92-db21-47e7-ac94-6997c9d82245">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c0f4359-ac0a-46be-84f6-5db0aa230901">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an organizational
@@ -4677,16 +4677,16 @@ Hat specific products can be accomplished following the following documentation:
 https://access.redhat.com/security/updates/advisory</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="953259cb-5358-469f-b93e-d2e54d26cffe">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="83f8e314-06b6-426b-b5f9-395a2f6998e2">
+      <statement statement-id="si-5_stmt.b" uuid="38658151-0557-406c-93de-a0a33b31ca75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c81518b-42bc-47eb-87e1-ecbd3b59996e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization generating internal security alerts, advisories, and directives as deemed
 necessary is an organizational procedures/policies outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="886c6c20-924e-45c3-96db-03bd93b3d632">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="df7eb533-5332-496d-94e5-5f15340cab15">
+      <statement statement-id="si-5_stmt.c" uuid="61adc42a-b045-4ab4-9041-2f6349f10343">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc7940a6-7fec-4aad-b086-5e8792390249">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined personnel
 or roles, organization-defined elements within the organization, organization-defined
@@ -4694,8 +4694,8 @@ external organizations are organizational procedures/policies outside the scope 
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="0ea42726-ac8f-40fc-b24d-447b86c5b639">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="25dfc152-c368-44d1-bdae-5c89664756cb">
+      <statement statement-id="si-5_stmt.d" uuid="b69855b2-331c-4eb5-9cd5-1fee573661f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c96147-de3d-4927-b91f-70aef285a171">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -4704,10 +4704,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5455cae8-5ceb-4fec-b7b5-590a26b21631" control-id="si-12">
+    <implemented-requirement uuid="7205643c-3fde-44cd-89f2-51341494df7b" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-12_stmt" uuid="87b54178-9d22-4a6b-81b8-6bdf0d268e75">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="d298914a-b163-4da5-9e69-ad59b6231dce">
+      <statement statement-id="si-12_stmt" uuid="61bd108a-4e6b-4c39-b959-4c294686cc5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="571f3030-adbd-47fb-ae1d-3e65521060c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Advanced Cluster Management for Kubernetes in
@@ -4720,10 +4720,10 @@ are met.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="437d8079-6791-43d0-9fc5-adc5d47f01b5" control-id="si-16">
+    <implemented-requirement uuid="a61b9e66-5638-4db3-bcd4-fcc71083a1b5" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="e1f973ce-8f0d-438a-9c6e-5896a43f064c">
-        <by-component component-uuid="7dfe7deb-dc42-4652-8f70-e4ea6e1c7d9f" uuid="108b09bf-7a26-4a6f-a875-1a01dd6d95ba">
+      <statement statement-id="si-16_stmt" uuid="11a543ef-80bd-47a9-b814-d2fd1ffbb3df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe9d115-183d-4519-9da9-7bd79a8b9842">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system implementing organization-defined security safeguards to protect its
 memory from unauthorized code execution is outside the scope of Red Hat Advanced Cluster

--- a/xml/rhacm-fedramp-Moderate.xml
+++ b/xml/rhacm-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="e6158da3-5817-4912-8009-31e2ec6dcb41">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2cf3a5c6-0244-4a0f-ad10-273331bd5908">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.33+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.20+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="3f78d4da-f879-49cb-aeef-612a1ffe6c7f">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="7bce0871-4ff9-4139-8c1c-956da3377590" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="f586ed56-bfd8-4219-a937-0460d5c630de" control-id="ac-1">
+    <implemented-requirement uuid="446a37a9-8d6e-46ec-bd4a-d588b86fc059" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="9e2704a4-de70-434c-9345-ba12374d40a4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c46a6bcb-1b90-494b-9da6-0277b9178cf0">
+      <statement statement-id="ac-1_stmt.a" uuid="a46fa548-3227-4b5c-9e93-b4551e31bdfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36092e00-4d2c-418b-880b-8666504caae1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination of organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.1" uuid="014005ef-bc94-4650-8376-fd601b624855">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e15937a7-8afa-4b8b-8c1c-30d5527a05f2">
+      <statement statement-id="ac-1_stmt.a.1" uuid="f0061df9-be8c-426d-9430-6f55ca66a31d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="848b0235-1b1a-4fcf-942c-013642a9448e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An access control policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance is an
@@ -503,32 +503,32 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.a.2" uuid="4adf3cee-431a-4bde-9e78-0cfe3ca18284">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f88bcbdd-8acf-4575-9a64-db9d588b4945">
+      <statement statement-id="ac-1_stmt.a.2" uuid="c8f713b3-3d22-40d0-bec1-0fd90c1d94c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="bef155fe-ddbc-4313-a0c0-d71ade3ffc5d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a513104e-b49f-4ca7-8761-2d936ff4d368">
+      <statement statement-id="ac-1_stmt.b" uuid="51ec5615-5e67-4f8c-94e2-6e1b8ce61aef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a99e9c01-39cc-4093-864f-9a0ea60cdf5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating current access control policies and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.1" uuid="9d9f5434-5e1a-422f-b207-090679353a59">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f904d51-66da-4381-a600-871b1ab11704">
+      <statement statement-id="ac-1_stmt.b.1" uuid="458d23f0-08aa-4e32-97c6-abd0be9e9bce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0679509e-52fb-4b00-a43b-3ef62a41877a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b.2" uuid="8bbeba34-6735-46f5-8bc0-47d4fa21d59e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="581e4aad-8be0-4a84-9aae-0113ad13f657">
+      <statement statement-id="ac-1_stmt.b.2" uuid="a729a20f-9875-4d17-ac07-0c78a62d7653">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3355f100-b665-40a9-ac04-a26e35f125e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current access control procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -536,32 +536,32 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fa2d86b-4175-4919-ae27-fc9e9bbd69c2" control-id="ac-2">
+    <implemented-requirement uuid="f48afcad-3715-41c6-abcd-de0aeb8f62c4" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="fe0f204a-c4ce-4bc4-a81f-c48e0ef196d5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5c7eed32-e8a9-4158-b193-c80aad75cfaf">
+      <statement statement-id="ac-2_stmt.a" uuid="071c595b-1c04-45fd-8884-54a98c532e59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd99f31e-58f4-4550-8889-f7593dd8fec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying and selecting the following types of information system accounts to
 support organizational missions/business functions is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="c035dcaf-c0cc-4f7d-a687-5254e8e60135">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="163f48bd-b7c6-42bf-9cdf-98f57785b3c2">
+      <statement statement-id="ac-2_stmt.b" uuid="056e1235-b35d-4b33-9e7d-6f66114715e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0db68032-e217-4080-ba94-6adfd1e97616">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning account managers for information systems is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="ac707ce6-e1a4-46d2-9dbf-a6af49badc1b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2ee6ecdf-d896-45d2-8976-a858c2da54c9">
+      <statement statement-id="ac-2_stmt.c" uuid="d4922d23-07c1-4882-b9a9-ae68419ba2c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af87783f-3e43-45ae-a397-c22e28fc4bc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing conditions for group and role memberships is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="83e540dc-e666-43a5-8325-fc82928223d5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8a24d499-1d87-4251-ab90-691a399bf954">
+      <statement statement-id="ac-2_stmt.d" uuid="e608893e-0645-4161-9404-db3af18049bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d23ed55-db60-4784-9945-229baa1dba09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specifying authorized users of the information system, group and role membership,
 and access authorizations (i.e., privileges) and other attributes (as required) for each
@@ -569,16 +569,16 @@ account is an organizational control outside the scope of Red Hat Advanced Clust
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="de1a2ebc-ee16-4b26-8e55-c21a03d315e1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="16498829-e7c5-448a-9d39-6565ab7c7f5c">
+      <statement statement-id="ac-2_stmt.e" uuid="96007fe4-1aa9-461b-b1c7-f57af74c3bc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3b5f0a1-6cca-46c6-8d74-a4d7af405163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring approvals by the organization-defined personnel or roles for requests to
 create information system accounts is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="b2d733d1-ddc7-4b10-a58b-f4e07836d79c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fb73aac8-fda2-4969-8434-923b29892878">
+      <statement statement-id="ac-2_stmt.f" uuid="94b4eded-4c6c-4732-9b2b-e1b523bfc2e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb1bba66-5aec-4056-8637-f249f7d9b368">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating, enabling, modifying, disabling, and removing information system accounts
 in accordance with the organization-defined procedures or conditions is an organizational
@@ -586,71 +586,71 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="1990da18-d756-4c64-b7a0-2709b5d8b84b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e45b3a1-5231-4cf4-8d99-4c9ef5a42c7e">
+      <statement statement-id="ac-2_stmt.g" uuid="71d1f487-08fd-4033-adf0-511d6baced01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5813133d-dc14-464f-a80e-a458308b0924">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the use of information system accounts is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="eb16e996-1320-422a-bef7-afbd05257aa8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="468e714a-154f-4a30-aaba-d96acf380ab0">
+      <statement statement-id="ac-2_stmt.h" uuid="9dfc8529-1ae8-455a-9f16-4ccd2e30b472">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5d5918ea-bff0-4d9f-862b-87eed7745465">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers based on organization policies is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.1" uuid="192154e6-a344-4958-8e60-2163da3299b0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="484cca2b-3a33-4958-9186-752b7e77bde1">
+      <statement statement-id="ac-2_stmt.h.1" uuid="6f3a1a5d-0e5c-4fa5-859a-2c354cbf7bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c3bf8a-966d-4ce5-99af-2112ab2db55a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when accounts are no longer required is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.2" uuid="f3cc3c2a-02e3-4745-a2c9-b01af2e8a929">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ad95c772-74e0-4965-8f7a-86e0eb223904">
+      <statement statement-id="ac-2_stmt.h.2" uuid="5410d25d-7179-4c37-b207-9770f42388ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eefeca77-e7cb-4309-ab70-98e43ee0f21a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when users are terminated or transferred is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h.3" uuid="ff2e6047-f272-4354-8157-db6451cc6d63">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5d825d27-5a9e-4877-97c1-d28a4d649d97">
+      <statement statement-id="ac-2_stmt.h.3" uuid="59a7dfb3-5417-40ca-8b68-fb05f204c519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709fa778-591d-43b1-99f1-57d85da2c984">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Notifying account managers when individual information system usage or
 need-to-know changes is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="1dbd84f3-135c-454a-93f5-acf42cb8c399">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="80f22baf-82f2-41ab-8627-ddee513381d7">
+      <statement statement-id="ac-2_stmt.i" uuid="72153925-174b-4b9b-aebd-3c4ee81886ee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3deedd5-b309-475d-8c14-2d3c4bd9d324">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on organizational policies is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.1" uuid="0614bd2b-7a17-4094-a8e1-24c3aeb49736">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f97ccd1b-b467-4983-af2b-ff1e9d15d68c">
+      <statement statement-id="ac-2_stmt.i.1" uuid="fc866425-422a-458b-b692-66f3ddba4077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6bdf2292-5cea-48c9-a97b-03c440bb886d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on a valid access
 authorization is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.2" uuid="3c891c43-8973-4cfc-8d99-80b96f9b1f96">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dfe3e53c-3a2f-46b6-b2c7-936e85065f8a">
+      <statement statement-id="ac-2_stmt.i.2" uuid="733525f4-4f43-4c42-b223-c7cda170e955">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b59c0b1-9f0f-4807-ae5b-3dc2cfd8f3d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on intended system usage is
 an organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i.3" uuid="8fb57e3f-bd02-4499-a8ee-f2ce69237068">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f94ebb7b-76c0-408a-8c5c-c44d16ee9365">
+      <statement statement-id="ac-2_stmt.i.3" uuid="39eb2761-3339-46ff-9006-e58ad19cc724">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="063e440e-bf85-4f03-a941-ba604aeecb07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing access to the information system based on other attributes as
 required by the organization or associated missions/business functions is an organizational
@@ -658,16 +658,16 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="53d1fd8c-4c67-49b1-a5a4-0d597f4c28fa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b6407d1d-3879-48fa-8dfb-bb373dac13ea">
+      <statement statement-id="ac-2_stmt.j" uuid="880ba87d-a493-4868-8e58-499d98903b59">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29ccfaaa-25ca-486a-a1c7-7f75266738e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing accounts for compliance with account management requirements is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="d243a685-44f6-4ab0-857e-23a594dd7ead">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e1050504-1232-4041-a82f-3237d871646d">
+      <statement statement-id="ac-2_stmt.k" uuid="e887fc23-6372-426c-a670-f40a1eee3726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adf77389-1a12-412f-b327-7b6a5a0cb558">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for reissuing shared/group account credentials (if deployed)
 when individuals are removed from the group is an organizational control outside the scope
@@ -675,10 +675,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cf7b715-3268-46ef-88af-0c5013820751" control-id="ac-2.1">
+    <implemented-requirement uuid="f7399bf2-752d-4761-9093-e193ecd06ab8" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="0215bb2a-e7a1-4c3e-8e82-b6d30be5227e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="78cf612e-aa0b-41d0-ac50-13e96be04470">
+      <statement statement-id="ac-2.1_stmt" uuid="bc485ba6-d871-4923-ae69-474368ae183f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bda05ad4-f3a1-47e7-84f6-1ffa3f3644a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to support the management of information
 system accounts is an organizational control outside the scope of Red Hat
@@ -690,10 +690,10 @@ accounts and system activity by logging of related information.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbb49d3f-821a-4488-b627-902a94e8e9ad" control-id="ac-2.2">
+    <implemented-requirement uuid="02f80c5f-9d81-47fd-a15f-169298ee2ab2" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="0b5c4d4b-a784-49e5-9fdd-ab9101d44507">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="802881bb-b5ae-48f7-8454-25e928778253">
+      <statement statement-id="ac-2.2_stmt" uuid="196ba0d7-9ccf-4679-807b-4da4732e1705">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06ebc894-7ef2-4457-8e8c-402ebc90c1f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically removing or disabling temporary and emergency accounts after a defined
 time period is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -707,10 +707,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="688ab9b0-c072-4c59-80b4-afc932a5dc5e" control-id="ac-2.3">
+    <implemented-requirement uuid="7af6f57b-ddcf-434d-baf2-551f78ff5bfe" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="8e8238dc-b5bd-4c33-bc3c-22787f98ac4a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ee8a0e4e-8f88-49f5-8901-f5371aa6a185">
+      <statement statement-id="ac-2.3_stmt" uuid="d797a971-ede9-449e-bd4a-083cde68f974">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49665e5b-422c-4d5b-a7a2-eee36d55890f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically disabling inactive accounts after an organization-defined time period is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -724,10 +724,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08e32817-ea04-4e79-96c0-631026b54a48" control-id="ac-2.4">
+    <implemented-requirement uuid="a69547c8-3022-4ed2-861f-a1d7f6912151" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="fcf395e5-53c4-45fa-8998-acd3dfc55411">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7fe2cd75-e9a7-42b4-a790-fa1661db950d">
+      <statement statement-id="ac-2.4_stmt" uuid="08b0ed07-18c3-468e-8956-35f32cd0db20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8c8cdd6-cf77-4d42-8a4d-4cf68c95bd9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically auditing account creation, modification, enabling, disabling, and removal
 actions, and notifying appropriate individuals is outside the scope of Red Hat Advanced
@@ -738,10 +738,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a30e7ce-b048-411c-bad9-75cff84cf49d" control-id="ac-2.5">
+    <implemented-requirement uuid="fcc3ebeb-bcb2-439e-b2d3-34ca27978ba5" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="66d4e182-afcb-4ac4-9d27-64c6709826f3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="50058120-5727-4442-992b-7d1978b140b0">
+      <statement statement-id="ac-2.5_stmt" uuid="a5d395b8-d242-481c-ac50-135e4bca69b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0442fea5-8a3d-4cd2-b1e1-57b356c29a07">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that users log out after an organization-defined time period of
 inactivity is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -751,10 +751,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8ea4381f-8280-4a49-ba3f-ca130020dac4" control-id="ac-2.7">
+    <implemented-requirement uuid="bab47875-ff44-42c1-be76-846295c07035" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="8395b799-fd99-4a0c-a7ab-0324197b6aab">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8ee1a809-0d7d-4a3f-bb27-3a7ad1053192">
+      <statement statement-id="ac-2.7_stmt.a" uuid="6b15c7f2-959a-4ed2-815b-82b772804851">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1497d780-46c3-479c-bbce-7c0fff4ccadd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and administering privileged user accounts in accordance with a
 role-based access scheme that organizes allowed information system access and
@@ -762,15 +762,15 @@ privileges into roles is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="9343b729-aad0-4be0-826f-7f6e0ff0501d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9bf8e4ce-648f-48e5-9d27-63fd5c564cae">
+      <statement statement-id="ac-2.7_stmt.b" uuid="da5b3975-8b02-48c6-b63f-92b60fe828ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac765034-4571-46c6-9cdf-78c5ef7480ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization monitoring privileged role assignments is an organizational
 control outside the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="4515dc32-35f8-4ea2-88f1-c51cedffc851">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e1776b36-9465-427d-945d-0ea5e49193e3">
+      <statement statement-id="ac-2.7_stmt.c" uuid="91e4b8b3-8b3d-4e1c-bf22-2ab452555188">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c446e20-0a1e-4487-ab97-5544c100d3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization taking defined actions when privileged role assignments are no
 longer appropriate is an organizational control outside the scope of Red Hat Advanced
@@ -778,10 +778,10 @@ Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b038a52-f82e-4025-8b48-0d0e561403d4" control-id="ac-2.9">
+    <implemented-requirement uuid="9e48496c-0216-4bbe-91a9-936eb3e5b665" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="df1cebfb-ad01-4a68-87a5-aaabfbf6d9f6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fd8e437a-7f41-4aaf-a703-d3c3aa79be1c">
+      <statement statement-id="ac-2.9_stmt" uuid="9feb2350-7307-4d0b-a3a2-631a606d6d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e05ec4ca-2862-4b5e-823f-95c8554fc775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Permitting the use of shared/group accounts that meet organization-defined conditions
 for establishing shared/group accounts is outside the scope of Red Hat Advanced Cluster
@@ -789,20 +789,20 @@ Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b04c6567-2047-4324-8548-e34be2539f5e" control-id="ac-2.10">
+    <implemented-requirement uuid="da64370c-16d3-4dec-8138-1d6011f37044" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="2b4f3430-3539-4814-b2b8-dd40d18adddf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="817eaf1b-5f5e-4438-a9a9-3e4f506217f0">
+      <statement statement-id="ac-2.10_stmt" uuid="9b08132b-7046-4141-a124-38fa13f8b225">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a782a25a-dd18-4222-bc50-8f58d339ccb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Terminating shared/group account credentials when members leave the group is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e94aa2c-fcac-4b0c-b6cf-3e5fae3bb690" control-id="ac-2.12">
+    <implemented-requirement uuid="fd2235e0-861f-40b0-835e-56d782ec6b32" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="de9c0853-8e8d-43e0-98db-11e01f4c8cc0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6d33f2c6-6fd1-4215-90f2-bd99383c96d9">
+      <statement statement-id="ac-2.12_stmt.a" uuid="0a7ee324-2d6b-473c-9948-135bbb36a007">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="394fa83e-a22a-4483-bf3d-1e1d27faad2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring information system accounts for organization-defined atypical usage is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -811,8 +811,8 @@ Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="ca4e94ab-f56e-4d93-a2c6-a333154494ce">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7eda1e05-ddb3-4e71-9d86-5c034731af5a">
+      <statement statement-id="ac-2.12_stmt.b" uuid="f918cb14-5300-461a-bc8d-e005b243d992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c02ea8fa-17f9-40c0-ae6b-f824bf0cdf30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting atypical usage of information system accounts to organization-defined personnel
 or roles is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
@@ -822,10 +822,10 @@ relies on OpenShift for account management.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d67be46a-b4a6-4b6c-aa46-da86f7e9e9e4" control-id="ac-3">
+    <implemented-requirement uuid="1d94fe0c-7b3f-4b68-9e0c-a2f16f5ad4b2" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="04996fce-ccb4-4c31-901e-3a40597cdc55">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c64d0376-e810-4309-a1d1-dbf42a03d264">
+      <statement statement-id="ac-3_stmt" uuid="f9fb34c9-0b6c-4915-91ad-f5ec8476b3f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4a3ed62-15b5-4c8a-b32a-1ae088add7fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing approved authorizations for logical access to information and system resources
 in accordance with applicable access control policies is outside the scope of
@@ -836,10 +836,10 @@ relies on OpenShift for access enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69b51b2a-9381-40c2-81fd-885f2d057b66" control-id="ac-4">
+    <implemented-requirement uuid="b30397b2-37ee-4bea-9108-93c9f663a6b8" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="68743c3e-8dc3-47fd-8448-59a3faf1dabe">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="37561747-edc2-43e0-9542-cec9df540162">
+      <statement statement-id="ac-4_stmt" uuid="0a189e7e-c272-479b-96e9-555a015f8556">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff281e97-29b2-4f16-9dc1-d39c3ecf2f9e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing approved authorizations for controlling the flow of
 information within the system and between interconnected systems based
@@ -851,10 +851,10 @@ for information flow enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36c25d37-f866-4136-9d73-79f5d5affad7" control-id="ac-4.21">
+    <implemented-requirement uuid="98648fb2-edd0-403c-a544-2970341f61d7" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="41fd9fbc-dfb8-4a89-b752-47c190f9d865">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8bb7e779-8b15-433a-a0bd-da47e5a61dae">
+      <statement statement-id="ac-4.21_stmt" uuid="38f968a6-b0d4-4c4d-81d1-2ddd557cb762">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="228d3a03-1d84-4d1a-96af-e69a5d6956da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separating information flows logically or physically using
 organization-defined mechanisms and/or techniques to accomplish
@@ -863,10 +863,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></re
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e99de08c-3094-46cb-99a9-b749419b31d8" control-id="ac-5">
+    <implemented-requirement uuid="225e169b-6a2a-4012-a8ac-199fbc303432" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="67cf0e5f-e9f8-4a27-9ff7-cc6d68a9794c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b950349d-32be-4b48-a470-6c89747619cf">
+      <statement statement-id="ac-5_stmt.a" uuid="679544be-dedf-493b-9316-9d007868e832">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16396d80-e1eb-428e-9601-1cbb426d78da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes.
@@ -879,8 +879,8 @@ Cluster Management for Kubernetes RBAC capabilities can be found at
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="5da11269-bf01-4986-be48-d16c0e59e203">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="49f77a96-6a17-4cd8-b39c-2d7db47431db">
+      <statement statement-id="ac-5_stmt.b" uuid="b9e1e69c-8b64-40db-ab76-e3a04e23e311">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23200d4d-9439-496f-9009-b7d766de648e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -895,8 +895,8 @@ found at
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="cb76494e-d56f-4bdf-956c-e87c89c40105">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fcaa2a57-0b07-4943-8eaa-fd20375589fd">
+      <statement statement-id="ac-5_stmt.c" uuid="52a67292-3ab4-442f-8c00-98675e44d595">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e67f2e8-50f3-4e7b-9afb-f342b1276ea4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside the scope of
@@ -912,10 +912,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9890f8b-d6fe-45bc-9d4f-7da1d562fec9" control-id="ac-6">
+    <implemented-requirement uuid="8b506624-a626-421a-bc6d-b699dbf28956" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="5c2618bb-9aa8-43aa-a50d-0e8dfc6d40ef">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="913f9b21-e359-4e52-80f9-729154adae59">
+      <statement statement-id="ac-6_stmt" uuid="9008c49e-958d-4f07-9771-aba441779704">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7a99744-ee3b-41e8-9c2a-ddd4238dda53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -923,10 +923,10 @@ https://issues.redhat.com/browse/ACM-187</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ae4c8cc-249b-441a-a1ea-90faaa50bab2" control-id="ac-6.1">
+    <implemented-requirement uuid="9d9b4b69-7f28-4a21-b9c7-eba66270a577" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="a9eeda1c-3190-4198-856d-8a36fdafcd16">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0bbeea07-ec59-4581-8310-576e739acf5e">
+      <statement statement-id="ac-6.1_stmt" uuid="4665194e-a7c2-41c0-b68c-bd1c131f6cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2cda8c4-890b-4a20-9242-cd99b9e7140e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Explicitly authorizing access to organization-defined security
 funcitions and security-relevant information is outside the scope of Red
@@ -942,10 +942,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7899669d-57e6-4eaa-b06f-276c1cf75c32" control-id="ac-6.2">
+    <implemented-requirement uuid="5ecea140-1d51-4ec4-bc7d-b53fb6f0d979" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="fba66831-925a-4f54-baed-d48445542e02">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="80578840-6aef-49e3-8009-e1066c3d8677">
+      <statement statement-id="ac-6.2_stmt" uuid="c6c2aaeb-39a7-452c-8410-7212ac30b942">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e9eb3b7-5b9c-422c-bb22-f572ac5d43cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that users of information system accounts, or roles, with
 access to organization-defined security functions or security-relevant
@@ -963,10 +963,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f010d7c-eb94-4316-a02a-2bae0c59f34a" control-id="ac-6.5">
+    <implemented-requirement uuid="6a6ce6ca-b559-4ed4-b0e0-cb56805fd7f3" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="84727cf0-6bac-4941-8b44-3f6c44e575c7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4cd369a0-1311-4d3d-8704-66632ac68107">
+      <statement statement-id="ac-6.5_stmt" uuid="270d270e-c4a8-49c1-a670-167184c022b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="472b7ea1-8b87-4144-87b4-a033fc0f50fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Restricting privilege accounts on the information system to
 organization-defined personnel or roles is an organizational control
@@ -974,10 +974,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes.</p></re
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="080c8951-8dda-481b-bf84-c11e515dba5d" control-id="ac-6.9">
+    <implemented-requirement uuid="f668c333-325e-4781-99c6-432d9568fc11" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="8db74328-5236-4a33-af59-c88c1acdeb6c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="82675221-c95b-469c-8e10-0777ac28a2f5">
+      <statement statement-id="ac-6.9_stmt" uuid="04743cde-7e51-45ef-b80a-99feb9a5529b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbef4610-bfe8-41fd-9f3d-a2245008da60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -990,10 +990,10 @@ https://issues.redhat.com/browse/ACM-355</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc965932-52f8-4920-b183-2dfa6aefd4e4" control-id="ac-6.10">
+    <implemented-requirement uuid="0de2473e-99df-4e0f-8b7d-4cf41cbf524d" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="960efca0-a9d8-4990-875a-2e3b8de76879">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f85ce94d-27a7-43ec-af3b-475227ec3d2d">
+      <statement statement-id="ac-6.10_stmt" uuid="8fee44e3-4e25-4e67-9715-9091aa75ab2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f05cbb23-1d8e-468d-85b9-fb9d8b74ff83">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes prevents
 non-privileged users from executing privileged funcitions to include
@@ -1007,10 +1007,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92f30f48-52ec-450d-8169-a4a7928d5404" control-id="ac-7">
+    <implemented-requirement uuid="9e1db829-fdaa-4194-8af7-a78edf04eba6" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="23d5dcdc-3bc7-4012-984d-d98767a41726">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="65822e04-9ca4-4c83-a5b6-e2e01055ceb4">
+      <statement statement-id="ac-7_stmt.a" uuid="b3e410d3-f272-4815-90b5-03a1d6ee4c39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5e9720c-eebc-40e0-942d-9fb08a7b54ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a limit of an organization-defined number of consecutive
 invalid login attempts by a user during an organization-defined time
@@ -1021,8 +1021,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="054a6be3-4206-493d-b602-ab24c5feca69">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6e55ba15-eabf-4801-ba7e-60f667e07a96">
+      <statement statement-id="ac-7_stmt.b" uuid="c17db2f7-5064-4071-b4f2-c01afee07259">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52cbafe5-5b89-4cfe-aa8b-04f8077546a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Automatically locking the account/node for a defined time period, or
 locking the account/node until released by an administrator, or delaying
@@ -1035,10 +1035,10 @@ for handling unsuccessful logon attempts.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="426d0624-c27d-43ae-989e-e450cb282e6d" control-id="ac-8">
+    <implemented-requirement uuid="9dca821d-7949-44d6-846b-6c1c3258ca23" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="18b0bb82-1de8-404b-830b-851eee1fa2b3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="42b68bf0-3c73-4c02-86a7-d2f884605121">
+      <statement statement-id="ac-8_stmt.a" uuid="3db1117e-7344-4b25-bad6-9fa07294bbe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0939dbe-e45c-4303-a828-f73439cd2cb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 notification banner to users. A successful control response will need
@@ -1053,8 +1053,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="b39dfbd1-11a7-48a2-af6e-4365c391814c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="58659d47-7536-4b2e-8c1e-84288e722a06">
+      <statement statement-id="ac-8_stmt.b" uuid="1e505d13-6d01-4048-bc14-9c124464989a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57fefa6e-7f03-40b3-bf9b-2cd97e8e9287">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying the use notification
 banner until the user acknowledges the usage condition and takes
@@ -1068,8 +1068,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="4df05bda-3005-44a5-8661-31f58f640a93">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0096283a-c8b4-45ae-abd5-dda3e3743749">
+      <statement statement-id="ac-8_stmt.c" uuid="72c013ea-4aa0-4188-a6df-1a2abd22eb65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2671d163-9697-45bd-bf8c-8da3de9c7630">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for displaying a system use
 information message to users. A successful control response will need
@@ -1086,8 +1086,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="32e4b2e4-f162-4c70-9eb7-ac25d2b3cf50">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7d8e437e-063f-4043-b8bf-8d86bf413d48">
+      <statement statement-id="ac-8_stmt.c.1" uuid="5e025568-70db-436b-b07a-1263236aeb2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="505b0b2e-9e7e-4ed4-b3fe-8b8f917769f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed. These
@@ -1099,8 +1099,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="5fca1823-47e8-43fd-98b0-5f55483846a4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="574dd227-9ce8-4b51-8dc9-8a8554ac8242">
+      <statement statement-id="ac-8_stmt.c.2" uuid="4cc4d223-2e5e-4486-96d3-f09d672416f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f33d5c8e-5121-42ab-a713-f12b260eb0ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1113,8 +1113,8 @@ via:
 https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="ad291bda-1f6d-4bc1-8bbf-8c3c0b654598">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3da366c3-fff2-4e6e-a05d-bce4a0122f77">
+      <statement statement-id="ac-8_stmt.c.3" uuid="291f26ac-e5ec-40c7-ba2a-a5c85fe69824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69f46d8e-dfdb-4489-b4a7-5489aa0c8f4a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1129,10 +1129,10 @@ https://issues.redhat.com/browse/ACM-356</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4c3eb1e-8c14-47d7-9432-7450cfea4eaf" control-id="ac-10">
+    <implemented-requirement uuid="6dbea49e-d7b6-409b-8281-f06e95eccf7d" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="dca2376f-75c5-4b34-8dab-d90c0930daa2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="068efdf4-69b0-4f31-b791-d625d0623ce3">
+      <statement statement-id="ac-10_stmt" uuid="773bc3ff-9cb1-4c94-934d-731b9fd008c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92c68bbf-6191-46a8-9440-f6944313a740">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Limiting the number of concurrent sessions for each account and/or
 account type to a TBD number is outside the scope of Red Hat Advanced
@@ -1143,10 +1143,10 @@ for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b90d99c-4174-41ad-ad20-d2f2a779df02" control-id="ac-11">
+    <implemented-requirement uuid="c3d16a60-dd06-410e-b40c-4051aeb8901a" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="3ad54e2c-975d-4d8d-b491-e72e5393ff75">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ae4bb847-50c8-46c5-91e7-5cf3a24e42dc">
+      <statement statement-id="ac-11_stmt.a" uuid="2cb7c4f7-0f04-4ff3-b011-c57b352ca058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a2b5d5d-e88d-407c-ae70-3b7d5374b56a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing further access to the system by initiating a session lock
 after TBD time period of inactivity or upon receiving a request from a
@@ -1157,8 +1157,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="d65e77e9-4974-4987-b913-9d74b9623eb0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2f99cf9a-fc38-428f-9102-85acabdbb840">
+      <statement statement-id="ac-11_stmt.b" uuid="4cd02a73-89d3-4f02-80ee-f4b680839b1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8b09f05-bb16-4d7c-bcce-93bfa003a34f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retaining the session lock until the user reestablishes access using
 established identification and authentication procedures is outside the
@@ -1169,10 +1169,10 @@ for handling notifications of previous logons.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="942e13fc-3e68-41ba-88e1-8abd8f270eb7" control-id="ac-11.1">
+    <implemented-requirement uuid="fb3fa2f1-e44d-40fd-a916-2068b8f9da1b" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="71e3d09a-2ff5-4454-8ceb-c02eb0611551">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c6eb715c-ab77-46da-bb37-71ad505e3d3f">
+      <statement statement-id="ac-11.1_stmt" uuid="48b0f08a-e598-4410-ae91-caf86d2a827c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="971983be-8edd-48e0-8331-19d4dfaf7bf7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Concealing, via the session lock, information previously visible on the
 display with a publicly viewable image is outside the scope of Red Hat
@@ -1180,10 +1180,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76e0eb3b-3ecd-4854-acc0-cc9ce0d91729" control-id="ac-12">
+    <implemented-requirement uuid="91c1866a-ff60-4073-b5ce-0a4b9c43c7be" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="29214857-a198-4a83-87b9-d0674130b6e7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9c12b4d5-a672-43e5-a589-951205b42f8a">
+      <statement statement-id="ac-12_stmt" uuid="e4b0cfc8-c775-4e65-b7cc-87a71482004d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e9cca5d-f411-4c0e-a5aa-826b1cdb6951">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1193,10 +1193,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10a4f535-3eea-4134-81fa-898042f32914" control-id="ac-14">
+    <implemented-requirement uuid="77a08b50-4be7-4f66-8f4f-84855ef1cc49" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-14_stmt.a" uuid="d773326c-f8c1-4b8d-b07a-fce57acd7761">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2241b644-b101-4bb5-8e20-1456f7f2fc6e">
+      <statement statement-id="ac-14_stmt.a" uuid="5629b5ea-36ab-455c-8d73-cf6c88bfa332">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1255ed5a-781e-4085-9ebf-573f7faa1c7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organization-defined user actions that can be performed on
 the information system without identification or authentication
@@ -1205,8 +1205,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-14_stmt.b" uuid="d5a5d520-a490-4617-871e-9db18217d7d8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0b0c9910-9f55-4072-8103-97de8ebf54a8">
+      <statement statement-id="ac-14_stmt.b" uuid="368700cb-708a-4db2-b713-a770859e28d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce50b336-a265-411a-bc40-27ece30bac20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and providing supporting raionale in the security plan for
 the information system, user actions not requiring identification or
@@ -1215,10 +1215,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e830dac-96ac-45b4-832c-209e43f30bd1" control-id="ac-17">
+    <implemented-requirement uuid="7128e417-6249-45af-8571-c712eb28d094" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="b5ba0a85-264b-4563-8f9f-24da04ec986d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0d9d88fb-670e-45dc-ad1e-efb842ba9580">
+      <statement statement-id="ac-17_stmt.a" uuid="68cff69d-2bb8-4591-8f38-62249ae0b657">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15acf2ac-db91-4dd0-9b79-e7e64fb6a447">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing nd documenting usage restrictions, configuration/connection
 requirements, and implementation guidance for each type of remote access
@@ -1226,8 +1226,8 @@ allowed is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="69057ef6-fa6e-4c9a-9833-b5c0e1ca3e2c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="94f9af62-e58f-4887-b715-3b89e7f0e474">
+      <statement statement-id="ac-17_stmt.b" uuid="40ccd22d-b36a-4e0d-8390-e043a4dc09ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81512212-759c-488e-af52-ac47b733dd17">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing remote access to the information system prior to allowing
 such connections is an organizational control outside the scope of Red
@@ -1235,10 +1235,10 @@ Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55a9c98d-75f7-4d89-95e5-2d191d296467" control-id="ac-17.1">
+    <implemented-requirement uuid="37096164-49ae-4cea-b803-b76ca98c35d1" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="9cacd936-3aa9-4e3d-8767-fb38c6859710">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="56e5d9d8-7977-401b-a948-a45ed8fc37ad">
+      <statement statement-id="ac-17.1_stmt" uuid="cb656773-600a-4190-8b5e-805429cb603d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91205a50-2b5b-40e5-9b38-4110053d1ed0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring and controlling remote access methods is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for
@@ -1246,10 +1246,10 @@ Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc54253e-c579-4429-8fab-c2cf54ab21f5" control-id="ac-17.2">
+    <implemented-requirement uuid="fe9e919c-c9ce-40ac-8d76-90d61bfd40dc" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="80b6d998-1027-4cd8-9fec-60de481f865c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="63411234-8de2-4dae-82f8-9f16468baee2">
+      <statement statement-id="ac-17.2_stmt" uuid="0605ccc0-9c8f-4d12-ad37-764b30a9f641">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17d88f5d-c975-458c-a207-747d6a2fb16c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes implements
 cryptographic mechanisms to protect the confidentiality and integrity of
@@ -1258,10 +1258,10 @@ protocol, which all use TLS.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2933a7dc-e8a3-4a28-a1b2-0f044e19db56" control-id="ac-17.3">
+    <implemented-requirement uuid="76edd369-da6c-4ba4-a209-017b6c80bb8f" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="b0de4d7a-9a55-414b-8be0-65227370a568">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4c0822fe-1139-4349-a822-38a90425aba2">
+      <statement statement-id="ac-17.3_stmt" uuid="bf97bc49-2f3b-4d89-a402-9637ae81e305">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b86dc3-6e47-47f5-bfab-bd7ea5610c37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Routing all remote accesses through organization-defined number managed
 network access control points is outside the scope of Red Hat Advanced
@@ -1272,10 +1272,10 @@ for managed access control points.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2784142a-6cde-4582-8b0f-aa6c60d8cf1c" control-id="ac-17.4">
+    <implemented-requirement uuid="7af95b09-3ed0-49f3-bba5-31f47b115b96" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="ee88d7ec-fc57-4320-a4d6-39b244da8f33">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dc5e53e8-5144-44a2-b34f-dbfddec59764">
+      <statement statement-id="ac-17.4_stmt.a" uuid="144663b9-b8fc-4d3d-8f75-c3364716da4a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08da1fb-461c-4b21-afed-d2727e2850a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing the execution of privileged commands and access to
 security-relevant information via remote access only for organizational
@@ -1283,8 +1283,8 @@ defined needs is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="ccb4a2a2-de2a-4133-89ff-a452eb8717ec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cdd20687-d74d-45f3-a2fb-7f89117520bc">
+      <statement statement-id="ac-17.4_stmt.b" uuid="f94b663d-a948-4d67-9970-10b822124250">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16349eb9-d9b9-41b1-a7a2-d6ea7feb00bd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting the rationale for the execution of privileged commands and
 access to security-relevant information via remote access in the
@@ -1294,10 +1294,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b4ddf2a-73d8-42e2-ba94-4d6758297b23" control-id="ac-17.9">
+    <implemented-requirement uuid="345736be-8ef5-479f-9c0c-94cbbff09ff4" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="9d2bcbdb-ff1f-4988-81ee-e9535dfd860e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="97225310-b88c-4284-8f50-a83c0cf9afe0">
+      <statement statement-id="ac-17.9_stmt" uuid="e3309500-e30e-4fff-98bf-2a4348eba457">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8ec9c2e-4fbe-4f8a-a152-5c1eb1fe2d2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the capability to expeditiously disconnect or disable remote
 access to the information system within an organization-defined time period
@@ -1309,18 +1309,18 @@ for disconnect/disable access.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8e91f32-821a-4ecb-a04d-06286a421fde" control-id="ac-18">
+    <implemented-requirement uuid="81b0da80-f4cc-4d8e-9e32-03731ed286ce" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="3ed51455-fe10-438e-b49b-c2d2f3e45f19">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="204db1b6-eb7e-45a9-90ca-13ac40c8e7c0">
+      <statement statement-id="ac-18_stmt.a" uuid="ac4516ea-59d7-4493-9f0a-360aa160ccac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="706e0ed7-6e8d-4399-8bdc-3284bdc4d24f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless access
 usage restrictions are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="58256d9a-7494-41a4-8d3e-f5baa861a244">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="02cf5fda-991b-4da0-845b-e2b6b9be8c47">
+      <statement statement-id="ac-18_stmt.b" uuid="0571c9d5-0dc7-4fa2-8fe5-70ddeb67d2bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70d4bd5c-e641-4851-81a8-29309766ceb0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Advanced Cluster Management for
@@ -1328,48 +1328,48 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b176ac78-2dc3-475b-9ee0-2f0337232b7f" control-id="ac-18.1">
+    <implemented-requirement uuid="74d59e77-d7bc-4645-99b0-c47cb642addf" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="c04ef276-7f56-40de-9a3d-10cae3b9f021">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a5089504-dfc3-4e31-915a-5c444b46b670">
+      <statement statement-id="ac-18.1_stmt" uuid="6c5cac66-a4b8-43d7-bee1-889ccd138200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6314063-6205-42f7-a8f5-280934e258a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06125a63-dc83-48c7-89a3-a297451e8ccc" control-id="ac-19">
+    <implemented-requirement uuid="ab1ce503-1654-45eb-88e7-f92f730772f4" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="d98144d1-6bc6-4c69-a31b-9bf1952eb7e5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="af1ca3b1-bd85-4104-9753-e9409aaed30c">
+      <statement statement-id="ac-19_stmt.a" uuid="01754353-65da-42c5-a2ba-a8fbb18820bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aabd43cd-5bb9-47d2-9b2f-f270d6af778e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="d08ccf4c-42ce-4455-a39f-02a1454963da">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="783ff1c8-e307-4f6b-a090-81f8d60277a8">
+      <statement statement-id="ac-19_stmt.b" uuid="ddf9d051-c971-4d22-8dd4-1a4bf09571b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0007f9d-320c-4743-92e6-918f64f1605e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f182be6-3d4a-4803-839d-06b6fad0061a" control-id="ac-19.5">
+    <implemented-requirement uuid="caa10d5c-bbd7-4d0a-bd3d-adb8efbaa01c" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="b91c3c97-3c55-497c-92c8-7feb02c430d7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7b352255-94ca-44df-8f80-f23f5e214124">
+      <statement statement-id="ac-19.5_stmt" uuid="9c01348b-0f6e-4f7d-9230-8aaa41878375">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfa0b654-c704-4be2-a3a5-15dd773baf7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7fa151c-9f9e-433f-be42-e3342f0e5b40" control-id="ac-20">
+    <implemented-requirement uuid="21f8c09b-b7fc-46d0-9ab8-c90adab0f1ac" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="189bfb44-7bae-4b6f-9bf4-f8177abea9cb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b83611a7-c674-46e8-8a63-36253c95de78">
+      <statement statement-id="ac-20_stmt.a" uuid="e95daffc-210d-4201-b395-9d40aaaf8f2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d7a03b-2e25-4575-b1c4-9c3d3634b60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for
 accessing the information system from external information systems is
@@ -1377,8 +1377,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="388738ff-2f08-4a14-9ff2-c2dfdd40fb6a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9feb773d-ec44-4f29-a3a1-e4b9d4a4e68c">
+      <statement statement-id="ac-20_stmt.b" uuid="f4553ed7-066b-4f8f-bc8d-87ccf77e5546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3e2dcd3-f967-4d44-982b-9a17aa45ef34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions for the
 processing, storage, or transmission of organization-controlled
@@ -1387,18 +1387,18 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51890fa2-d57b-45f1-99ae-4a2e0cd227af" control-id="ac-20.1">
+    <implemented-requirement uuid="0a24ab17-f521-4377-8bd3-fd25854e66f9" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="76344975-26d8-44c5-b3a4-87129f0a49d7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ebc501ba-fc65-4892-b77d-b28215efe757">
+      <statement statement-id="ac-20.1_stmt.a" uuid="24dde360-4fd7-4329-811e-77bbb8e74425">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef917df8-9533-470e-9e3a-5143129bbad8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="ad249ff7-79d4-47d8-9497-e819a807dfdf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c411759f-2d45-43b7-bdcd-793bea060997">
+      <statement statement-id="ac-20.1_stmt.b" uuid="720b867a-34bc-4908-a065-e588deb5862c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af341842-1e0e-4e2a-ace9-2fda5cf675c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external information
@@ -1407,10 +1407,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a476bee-bcb4-471c-83cc-2beb21d85563" control-id="ac-20.2">
+    <implemented-requirement uuid="f9cbc530-f767-484d-96d2-c9b8fa053aee" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="68023415-adb0-41a4-a10d-4c962d466e66">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="87f81608-9afa-4ab6-bd2b-eeb15b5a496c">
+      <statement statement-id="ac-20.2_stmt" uuid="9fa9fa0d-abaf-4879-8cfa-5b56478d67da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="645b3fc8-5952-4846-9ee4-14168cb5a23b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or prohibiting of the
 use of organization-controlled portable storage devices by authorized
@@ -1419,17 +1419,17 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ae5f9fc-f478-4788-9e29-5e04f38905ef" control-id="ac-21">
+    <implemented-requirement uuid="75e7af21-f9b9-4128-ac42-e7b6e42262c0" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="7ebdff94-022c-46af-ae9c-dfebff77782e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="84af5923-b726-410d-8595-9dd8ef1a643f">
+      <statement statement-id="ac-21_stmt.a" uuid="ca38dbf3-f21b-475a-8dc5-106366c68536">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25a62fc8-0f04-4aa9-b834-d3062fe4adf3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="ba5e71d6-4665-42eb-80bf-3e5acfabf53f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9fc6b07f-2479-4ed1-8c75-ac5fda448065">
+      <statement statement-id="ac-21_stmt.b" uuid="fdf10e02-a231-4361-9f06-546262765adb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71526be0-f003-4ed9-bde1-6b703f32f85c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside the scope of Red
@@ -1437,10 +1437,10 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17eac54c-e518-4a16-a7e4-e77f332d1616" control-id="ac-22">
+    <implemented-requirement uuid="675bf8d7-bd6f-4f1f-9e04-44762cc751f3" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="11e1f228-c85c-48f8-94a1-7c13e361ad47">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="10cfb359-b7da-44c3-882a-5844f884934f">
+      <statement statement-id="ac-22_stmt.a" uuid="14806bcc-f83f-4408-922c-53f570a5cf0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2636d175-e8a1-4668-9723-bebf0f555433">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1448,16 +1448,16 @@ system is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="4657a2e5-69e0-45db-aba4-631fe4bca85b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5ca87a5d-76cc-4205-8b50-27280e1bf3b3">
+      <statement statement-id="ac-22_stmt.b" uuid="ed069c5d-4f75-460c-aa1e-937e618e2d0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d07655f-56af-4e87-bc90-2467e6b3df99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="4a9e45a4-e788-456e-a540-db9744d07b3c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="575efaf2-7feb-44d7-aaa6-ee76610baef9">
+      <statement statement-id="ac-22_stmt.c" uuid="fa8310c4-487f-4cc1-9e79-e0c0360f2413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72fc5d98-cf5a-4240-b0bd-bdf9d0bfa482">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto the
 publicly accessible information system to ensure that nonpublic
@@ -1465,8 +1465,8 @@ information is not included is outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="04954433-48b5-4130-b2d5-91d13bb7daab">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aab53ef3-1e66-495d-a09a-e6235ac1491d">
+      <statement statement-id="ac-22_stmt.d" uuid="c8214e90-c694-4709-a058-085720e7ede6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f4c2c7a-9aa2-4c48-a223-dad78aac1f7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system for
 nonpublic information at an organization-defined frequency and removal
@@ -1475,10 +1475,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2844f640-28d9-4e83-936e-deeedc1f0af2" control-id="at-1">
+    <implemented-requirement uuid="3d53f5ba-0388-464e-9ed2-226cdbaf9b51" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="ae5f3a79-001c-4654-b640-43fe36c209b3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5b00c1e0-6bc6-46fc-8f7e-355a450986a9">
+      <statement statement-id="at-1_stmt.a" uuid="7db712a1-e7a4-40f2-8040-fa0b61ce15de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1a2fc15b-b52c-4d67-9db2-82f2b71fbeb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to organization-defined personnel
 or roles is an organizational control outside the scope of Red Hat Advanced Cluster
@@ -1486,8 +1486,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.1" uuid="62255237-f771-4822-b888-8dd1edd6b08b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fa18e22c-02e1-4ed1-824a-e2b4d2d3ca7f">
+      <statement statement-id="at-1_stmt.a.1" uuid="c36d15a6-7c20-415f-aec2-db0d8b83ffe8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3624a79a-adf7-4b9a-a6c1-bece2aa3f97a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles a security awareness and
@@ -1498,8 +1498,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.a.2" uuid="c47ce974-4d6c-42ff-9513-8c476ff11ff9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="58972c29-dd87-4d3d-8613-d291f2928edc">
+      <statement statement-id="at-1_stmt.a.2" uuid="e07b53ed-3179-401d-a4a2-d3fdea6560e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5d8f64c-5e67-4b22-bf59-9d33772a5147">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development, documentation, and dissemination to
 organization-defined personnel or roles procedures to facilitate the
@@ -1510,8 +1510,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="4fc70182-9c06-4fc3-9ad3-81a376c00497">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5048f0d6-e51b-4725-9b22-d623da814e8e">
+      <statement statement-id="at-1_stmt.b" uuid="f01cc4c9-9890-48b2-930c-1aabdc40f441">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a296282-0d22-40c0-a0ae-d7297eff630c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness training policies
 and procedures is an organizational control outside the scope of Red Hat
@@ -1520,8 +1520,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.1" uuid="e57364ac-d0f2-4eac-8d76-dc9d8113479e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5dc601b3-2979-4df4-a619-3483d74d24a7">
+      <statement statement-id="at-1_stmt.b.1" uuid="6a893871-b841-4f12-8149-b6894e65aae2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="573a8d1d-647c-4672-994d-e1a08cb74495">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 policy on an organization-defined frequency is an organizational control
@@ -1530,8 +1530,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b.2" uuid="dc7d4944-f95b-42c4-9d6b-4fb31869aebf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="722cf345-b93b-4e47-8a95-21b11bde209a">
+      <statement statement-id="at-1_stmt.b.2" uuid="224d4d2e-cfff-409a-b773-0910fb235c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9659903-f239-41f0-bbc3-f13d2e6d3a01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current security awareness and training
 procedures on an organization-defined frequency is an organizational
@@ -1541,10 +1541,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="146aff40-a74f-415b-ac06-1c2d9f55621d" control-id="at-2">
+    <implemented-requirement uuid="e6ed68bb-0870-4dcb-9b24-17c1ebce64a8" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="c85f8692-a49f-481a-a81c-24e28b670b8f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="714db990-76ac-4b3e-ac96-d6fe7d7752b4">
+      <statement statement-id="at-2_stmt.a" uuid="8503c131-86bc-4578-a094-8bdda4893fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14ebc016-0547-4d5d-b10d-d315cba099ee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) as part of
@@ -1554,8 +1554,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="9c3ebee9-fc36-4d12-869c-eb2ff6ac1159">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="66b8c508-145d-4752-9947-5db8d3db2f5a">
+      <statement statement-id="at-2_stmt.b" uuid="01cdbb14-ba93-4579-bd0b-1c3cf8b62da0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46d6e9ac-9d48-4d7c-baec-7c7a2083c708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) when required
@@ -1565,8 +1565,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="d925b353-03c0-40e3-8b22-4f0e0ae00bdb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="982cb789-e9e4-4d55-a0dd-4109d75d064c">
+      <statement statement-id="at-2_stmt.c" uuid="da6133dd-b73d-4380-bb5a-861448a188fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="132b46ae-43ce-48f6-a591-be355da2ce1f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing basic security awareness training to information system users
 (including managers, senior executives, and contractors) on an
@@ -1577,10 +1577,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4713da1d-2d7f-40a6-b32c-3331b18f2e96" control-id="at-2.2">
+    <implemented-requirement uuid="19712fc7-3765-46e8-adb5-b70150fbf51a" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="2ef656a8-b040-4d77-8635-978454891861">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="513db42e-2a15-42ab-b08f-bb90d0c03374">
+      <statement statement-id="at-2.2_stmt" uuid="8466cbc8-5e6e-4c7e-9b94-65889620de9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31358141-fbf3-47ba-8df5-97f90e9df0b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including ecurity awareness training on recognizing and reporting
 potential indicators of insider threat is an organizational control
@@ -1590,10 +1590,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fbad82f-9fb1-4234-a482-7dfb0071c6f8" control-id="at-3">
+    <implemented-requirement uuid="a16777d8-142c-4f9a-906d-b955c88bf4a0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="6c86de6e-7043-4686-af5a-3a4071d84f62">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0bd62c7c-4727-49df-b854-e36e475abbbf">
+      <statement statement-id="at-3_stmt.a" uuid="7b4ef1c4-73cb-4b9c-a509-733b33d61428">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9fb373e0-5af9-4d04-be11-a02bfbef71c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities before authorizing access to the
@@ -1603,8 +1603,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="038f9a4e-fb1e-410b-a936-48908c31a45d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a666e8c2-cfbf-4077-a0ca-129e39310cc2">
+      <statement statement-id="at-3_stmt.b" uuid="f6d28bf3-3ac5-4c73-9c71-7230cced8cec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="903135ca-e9e4-493b-a7a6-add2514eebcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities when required by information system
@@ -1613,8 +1613,8 @@ Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="4bf83b68-9458-48bc-8c98-fc1984813483">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7f7fc110-5410-4694-bf08-53804f75f9d4">
+      <statement statement-id="at-3_stmt.c" uuid="86749632-bd79-45d4-b60f-9b5fcc96a451">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4aa49d88-350e-43ed-9ee8-dfd4807cdf61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing  role-based security training to personnel with assigned
 security roles and responsibilities on an organizational-defined
@@ -1624,10 +1624,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e940b24-4cd7-462b-abbc-7724eef712e0" control-id="at-4">
+    <implemented-requirement uuid="d8b591f0-19de-4755-ae3e-345052f4cb56" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="554dd6f0-97c8-497f-970c-5e6c3602f46d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d3fe5ac9-9809-4868-990b-cc0ccfe504da">
+      <statement statement-id="at-4_stmt.a" uuid="0087eb27-174e-490b-b0fc-dcf52ce768b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22f347b7-eaef-495f-a58e-700c61644f3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting and monitoring individual information system security
 training activities including basic security awareness training and
@@ -1637,8 +1637,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="0fb51cf7-6cb9-4d23-8972-18bb7a5059e2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e76a356a-e9ac-4d03-9023-844503888d32">
+      <statement statement-id="at-4_stmt.b" uuid="9904e3c3-abb9-4091-8f38-c1bbafa94d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="225f3983-c3eb-4a20-8b70-52480656e170">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retaining individual training records for an organization-defined time
 period is an organizational control outside the scope of Red Hat
@@ -1647,10 +1647,10 @@ Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdda3bd0-8406-41d4-a51f-f6d4128331e5" control-id="au-1">
+    <implemented-requirement uuid="93522bc6-7b1e-46e0-b2e9-4fc565ab55d1" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="d9656ec6-32ce-4d05-a456-840e37708642">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="26100f3e-de0c-48f8-96de-403f9076f343">
+      <statement statement-id="au-1_stmt.a" uuid="89ecb81a-977e-453b-aa96-fb6e0cb4b418">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce489d2-2ab4-40a3-8a56-d77d87a28670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Advanced Cluster
@@ -1658,8 +1658,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.1" uuid="be4068f4-f499-498b-a470-f023a37107d4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="54538556-3a7e-4552-9dfb-f1dbd0b7825c">
+      <statement statement-id="au-1_stmt.a.1" uuid="c2e804c1-4b19-42f5-8170-b199f7f06f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="128c9f3f-1bff-4316-98c6-5cb24150cc87">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy that addresses purpose, scope, roles, responsibilities,
@@ -1669,8 +1669,8 @@ Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.a.2" uuid="2777dd74-535a-413f-98ac-7d5f808a184c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="519ddc23-3f19-4275-96c2-0367292274a4">
+      <statement statement-id="au-1_stmt.a.2" uuid="fbdb7c26-1ad2-4e01-b276-caefef2baddc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a2d115ed-16a4-4dfe-a543-32be43c3d405">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level procedures to facilitate the
 implementation of the audit and accountability policy and
@@ -1680,8 +1680,8 @@ for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="159ddfac-db6e-46f9-91eb-852206980299">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7dcabc8b-58be-454d-b899-7a084250e37f">
+      <statement statement-id="au-1_stmt.b" uuid="e55963d2-5a06-4ec1-bb13-1bf5f9ae9a96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147568cb-e0e1-4ce7-97d1-3b200534508d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat
@@ -1690,8 +1690,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.1" uuid="9d519494-5dd8-4e3f-8e56-d322a35a67aa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="18aecfd4-f99d-4b6b-9697-743a029106cc">
+      <statement statement-id="au-1_stmt.b.1" uuid="d7166a9b-8fdf-4cf3-8af2-84a77d67636b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e63d95d9-1312-427d-b9f8-0a6704c04dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy per a defined frequency is outside
@@ -1700,8 +1700,8 @@ Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b.2" uuid="fa9028ce-69ec-46df-86a0-1c3dfe31bc05">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="90278904-1b61-446d-a18f-3521f2d59a36">
+      <statement statement-id="au-1_stmt.b.2" uuid="8ef977d8-1e69-4b30-a44c-d8f1fc5b5070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7e298296-2a66-4578-998f-b5bce664d747">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating an organizational-level audit and
 accountability procedures per a defined frequency is outside
@@ -1711,10 +1711,10 @@ Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68404fed-1757-4250-b71e-a55e8f611d7b" control-id="au-2">
+    <implemented-requirement uuid="b03e41af-2673-4478-b4ef-fabb7dfc78bd" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="212eddb0-8c3c-4f37-94aa-519a68a334bb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="70ebe4b4-0270-4e47-9248-5720e8c1ab38">
+      <statement statement-id="au-2_stmt.a" uuid="1b8b0e5b-da43-45bb-ba31-0b2bb2e19836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1725,8 +1725,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="a88150a5-35fd-457d-ba10-020e67cf13bd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c49d1f95-df37-4333-8d5e-5dbc6ef0b9ec">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1734,8 +1734,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="a7ab9ce5-72ae-418e-aa81-78ad3a19de7f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="01607f41-1486-4277-8b79-baa171bd3cfb">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1744,8 +1744,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="08f8de65-80df-4d87-9c8b-1ad980aef70d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6099086e-370f-432b-bf16-1989eff28086">
+      <statement statement-id="au-2_stmt.d" uuid="21380c65-89e0-46ae-9f7c-c077c3f43f2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1757,10 +1757,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e9c5ed5-fba8-4063-8373-ce736254f533" control-id="au-2.3">
+    <implemented-requirement uuid="37d962d0-0fea-41fb-9346-03a18cab003e" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="21f3f709-beaf-448e-b77d-eca41d3f0341">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4ff03c9c-684d-4e8c-be77-4ae5833db4a6">
+      <statement statement-id="au-2.3_stmt" uuid="29f0f773-5045-4a4b-8027-f47dee16b1c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1b2ecc01-ef39-4c49-9e65-022c289bbd65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -1768,10 +1768,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="596f96f4-e894-41f1-bd9f-c1fa8b175de6" control-id="au-3">
+    <implemented-requirement uuid="565157ed-c989-45de-9051-e3e39cdc5baf" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3_stmt" uuid="977041ef-d8e3-4ee9-bd13-7647ba386882">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="80d5dbdb-5f1c-4395-a9d5-73ac3e2775aa">
+      <statement statement-id="au-3_stmt" uuid="efd94e80-a7d7-4e59-9d8b-d97f7418a986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1783,10 +1783,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a3bed79-44a8-4950-af2f-1e866be21f97" control-id="au-3.1">
+    <implemented-requirement uuid="d2d30979-56de-415e-97dd-3a1bcf12d5b8" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="42762ff0-4d48-4ba0-bec8-b3aa5a43a9ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5f5c8aff-5d5b-4fa7-ab78-a20b635fc0c0">
+      <statement statement-id="au-3.1_stmt" uuid="fc45f333-f6bc-4119-87c8-8f870ed410b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1798,10 +1798,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fab8d6a5-4a0a-4bc8-b60f-e7f8b83b6856" control-id="au-4">
+    <implemented-requirement uuid="fda69e31-a6eb-4841-8f77-97b9def4c605" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="ddcc6a3b-e740-4115-9e56-ddae1463120a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f6bfabc-3a1a-45f0-90ea-1b7b095260d9">
+      <statement statement-id="au-4_stmt" uuid="621babff-ebe8-45d6-bb9c-8ededcfc5c0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1813,10 +1813,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="457ef0bc-f009-4297-a1ec-3ead28a9d7af" control-id="au-5">
+    <implemented-requirement uuid="f1968243-07bd-4385-bba0-7104ebd712e0" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="9689a602-e0e7-4f27-9642-d083f9d42e66">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="13ee606b-11bc-461d-bcec-ff7d5b3bd603">
+      <statement statement-id="au-5_stmt.a" uuid="151d383a-efd6-44e0-b745-12d1fc7d6ac1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1827,8 +1827,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="4b59b755-a2fc-41fa-b761-7d53f6f67812">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ab7d0d23-b6c9-40ec-a3cb-99790ee5a1a5">
+      <statement statement-id="au-5_stmt.b" uuid="a6646919-06bb-478a-bcdb-b2d8386b09b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1840,10 +1840,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a70a05c3-b99c-4f20-9e93-6e2c0bea2aba" control-id="au-6">
+    <implemented-requirement uuid="f402cea2-a394-465d-a946-c6d65a71f86f" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="8e3f88bd-2245-4a23-84a6-390abdfab094">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a8bcc873-f2f0-4305-a47a-dbaaba9483c0">
+      <statement statement-id="au-6_stmt.a" uuid="bad96ef8-562a-4ccb-a6dd-0b1bcff62f78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27f022e-887b-4ae9-8345-28848b08f1f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1852,8 +1852,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="d48ea99a-8353-48ee-8532-c7f5c101c27c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="80d8330c-b1e4-4b06-bc14-160373dd8aa0">
+      <statement statement-id="au-6_stmt.b" uuid="b4d9453e-3213-4bd7-b194-30d0da550f27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1dd55b1d-9d68-43e2-8156-2c1d86cf1a3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1862,10 +1862,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bb1e6e3-1bfe-48fb-ad59-b5b6f5c36a95" control-id="au-6.1">
+    <implemented-requirement uuid="1777b50d-0b9b-4d2f-ad93-56a76d10a9f0" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="59673ead-c139-4763-8303-81f652165073">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="40708ad1-2d42-4553-8bae-6a167fec18c9">
+      <statement statement-id="au-6.1_stmt" uuid="e214be91-36b0-4a5c-8dcf-1ddcc04834de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1877,10 +1877,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d4dc942-cc74-46f5-a1ac-d6619427b31e" control-id="au-6.3">
+    <implemented-requirement uuid="a85ff011-d8ef-4a1f-85cf-6f3b7121cd4e" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="aec50a1d-b09a-45dc-8940-27c5c01fdcbb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="83d2288b-5d98-425c-aab3-fb7e62cd88a7">
+      <statement statement-id="au-6.3_stmt" uuid="959cc9c1-1262-4d42-85bc-5074b990d64b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed0a8afe-8cc5-43e6-b7c0-0bec5161dfd1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1897,10 +1897,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a75f98d7-cdb5-4aa7-bea6-9b9048d956b4" control-id="au-7">
+    <implemented-requirement uuid="3a5af7ba-cc6c-4809-aef3-603b089d188a" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="41eb6cae-7737-4d74-91ba-2a9a4342a3cb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="077cef90-cc48-468a-ad3c-6287841fa874">
+      <statement statement-id="au-7_stmt.a" uuid="0d0bb9c5-1b89-4c9d-8a7b-4e6e52ce640b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1911,23 +1911,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="651c980c-f22f-404f-9d88-a37d17eec01e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="971a70bd-a322-4ef1-a64a-9f5429bf0611">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
-OpenShift for auditing capabilities.
-
-This control is applicable to the OpenShift Cluster Logging
-Operator and to the OpenShift cluster and is outside the scope
-of Red Hat Advanced Cluster Management for Kubernetes configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="21c7f584-ac8a-45fb-9392-7e363a9984fd" control-id="au-7.1">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="790f7be0-f3a2-4bc6-9bc9-4ae57b13e0ba">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fa1ca0cd-a94a-4abb-80bf-bf0d95d6a683">
+      <statement statement-id="au-7_stmt.b" uuid="72263aa4-0732-4a98-b0e3-0f760ae34bd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1939,10 +1924,25 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53976155-d9e6-4209-a1c0-7497b3503127" control-id="au-8">
+    <implemented-requirement uuid="355be9b1-ea23-4a88-a9b6-f1505e85f6d2" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="e1368323-34b4-4b93-9970-342abb82d6e1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="08c11869-2fd2-4524-8a53-dedc58320312">
+      <statement statement-id="au-7.1_stmt" uuid="4f83c856-2c1b-4ab5-8fb3-f1c07e768b56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
+OpenShift for auditing capabilities.
+
+This control is applicable to the OpenShift Cluster Logging
+Operator and to the OpenShift cluster and is outside the scope
+of Red Hat Advanced Cluster Management for Kubernetes configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="bc57b069-5a92-4967-af4d-a8b7d562cf0a" control-id="au-8">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="au-8_stmt.a" uuid="2514ddf3-efed-429e-bbbe-4de6676b6a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1952,8 +1952,8 @@ Operator and to the OpenShift cluster and is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="58c212ba-f616-4fb0-8997-3fceaaf455e4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cae3b33f-8b97-451c-b52a-9f101eda164e">
+      <statement statement-id="au-8_stmt.b" uuid="0f88897c-bea3-40de-8f58-22ce0807fdf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e9a9bfe2-4cc1-4021-b24b-61d99b8c5a74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -1964,10 +1964,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fde0fc3a-7e27-4e43-8955-25fa8af7295a" control-id="au-8.1">
+    <implemented-requirement uuid="f349c83c-1886-454c-b7e5-738690311868" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="41d6400a-2b28-490f-ba47-5b00680b16fc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="65cfa7c3-9c4a-4ea4-abb1-353338e9d0e7">
+      <statement statement-id="au-8.1_stmt.a" uuid="089785b2-37ff-45f3-a096-1cc0102ccb84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33c5076-4803-493c-a2e9-571ea66e69c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing and time synchronization capabilities.
@@ -1978,8 +1978,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="831f9779-ea95-4d17-8d01-d5db2623b398">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="445979c1-9316-4a64-b3df-527ab70ff483">
+      <statement statement-id="au-8.1_stmt.b" uuid="12cbfe02-8198-43fa-84b2-e1ceeb039cdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33c5076-4803-493c-a2e9-571ea66e69c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing and time synchronization capabilities.
@@ -1991,10 +1991,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aad7e2e3-ab24-42b2-9754-3b96c2f513d6" control-id="au-9">
+    <implemented-requirement uuid="fa8e2aa7-1ffa-4aa6-a9a7-7ffd06c379da" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9_stmt" uuid="c30ec2a1-91c0-41bc-ae4f-0c3a987d1b14">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="070a0ebc-47e8-4db4-b8b7-2a7c27b1d034">
+      <statement statement-id="au-9_stmt" uuid="0636913e-ee07-4cc2-a565-a356ba89844c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2006,10 +2006,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e77a51c7-38e2-43ce-a93b-c21cdd0f4dff" control-id="au-9.2">
+    <implemented-requirement uuid="5a7abf91-c139-46ba-ba7f-f47a0adc590c" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="e96858fc-9b8d-4d10-8b00-5bd408b2a319">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b3a3ef18-33e2-44cc-a695-f960ff0f74b2">
+      <statement statement-id="au-9.2_stmt" uuid="2f285e35-8a64-48cc-9d5e-ad12a86a8f31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9dd5404-7995-4778-a75a-cdd8bfcfa8c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2020,10 +2020,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53c1d2d5-7cbc-466b-bc19-07bb145a67b7" control-id="au-9.4">
+    <implemented-requirement uuid="3ea16657-1a47-4e4a-aa09-73c4bb429903" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="c1a544d4-784e-43b0-880c-b910cb570cd0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5539816f-0e4c-406a-96fb-59811603033c">
+      <statement statement-id="au-9.4_stmt" uuid="ab2f8b34-6e04-4192-baaf-01df458fc575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2035,10 +2035,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15ec037f-7235-434e-b600-59a040227508" control-id="au-11">
+    <implemented-requirement uuid="e7bcea13-2029-4aea-8e07-ba3593be0301" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-11_stmt" uuid="30f2757e-6727-4fc1-a337-a162a9884dac">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1350cc05-7ef8-40a7-a642-699e86598af4">
+      <statement statement-id="au-11_stmt" uuid="d7e22308-ca97-42d6-b7b7-39775e6e92e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2050,10 +2050,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ccdc2f7-9096-4bdd-addc-1c716fcd9247" control-id="au-12">
+    <implemented-requirement uuid="6da943ff-8ed1-4a0e-9856-1c6f0d776cf4" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="8a566f15-7974-4126-bc64-680f991b884e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="975af796-4603-436e-abf8-e1c1f4a06a30">
+      <statement statement-id="au-12_stmt.a" uuid="e8e03e01-00af-4235-89ef-f45557254e07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2064,8 +2064,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="5d2c22f7-5974-49b7-ac01-1a46164decd6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a6ea2a51-05f0-4a7c-8c11-f2e3bdcc458c">
+      <statement statement-id="au-12_stmt.b" uuid="766ed89b-14a8-478c-b140-61e909d67881">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2076,8 +2076,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="76e77095-f8a2-49e7-b653-325c6a391e5b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7bc8ec15-4e8c-413c-ae31-5f02bc358e0e">
+      <statement statement-id="au-12_stmt.c" uuid="c6e873a5-a73d-4a3e-8264-7b1b0848562d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c34314-8b01-41a7-b0ca-4a9a8cb32d38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes relies on
 OpenShift for auditing capabilities.
@@ -2089,18 +2089,18 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68f0a39d-ee1a-4fe5-bc2a-d07dabe18a43" control-id="ca-1">
+    <implemented-requirement uuid="01f4c3ba-c968-46bc-8330-f85b6bcc8467" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="3a4f1166-259c-401a-84ce-0e00b7120dee">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8b6e478a-189d-4044-b734-8bdd267539fd">
+      <statement statement-id="ca-1_stmt.a" uuid="519ae86e-7b1a-4ca9-bed4-cff7f2c53d33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="fca7f4ab-097c-42c9-937c-f4f9e2309009">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="51944459-7735-445f-82e1-e8cd1b442a03">
+      <statement statement-id="ca-1_stmt.b" uuid="2639125c-d328-4613-a73c-3e9c3beae532">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="458a4b0d-6afc-4eaa-986a-62a5d4dc4b61">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2108,34 +2108,34 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration gu
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59f5ea68-8ae4-4624-b4af-79b3dd493be0" control-id="ca-2">
+    <implemented-requirement uuid="c672dd8d-a42c-4506-b5c5-aa859ae35fa6" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="bec9db87-a874-4e28-a72e-2b593f8c992f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="77a7e123-b4c1-4b55-8c85-a2c317aab0f5">
+      <statement statement-id="ca-2_stmt.a" uuid="5ad78120-51f6-4cb6-9f11-60323121f058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="35253bd1-eded-4351-ac8b-f3671885d248">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b7b23d60-1200-41b7-ba91-036fcd875fa6">
+      <statement statement-id="ca-2_stmt.b" uuid="55b6f393-d145-48bf-bb19-b8c5f9152e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="2a916e7d-6cca-458c-ad24-bd511a466dc1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5380b24e-67d1-4425-a13a-9a5d6fdc7d5f">
+      <statement statement-id="ca-2_stmt.c" uuid="a48b116e-64f7-43bf-bfb8-d5400123afc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
 guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="47568642-2479-413c-af39-38fe00c0c297">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9f85fa62-911f-4ab3-8ff9-08de30df6973">
+      <statement statement-id="ca-2_stmt.d" uuid="32344de1-3c92-4154-951e-ef77e7e0b719">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e5883b-c484-4cac-9979-54abad45a5d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2143,10 +2143,10 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b66fd837-1703-4359-872a-f8fb54049196" control-id="ca-2.1">
+    <implemented-requirement uuid="b2a4477a-ef14-4efe-a747-daf74eff8f74" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="b2289772-95c4-4740-9cc2-2111796017de">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7bcdd6ad-3325-49ad-b130-9d6e38e3b3e3">
+      <statement statement-id="ca-2.1_stmt" uuid="72d3ad7f-82e8-448f-8abf-ef69c5c57aad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2c057b-c13b-497d-baf4-043ee1ee1c6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2154,46 +2154,46 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc59260c-7ed5-4579-8945-a04c90e9de46" control-id="ca-2.2">
+    <implemented-requirement uuid="2b305009-330f-4203-b115-7e11c27188e8" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="3154653b-fa91-460f-b291-dcc5511d1739">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dc7f9acb-3ae1-40a8-a840-e38b49f14a18">
+      <statement statement-id="ca-2.2_stmt" uuid="a60077d8-9f00-4a1a-8656-12dc34a1a416">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06346907-f2f2-457b-a898-5055fecd7763">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7756a029-d7bd-42d9-b0f5-5e3018e3a4d3" control-id="ca-2.3">
+    <implemented-requirement uuid="a9227041-a057-4a35-accc-64c89dd63d50" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="f060846a-a1e6-4316-935d-da8a232577e7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6b2da708-7471-41b6-abfd-9dfb49a0c479">
+      <statement statement-id="ca-2.3_stmt" uuid="abac2599-1413-4510-aabf-611d6f605ee1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="517a0930-155d-4826-bfed-87a5125cacea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2df8d9c-163e-42a1-afb0-65b9433f25d5" control-id="ca-3">
+    <implemented-requirement uuid="b57f061e-790a-4ea9-aef1-3bdeaae3d6a7" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="9d0d159b-1ca8-4e32-a652-f4c330dda206">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2e712471-1469-47c4-b6a8-19f0bf638f7b">
+      <statement statement-id="ca-3_stmt.a" uuid="1ed9d428-4eff-4ed9-9345-c103b6e33df6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="cc450b82-524a-450c-a516-7011c51d1481">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7096a6d2-ffa4-493f-8bc6-27c56e290d62">
+      <statement statement-id="ca-3_stmt.b" uuid="2625543f-8485-4cce-aadf-f54753f5eff0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="2f0b1c3a-6927-4666-b6e3-146db666a121">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="55da42ce-91d5-47d4-89a4-bb5ce006dce4">
+      <statement statement-id="ca-3_stmt.c" uuid="1a5d17dd-405b-4e8f-8d25-dbef8f40a7cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="25ee5e62-02b8-4773-b253-e5545e6656db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -2201,20 +2201,20 @@ configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96f2fd9a-218f-4d10-8e80-247292c8ccd8" control-id="ca-3.3">
+    <implemented-requirement uuid="c3c6ad16-99fe-4e42-a6f1-8ecab2864dbb" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="b3647c8e-d40b-4c2e-848a-28acb00ea774">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0e3ff2fd-275a-41cd-9abd-9382f145b770">
+      <statement statement-id="ca-3.3_stmt" uuid="a89dfb51-25c6-435c-9266-1c853cd21229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d93a1ea-756b-4fd4-b976-abc36c0f8a8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="497d0bf9-edc5-478d-b8c7-563927750d61" control-id="ca-3.5">
+    <implemented-requirement uuid="c2663155-a5dc-46db-a1bb-12ba75737c0a" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="0268e791-b475-45f2-bda3-f92aa567470b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d662ef3f-4e4a-4e6f-823d-5b3627850189">
+      <statement statement-id="ca-3.5_stmt" uuid="92a48818-080d-4a8d-97e2-54fe007a6c1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8079fd90-8044-449d-a968-1d5e85ec38e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing an allow-all, deny-by-exception; deny-all, permit-by-exception
 policy for allowing organization-defined information systems to connect to external
@@ -2228,10 +2228,10 @@ organization and to the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8d43cbe-64bb-4419-acfb-1152eeb4a924" control-id="ca-5">
+    <implemented-requirement uuid="1bd5743e-193f-4be9-b335-a1ac7999bbb4" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="5ad7f782-4301-48af-b2ab-e9ca4d6d9e47">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="79b4108a-d43d-4b25-a462-e4d48466e2f0">
+      <statement statement-id="ca-5_stmt.a" uuid="959605c7-23fd-4050-b5c1-48d5ac034bb6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f79d6ae-edfe-441a-b485-8f3c80a8a60d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Advanced Cluster Management for
@@ -2247,8 +2247,8 @@ Management for Kubernetes POA&amp;M, Engineering progress can be tracked at:
 https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="31f6c09f-b652-48ab-800c-5454b19a2aa0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="174c6876-0945-4b0d-9a98-2f7286156597">
+      <statement statement-id="ca-5_stmt.b" uuid="84692ecf-2d34-4137-9dd1-aa808d86317d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="112a979a-cc94-4e65-903c-099daa507bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2263,34 +2263,34 @@ https://issues.redhat.com/browse/ACM-348</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ffd6bf-f6af-4a7a-9a1e-5ae64e94b339" control-id="ca-6">
+    <implemented-requirement uuid="9cac12f1-c86a-48a1-9afb-2b3110154cc6" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="2b948009-d7fb-4868-8a11-a79cc7954a49">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9d3d0116-f0fa-4b5f-8d65-0adddc41755b">
+      <statement statement-id="ca-6_stmt.a" uuid="9bd01460-b742-446b-9268-e6cde83176df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="e7a1993e-7218-4e1c-b86d-0707ec862ac8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="08690c33-cd49-4fa7-a8e5-c6657838fd2c">
+      <statement statement-id="ca-6_stmt.b" uuid="fb426be2-214f-4715-9254-482db9f1bc83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="fe16d29f-4a0c-4041-8a36-ecaf5934bb2c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a190f56f-5e4a-4259-97a1-102721504812">
+      <statement statement-id="ca-6_stmt.c" uuid="9c030712-735c-49b7-801f-b934d6b58413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fbf1767c-4054-49b8-9a2a-350c1787ebea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="906055f4-a80f-44ad-bcb9-023d7236f312" control-id="ca-7">
+    <implemented-requirement uuid="6c564476-fae9-49f2-a572-42196d208bbe" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="967a3b8d-2914-43b8-b3f2-6e55bee2998b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5f6e6ab4-24ae-4e8c-8b1d-e9cc783fbb6c">
+      <statement statement-id="ca-7_stmt.a" uuid="3283410d-f341-42d7-8822-c01d1690337b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="758b258c-4b30-4271-92f4-8e61b4afbda4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined metrics to be
@@ -2298,8 +2298,8 @@ monitored is an organizational control outside the scope of Red Hat Advanced Clu
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="2552dc54-24cf-4023-ba94-8f536b6b19d2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9fcfe5f5-27b1-41d9-8868-477dfc7eafd7">
+      <statement statement-id="ca-7_stmt.b" uuid="48871aa8-8b97-4cbe-9e3e-931acd8a9136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15daea3c-f9bf-4a50-b2d4-42ae6bf92ef3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development and implementation of a continuous monitoring program
 that includes the establishment of organization-defined frequencies for
@@ -2307,40 +2307,40 @@ monitoring and assessment of such monitoring is an organizational control
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="0ae2119c-e54a-4203-bf24-bb7312a9f544">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5484177b-8890-42fc-be2a-a0c9122e2ad3">
+      <statement statement-id="ca-7_stmt.c" uuid="c61aefca-5fb6-4ec0-b86b-8a3c2ae2cf5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="c295bd53-4ff0-4a94-aa21-438dad81f8a7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="454da531-8315-49cc-93b2-93500b8d9738">
+      <statement statement-id="ca-7_stmt.d" uuid="fa928e68-9aee-43a7-bf4a-6c6b78cbce0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="cdceebbe-d4ba-4680-aa9b-90507cc1920d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="50a8a885-1471-4104-9cc8-ac6df146362b">
+      <statement statement-id="ca-7_stmt.e" uuid="6a25579c-105d-4374-9cb5-d4253403d253">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="962ca373-4463-44bf-b5f3-9ce33a62bd8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
 https://issues.redhat.com/browse/ACM-364</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="43178f26-43a6-4103-8d39-2f4c0730aba5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0d713b23-ef66-4aa8-905b-fe1bfb868c11">
+      <statement statement-id="ca-7_stmt.f" uuid="a2f92bfc-f9f8-40c7-ab30-00922de2c237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd1e0580-e27c-4e69-91c6-a25f4f1ebfbe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Response actions to address results of the analysis of security-related
 information is an organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="f2faab75-10c5-41ff-8895-bc4515b0f3d0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0080172f-2f4f-4311-a4e3-15ebda339c8c">
+      <statement statement-id="ca-7_stmt.g" uuid="909988f3-0b2f-4ed8-a609-43f5e85394ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="defb78fb-f730-4013-87f4-f1eeb599f705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting the security status of organization and the information system
 to organization-defined personnel or roles at a specified organization-defined
@@ -2349,30 +2349,30 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60a8551f-b37c-4f5a-95f1-d421396afb10" control-id="ca-7.1">
+    <implemented-requirement uuid="4a38d6f0-dcb6-4942-b2fc-5d2f35f3638d" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="e7b8c73b-e107-4317-8d00-7df15aa559e4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5a0690e3-383a-4ff7-a9ae-175384c5070e">
+      <statement statement-id="ca-7.1_stmt" uuid="495c5a5e-ac22-4de0-b173-eac526866e47">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="caf9edee-197a-4fa3-9b81-f1afe07fd21e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="701c0a40-1998-44bd-8ba1-f2d43b754693" control-id="ca-8">
+    <implemented-requirement uuid="e12b1330-30a8-43fa-abbe-01e152b4a631" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="f40a50bb-f206-4add-9e3f-b55db7d6233e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9fb0a3bb-dae8-4cbf-9184-4bf0ac85b425">
+      <statement statement-id="ca-8_stmt" uuid="36ab4fb9-ea1b-4666-963e-d6ce37b7a8d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ae5b32f-75ee-4887-9ba6-48e7a5a313dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ea7b5ea-49e8-4f08-b311-f5f5a273aa2e" control-id="ca-8.1">
+    <implemented-requirement uuid="28decff2-883f-43d9-9228-7d77d0a4de4c" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="9e50e910-d74c-4a93-b235-d78f67be4a89">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2ba7146b-60ce-487e-a86b-66f1ae025956">
+      <statement statement-id="ca-8.1_stmt" uuid="71258c91-d662-4a14-a1ee-49feab12a8f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5035d9e-753e-42db-8950-0f435a49658a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Advanced Cluster Management for Kubernetes configuration
@@ -2380,18 +2380,18 @@ guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec6091fe-7ef6-4029-8866-569c47bf8eb7" control-id="ca-9">
+    <implemented-requirement uuid="fb8dae49-0d16-4648-b836-94ba226c896a" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="e6a2e0db-5ddc-4157-8121-546347daa2f2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7ddfca7e-1648-47a1-bfe6-e84402a4e12d">
+      <statement statement-id="ca-9_stmt.a" uuid="3766cc50-8615-4b7b-bb50-d26dffcf813d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30b2b449-8b0e-4aec-8bca-769e02bc9335">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorizing internal connections of organization-defined information system components
 or classes of components] to the information system is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="2b5bcf12-b8ca-4c52-8823-4574c3601261">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e753c0c1-c158-41f1-9c58-7e134288e6a5">
+      <statement statement-id="ca-9_stmt.b" uuid="45f6f5ac-2298-4437-ab64-74ffa3b7f354">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ed18582-8a10-4c66-bbc4-d598891b6257">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting, for each internal connection, the interface characteristics, security
 requirements, and the nature of the information communicated is an organizational control
@@ -2399,18 +2399,18 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="398ffd4e-9d1a-4544-8585-ba4324a5c9d9" control-id="cm-1">
+    <implemented-requirement uuid="48bb0d88-da47-4cbc-9d34-bf0ccaed2fad" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="a524c253-340a-4987-b352-d93c030478a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1e7cdaa9-5654-4542-a40f-907cd465935b">
+      <statement statement-id="cm-1_stmt.a" uuid="60c79fbc-29d7-4e5a-b683-463c626aad98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f517f39-42dd-4978-b5c0-209b1d8a2ff4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="1f3e2c91-2ed9-46ca-b20a-5ed55b3092a7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7d367d05-1951-46c4-a1e7-4a96d20210b8">
+      <statement statement-id="cm-1_stmt.b" uuid="baf16baa-b205-4934-8794-c50d0b74a322">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1070a7df-1715-4de8-a48e-ed5d829e68c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Advanced Cluster Management for
@@ -2418,10 +2418,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d8a18cd-420b-4ca0-b157-b654c9f83e38" control-id="cm-2">
+    <implemented-requirement uuid="a1d079dd-398c-4f9c-b11e-3c65e3cd857a" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="b4e326f2-f9e6-4bda-ac84-9d45a93d4fb7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="256c5afe-024c-492c-b7d2-81285add0172">
+      <statement statement-id="cm-2_stmt" uuid="a9e3b1c4-87e9-45c7-a9d8-90ee1adcc060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dcacec4-2e1f-4a03-975a-494dd6fbf8fd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The recommended approach for configuration management for Red Hat Advanced Cluster
 Management for Kubernetes (RHACM) is to implement the principles and patterns of GitOps
@@ -2440,10 +2440,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b86104b4-39f1-44ec-bef6-9e73f5857b00" control-id="cm-2.1">
+    <implemented-requirement uuid="2d58debb-50d8-49b5-a2e8-a0243facb356" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="a71e4d9a-fddf-49a9-b37e-0221cd239f06">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="28f5d629-47f1-4aab-8ed9-5895cc1efa22">
+      <statement statement-id="cm-2.1_stmt.a" uuid="5fd409eb-b7cc-4f45-ba9b-494e72aa4950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="73f930a6-75f4-4929-8f8e-66e385cbd00e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of
 Red Hat Advanced Cluster Management for Kubernetes per an organization-defined frequency is
@@ -2463,8 +2463,8 @@ managing channels for GitOps approaches using RHACM, see:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="971343c1-6e35-421e-a7c2-da38f66b226f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5906c335-eb85-40d1-b9e3-d9317b9c6177">
+      <statement statement-id="cm-2.1_stmt.b" uuid="a9fa4de9-f38b-486b-a042-fa7d9b6d3c28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6079308c-7bd1-43e8-a116-61090c1b09c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of Red Hat Advanced
 Cluster Management for Kubernetes when required due to organization-defined circumstances
@@ -2484,8 +2484,8 @@ managing channels for GitOps approaches using RHACM, see:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="050ba99a-5107-41f9-9b18-e92c19f44fa3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="51074dfe-80c1-4a61-afde-cb76cad1f0ec">
+      <statement statement-id="cm-2.1_stmt.c" uuid="c319cc1c-795c-400d-975e-2884cc5d514a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e14b719f-5d5a-4d61-a3e9-390483dc9b27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing and updating the baseline configuration of Red Hat Advanced
 Cluster Management as an integral part of Red Hat Advanced Cluster Management for
@@ -2507,10 +2507,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a118200e-e6e4-4064-a6aa-6c8aa7401bc6" control-id="cm-2.2">
+    <implemented-requirement uuid="439445b8-c667-4f59-ad42-eca4439f8813" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="9a4a4f0b-cdd2-4a91-a2fb-378e83652fba">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9a2b820c-70a7-4dc7-ba1b-6c335bfd9c59">
+      <statement statement-id="cm-2.2_stmt" uuid="c3b10a55-49af-4e69-b7d9-a06c24d0c996">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f820247f-7dda-4b28-b932-6295fe3321cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2519,10 +2519,10 @@ https://issues.redhat.com/browse/ACM-357</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f2447ba-a445-40d5-b977-e829e6fb9939" control-id="cm-2.3">
+    <implemented-requirement uuid="def72b46-b60b-4e0b-9039-0fe60a9c5a13" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="8e70dd86-c2f1-4830-8d19-c1a36b9f0123">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9bc971c1-b8fa-474b-a9ae-d0165218e8aa">
+      <statement statement-id="cm-2.3_stmt" uuid="efbf48d9-e820-4cb6-a7e6-487ba704dab1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09ff01a3-40ce-44c0-b3de-fd22309bca26">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization retaining an organization-defined number of previous versions of baseline
 configurations of the information system to support rollback is an organizational control
@@ -2543,10 +2543,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a612787-2f1b-4fcf-85c0-915a9dffbd82" control-id="cm-2.7">
+    <implemented-requirement uuid="f52d45a3-512a-4a4e-97df-ac310e26600a" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="d925ec5b-942d-44be-830b-bc10af36326a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0f5a799a-0ba6-4075-a23f-967809933e63">
+      <statement statement-id="cm-2.7_stmt.a" uuid="f5b79b72-89f0-4438-9d75-16984540c112">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f4fa786-5509-4e45-8913-8da939d5aa34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2555,8 +2555,8 @@ organization deems to be of significant risk is outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="7fce832e-0cff-4b4f-97ca-193d48970bf1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="87f966d4-e8da-457f-bbdb-20fc2494af3d">
+      <statement statement-id="cm-2.7_stmt.b" uuid="5ec0484b-35c2-4a7f-bf19-bb67adc77178">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcaf3e43-a6d9-459f-bd5e-79f9cedd536a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2564,10 +2564,10 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11faf6c1-61cb-4fbe-97bf-af8923535529" control-id="cm-3">
+    <implemented-requirement uuid="6a168e12-7f15-4610-870a-7de7e1dcce67" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="05bd0859-5efe-4afa-aeb6-3611b4cda219">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3a4b4e8b-3f33-4f2a-b799-a844e1d998f0">
+      <statement statement-id="cm-3_stmt.a" uuid="96a7ac9e-b6f6-4d0a-b5f5-c3c0427c53d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2575,8 +2575,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="e489de14-60c0-49de-a19d-72bb82c57725">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0a66f8d5-e135-4b04-a0a6-35f583dbb905">
+      <statement statement-id="cm-3_stmt.b" uuid="3cb30e6b-fb54-4480-a031-cf2ad73423f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2584,8 +2584,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="3d4ae667-62b3-4698-857c-1c6a3dfac87c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e96a8979-a4a3-4542-bd0a-5bb582901933">
+      <statement statement-id="cm-3_stmt.c" uuid="52bb3395-737a-436f-9eae-6c5ccd36ebd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2593,8 +2593,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="c4ae1003-8002-44cb-b76f-d1e540bf79a4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e7c1b75-4105-4948-8a34-90b4b6c875b2">
+      <statement statement-id="cm-3_stmt.d" uuid="19b0a41d-89cb-4177-92ae-9d2ce720f010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2602,8 +2602,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="d49f6067-5ab9-4ed0-9bf0-baf8af79359e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1e7008ad-cf86-484b-b3fc-0b7458e4311e">
+      <statement statement-id="cm-3_stmt.e" uuid="fc11469e-518b-4d61-834f-76d9e510c0bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2611,8 +2611,8 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="7734f05d-d012-4a48-9248-d56697f3b70e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="41d8f1b7-a7a8-4457-a2e3-d96d1f2a5c30">
+      <statement statement-id="cm-3_stmt.f" uuid="f53cca64-48ac-42ac-9fd6-78ac3150b14a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ae700d9-0aa0-405b-b364-8ead08e2a8b9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2620,18 +2620,18 @@ tracked via:
 https://issues.redhat.com/browse/CMP-265</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="6b059b53-4264-4eb7-b608-e2148eeba930">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c3b5e5e5-fd97-41c3-bcec-2ed087d2bf67">
+      <statement statement-id="cm-3_stmt.g" uuid="e205a09b-8ec0-41a1-95c4-9a430d11a297">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a4de9ad-661d-4d3c-82fb-bbdac7b12f50" control-id="cm-4">
+    <implemented-requirement uuid="c466f2a9-5044-4f6a-923a-a22d2c787b37" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="19d872b8-ad0a-499d-b5d4-dff7db14dd00">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="44c12798-5ff0-455b-8c71-66878204579f">
+      <statement statement-id="cm-4_stmt" uuid="fd2632e7-3b6a-42db-99c7-2a933d3e73a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dcbfc6f-0506-47c9-88ff-91088ccd1d3f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2639,10 +2639,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa9a9f8d-e727-4a36-9dc9-2e5389e5320d" control-id="cm-5">
+    <implemented-requirement uuid="7fdd2e49-89fc-4941-b917-40d11d51b291" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="ece2484a-50e9-4a32-886c-703174277e31">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e0379306-9c47-4a5e-8da3-e5a28f79e048">
+      <statement statement-id="cm-5_stmt" uuid="1c596853-5a4a-494b-bcae-2a0fa049d3d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7aa613fd-e3df-4cd8-844c-c8093620a9e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2651,10 +2651,10 @@ https://issues.redhat.com/browse/ACM-358</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f39d8fa7-622b-428a-b76f-d4781e9c8aa5" control-id="cm-5.1">
+    <implemented-requirement uuid="474b021f-49dc-4f88-86ae-c1ec9ed81999" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="41ddc298-008e-4a91-9f85-88d2a2934655">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8a9e659e-503d-43c4-af8c-1b367c65e619">
+      <statement statement-id="cm-5.1_stmt" uuid="32b3c908-b112-43b4-8755-3c84cebc7b3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe98536-e0c9-4f84-a52a-236459ef6aba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2663,10 +2663,10 @@ https://issues.redhat.com/browse/ACM-359</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="630b7756-c570-42a6-9fb1-9878bc0e0990" control-id="cm-5.3">
+    <implemented-requirement uuid="9c35d698-950e-4531-8803-f69b143805a2" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="1a34fad5-4504-4826-a345-6b941cba4076">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8dc67c10-cd32-458d-9cc2-60da724550e6">
+      <statement statement-id="cm-5.3_stmt" uuid="67f855ac-0d58-42cb-84c4-b7fab0d6ac15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a4932db-bad9-4b03-8efc-27cb1a5fde5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2675,27 +2675,27 @@ https://issues.redhat.com/browse/ACM-361</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7aec2996-7685-472c-8f8a-ed3d9418ea02" control-id="cm-5.5">
+    <implemented-requirement uuid="206cfe8d-425a-44ff-b112-eacc2e05ed4d" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="44ac30fc-34df-42ed-9a5c-e83f85169684">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d08f81b0-316c-4280-aba9-3810598a812e">
+      <statement statement-id="cm-5.5_stmt.a" uuid="3e6e07d0-c7a4-47c8-860b-af5d080580e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81428e2c-aa63-42f6-93fd-254657a93f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="4f63cd12-b5c3-49e3-897e-72b52691e58a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d1d31b21-0c30-453c-9c8c-b3866403c1a0">
+      <statement statement-id="cm-5.5_stmt.b" uuid="82c24edb-c194-4658-be04-61d5a7ef794b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70fd8e44-ec9e-4936-a219-73d710a71909" control-id="cm-6">
+    <implemented-requirement uuid="4211401c-63bc-48ca-be02-d58c081cf1cd" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="c5a7dd24-971d-4cf1-b880-08300484ada0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b3da4a97-0c69-4722-8bee-b355c3cd77d0">
+      <statement statement-id="cm-6_stmt.a" uuid="7923dc4b-0415-4bf6-aa37-b3f8f61fa18d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2703,8 +2703,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="8add05c2-2146-48b0-9912-b5ea463816e9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="24ddde8d-dfe2-4a0e-85fd-4f5ecba57236">
+      <statement statement-id="cm-6_stmt.b" uuid="be4fee0d-706b-4133-bd8a-7a0465a2b3d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2712,8 +2712,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="07a48d9b-09c9-45c7-8097-5d711043b816">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f1a214ca-f199-472b-bfee-4b90d2f8d89e">
+      <statement statement-id="cm-6_stmt.c" uuid="a8d60edf-af95-40b5-a21d-b1b354c8c8e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2721,8 +2721,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="697672a8-e8f2-46e5-8222-4b900a290883">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d956f7ba-6d3d-4396-8101-542678464507">
+      <statement statement-id="cm-6_stmt.d" uuid="7576c408-1315-4f8a-9728-018dfb256f0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2087d7-406f-437f-9a38-9ee76a5a0c36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2731,10 +2731,10 @@ https://issues.redhat.com/browse/ACM-365</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99c756aa-477c-4877-ad40-a8917cb9b587" control-id="cm-6.1">
+    <implemented-requirement uuid="96fc4f30-6d34-4bb7-ba96-5a4cecb50999" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="1689cd74-5038-4bdd-9ce1-a2bd09240e7e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f69943d9-84b5-4efa-aa2c-ad1bf838e8b8">
+      <statement statement-id="cm-6.1_stmt" uuid="9e373a84-b243-44f3-b704-f74d7e0a283c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed93fac-217c-4d62-b645-2b398d12f945">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2743,10 +2743,10 @@ https://issues.redhat.com/browse/ACM-366</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5405df3-5a99-4223-845f-b2838c8c43d7" control-id="cm-7">
+    <implemented-requirement uuid="b4c719a6-2dd9-460d-95cc-d441e140740c" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="c7727bc4-9666-4c88-9590-99e5ce9a1b2b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ee4ba0bf-6295-41d9-96a9-765b9472745c">
+      <statement statement-id="cm-7_stmt.a" uuid="1da9a8db-41f9-49e4-ae38-6822a89fa077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2754,8 +2754,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="e7f16599-b145-4741-9067-78f8868c2a3a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="01f5494f-0b29-4f1e-acbd-c3a32626ac83">
+      <statement statement-id="cm-7_stmt.b" uuid="28cb523a-0175-44c2-972e-cbb34e905615">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3462e4ef-325e-4899-80b5-ddc57b3a676f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2764,10 +2764,10 @@ https://issues.redhat.com/browse/ACM-367</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8076b64b-936c-411a-8a66-d3290a2ba059" control-id="cm-7.1">
+    <implemented-requirement uuid="1eb8e85e-d77d-4b52-8056-c92d4cde2e75" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="2518b162-91c2-438c-b693-18df32607ab1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="74b7ba1a-2903-4382-b463-0e518636f63d">
+      <statement statement-id="cm-7.1_stmt.a" uuid="cef486bb-3ad8-4023-8b7e-c1bcd2b80824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ff4da6d-0aa9-4c97-8645-52f997a136e2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization reviewing the information system per organization-defined frequency to
 identify unnecessary and/or nonsecure functions, ports, protocols, and services is
@@ -2775,8 +2775,8 @@ an organizational process/procedure outside the scope of Red Hat Advanced Cluste
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="ee167c4b-7bdc-48b9-9b75-ef2c1c05df61">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bba550ec-4f1d-4108-b762-d97c20c665a7">
+      <statement statement-id="cm-7.1_stmt.b" uuid="b555d7ae-73f6-4a3a-a013-8f23296e6d1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbe5722e-0a9d-433b-86da-610c2175f8c9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization disabling organization-defined functions, ports, protocols, and services
 within the information system deemed to be unnecessary and/or nonsecure is
@@ -2785,10 +2785,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="045ad84e-29e1-4a8c-8e94-89f8f36c2e02" control-id="cm-7.2">
+    <implemented-requirement uuid="e344609c-61c2-4054-bab6-2c0663fb95fc" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="8ea89710-e975-4029-860a-4cd07c6e63ec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fdf45ae8-66e7-42e4-9d97-de7fb6d33669">
+      <statement statement-id="cm-7.2_stmt" uuid="809e7c7b-3277-41fb-9233-3639738bd864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="97405f6c-4ff8-464d-8aaf-7b5f88712aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2797,10 +2797,10 @@ https://issues.redhat.com/browse/ACM-368</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ab5e494-2c2b-4b54-9b29-10a43ba4f34f" control-id="cm-7.5">
+    <implemented-requirement uuid="d92fabfd-8644-42d2-ac4d-6bbbe39b0df1" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="6669756e-8c80-451a-9e2d-fcdd0f4c40a0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6e833935-7572-43d9-a0cb-75a69f448a70">
+      <statement statement-id="cm-7.5_stmt.a" uuid="35e3c77c-1244-460d-970a-a43b5774881f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0ce7ff33-77bf-472f-8f86-0431dbe19b99">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for identifying organization-defined software programs
 authorized to execute on the information system.
@@ -2810,8 +2810,8 @@ to provide authorized software support in allowing authorized applications from
 running on the cluster and in a container through allow listing methods.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="bdbbd731-4741-4f31-a5cf-a0fd8fea128b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1423b8a2-ba9e-411e-b8a6-204b4c1eafe3">
+      <statement statement-id="cm-7.5_stmt.b" uuid="02866c42-5125-4eae-8ca3-1f6ecb689511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec0f9591-6a43-4237-b61c-a7aeb4c202a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for employing an allow-all, deny-by-exception policy to allow
 the execution of unauthorized software programs on the information system.
@@ -2821,18 +2821,18 @@ to provide authorized software support in allowing authorized applications from
 running on the cluster and in a container through allow listing methods.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="d8aa5472-872c-410d-8a5c-256957f09e4d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aff5adeb-748a-4e52-8e84-f4e98adc99f6">
+      <statement statement-id="cm-7.5_stmt.c" uuid="95252faa-256c-4113-9ed2-d9437668739e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46f3dac3-8610-46df-a19e-93db96a65cdf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for reviewing and updating the list of authorized software
 programs per an organization-defined frequency.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3151652-e6db-4504-9eb3-a8fd164638da" control-id="cm-8">
+    <implemented-requirement uuid="b8130d75-ef47-4fd6-88de-d3de4c957d55" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="dd8a2cfa-28dd-4f45-870f-5201d6b842a2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="76160c9a-c284-460f-927c-232055c7d0d7">
+      <statement statement-id="cm-8_stmt.a" uuid="4b7997c4-b95c-4da6-b56d-328df955facd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2840,8 +2840,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="d82a5324-21e8-4172-bd70-a19e3eba1ccf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="053e98eb-0c3b-4a94-b3ae-4fcb0425caae">
+      <statement statement-id="cm-8_stmt.b" uuid="e13c5af3-18a5-4196-9749-c50c638c94d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a6456ed-2298-4914-bf83-46210cc7f98b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2850,10 +2850,10 @@ https://issues.redhat.com/browse/ACM-369</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f3cc199-943d-4c6e-9ff5-069f578d4b5f" control-id="cm-8.1">
+    <implemented-requirement uuid="9fe36fbf-f7f2-42b4-9d2d-389f0f796e9b" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="0d26710a-e301-4b91-b3d4-25895c500761">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="45d69ef7-394c-4319-bd29-78cdf4920f38">
+      <statement statement-id="cm-8.1_stmt" uuid="2302c565-4ac2-4bd8-82ac-35841670fde6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f87ffde9-a4ba-472d-8283-9c918606a35c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for updating the inventory of information
 system components as an integral part of component installations, removals,
@@ -2865,18 +2865,18 @@ the Operator Lifecycle Manager (OLM) operator.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78f0d862-d1b1-4a22-9aec-5511023a1988" control-id="cm-8.3">
+    <implemented-requirement uuid="b1a4fb12-f627-4e35-8547-689a4f1f0ade" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="6072362a-640a-44c9-9620-442f999383d5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="275c4ffc-a176-454b-81ab-503d93b59488">
+      <statement statement-id="cm-8.3_stmt.a" uuid="085de839-f1b8-4149-8c61-97229df41658">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58fc2fb1-9eef-43c0-8520-ae9eab6f2f2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for employing automated mechanisms per organization-defined
 frequency to detect the presence of unauthorized hardware, software, and firmware
 components within the information system.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="f1899f76-c51d-4abd-a47b-7c15338aa7ef">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="59fd0cb7-831c-4284-af08-d73f61fdcfeb">
+      <statement statement-id="cm-8.3_stmt.b" uuid="c12bb9e0-d4cf-4da0-b7fb-c4641c152f3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c619c8d9-7502-45e2-b2e0-213f7121f772">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for taking the following actions when unauthorized
 components are detected:
@@ -2886,10 +2886,10 @@ components are detected:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0f5710b-078b-4c7e-9339-559f1cd2d511" control-id="cm-8.5">
+    <implemented-requirement uuid="3bb1d332-05d6-4735-9fcf-28e24573cb73" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="905192c5-37c0-41c8-a721-df06addbe34e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6afa1fa8-21bc-4cba-a2af-8c677f984931">
+      <statement statement-id="cm-8.5_stmt" uuid="f401ed70-e67b-4d53-ab5b-4db95b45623f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d6be519-fb3f-4566-8036-c3ffb0bc3f40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -2898,41 +2898,41 @@ inventories is outside the scope of Red Hat Advanced Cluster Management configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dd63a2e-ae6d-42f4-9b37-660c0476f045" control-id="cm-9">
+    <implemented-requirement uuid="0acf0ab9-64c8-4cce-93f6-398147c7822c" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="51bcf17b-daf7-42ed-96bb-e81ac5069553">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4315bccd-e2cc-40f4-914e-f25a69ae9c40">
+      <statement statement-id="cm-9_stmt.a" uuid="2699f6ad-fda5-4efc-9972-b75232ca1f52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="757b80b8-e033-40bd-a1c1-ddb187505116">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="53190456-db37-4461-81ab-3d02936af52d">
+      <statement statement-id="cm-9_stmt.b" uuid="974d06f4-3038-4099-9964-6a277153baad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="2adf1b03-f648-43f4-9a43-a97caeb78dbd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3d0f019b-8c1e-4e20-8f27-52b1897d0ca3">
+      <statement statement-id="cm-9_stmt.c" uuid="c302619e-cb73-4e2f-87f9-a5cd5eada43c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="78fe90ec-e65f-4864-a6dc-2dafef2458a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="01ea713a-5b25-4c31-8abe-21b41c668168">
+      <statement statement-id="cm-9_stmt.d" uuid="66a8875c-21f7-4ea3-839c-78b7430e54dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ddc6b8aa-512a-41fa-89e8-f50086fd02a9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Advanced Cluster Management configuration guidance.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46d9fd64-9bda-4f7e-81d9-f3e2df04c349" control-id="cm-10">
+    <implemented-requirement uuid="d2ed696b-72fe-4c1e-a30e-6e0b4dd715dc" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="c8e1e1db-9df4-42fa-a8e5-fe49e036b2d0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6aba96c7-2245-41e9-b0f5-085ccd5309ee">
+      <statement statement-id="cm-10_stmt.a" uuid="c204f5be-2ae0-4e05-8073-f7a8f059fa95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2940,8 +2940,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="fb68eac1-a3a7-4c9b-8831-6d9529d8423a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="47058eab-2274-466f-a12f-13c28ceb7530">
+      <statement statement-id="cm-10_stmt.b" uuid="0d44fe12-5465-48b5-bc36-ca6c8b6b90ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1032ae9-8cd9-4a2e-b9e6-1998164f35ce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2949,8 +2949,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-370</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="2369353e-f967-4e83-b6d5-6a69cbba72b5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a0a816e1-10de-4b9a-8abf-c746311458ee">
+      <statement statement-id="cm-10_stmt.c" uuid="5a6b0389-ea77-4714-9d3e-df2a16349d58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2c0c71e4-b352-4edf-9457-d61b459c03a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling and documenting the use of peer-to-peer file sharing
 technology to ensure that this capability is not used for the
@@ -2960,20 +2960,20 @@ of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0afbe0f-cf71-4da2-ae31-e57ff9e35ec4" control-id="cm-10.1">
+    <implemented-requirement uuid="7fae52bc-7ac0-41c6-9e39-16df109935ad" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="c7cfc497-3134-4a53-a802-b5c53cba1511">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ef36c14a-ae8c-44c6-a0d4-8483fc2e12f0">
+      <statement statement-id="cm-10.1_stmt" uuid="b1ec6f62-6086-41f9-b45b-d097b6837dca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76b3e3d6-0eb5-4d4b-abe7-59ff3fe5eb3e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Advanced Cluster Management configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50711ad2-d99a-4eae-995b-5c845b02e437" control-id="cm-11">
+    <implemented-requirement uuid="f0a92b60-8313-455d-b277-ad4aee766be4" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="614b51a1-bfe1-44ca-8d7e-9bad7523edfd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0ef91e81-b2a1-44da-8429-12b99f88cc2d">
+      <statement statement-id="cm-11_stmt.a" uuid="8943b6ab-a43a-446e-9f27-4101bcbb7a8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2981,8 +2981,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="7612c72d-4d13-4db2-af1f-098f60ddbad0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b6213e32-b02b-43f3-add1-933aa72398cc">
+      <statement statement-id="cm-11_stmt.b" uuid="4a42ee86-9eea-454f-ba92-9007a155c8d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2990,8 +2990,8 @@ tracked via:
 https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="c1d76295-a276-49b6-b36f-b74e3f55b924">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2837b052-5f33-483c-840e-6deda9dd2d72">
+      <statement statement-id="cm-11_stmt.c" uuid="072b5c4c-0b3c-460a-a682-9ceff1672f00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0ec7ce0-3494-4a97-aa51-e76894b31e7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3000,17 +3000,17 @@ https://issues.redhat.com/browse/ACM-371</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e47656b-aaf1-498e-88c3-edffcf8d1043" control-id="cp-1">
+    <implemented-requirement uuid="5d89307c-fcba-42e8-a63c-7321194df6e1" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="b62a7b32-7e81-40e0-aee6-c39881886c10">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0d27a22b-52dc-4f66-baf0-55d3da6f3d97">
+      <statement statement-id="cp-1_stmt.a" uuid="1bf1c075-f91f-4e45-8630-64c74b536c9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="e168de81-a51d-49f2-ace7-d517da169756">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="376b3b61-077c-403d-abd0-e340fe3a739c">
+      <statement statement-id="cp-1_stmt.b" uuid="fdc67e19-0880-459a-9c0a-8e7d819f9981">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c68ccf8-7f70-482d-a507-7df58cddbd66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3018,55 +3018,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cc66a60-6924-4c48-af6b-c9858ee9fafc" control-id="cp-2">
+    <implemented-requirement uuid="11c62a0f-f3c4-4e2c-abb4-adf83b38a3fd" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="2a99147f-6564-4456-90a5-89977a306746">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5e20cb06-4d53-405e-a6cd-2d302918035a">
+      <statement statement-id="cp-2_stmt.a" uuid="a84d8f70-d8b4-4f6a-85e5-4b07593f1470">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3015270-fb69-4a81-bfd1-60e0b3bd631f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="50d869fa-8bf7-4d01-a6cb-fe465a3e5248">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d831eccc-ae1a-4b1b-b52c-e7b4804dacb7">
+      <statement statement-id="cp-2_stmt.b" uuid="e18ca0c2-6176-4438-8caf-fee362ffeee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="849bf386-2a30-4d64-9583-39030ec78388">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="a3252457-f49b-4abd-ba7a-87e3d248c9a9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="92180504-37cc-4e4f-a7c5-3772eca9f87b">
+      <statement statement-id="cp-2_stmt.c" uuid="b6f9e6e9-f6f1-4174-8eab-d7748772bca3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e898768-5605-432d-b28c-df65f38fc1ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="a6a7b8b2-5c26-4eb2-8f9d-df804eae075a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9a57763d-1d47-44cc-b98f-675086567516">
+      <statement statement-id="cp-2_stmt.d" uuid="434ce3b2-0158-40a4-b8d9-bf42c632739f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1740afb5-c728-496c-a5b0-ec2baa4fec28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="80001c7f-34d9-4aa3-96be-100fd467eb3b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="53a7da69-5e74-416d-97c1-eb8e077f280c">
+      <statement statement-id="cp-2_stmt.e" uuid="34788329-aa5c-411e-a1b9-b7ca0efb4c73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f230f99c-b3e4-4d24-b559-1da764fec833">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="d3d9a8db-eadd-49e0-95fd-880099320af3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="27100f21-ec6a-48e2-b7f9-2c7345461e88">
+      <statement statement-id="cp-2_stmt.f" uuid="85109794-b537-4232-b40c-a3845c065b9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c18bc9c4-74bf-4870-a918-18c8527a7649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="36bf7744-a7d7-44de-970a-f8c89db9a3b2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a286e26d-5f55-4b92-965a-2f944126ba29">
+      <statement statement-id="cp-2_stmt.g" uuid="035392f4-c3ed-42ec-bc2b-de34fa140b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="397a9793-a389-47c6-b6e7-395dbb57b613">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3074,10 +3074,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3702972d-b3c0-4b62-ae36-189e277690a1" control-id="cp-2.1">
+    <implemented-requirement uuid="76831693-481c-4cee-891a-297941e7c6ea" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="767d651f-08e0-4b90-b79d-3d46b4c429cd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4302dd92-3c39-4ccc-8c97-3f8493041a56">
+      <statement statement-id="cp-2.1_stmt" uuid="7b1452fe-e16f-4007-887a-4e521b570561">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="409fb1e3-9c83-462c-acf9-2cfd90e8c49e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Advanced Cluster Management
@@ -3086,10 +3086,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db50dfdb-1a6f-4fd1-8357-a38063a60d0f" control-id="cp-2.2">
+    <implemented-requirement uuid="48f42b75-b4d7-4533-aa88-4d8106319a5e" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="dbdd331a-561b-4070-931e-5d31c9e543ee">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f47ce49b-5260-4910-8536-9e8017d11f46">
+      <statement statement-id="cp-2.2_stmt" uuid="1ce6a377-4f80-47fb-9f98-1ccb1e547ff3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="353e3e92-ef37-48d9-a9d8-86864628c36b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -3099,10 +3099,10 @@ https://issues.redhat.com/browse/ACM-373</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6afb7e4a-c23d-4955-80c1-1e07a9cb495d" control-id="cp-2.3">
+    <implemented-requirement uuid="e1421c7a-01bd-4604-ac0f-73cccfe36ff3" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="a0ff5c01-c6b2-4d57-9427-f3b8dbbdde01">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9b391969-0587-4ded-8b1e-06779ec2fea2">
+      <statement statement-id="cp-2.3_stmt" uuid="fd162305-bad6-4974-afba-5bd750961fc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a134b77-9c44-4623-a092-1daf98fb7f81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3111,20 +3111,20 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f54ba43-d330-49df-99d6-757a76c63969" control-id="cp-2.8">
+    <implemented-requirement uuid="9c322598-1051-4c4e-aa07-91df1930c819" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="3c4e9df0-7395-4613-b7f8-2950c02d86b4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="364f623b-1838-4687-ab31-530de003f449">
+      <statement statement-id="cp-2.8_stmt" uuid="57ce58f8-b40f-4258-9d2c-d5c650b7d491">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae263a8f-7449-4308-9666-0ca4729a2536" control-id="cp-3">
+    <implemented-requirement uuid="d7726a10-26e1-40f1-b3df-d3cc2fbdc12e" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="544aa464-bed4-4ace-b836-7bbfdd73117a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5e3992ef-4690-4bc9-a0d3-88de423f7cb6">
+      <statement statement-id="cp-3_stmt.a" uuid="43e18881-4cda-49eb-981d-5565ad5cf5f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b68b2d-f9ad-4603-a627-c390d6207f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3132,8 +3132,8 @@ time period of assuming a contingency role or responsibility is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="42b52c10-2162-40c0-983d-6243402d9c2d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="07a37a6c-8f0e-4849-b18d-b1e54f8d04ae">
+      <statement statement-id="cp-3_stmt.b" uuid="61cdce07-2078-4888-a636-0efc0ec77b98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4ee3bc0-f404-4c27-8321-75ba15125726">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3141,8 +3141,8 @@ system changes is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="c375ab2b-76c3-4109-afa8-b049f05c07e8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e7c96e6-802c-49dc-ba4a-e19b3edc1293">
+      <statement statement-id="cp-3_stmt.c" uuid="35a2eb77-eec3-4d12-b4bc-a7a2af6bd0df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78771afd-c818-46ce-b95f-5005d1227925">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3151,10 +3151,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9fb5f3d-b4f6-4ec7-a63e-b36423d695c2" control-id="cp-4">
+    <implemented-requirement uuid="1fa0d7ae-5369-4255-ad14-0cf27e6553f1" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="8a1c0ba9-cb69-4102-be7b-4e9341d44850">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a3a13a8f-261f-4bc7-9db8-1578724df2d1">
+      <statement statement-id="cp-4_stmt.a" uuid="dfbb243f-8b6f-4ff1-9ecb-5e6c92fa29bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c19e5d23-30d2-412a-869f-936c964e9aa5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3163,25 +3163,25 @@ readiness to execute the plan is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="42767e72-5844-42cb-a2bc-c77f38dc5ad8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f1dfb15c-1631-4ced-a2cb-517957005f48">
+      <statement statement-id="cp-4_stmt.b" uuid="23e54280-9fc0-4e6a-b638-a9101ab658ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="735b0a4c-85ff-4a56-a37a-1d98bee952e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="b5fefe39-b7c2-46a5-9877-664ff49ef4a4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f3aafc3c-38de-4024-8226-4278ae5e9f60">
+      <statement statement-id="cp-4_stmt.c" uuid="93f8964e-ade9-4166-b97f-eea1360ad93c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="594d0868-fb2a-4f85-b5ea-4bb04dcc00af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93d63966-76dc-4bde-bce3-13084100e5dd" control-id="cp-4.1">
+    <implemented-requirement uuid="12575e08-268a-4053-a44e-eaeadbba9e51" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="b377e5a7-54ac-4d1f-807c-7a97be465407">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="65711ca8-1e72-457e-91ff-8db7ebf85763">
+      <statement statement-id="cp-4.1_stmt" uuid="672427c9-1dec-466e-ae09-97c04936193f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57021a96-c3e7-409f-8168-aac348dc14ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3189,10 +3189,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6be1be0-b389-4662-b67b-390f90618763" control-id="cp-6">
+    <implemented-requirement uuid="32d4c240-6b73-40c3-8e1f-2371bf2cd16c" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="ae657624-5b10-477c-8bf1-f0a3095b51d4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9cc34014-afb9-443a-b683-33be7bcd5dc8">
+      <statement statement-id="cp-6_stmt.a" uuid="62deccc3-3c15-40e0-b92e-b2d35af21899">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b8aeaeb-7920-49e4-a075-9bbe51eab52c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3200,8 +3200,8 @@ of information system backup information is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="4e510a54-69bc-4fc8-925c-20149d427b09">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="982a9a1a-6724-4fd3-bb41-32d3ac9c5110">
+      <statement statement-id="cp-6_stmt.b" uuid="59d52f4f-a39e-4a18-993c-17aa03205ed6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33264ae2-bd6c-40b0-8f71-da948db1a710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3209,10 +3209,10 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08a280d1-fdcc-4d5f-be83-f4561949028d" control-id="cp-6.1">
+    <implemented-requirement uuid="88217ea5-874e-466e-813a-93ab0b2aa49f" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="b3d542f4-471b-4abb-8fb3-6d1d58f84c1d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2b1901fc-f4a3-4ab6-91c0-488ca84b5110">
+      <statement statement-id="cp-6.1_stmt" uuid="20584f5e-78ce-4c75-adad-02c80d123efa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2575d1fe-aa7f-40f7-ac96-4edb911f947a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3221,10 +3221,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e8f8ebf-4f2b-4206-9ba0-112479007478" control-id="cp-6.3">
+    <implemented-requirement uuid="ea6cfde7-446b-458d-85b9-0ef1e928055a" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="6ce8f032-2501-495f-83ac-18b09a0eb8fd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="79bfeed4-be46-407b-bcc0-e62b1d523a35">
+      <statement statement-id="cp-6.3_stmt" uuid="dee4cd32-d0b8-432d-8392-c99e47a06dfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c5a5077-53af-4e4c-bef7-dc28b6a55b0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3233,17 +3233,17 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5aec34e-3b6a-421f-9d3c-44582b637e4a" control-id="cp-7">
+    <implemented-requirement uuid="7dca179b-5858-4e27-a86e-4a3111c8ee00" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="e7c35013-be12-4ca4-971e-d76b74d1768c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ccdabd20-a7e4-4fbe-9dbd-fc221e6e4a5f">
+      <statement statement-id="cp-7_stmt.a" uuid="72673866-9001-4557-9a2d-c5b7d2ff9771">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="0cba3bfd-fd01-444b-802d-9d8ef4d40269">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b01a741c-a982-480b-abe3-c27f2b1f3300">
+      <statement statement-id="cp-7_stmt.b" uuid="937a0b02-31aa-4850-9045-abfab49f0554">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="684ef428-96df-4911-a28e-3fe0da611e04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that equipment and supplies required to transfer and resume
 operations are available at the alternate processing site or contracts
@@ -3253,18 +3253,18 @@ organizational control outside the configuration of Red Hat Advanced Cluster Man
 Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="f7f045dc-6544-4584-b401-7422a798ac8b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a0a02fac-10ed-4e36-8f55-4778e548d2b1">
+      <statement statement-id="cp-7_stmt.c" uuid="44457aac-178e-455e-b05d-20e96d062c18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab455280-b89b-4ac9-8dc8-6abca32ba72f" control-id="cp-7.1">
+    <implemented-requirement uuid="5bac4361-75cc-47f6-92f3-857de3e4e31d" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="8803ed7c-7d01-43d3-932a-c305b182cef1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="eec5718a-8c97-4fc1-a539-5cc5728a6eac">
+      <statement statement-id="cp-7.1_stmt" uuid="ecd6c7d7-4cad-4af3-b82f-c418e26fe910">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5938fe8f-6218-4412-9de9-e85c41c6f6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3273,10 +3273,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24408250-6ba8-429f-85db-273d3a9c657d" control-id="cp-7.2">
+    <implemented-requirement uuid="1dd09133-c120-4e89-9dfb-1853498bb535" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="c2576c89-49b6-485c-8011-b06787de2c83">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f4b23865-6842-4cea-949e-cb7357cef5ad">
+      <statement statement-id="cp-7.2_stmt" uuid="cd68be50-cb1a-4e44-acf0-87aee57d13b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d71aad49-c607-4bb1-be8a-7358ebffb596">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3286,10 +3286,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ddb09e64-de06-458e-83c4-96de5ea5cd58" control-id="cp-7.3">
+    <implemented-requirement uuid="d987f837-e8e9-4bb8-8249-9678aa579b1d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="3596cedd-c2a1-4b6a-af40-d2c8f3b679cd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7a680672-94d5-4f89-bee4-418a905cd0fc">
+      <statement statement-id="cp-7.3_stmt" uuid="e691926f-43ab-453d-8bae-77912e7180f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="26ddeac3-0a15-4039-a1d5-406d9c8f709e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3298,20 +3298,20 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03ce701e-e2f2-4b45-8f3f-5f7922c41696" control-id="cp-8">
+    <implemented-requirement uuid="68ab531a-2f09-4e04-9ee8-d88dd9db911d" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="12d5b5bb-f33d-4059-bcca-96dfa39790ac">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9ad5a36d-c63c-4ccd-ac4a-01978346b776">
+      <statement statement-id="cp-8_stmt" uuid="47bc43c6-56fb-4c11-a2d3-06912f98043e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a21ef46e-67bc-4c3d-806a-1dc80e1fb28a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ac24b39-7381-43bd-a4fd-ca667cd448d5" control-id="cp-8.1">
+    <implemented-requirement uuid="1b74fcb7-c19a-44a6-928f-284a5bec110b" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="86576781-818f-4fb1-b169-a3564b41e03f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f608cf75-5b9b-49a1-808c-c510839d4314">
+      <statement statement-id="cp-8.1_stmt.a" uuid="f290cce3-91be-4f8a-8567-d08fb200f5c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39887fe4-9c3a-4817-ae8b-f759d9dc32bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3320,8 +3320,8 @@ time objectives) is outside the scope of Red Hat Advanced Cluster Management for
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="5054bc8e-d0a9-4b50-bb26-360f17845ad1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d094ec48-52f5-4995-bbee-6bb6a9126123">
+      <statement statement-id="cp-8.1_stmt.b" uuid="542ba68e-4407-4aa8-909c-bde5099ab5e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="803113d2-952a-41dd-9f92-1313bd741c18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3331,10 +3331,10 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93dba018-7ea9-41b4-8c1f-0188923b78a7" control-id="cp-8.2">
+    <implemented-requirement uuid="4eabc6d5-e9f9-42cb-aabf-84f982d25b15" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="6546005a-094c-49e6-b3cd-bef717822a7c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="08c4b0a3-1fd3-46ee-aab5-e96e9c6ce6f0">
+      <statement statement-id="cp-8.2_stmt" uuid="9844759c-bc36-4676-aa67-3586ce5ee6b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="509d23bb-d5e7-4d92-a2b3-4808d8242118">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3343,10 +3343,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="182e0d2b-6fdf-4879-803d-d7987fb2c0a0" control-id="cp-9">
+    <implemented-requirement uuid="fec472c4-1589-4e1d-8a69-3ca9d061a9f8" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="f9932c15-7446-4204-b0ae-099f47fb1cfb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aeca2b5a-5d38-48c0-907f-7c718cf3c50e">
+      <statement statement-id="cp-9_stmt.a" uuid="db2f5394-8ff0-4521-bbea-025b27b87ca5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21491395-89e7-468f-a092-40db18acd64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3362,8 +3362,8 @@ a centralized identity provider is an organizational control outside the
 scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="e766df95-8188-4742-8c5d-7bbaa7577be9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2aff883b-8495-4abe-bd08-25c013595d4a">
+      <statement statement-id="cp-9_stmt.b" uuid="fd4db9c4-afcb-442a-a405-e71ceda7c02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4bd1f00-0443-4329-b52c-e9c1b8f1c1b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3379,8 +3379,8 @@ control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="448e6a38-0cc1-4033-b4d5-d9ec999b4bf0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7c40f3f3-f284-4722-abbb-f8a01bb0f417">
+      <statement statement-id="cp-9_stmt.c" uuid="45309e62-9dc2-4f5a-b2da-2e6544d065de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98cbd01d-34f7-4052-ba01-45667bf85f9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3391,8 +3391,8 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="5020e8d6-b0aa-4323-806b-f71025ec1e82">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="96f9e1b3-be47-4be8-b789-10a5a3bccef3">
+      <statement statement-id="cp-9_stmt.d" uuid="9ad6beca-4b76-4ad1-9e69-d865051bc5a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2239660-ea6d-4404-99ac-d8705981d473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3408,10 +3408,10 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d720a50-64d5-4601-8afd-99051bf03b31" control-id="cp-9.1">
+    <implemented-requirement uuid="cfb4a2f0-ece1-4b69-9410-9b9ae76ac701" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="998fde6b-bf26-401c-81e7-57a945e4c6d1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d30dd8c8-80bd-4897-8a84-5efc2742e86d">
+      <statement statement-id="cp-9.1_stmt" uuid="70710f1e-3008-4f12-abda-05de087517fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2258e8d5-e2f7-419c-affd-8cc39dec7d3d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The testing of backup information to verify media reliability
 and information integrity is an organizational control outside the scope
@@ -3419,10 +3419,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81e28cb4-042d-43fd-946c-2d6227ed049f" control-id="cp-9.3">
+    <implemented-requirement uuid="a48c0fa9-7454-4929-8bbf-dfc2ad8d9b96" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="514feaa1-529c-4bf6-b3db-5f3eeee67f4b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="172c1faf-1a7f-44b8-a342-ce5992c03b1c">
+      <statement statement-id="cp-9.3_stmt" uuid="5e5931eb-e295-43fb-ba48-df4d9a18425b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="feb28f0b-ca1f-4f4d-9d28-d8e247fa0105">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3432,10 +3432,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f99fe7ce-bf0e-4be4-a755-1054b34567b2" control-id="cp-10">
+    <implemented-requirement uuid="2e3283e1-329e-4162-bf29-d4e3126e42e6" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="11be0217-6e7d-41b4-9bbb-f54e77165989">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7ab96fa2-4b5c-4336-868b-c4ca63dea735">
+      <statement statement-id="cp-10_stmt" uuid="c1b5e152-3add-4732-88c3-5df00b1d4d7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2df5ba56-c93c-4b4e-9691-bfc0ace314c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Advanced Cluster Management for Kubernetes environment. A successful control
@@ -3444,28 +3444,28 @@ Management for Kubernetes environment.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e1588b-dfb7-4b79-8332-fbf6df4f17c7" control-id="cp-10.2">
+    <implemented-requirement uuid="3c3c63d2-8a5c-47a5-98ce-f4fbbe4f20e8" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="d6f8ccd2-6cbb-4783-9a5c-15b453e52008">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="10e6fa3d-b5b7-4973-87f3-c35f000a2f39">
+      <statement statement-id="cp-10.2_stmt" uuid="1b464d3f-2cce-46ad-a410-7deac057195a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a74480c-f269-4b50-888d-5cf95c744762" control-id="ia-1">
+    <implemented-requirement uuid="36fc9605-761a-4aa5-aa4a-fd84c82053fc" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="ca770af4-0d0f-4cf0-b9df-59e50a28db41">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="da019cdb-efac-45fd-a8a3-9d8661f8ed9d">
+      <statement statement-id="ia-1_stmt.a" uuid="cf609d09-28bc-4a20-97e1-d98ca638d155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393d5912-7a1b-4110-8ad3-fc49b152819c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.1" uuid="66641133-2358-4730-a756-69690fca0358">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c0c213ea-8dde-4e79-9f0b-b31bdb6ccba8">
+      <statement statement-id="ia-1_stmt.a.1" uuid="789a9860-a58c-45ea-b3a8-313fa0e13136">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="edba927a-c814-49fe-8c04-ff0c10424628">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An identification and authentication policy that addresses purpose, scope, roles,
 responsibilities, management commitment, coordination among organizational entities,
@@ -3473,8 +3473,8 @@ and compliance is an organizational control outside the scope of Red Hat Advance
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.a.2" uuid="7b20d2ef-9ee1-41d2-a3f5-5ce12b6f09d0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="921a0786-959c-4fbe-8fdd-e97440cc9ec2">
+      <statement statement-id="ia-1_stmt.a.2" uuid="8ab56ad8-0bd4-49cc-893f-e209dc583aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="748fc141-4383-4293-bba9-cf7826741c15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the identification and authentication
 policy and associated identification and authentication controls
@@ -3482,24 +3482,24 @@ is an organizational control outside the scope of Red Hat Advanced Cluster Manag
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="c930ed6f-1759-4a82-ac4f-1f151dc515a9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a055dfe1-9fc3-4ae2-b0e1-564c76a4fd54">
+      <statement statement-id="ia-1_stmt.b" uuid="26b903e8-b266-4924-b37a-8f0861172a9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f9cb66a-f50e-4bb7-ab29-7b634d4309d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.1" uuid="817cef2a-5449-42e2-a9d5-5d17f91b61b0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c53b3f6b-4ee1-4478-8c18-95458bb406ec">
+      <statement statement-id="ia-1_stmt.b.1" uuid="eda88c29-1ff5-458c-8b80-a417b8228841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4abe27-7c28-40f8-b37b-0bd096de234d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication policy is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b.2" uuid="e1aa71e6-de7f-4b48-8199-2f41a3c737cf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="419ba846-692e-4468-a94c-c34f33c854bb">
+      <statement statement-id="ia-1_stmt.b.2" uuid="ec20ebe0-88c2-4cc6-96c1-5b38b97d9968">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c07e8de5-a0e9-47c9-a078-1c50109032ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current identification and authentication procedures is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -3507,10 +3507,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cc495c6-e10d-486e-8a82-770c1a1a163e" control-id="ia-2">
+    <implemented-requirement uuid="6a4e724f-263f-43f3-9729-9c8ea63514cb" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="73bd4e3d-9afe-4c65-84b6-95b7d652c7a4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="760c8204-742a-439a-8b8a-dcf4db26d112">
+      <statement statement-id="ia-2_stmt" uuid="162c972c-1af8-4c4e-b17c-349af061b17d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3521,10 +3521,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad50bcbf-3e4c-4fa0-a975-f78614703459" control-id="ia-2.1">
+    <implemented-requirement uuid="3c240960-c351-40a6-b2a4-a1e32a79afd1" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="9bbf38b7-2063-4e66-ae85-21abbd9dbfe1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9eaea66f-78e0-42a0-99de-8838dd58c330">
+      <statement statement-id="ia-2.1_stmt" uuid="e18e8632-5d36-4387-8b08-fb985282ab8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3535,10 +3535,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fe34b5a-cd41-4c3d-9ca3-bd7258a60835" control-id="ia-2.2">
+    <implemented-requirement uuid="c932829a-e011-4891-87a1-0eec3d4aec19" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="96afe714-f9c3-487a-9f02-26b41ab1b436">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1c0680ea-a173-47b1-b92c-d1c4707d200d">
+      <statement statement-id="ia-2.2_stmt" uuid="8ff22189-d8d1-43cc-afb9-7742620205b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3549,10 +3549,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91903f0c-aede-4966-a685-9c43df462060" control-id="ia-2.3">
+    <implemented-requirement uuid="641e39d6-276f-4f4a-85b0-0c0738574b10" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="6ea64b1c-f70d-41da-811b-e55a52dddf21">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="18351c5d-a9db-4bc8-8660-b32c6f6f9c67">
+      <statement statement-id="ia-2.3_stmt" uuid="f48e8ea9-20a2-4637-b7cd-e345d3663976">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3563,10 +3563,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aaacb3ef-eb2b-4b1d-9bdd-7922b9785b5c" control-id="ia-2.5">
+    <implemented-requirement uuid="ca68cc56-407d-4504-aac2-6cd5f0045191" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="79b45a08-8e0c-470c-a5da-28ebe40135dc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7ed7efe5-992e-4b5f-a879-180cd21fdf4d">
+      <statement statement-id="ia-2.5_stmt" uuid="fbc3df07-a142-42fa-b039-d5b43cd4b5c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3577,10 +3577,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="860c5dcc-4c50-431d-a965-079aef743074" control-id="ia-2.8">
+    <implemented-requirement uuid="b68ea6b1-f488-4173-85b2-3da985f97e73" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="85c95573-7a81-4c35-9e3a-f8697ecb327e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="441713a8-0314-4c4e-bf12-7da3b186a0bc">
+      <statement statement-id="ia-2.8_stmt" uuid="18245bab-c3fe-4457-ac7a-68f7fcb4b39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3591,10 +3591,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e00bbd2-6feb-480e-ac64-cfaf4da2c9f1" control-id="ia-2.11">
+    <implemented-requirement uuid="71c2233a-671c-4607-b95a-f0bc869d6405" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="1b497fb0-b0c7-4ced-a82b-031671b27080">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e5046763-891f-4466-8e79-3428747774c7">
+      <statement statement-id="ia-2.11_stmt" uuid="5a253ee2-4463-4b3c-8fb4-b31274886fee">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3605,10 +3605,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f946d54c-49db-4efc-b093-a75c8f11e079" control-id="ia-2.12">
+    <implemented-requirement uuid="4501f960-57c6-4dad-81f0-d60c4c694d6c" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="b884c059-7b4a-4979-983d-4db73b6ffd2c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="69010085-933d-4e6a-8fa4-1a10c08610e9">
+      <statement statement-id="ia-2.12_stmt" uuid="204fce8d-b288-418d-806a-cb177bf47091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3619,19 +3619,19 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62cf46fc-4f36-4eec-963a-b6fc6b319535" control-id="ia-3">
+    <implemented-requirement uuid="23e22f3c-9aa0-4cbf-9ad1-823f9dcf2926" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="3a6b8ea0-5533-463a-9173-a667cf28f3ff">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c1ffce8e-efad-4c24-b245-4f11b78d1bf4">
+      <statement statement-id="ia-3_stmt" uuid="b0106689-c877-4dd2-b7fb-48be934113bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4094f41b-39e5-4be9-a5c0-2b03948cd290">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for IA-3 is planned.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62a38def-705a-44f0-ac63-177b6c03b955" control-id="ia-4">
+    <implemented-requirement uuid="3b7e2336-a2fc-4c93-abff-cfe316af78ca" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="e6e4fde7-53ca-45ac-801b-318871cbf44e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8628b6f2-07d4-4ebe-8f92-1262afb22b77">
+      <statement statement-id="ia-4_stmt.a" uuid="956405cf-6586-4af5-83d0-ca267a6d897f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc183fe8-bb35-4cc4-8727-634f92deb444">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving authorization from organization-defined personnel or roles to assign
 an individual, group, role, or device identifier is an organizational procedural
@@ -3639,8 +3639,8 @@ requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="0b68cc03-6c1b-4190-86cf-7599d53adbab">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1d1af5de-8a6c-476e-949d-ba6412749508">
+      <statement statement-id="ia-4_stmt.b" uuid="49d43cd4-1e4e-475a-92a4-88ae451ab482">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2230bb0b-2181-41ee-8168-57e5e9754791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Selecting an identifier that identifies an individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3654,8 +3654,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="bc4d64e4-f2a6-4360-b87a-bc9a21b9faaf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aa13e0b0-08ba-4c95-96b1-79a228647a45">
+      <statement statement-id="ia-4_stmt.c" uuid="a99ba3ee-7060-4ee7-9cac-e8dcb1e35f5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="16e13bdb-c71b-41be-b43f-d677d7fbef35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning the identifier to the intended individual, group, role, or device
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3669,8 +3669,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="acd21e12-cb98-4fc5-a683-55c641149978">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dcdb7a05-8cac-48af-b142-09c8356ea6f1">
+      <statement statement-id="ia-4_stmt.d" uuid="bd53f8e0-2baa-490d-b35f-cfd55fe18014">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f1be769-82de-492d-8cf4-b3e0f08d2e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing reuse of identifiers for organization-defined time period is an organizational
 procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3684,8 +3684,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="edd7d557-c0a7-4e5f-9679-d62fa45f8cad">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8b0715ca-f371-411a-9122-19929969324d">
+      <statement statement-id="ia-4_stmt.e" uuid="f395857f-0985-4aa5-80f1-08859ab23603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4fb2e15b-d2df-4392-bf93-095644224c53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disabling the identifier after organization-defined time period of inactivity
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3700,10 +3700,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="858d02b9-5137-46a0-b3be-eef0ef50717d" control-id="ia-4.4">
+    <implemented-requirement uuid="c78aec61-a021-4d55-bbfe-958672079e87" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="9567e138-ccc3-4ab0-932a-99919b39b96f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="98d6a222-4bc1-4703-b457-856fe546ceba">
+      <statement statement-id="ia-4.4_stmt" uuid="e97a8371-46e3-478c-bebb-9f56b8004e10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0f8031f0-f9be-45e7-b1c3-bddedbad2dbc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization manages individual identifiers by uniquely identifying
 each individual as an organization-defined characteristic identifying individual status
@@ -3712,10 +3712,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b21cdb2-4eb7-4929-86e8-24aa1059e128" control-id="ia-5">
+    <implemented-requirement uuid="265bbbe5-6012-4f0b-98f3-ac0f0d0caabb" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="67f0c2ab-5059-42ce-942b-cab3da2db422">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fe2e8697-f346-49ad-9041-a88b03b27d15">
+      <statement statement-id="ia-5_stmt.a" uuid="0eb4ddac-916b-4bbd-a20a-8048259facc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13d72afa-d441-4373-8afd-67699887a6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verifying, as part of the initial authenticator distribution, the identity
 of the individual, group, role, or device receiving the authenticator
@@ -3724,8 +3724,8 @@ outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="c6b4662c-3e78-4d6a-ba7b-fd93b8fa0b77">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fc9c462e-7413-4b01-86b8-ccf977915e77">
+      <statement statement-id="ia-5_stmt.b" uuid="2342220c-0d99-48d2-b27d-7f8c11acd128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2e3e436-8413-4ff8-8dc3-390795606ce5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing initial authenticator content for authenticators defined by the organization
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3739,8 +3739,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="d5e4c992-5d6b-47b1-9d7e-46d6302e0d12">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d80717a1-768a-4b63-b8ea-d9002bb3e748">
+      <statement statement-id="ia-5_stmt.c" uuid="c05a851b-49e9-473c-9fd3-b2f9d747468d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab69c0d4-d7f0-4b2f-9765-59abe70b49c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that authenticators have sufficient strength of mechanism for their intended use
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3754,8 +3754,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="f4682775-e986-451f-a4a8-6559d90dd40c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1eccff72-9edc-4012-b04e-1f4372b86125">
+      <statement statement-id="ia-5_stmt.d" uuid="9e482f09-b15e-4f27-900a-115b03c2ada5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb468c08-e46b-4a87-90d7-1a74a4f9b2c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and implementing administrative procedures for initial authenticator distribution,
 for lost/compromised or damaged authenticators, and for revoking authenticators
@@ -3770,16 +3770,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="9d798ed1-16da-48bd-96db-298462f51c35">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="64c2ca4c-053f-4a9b-9ec7-7e6a65147409">
+      <statement statement-id="ia-5_stmt.e" uuid="2e7a4efa-6dc2-466f-87f3-2bdadaa24503">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b86ca812-e136-48d6-8e5b-bf1c0dd4fdfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing default content of authenticators prior to information system installation
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="f5e6b436-5781-4926-81c3-a2d2c4656c7e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="55be77d3-f28f-4b74-8e01-78d035bda2b2">
+      <statement statement-id="ia-5_stmt.f" uuid="54e797f3-6ccf-495a-b007-55422183d904">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87585da0-88d9-4846-bd0a-5474bc47b4c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3793,8 +3793,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="2aaf2ac5-0784-4cc8-8d39-ca96b40a5571">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d444b2cc-36dc-4eb7-beb4-99b39147907c">
+      <statement statement-id="ia-5_stmt.g" uuid="96667bec-cb90-4b27-b4d4-b688f8f5548c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2b0d11d-4985-4ae8-867f-246e2e38b3f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing/refreshing authenticators by organization-defined time period by authenticator type
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3808,8 +3808,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="a6de5ce4-96f2-4e60-97f1-7277dc14d9f2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4f383e95-7456-43ca-99c6-601d264d9bb5">
+      <statement statement-id="ia-5_stmt.h" uuid="566c4239-0ba8-4637-9a1b-0e367a33b808">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45f712dc-0a01-4159-90c9-1645587ffc6e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting authenticator content from unauthorized disclosure and modification
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3823,16 +3823,16 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="b49b8606-24b9-46c7-af6e-c588bc72fc9a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="78072016-eed9-4333-8af1-3d7b472f4a53">
+      <statement statement-id="ia-5_stmt.i" uuid="2aa2e02f-3e59-4431-a53a-6cc4928d33b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b590118c-ff62-4109-ac1e-af0d7f72200a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="ac70bff8-eda1-4eb2-a5de-01651495e829">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1f5313b9-053c-4770-a78a-f3f56aca0778">
+      <statement statement-id="ia-5_stmt.j" uuid="2e55020b-a7e2-46bb-8718-650c6fa84427">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cac92e2c-d40c-40b6-98f8-387d4166365f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing authenticators for group/role accounts when membership to those accounts changes
 is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
@@ -3847,10 +3847,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7581c3d8-fcfc-42b9-b312-98f9b6611987" control-id="ia-5.1">
+    <implemented-requirement uuid="843cd7f7-3c91-468c-8133-8154d72fd572" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="2d668eaf-8f18-488f-9e51-21acb3f0ff93">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="86c18526-3961-4532-a08b-e79cc86b24e8">
+      <statement statement-id="ia-5.1_stmt.a" uuid="b36b57f1-0da7-4b49-9dc4-3090d542e914">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e277b16b-df3a-4d18-b9ac-3e358b0a27f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
 number of characters, mix of upper-case letters, lower-case letters, numbers, and special
@@ -3865,8 +3865,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="d7e73d05-f08a-4ba0-8ced-566559049bcc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8b60b774-e872-441a-a0b3-6826943effc9">
+      <statement statement-id="ia-5.1_stmt.b" uuid="05a4aa2e-3727-40e9-bbfa-b42196a24986">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="749a8823-7ea0-454d-805c-5f14111f539a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing at least an organization-defined number of changed characters when new passwords are created
 is outside the scope of Red Hat Advanced Cluster Management
@@ -3880,8 +3880,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="68b03b8a-2cfd-4d19-b24c-43ce468e5ff4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7afd16f7-2d36-4c14-a271-29b07cee6bb3">
+      <statement statement-id="ia-5.1_stmt.c" uuid="675e2c54-d959-44c1-a159-3eb07b727a18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="147fade7-a31c-46bf-9458-87b74cc33323">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing and transmitting only cryptographically-protected passwords
 is outside the scope of Red Hat Advanced Cluster Management
@@ -3895,8 +3895,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="6d6c36e8-fb0b-4417-9da6-8aebac5f53c1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e547208-96c9-4e24-a73a-81a6d34c08f3">
+      <statement statement-id="ia-5.1_stmt.d" uuid="ab6f04ac-c266-425d-a68d-2b6125259dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff725e3c-9cab-4d6f-86d1-89512be1db88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
 lifetime minimum and maximum is outside the scope of Red Hat Advanced Cluster Management
@@ -3910,8 +3910,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="111d9524-e8d2-486e-b34d-2f7878c881eb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2d97b5a0-3f34-488f-b95c-f27decc9a826">
+      <statement statement-id="ia-5.1_stmt.e" uuid="da41ab94-07c2-4138-8286-633977639ff3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fdcbfc-cd31-4062-9075-c3649ced9f7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Prohibiting password reuse for organization-defined number generations
 is outside the scope of Red Hat Advanced Cluster Management
@@ -3925,8 +3925,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="17c125cc-ab9f-4c88-aece-91d0204d4c55">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7c2e304d-73a1-413d-ad99-0f61285aa0d1">
+      <statement statement-id="ia-5.1_stmt.f" uuid="b16315b7-ff09-4cf8-b46b-4ebc4827c3c7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43f8ae77-bbff-45d1-9a26-2c46568196e4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of a temporary password for system logons with an immediate change
 to a permanent password is outside the scope of Red Hat Advanced Cluster Management
@@ -3941,10 +3941,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff27d92e-aded-4cb0-978d-eaa50f6b5e74" control-id="ia-5.2">
+    <implemented-requirement uuid="5d7b02e4-5421-4b3d-82ec-e9901d226d72" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="af738380-e2c2-4ce5-bbc8-578f0e5d5724">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7bd05b6a-4b56-4f8d-b77f-fb3885b5cc9e">
+      <statement statement-id="ia-5.2_stmt.a" uuid="d5459896-f2be-4d27-9558-994e1061291e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3954,8 +3954,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="59dfe796-ade5-4e96-b04e-72099b13d12e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9388a72e-5793-48c0-889b-e4314a15168e">
+      <statement statement-id="ia-5.2_stmt.b" uuid="0839b2c4-4a2d-4b6d-897d-44ea9aefdb1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3965,8 +3965,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="87dcc9ec-9db2-4fd5-9e9a-1c59f7b082ee">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ff99853c-f945-4c4b-8067-2b29df33079f">
+      <statement statement-id="ia-5.2_stmt.c" uuid="ae70c50d-43aa-4494-b675-14f4a2aa8363">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3976,8 +3976,8 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="4914e4fc-4da1-442c-b4b1-0b18e459893c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="39249042-ff88-4f08-bb52-2afa7dc892a3">
+      <statement statement-id="ia-5.2_stmt.d" uuid="77ad8082-0c4d-4c62-a426-51e42bba90f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -3988,10 +3988,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="793f918b-50d5-408d-aba7-372959fb7e55" control-id="ia-5.3">
+    <implemented-requirement uuid="75470eb5-ee40-49e6-bc7c-edb902adfc09" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="5e867218-07d9-4aee-8cc0-cb9ba597b464">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b18d11c8-7851-41e8-adf1-92aa58c73cca">
+      <statement statement-id="ia-5.3_stmt" uuid="886abe09-c4bc-47c5-ba3b-972e0036aa3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bbb90a3b-f770-4bba-b0e2-8dcb718f63be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4002,10 +4002,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cab37f31-b159-4c57-9729-7278c8ddbd1f" control-id="ia-5.4">
+    <implemented-requirement uuid="95a864b9-bcf8-42ac-a31c-68fc921e0c01" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="cc5b67ef-a662-4fd9-adf0-68f338bdd885">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4a83116f-4d19-4cc8-a697-8c81ea2b1ff0">
+      <statement statement-id="ia-5.4_stmt" uuid="0f1f6ee1-b000-4338-8e76-68220026357f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4016,10 +4016,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ae5221a-d019-4d8c-b6fa-727ad17fce71" control-id="ia-5.6">
+    <implemented-requirement uuid="b59d07fd-2af2-4fa0-9a4d-5f1b7d5f0d83" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="bc79b222-f077-4aa3-a8e6-fc8320250d15">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ade2569c-709b-4334-882d-a3af872cfc9c">
+      <statement statement-id="ia-5.6_stmt" uuid="fa3f5314-e96b-48ae-b625-5ffe2a2b6c9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76659440-64c4-4e73-818d-f60d84062eb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization protects authenticators commensurate with the security
 category of the information to which use of the authenticator permits access
@@ -4028,10 +4028,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1b5ab19-4b55-4220-8fdf-b44eadcd3d31" control-id="ia-5.7">
+    <implemented-requirement uuid="8520b60a-a92f-479a-8325-e3f6822d94cf" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="71b077a5-dc85-4789-86e6-50c586cefb44">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e42d0716-cffd-4021-9d3b-7a7b1ecd0cc4">
+      <statement statement-id="ia-5.7_stmt" uuid="8afbe54b-4d3f-43b5-82ed-72ae6e71f49a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4042,10 +4042,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bcb5d52-792b-46d6-8c03-c97f3eb43fa2" control-id="ia-5.11">
+    <implemented-requirement uuid="0ef7576f-e66e-44ec-8b1b-71fad3011062" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="92854d7a-b4f7-4881-ad23-58b27ecc38cc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6e644cee-efe8-4c16-b6f1-47349e2626af">
+      <statement statement-id="ia-5.11_stmt" uuid="8283a521-2085-4088-8db4-ad9d30e7c0bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1076d1db-258f-4a24-8819-8a454d268091">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of mechanisms that satisfy organization-defined
 token quality requirements is outside the scope of
@@ -4053,20 +4053,20 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eaa158aa-3129-42e5-add5-4856d2e6dabb" control-id="ia-6">
+    <implemented-requirement uuid="584d5061-9946-4ade-9e7a-b7c9fc24fcf9" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="f9471e88-2ff1-489b-ac32-4296d6834ef1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d343fd08-39e0-44bb-92da-8b842fdd42d7">
+      <statement statement-id="ia-6_stmt" uuid="19ea4177-7de6-4e00-a9e1-390db0e1cc84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffa2f7af-7974-4fb2-b968-8f27f77cd7ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Advanced Cluster Management for Kubernetes session key and account login
 passwords are obscured by not being displayed on output or by asterisks.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79acd2a4-783e-4fe2-b774-e2561c1319e8" control-id="ia-7">
+    <implemented-requirement uuid="7b05aab3-651e-4c16-aee9-5f5cb58513b9" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="db37db02-e52b-4071-853c-b1fd6e151e81">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f102a560-d5ac-4f75-a8a0-7fb4716b7bc2">
+      <statement statement-id="ia-7_stmt" uuid="b33fcaa7-f0ce-49e1-a782-d5311d91ec4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4077,10 +4077,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26c28d0d-39a2-4023-a139-7cae93e0a3cc" control-id="ia-8">
+    <implemented-requirement uuid="15dd3aa2-0356-4f5d-8200-d30f8256d773" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="7888db04-2cbf-4779-aaed-ff8d0a12a20e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e448c0f9-c86f-427a-9ffb-2e05f2851fe2">
+      <statement statement-id="ia-8_stmt" uuid="384de7fa-27c4-4f40-a6a2-6cf58c00a1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4091,10 +4091,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75808fb4-4233-4344-bb2f-7962fecaf76c" control-id="ia-8.1">
+    <implemented-requirement uuid="922dcaf1-78dd-4dc9-9a7a-fc83d03cd39d" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="e23373a5-0b9b-40b7-b160-ddbffd392c9c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="838962a5-963e-4ff8-9a58-32f62fc073e8">
+      <statement statement-id="ia-8.1_stmt" uuid="2b939949-8825-4a80-8ba9-dc6f5241d760">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4105,10 +4105,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c205d429-f36b-4664-afdd-57a87cd055ea" control-id="ia-8.2">
+    <implemented-requirement uuid="582b2033-a58b-440a-bb7b-842a64c8e6ab" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="3db4b568-d8a1-44d3-b0d5-d9f2be9994c9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2ef3acdf-f99b-4453-87e8-01475b1f57b8">
+      <statement statement-id="ia-8.2_stmt" uuid="cb36cefd-7292-48a0-8850-aff4e257b77d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4119,10 +4119,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c14ff31-3b23-4e42-83aa-d7c5b872623a" control-id="ia-8.3">
+    <implemented-requirement uuid="246f5842-7f1e-49d0-a393-d6aee19949a4" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="d681fa39-0365-4d19-955c-ca62bd440396">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5a922a44-b155-4e99-ba22-a61ed48903cf">
+      <statement statement-id="ia-8.3_stmt" uuid="f32e9b5b-4cbd-46bb-a794-d9cf1a55c8cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4133,10 +4133,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04cd0523-f437-4175-92b3-afd5c59aaeb9" control-id="ia-8.4">
+    <implemented-requirement uuid="903874b7-4e6c-4a85-928b-6d9a96084e0b" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="a0d7f414-450a-464b-8999-eb271de19ce7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="125e1968-fb98-48e7-ade2-a016a1509e88">
+      <statement statement-id="ia-8.4_stmt" uuid="055f41bc-d4f2-4c99-b487-8ac2a3e1e401">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fba70161-1529-4286-95da-fbe6dd061976">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for identification and authentication.
@@ -4147,10 +4147,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6aa4828b-9cec-4e3b-8afe-a25823578fad" control-id="ir-1">
+    <implemented-requirement uuid="e9254f4c-c4e8-418f-bd54-3412a87ddb77" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="af264f93-8389-4cdc-85e1-77426f42facc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="26c93f37-36cb-454e-a6f0-e7ef507c114f">
+      <statement statement-id="ir-1_stmt.a" uuid="2e19fb0a-b243-4978-b25e-a6dbdd4cb2b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c15b72c-d254-49a5-92c0-55715caf39c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles of incident response policies and procedures is an
@@ -4158,8 +4158,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="1e43e00f-0c73-4d2e-8972-ba98ad612294">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1c844305-1ebb-4ab9-831b-f440a4b9ada6">
+      <statement statement-id="ir-1_stmt.a.1" uuid="4c891716-7c1b-44e5-9b2a-57b135457102">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f612b7e1-3d6a-4556-8aaf-e7f2d977b4bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles an incident response policy that addresses purpose,
@@ -4169,8 +4169,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="dd98a5bf-c6f6-4dad-a2da-837993b3de73">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c9d80a3b-cb1e-43a4-93c7-53cd4854f124">
+      <statement statement-id="ir-1_stmt.a.2" uuid="b0a371b6-f0ae-495f-a1eb-2e735999acfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a042372f-1c80-4116-adb6-fda1b41ec201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and dissemintating to organization-defined
 personnel or roles procedures to facilitate the implementation of the
@@ -4179,16 +4179,16 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="3376649d-1b71-47e8-88c2-14de429688e8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7a639935-3e6c-44e2-bb35-6b37e2e71d87">
+      <statement statement-id="ir-1_stmt.b" uuid="edd9c3eb-d4e3-4df4-8722-bb310cd34222">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3b3f0a9-17e3-460c-8777-c47f43a9dd74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating incident response policy and procedures is an
 organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="60a9f189-a9fe-4bf6-99cc-53392b3cb6c5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="158d98f4-64a8-463c-b90c-7d0d3d40d9ca">
+      <statement statement-id="ir-1_stmt.b.1" uuid="39db6397-b221-422b-81ef-53daa7817782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e7fda435-0b22-4225-aa3d-5c11d7eb2b0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response policy on an
 organzation-defined frequency is an organizational control outside the
@@ -4196,8 +4196,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="b0395780-8351-4c3e-876b-796f68da7d94">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1159350a-b6b8-46f7-9b72-356ff0e2ab01">
+      <statement statement-id="ir-1_stmt.b.2" uuid="36560876-f8de-4ffa-8d36-af3c67f649c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de30e301-2ced-49e8-9acd-6bc32d3ac131">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current incident response procedures on an
 organization-defined frequency is an organizational control outside the
@@ -4206,10 +4206,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ab28171-5794-483c-b1c0-50d08aa85ac9" control-id="ir-2">
+    <implemented-requirement uuid="a15791af-da74-408d-8450-fdabec814d43" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="3b79f9fa-d5eb-4574-a779-2aa97af0db1a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6ee00f8a-ea6b-41f0-bc50-f13777385c7c">
+      <statement statement-id="ir-2_stmt.a" uuid="d0ea58f3-d80e-4734-aec8-dbc72e2dbc20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eafdb258-f903-4d7e-ba22-9e608d95ecb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities within an
@@ -4218,8 +4218,8 @@ or responsibility is an organizational control outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="1a00cb2e-e1b3-4863-a62d-9db300536c16">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="29a514c1-9b18-4b0b-a0e7-fb3539bca35e">
+      <statement statement-id="ir-2_stmt.b" uuid="7a3fc29a-b3e6-4ba1-969b-4d919175c9e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="709f8fbc-2302-4992-ac8c-8735d21a7224">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities when required by
@@ -4228,8 +4228,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="f4d65fda-ce3d-49df-9263-226652e1763a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0f3cacaf-7030-4333-9ec8-a33e6a0a859e">
+      <statement statement-id="ir-2_stmt.c" uuid="1c37f0f9-5821-44e5-a513-d090941546e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cea18629-49b6-4cce-8db2-0cf050b88697">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing incident response training to information system users
 consistent with assigned roles and responsibilities on a TBD time
@@ -4238,10 +4238,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="397bd1cb-8022-46ee-9bff-b0477e5cee71" control-id="ir-3">
+    <implemented-requirement uuid="5fe91210-3ad7-4b59-b11e-4b50f1b8f556" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="1f11cfc4-3347-430b-937a-91a8cebd60eb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9651dac2-15dd-4ac4-a51f-8c0d7d7f7b25">
+      <statement statement-id="ir-3_stmt" uuid="19edf186-549c-4bf8-8965-5045bfa4a58e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10f32706-e44f-49be-8b7a-695b071a6235">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the incident response capability for the information system on
 an organization-defined frequency using organization-defined tests to
@@ -4251,10 +4251,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b994054-1928-4b1d-b118-4906a28b4ea7" control-id="ir-3.2">
+    <implemented-requirement uuid="fd32563b-889b-4e7c-82d3-39bef4a0e873" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="9b4b9491-dda3-4802-b062-257bb0c066e5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2beae723-c6cc-4430-959a-cc526fb66e07">
+      <statement statement-id="ir-3.2_stmt" uuid="994526cd-4483-43fc-8908-637aab69cf62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23179ad5-4db8-4be7-b47e-a05edbd02d7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating incident response testing with organizational elements
 responsible for related plans is an organizational control outside the
@@ -4263,10 +4263,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02ca35b6-76de-470d-a4dd-c20dd924c2ba" control-id="ir-4">
+    <implemented-requirement uuid="265c7809-fc7e-4390-b429-9780daa3bda7" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="53d92235-cf8d-4fb4-8699-f64eef56e9eb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3a0bac1a-2e64-4af5-abc4-e89c108ba76a">
+      <statement statement-id="ir-4_stmt.a" uuid="6de145d9-7b86-4d6a-aee3-c1c7e7803aab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="19a22a0b-bddf-4faa-8ea9-be2b0974f2bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing an incident handling capability for security incidents that
 includes preparation, detection and analysis, containment, eradication,
@@ -4274,16 +4274,16 @@ and recovery is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="8e11664d-1cec-4ebc-8b5f-26dd7674a6c1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="22397586-a940-4e46-8eb4-e13d24aa617d">
+      <statement statement-id="ir-4_stmt.b" uuid="293ce7b1-ff84-4d9c-b8df-803e4aeedc76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c1d81b1-e794-4734-8733-0a934a977389">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating incident handling activities with contingency planning
 activities is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="5fb40f24-3016-4c58-9e52-fbd88b49642f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4b8bd6af-e297-49a0-9b30-554148af94e2">
+      <statement statement-id="ir-4_stmt.c" uuid="0a6e430e-4502-48d8-994b-538997e10a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe23a19c-6c01-41c3-929f-7c8fe05e7724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating lessons learned from ongoing incident handling activities
 into incident response procedures, training, and testing, and implements
@@ -4293,10 +4293,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d3f4404-73a8-4f0c-81fd-0c9a2a4a5919" control-id="ir-4.1">
+    <implemented-requirement uuid="84e95595-1884-4a1a-809b-22f6e1189e64" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="dfb66ee4-b979-4df9-8a64-265637828c4f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ea4ef7a5-4cd0-4b3c-98d5-a4172cd0883b">
+      <statement statement-id="ir-4.1_stmt" uuid="6b82ce3b-6930-4529-84c7-95d15ed03051">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fac86649-d5ec-4e81-a6b5-366c12292299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to support the incident handling process
 is an organizational control outside the scope of Red Hat Advanced
@@ -4304,10 +4304,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf873e23-7401-439c-97d8-5ffd392ec4fc" control-id="ir-5">
+    <implemented-requirement uuid="f0383d76-28c0-45e7-8319-4e58a63abf89" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="b3b8c3aa-37fd-4a97-989d-daeb48410f4a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2af4850b-a649-45e2-9639-97200bd60e5c">
+      <statement statement-id="ir-5_stmt" uuid="d79d2e79-08a0-4132-bb51-6640123337a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f419747-33f9-4dcd-b671-a38a0487db60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Tracking and documenting information system security incidents is an
 organizational control outside the scope of Red Hat Advanced Cluster
@@ -4315,10 +4315,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82ef2fb0-054c-4c2f-81fa-fcd1b9a9a326" control-id="ir-6">
+    <implemented-requirement uuid="15b4e51e-95e6-444c-91c2-38df890f012a" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="85b87bb0-dc4d-41ca-902a-192cdb30ca4b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b1035901-aa44-435b-8580-08a125f8cce0">
+      <statement statement-id="ir-6_stmt.a" uuid="35dfa24e-455a-44a2-88b0-fc4b2bdc0b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9724fc04-f64e-463c-aa7c-cb4cd7ef23e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring personnel to report suspected security incidents to the
 organizational incident response capability within an
@@ -4327,8 +4327,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="14d2fafd-43da-4ca1-b29f-5e4a6ffccdb1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="176b5f58-e2e4-475b-86ae-caa04cdfefc4">
+      <statement statement-id="ir-6_stmt.b" uuid="6d39bf4d-93f3-4d29-ae7b-4776103b9584">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ad30abe-b363-4997-a990-56bd4b0d2a46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting security incident information to organization-defined
 authorities is an organizational control outside the scope of Red Hat
@@ -4336,10 +4336,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="379ac085-1caf-41af-81df-b54c808a35ab" control-id="ir-6.1">
+    <implemented-requirement uuid="4e07f6d1-b043-4cc6-8279-a7881a860bb2" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="c0d7c0b2-f58c-4c76-b281-b3d7bb95b204">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f5330dd-39e0-4632-b8b5-84b5a91ed1a5">
+      <statement statement-id="ir-6.1_stmt" uuid="596ae1fc-3c86-4899-94a2-9297c2000dc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="27c17396-6e7d-421e-af32-651ab113be30">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to assist in the reporting of security
 incidents is an organizational control outside the scope of Red Hat
@@ -4347,10 +4347,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5124871-e319-4c3b-a671-d7e9318e20ca" control-id="ir-7">
+    <implemented-requirement uuid="ae856240-505a-4b8d-8c8b-6d9c6a2f9b77" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="8315dcbc-672b-489d-8f7d-fe2912ad32c6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fa8f6abd-76cc-4642-8754-d3dbe8c7f027">
+      <statement statement-id="ir-7_stmt" uuid="b84e786e-ffdd-4e75-a08a-a3756bd47da1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab5b2742-c274-4906-9724-73db577f414a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing an incident response support resource, integral to the
 organizational incident response capability that offers advice and
@@ -4361,10 +4361,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3dea9576-65dd-4dc4-a7bc-82717ebb0c3b" control-id="ir-7.1">
+    <implemented-requirement uuid="51be95e1-e369-4baa-ae88-e321e0e8f2e0" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="5fed7510-da4c-4db8-996a-4ba63ce7ea14">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a1967213-a89e-4600-bdb7-05ade6891db2">
+      <statement statement-id="ir-7.1_stmt" uuid="9c23e1af-4162-4013-a7be-058da770e376">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c31820af-03e7-496f-95fd-9bd9db8c25ed">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing automated mechanisms to increase the availability of incident
 response-related information and support is an organizational control
@@ -4373,10 +4373,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee3b46bf-33a0-438b-a2e7-13d55ce26045" control-id="ir-7.2">
+    <implemented-requirement uuid="05a3a6d1-2f0b-4619-9d5a-cd5a6f84fef2" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="212e45ce-35fa-4d06-b69f-1ee203831fcd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0ac20428-cebd-4619-8470-4b29e1f3ee2a">
+      <statement statement-id="ir-7.2_stmt.a" uuid="dec6579e-7924-4804-9d24-0199baec3fa5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ae0414b-c1a5-418d-bcfc-ec1803f5a452">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a direct, cooperative relationship between its incident
 response capability and external providers of information system
@@ -4384,8 +4384,8 @@ protection capability is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="8d672dac-1412-4b36-abb3-57580f346866">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d888793c-dc99-4dfd-b8cf-e6f3753c77ba">
+      <statement statement-id="ir-7.2_stmt.b" uuid="d82c321b-c221-4df4-994b-efd49e6a2a1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b6eeafa-e5e6-4aa0-9d08-af8a45033d3b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying organizational incident response team members to the
 external providers is an organizational control outside the scope of Red
@@ -4393,18 +4393,18 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="440c89d0-19f6-40cd-babb-8fba9578aa4a" control-id="ir-8">
+    <implemented-requirement uuid="49acd465-9d15-4a96-8f07-ba73e146c21c" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="37599036-f95b-4b68-b490-62da9f9e4eb5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="25590c57-2f28-4014-9661-fd467b007bca">
+      <statement statement-id="ir-8_stmt.a" uuid="f8965741-5603-49e3-af65-1d659f54ce7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9c2255d-be43-4916-b2a1-2ec4545adaf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The development of an incident response plan is an organizational
 control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="648633e7-6bee-4af6-bf91-d50de1e7f41f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="25e8ee10-784d-46af-aacb-38673df3b46f">
+      <statement statement-id="ir-8_stmt.a.1" uuid="6a896184-1927-4bad-aa83-85d46f80e335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e97bf89b-5b19-4be2-89c5-71e395ca99c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides the organization with
 a roadmap for implementing its incident response capability is an
@@ -4412,8 +4412,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="14c0c435-f44e-4093-885f-4a58be404c2a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="af66456e-9c7f-4743-9e1e-7c43a5db21d4">
+      <statement statement-id="ir-8_stmt.a.2" uuid="bfed941e-cd44-4c6c-9ede-3cbb9c0cf335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="35f4b1c0-c930-4494-9e1d-10b5cc502a2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that describes the structure and
 organization of the incident response capability is an organizational
@@ -4421,8 +4421,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="1fd145a2-7014-4613-976d-7bff2c270ca1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b9dd892a-f584-499c-9be8-d8b5a186bbb7">
+      <statement statement-id="ir-8_stmt.a.3" uuid="995382ba-a9d1-4436-ab78-cdc74c7b869c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa50678c-feac-45b8-9d04-c5b15e42ea8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides a high-level approach
 for how the incident response capability fits into the overall
@@ -4430,8 +4430,8 @@ organization is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="09a39bda-87ca-45a8-b470-1eeb843a3068">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7fcece0a-5ad1-44d5-af38-154f6e7252be">
+      <statement statement-id="ir-8_stmt.a.4" uuid="5f3a186f-2239-4197-94e6-881c17aadd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d268ee8d-5af1-44a1-82e8-e229f663e4cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that meets the unique requirements
 of the organization, which relate to mission, size, structure, and
@@ -4439,16 +4439,16 @@ functions is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="4a4cee76-8abe-4ca3-af42-fcac12296c32">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6ec55203-36e4-4862-88ca-116eb9a20867">
+      <statement statement-id="ir-8_stmt.a.5" uuid="a04aac7a-4837-4615-a218-ba5036fe90d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a376441-33f6-42ba-b42d-573d7d61f23b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines reportable incidents
 is an organizational control outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="ef081618-04c9-472a-850e-08dca635b798">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5e1c7bbf-5ade-4574-b066-815dccfa80cf">
+      <statement statement-id="ir-8_stmt.a.6" uuid="42df1525-94f7-4f76-a393-7f54353468f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea7560b7-39dd-49ba-9db7-7c0db486421b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that provides metrics for measuring
 the incident response capability within the organization is an
@@ -4456,8 +4456,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="7d77ecb8-5bc1-49ef-91a4-355a21332d32">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0deb44ac-1581-4a22-a7a8-b333bf762e40">
+      <statement statement-id="ir-8_stmt.a.7" uuid="a41628b2-c5e2-4a61-bd79-b673113ecdc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b644290c-37dd-4108-bbbf-7d7fce8c7896">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that defines the resources and
 management support needed to effectively maintain and mature an incident
@@ -4465,8 +4465,8 @@ response capability is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="83f35eff-333e-4603-a8a5-d412c71385e2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="933cbe28-a856-417e-8efa-55854a9d8706">
+      <statement statement-id="ir-8_stmt.a.8" uuid="dd7a765e-6f70-47ea-8bfa-6f08f1d7ace4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdef4f08-aa76-4a99-aaf7-054945ac0d27">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an incident response plan that is reviewed and approved by
 organization-defined personnel or roles is an organizational control
@@ -4474,8 +4474,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="97e30124-99fa-4f3c-83e9-f1cc0a2791d9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="106d83db-60a1-4077-ac8a-0f28536b1a6d">
+      <statement statement-id="ir-8_stmt.b" uuid="c6e28213-ecfd-4592-8a64-8e7504cbb040">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9d8235-d089-4c09-b019-7406facd972f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distributing copies of the incident response plan to
 organization-defined incident response personnel and organizational
@@ -4483,16 +4483,16 @@ elements is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="810c74cc-c361-4b77-a271-ae557a23e444">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dfe762ee-c204-43d5-9c87-ff0fa6e6dab2">
+      <statement statement-id="ir-8_stmt.c" uuid="27d959fb-0e24-4369-99c2-52ce1811a973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d850403-75e5-4b1b-b494-d70b03c03b40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the incident response plan on an organization-defined
 frequency is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="9a0778f1-564a-45bc-a6e8-3d449d536dda">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="396e974b-0bf7-462d-a4ba-89aaf27fc2d1">
+      <statement statement-id="ir-8_stmt.d" uuid="6585a985-8ab0-4b01-82f8-c8c294e9d4ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0b9823c-fff1-4de3-bdb6-59a79905784a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating he incident response plan to address system/organizational
 changes or problems encountered during plan implementation, execution,
@@ -4500,8 +4500,8 @@ or testing is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="80e7d5c8-384c-405f-850a-3f26c564c766">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0094d1b5-4d25-4fae-b4f7-e7945a4c93fe">
+      <statement statement-id="ir-8_stmt.e" uuid="6f9441f0-de94-439f-8988-4042e6827f16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befbacf0-182f-4f92-8e7b-23c4d64331bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Communicating incident response plan changes to organization-defined
 incident response personnel and organizational elements is an
@@ -4509,8 +4509,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="68d2c418-506e-4003-b815-4a0188f1712a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d1dc918b-e8f3-43ad-8371-63d2d8877dc7">
+      <statement statement-id="ir-8_stmt.f" uuid="50f96740-c6e7-4edd-a0c3-1b20022f457e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6749410e-7c77-400a-9447-cc1b7ab43744">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the incident response plan from unauthorized disclosure and
 modification is an organizational control outside the scope of Red Hat
@@ -4518,10 +4518,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cd01d1f-2ea4-49a1-9852-9c4c5f1aa67f" control-id="ir-9">
+    <implemented-requirement uuid="98b98827-0cf7-403d-be20-13b2aa21e684" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="175d77e3-9997-49f3-a9c2-dc9913c8b4e8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e84ebc66-1207-40a6-8513-907432710573">
+      <statement statement-id="ir-9_stmt.a" uuid="60d227bc-31c8-4afb-929d-ae4192e47146">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b421293e-ee50-4a6b-91e4-158fa3744172">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by identifying the specific information
 involved in the information system contamination is an organizational
@@ -4529,8 +4529,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="15993e08-7179-4902-bc72-e3f739101f81">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c4e1cad6-e753-4099-bed6-3b7144cf92a5">
+      <statement statement-id="ir-9_stmt.b" uuid="55aa3c25-b7c9-4e4d-97bb-a566887a2b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d55fc4bb-4596-4334-83d8-320cb93449c9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by alerting organization-defined
 personnel or roles of the information spill using a method of
@@ -4539,8 +4539,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="9c6822bc-f83c-4c3a-bfe3-e47ce0f4352e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="82eb6617-9eed-4398-8e31-0bc13b635c0a">
+      <statement statement-id="ir-9_stmt.c" uuid="cbadfff8-7d76-4d87-aee3-4ad745601930">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0898d7e-b63e-4fa2-ad9c-86a45f3ea4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by isolating the contaminated
 information system or system component is an organizational control
@@ -4548,8 +4548,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="eff127cf-b57e-4ca3-b682-75d9c2b316c0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="04c383e1-95d5-4149-97f4-728e0716d677">
+      <statement statement-id="ir-9_stmt.d" uuid="b2d5dd70-0e8e-4439-bf8e-250f7f516bc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bfa0460-18b4-4c21-a1a6-1f1ee454e13f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by eradicating the information from the
 contaminated information system or component is an organizational
@@ -4557,8 +4557,8 @@ control outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="cfe2de01-7b6f-4c50-9bf1-4c460ccd960f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6a674ff2-f88b-4b56-b921-7ab531f9c146">
+      <statement statement-id="ir-9_stmt.e" uuid="49d9240d-a8d6-4a80-9b78-d5834c271fba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04020748-d4ce-42c4-82f8-f8de764e9732">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by identifying other information
 systems or system components that may have been subsequently
@@ -4566,8 +4566,8 @@ contaminated is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="2498c03e-d5d8-4282-8ae0-4bc965989a13">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="068342cf-c7ec-465a-a84a-204e8ea5c218">
+      <statement statement-id="ir-9_stmt.f" uuid="24199734-1f3c-4565-af76-40991b3b95e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87d1ad3a-83b8-4de2-bc7d-4ef82d028dc5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Responding to information spills by performing other
 organization-defined actions is an organizational control outside the
@@ -4576,10 +4576,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d4b9d38-8537-437a-8339-2322863187a4" control-id="ir-9.1">
+    <implemented-requirement uuid="abebdf7c-86f6-42fb-b3af-a66fffeb2f62" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="59c72392-1797-424b-8534-6751a49e5655">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2bc6fdcb-dddb-4bb2-998c-5c4acb44f9cc">
+      <statement statement-id="ir-9.1_stmt" uuid="661ab6b4-9978-47ba-b6d6-ebedd98eba88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8644d696-55b0-423c-a449-826f8485de22">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Assigning organization-defined personnel or roles with responsibility
 for responding to information spills is an organizational control
@@ -4588,10 +4588,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="963f67a0-8958-46d8-bfeb-9cb7c7eedfa8" control-id="ir-9.2">
+    <implemented-requirement uuid="9d631431-12bf-469c-9285-e2db3fc49bd6" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="d5c0c6c3-b7f7-4dd5-82d1-ce1263e49b76">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e91f27c9-dad1-45e0-9e3d-86b6d3a1f5f3">
+      <statement statement-id="ir-9.2_stmt" uuid="568d3a79-504e-4ff4-9c58-23fa53b3d557">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38d5838d-0dee-4dda-949c-7c4f1f723d37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing information spillage response training organization-defined
 frequency is an organizational control outside the scope of Red Hat
@@ -4599,10 +4599,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="378d047e-d708-4f5b-84fa-07bade5a2e3a" control-id="ir-9.3">
+    <implemented-requirement uuid="519efcc8-6a50-4127-bba2-1b89b88399d5" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="7810eb4b-3cdc-481d-8dd5-bc922118feec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aa992bbc-243a-4112-a0d9-a14bc4f184df">
+      <statement statement-id="ir-9.3_stmt" uuid="ea197bce-ee86-4494-a3f2-526ca19424a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a37c4a9-030a-4426-9034-cf7f74ad912f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined procedures to ensure that
 organizational personnel impacted by information spills can continue to
@@ -4612,10 +4612,10 @@ Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e3502e3-f863-4711-a8f5-b5b6e80b53f0" control-id="ir-9.4">
+    <implemented-requirement uuid="d60aa74a-b75d-4be7-9c37-53a8315a467a" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="b99318af-e55d-49e8-985c-571e63d0b235">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9c53d955-4bfb-4092-813e-a988a08b6996">
+      <statement statement-id="ir-9.4_stmt" uuid="d3cdc512-8275-495e-a45d-ba9262e8cee2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f1bf98b-54a7-4867-9a8e-959f80ec9709">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employing organization-defined security safeguards for personnel exposed
 to information not within assigned access authorizations is an
@@ -4624,18 +4624,18 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4bbe6808-7c85-4128-8784-7562cbef173a" control-id="ma-1">
+    <implemented-requirement uuid="68253bf9-1ed6-4f5a-acd8-c5e98a2fc249" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="910abc1d-6999-4854-97e0-f1eb474a1128">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="49362c76-50db-4ea2-9c46-7b2ac1afbc04">
+      <statement statement-id="ma-1_stmt.a" uuid="3ca0fcfb-f14f-44c6-a572-bd4c7f32c310">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f846a086-263b-4370-892d-c68491d0cb41">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating to organization-defined personnel or roles
 system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.1" uuid="6f7cfd4f-2189-43cf-8a63-b0f2498b0c8c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ad67a644-9e6a-4f3e-8c58-8d458584eca7">
+      <statement statement-id="ma-1_stmt.a.1" uuid="f6fda425-2406-4e85-b70e-3944456f3beb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5e3d7f8d-e593-4cac-b880-3507a5d1f387">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A system maintenance policy that addresses purpose, scope, roles, responsibilities,
 management commitment, coordination among organizational entities, and compliance
@@ -4643,31 +4643,31 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.a.2" uuid="4e8723c9-6aff-4768-a763-c990bdf66cf9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a27eeb9a-1c3c-462b-a69b-a676676a93ee">
+      <statement statement-id="ma-1_stmt.a.2" uuid="f1982d96-04ac-490c-ac02-bc368cee4f66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4fe0f90-664a-4be2-afcb-160a8771bac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Procedures to facilitate the implementation of the access control policy and
 associated access controls is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="276ae640-bff4-4366-b85f-e489ca6a1301">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8d0d5064-1dde-4bbf-92f2-1cd8ed61cc3c">
+      <statement statement-id="ma-1_stmt.b" uuid="0a2f3d72-f568-4e80-8084-3395f2230ef2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bab8b16-6740-483a-8871-adf6413e9677">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy and produres is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.1" uuid="10fc7b4b-6cb4-4fde-8793-98d8c8293ee9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ab04a817-2ca4-4450-bc6d-c6f9c0d85737">
+      <statement statement-id="ma-1_stmt.b.1" uuid="f56a278e-dad4-43fe-ad86-2cf5e6cff1e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e461e8a-ef48-4750-8679-909287d16598">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance policy per an organization-defined frequency
 is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b.2" uuid="f56fa61b-6761-4f48-9359-5ae6d74c1189">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a157a099-6db8-4b85-b763-41bfbd8c6c3a">
+      <statement statement-id="ma-1_stmt.b.2" uuid="4b62389b-a32e-42b3-8576-acd9c0aff016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3252c66-90f0-4b1c-953a-3142eba06e77">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing and updating the current system maintenance procedures per an organization-defined frequency
 is an organizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -4675,10 +4675,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebe2c1d8-e7df-4af9-9577-c9ff729ad7bf" control-id="ma-2">
+    <implemented-requirement uuid="d0521ab2-47f8-4c54-b9a4-ebb7e6fc728c" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="e7a702f8-566d-4cfb-a154-25df9e7b9f39">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="82b59b1a-613e-46de-9a49-a099d3db46ea">
+      <statement statement-id="ma-2_stmt.a" uuid="bc734b9b-0490-4393-88a5-09b06ba33b61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a5ff649-d883-4d1e-a467-9e321e2d4d0c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Scheduling, performing, documenting, and reviewing records of maintenance and repairs
 on information system components in accordance with manufacturer or vendor specifications
@@ -4686,8 +4686,8 @@ and/or organizational requirements is an organizational control outside the scop
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="e28492a6-040c-492a-bfb9-531d231baeec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f377a94a-27e1-4cc7-a2b4-6d3485ac89c7">
+      <statement statement-id="ma-2_stmt.b" uuid="d1cac324-6b4a-4c23-863b-dfe5232dd176">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b722d8bc-31e6-4be2-b4a4-9f6e0cd15408">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approveing and monitoring all maintenance activities, whether performed on site or
 remotely and whether the equipment is serviced on site or removed to another location
@@ -4695,8 +4695,8 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="1a3734ad-ac36-4dc6-b0e8-ad1ca85bf997">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="91414082-cf8d-4ae1-9dc7-a68ab7a0acd2">
+      <statement statement-id="ma-2_stmt.c" uuid="7a207c63-3cc7-4821-9596-a4b41a662023">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed6a4e6b-a9bc-4146-9134-466a89b59741">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring that organization-defined personnel or roles explicitly approve the removal
 of the information system or system components from organizational facilities for
@@ -4704,8 +4704,8 @@ off-site maintenance or repairs is an organizational control outside the scope o
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="51db7263-848d-4902-9c23-2bb4b006587c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="08c2e2f8-ca47-4c46-bc52-d634e70209cc">
+      <statement statement-id="ma-2_stmt.d" uuid="ef69704b-a3d8-462b-bbe9-12af2107ccb8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ed82a90-b826-4aeb-8b9d-91820b3a5734">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Sanitizing equipment to remove all information from associated media prior to removal
 from organizational facilities for off-site maintenance or repairs
@@ -4713,16 +4713,16 @@ is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="4965cc0d-a460-4ce2-927e-f0f689e43738">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b118ab41-a81e-4d18-bffb-1d4326311fd2">
+      <statement statement-id="ma-2_stmt.e" uuid="4b99101f-ed9b-4f60-b2b4-6137650183a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee78984e-c60a-4a96-9949-7f60acf14d5e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking all potentially impacted security controls to verify that the controls are still
 functioning properly following maintenance or repair actions is an organizational control outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="90d37a2e-db0d-49f6-92e0-7437e7060d0f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a0b1104e-cd54-4d88-bd2a-f198cd33164d">
+      <statement statement-id="ma-2_stmt.f" uuid="c17656a2-3255-4d50-bee0-a64d02c2908b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75b29e40-c2f3-477e-b645-ff552864f6b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Including organization-defined maintenance-related information in organizational maintenance records
 is an organizational control outside the scope of
@@ -4730,10 +4730,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3873e254-8596-4d24-8f31-6f11dc1f58b4" control-id="ma-3">
+    <implemented-requirement uuid="5b7ca057-e202-4aec-bca6-8e1990d2ae37" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="610f5620-739d-403f-8c86-65e53c2dacb2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="63dbce1f-efe7-428b-b9ef-696bec4b2533">
+      <statement statement-id="ma-3_stmt" uuid="db3dbe53-8d00-463f-874f-414cce113a3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6d20b73-12aa-4c9f-b574-8e6c68764fb7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization approveing, controlling, and monitoring information system maintenance tools
 is an orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -4741,10 +4741,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b39d263-5a04-4093-8e89-7afd88835337" control-id="ma-3.1">
+    <implemented-requirement uuid="d79dfc91-8495-49c8-a3e4-ba1bcbd32aa2" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="ef81e33f-c5ca-425b-9941-24b3041ac448">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="39488b80-49f7-4556-945a-c9b83a72fbd1">
+      <statement statement-id="ma-3.1_stmt" uuid="49bfdbf8-fdd2-4832-8dcf-9289a33bf93e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="353ae4dc-1b52-45f6-a800-dd3681ceab70">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization inspecting the maintenance tools carried into a facility
 by maintenance personnel for improper or unauthorized modifications is an
@@ -4752,10 +4752,10 @@ orgnaizational control outside the scope of Red Hat Advanced Cluster Management 
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7ebb7db-3e5d-4c1d-9cd6-4d5c08c9fb03" control-id="ma-3.2">
+    <implemented-requirement uuid="cbdc8ca6-4a4a-4523-b872-fcf2aa981ecc" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="c1de63ac-505e-4802-b77c-04166dea85fc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fe18f696-0c12-4bce-a070-5d2538ffc3f5">
+      <statement statement-id="ma-3.2_stmt" uuid="c288bb45-0823-42f6-8b7e-a0752854eb76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7518b57-5c36-45d7-9fb7-665748b1bfd2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -4763,10 +4763,10 @@ system is outside the scope of Red Hat Advanced Cluster Management for Kubernete
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7e6e1e4-78c1-4a28-a258-714e019d60ad" control-id="ma-3.3">
+    <implemented-requirement uuid="574548e6-09a5-415c-ad07-f8e1b3cb7ef6" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="952df00c-0af8-49ce-9b43-f7777c13d679">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8f927261-c1e1-464d-9f81-1ca5a9c14ad7">
+      <statement statement-id="ma-3.3_stmt.a" uuid="c6f0bab4-b3de-4823-9fe0-c9281f74b817">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49e28527-4a01-4fac-8017-97020217f2b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -4774,24 +4774,24 @@ information contained on the equipment is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="3d176421-a617-4810-9d35-19212a503a5f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fa01df23-99b3-4276-bd07-9b361c44a30b">
+      <statement statement-id="ma-3.3_stmt.b" uuid="e684f3e5-4490-4332-bb89-2b27f45edfd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b26e073-bdf9-4805-9b73-008a169701fc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="c2857f58-8f94-426c-8f4e-2af88f1aba49">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="eb635d0f-f261-4b95-b9a3-c6edd36125cb">
+      <statement statement-id="ma-3.3_stmt.c" uuid="981191c3-0955-4bd3-b4c7-83ecb80ffc69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4a3e7cc-8783-40d9-8335-7a37a0412db4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
 facility is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="3e798647-dcda-4242-84e1-07b7dc728a3f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f854308e-1262-438e-bf57-dfc7dc2e462d">
+      <statement statement-id="ma-3.3_stmt.d" uuid="cd39c45e-c1fb-47e7-bffe-6783f778a3d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf64b687-a3a9-4671-b1dc-155461eb82ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -4801,25 +4801,25 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03aecbbc-e505-459b-9e29-eea4d1cd35a0" control-id="ma-4">
+    <implemented-requirement uuid="ee08bf70-ba34-4996-882b-d3dffbde4407" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="2ca51303-1472-4c31-99f9-f663f18eecb4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2c472f49-bf17-4804-8d82-f95689d328b6">
+      <statement statement-id="ma-4_stmt.a" uuid="eaf394c6-d6bf-4a30-888f-89b5e0c84c00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e991af1-6b2c-42d8-8073-794564765dac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Approving and monitoring nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="f309b775-ce2f-4759-bd26-893ba61c8f59">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6dc91bec-184e-4cc1-b600-f7d543078767">
+      <statement statement-id="ma-4_stmt.b" uuid="341e27c3-1473-4701-9e46-f6ea142e7911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5bf896e2-fb2f-41a7-a919-56de5f20e98a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
 organizational policy and documented in the security plan for the information system is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="3c485f28-12e1-47e0-8cc5-4e991bc38fe1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="642852a5-58e3-4188-a146-1dbda16069cb">
+      <statement statement-id="ma-4_stmt.c" uuid="7c948163-c39b-4a03-8be5-9371269b0fc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a4a4496-4701-4b07-a53d-7c8bc683c411">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for authentication management.
@@ -4829,15 +4829,15 @@ and outside the scope of Red Hat Advanced Cluster Management
 for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="256c9937-5cb7-4b22-a986-3e327abace92">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ec86da4b-e7b6-42a7-a979-d391b9741a13">
+      <statement statement-id="ma-4_stmt.d" uuid="34cfca8e-60e9-480f-a3fe-b9fe80c948cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9aa9e088-f7a8-44ff-9b10-81842f8f02af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The maintaining of records for nonlocal maintenance and diagnostic activities is an
 orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="aff8bf9e-09e9-47b6-80a1-b683ff928aac">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c2974689-c216-4cfc-b07e-de07bd62bacc">
+      <statement statement-id="ma-4_stmt.e" uuid="b171c76d-5876-48a5-833b-544ca7fc02ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08c2886-6ec5-466a-b1bc-29a30be73431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes
 relies on OpenShift for session management.
@@ -4847,10 +4847,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba41bcc2-0eaf-487f-9e4b-7e5593209076" control-id="ma-4.2">
+    <implemented-requirement uuid="ead10857-a33d-49d1-bc56-50dc27385779" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="b864d4ac-50c8-4b5c-b938-8af7dd12f4f1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="54d28b10-5a52-4891-8964-acf787b61353">
+      <statement statement-id="ma-4.2_stmt" uuid="8f138674-4e31-430f-a4e9-8721ab6ee6d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f459ef2e-51bc-4fd3-8e14-4625f48214f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization documenting in the security plan for the information system,
 the policies and procedures for the establishment and use of nonlocal maintenance
@@ -4859,26 +4859,26 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfbf0726-823d-4e54-8bb1-2111711d6db8" control-id="ma-5">
+    <implemented-requirement uuid="87aea603-cd1d-4f8f-bdba-d48f5344411c" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="c0662c2f-1edd-4995-87c1-95758b9dbdea">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="340d6379-b70a-44a3-a344-b20a6ecf6087">
+      <statement statement-id="ma-5_stmt.a" uuid="0e5e0116-5d08-442b-b42c-5bd8a7f6fdff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7a30174-580e-4087-9026-06b18bc07a76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
 is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="868a8f43-fdca-4bea-a832-34f1efb042a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="94e10070-fd2e-4251-ac05-f220930c26dc">
+      <statement statement-id="ma-5_stmt.b" uuid="9772139d-fd4c-418a-b7bb-1eb86d96c0b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e903203a-181e-4244-bbd9-00f6b730e88e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="875023b1-8d2b-4f89-b1eb-8b4b7ac7c672">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="375be520-97d2-4531-aba4-d316253c1420">
+      <statement statement-id="ma-5_stmt.c" uuid="c183f370-501b-4f89-b541-8c349f2603f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd516f90-7eb6-43a6-a738-333a08f568cb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -4888,18 +4888,18 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ef9e45b-bcc9-46d6-9708-e541eb6a4884" control-id="ma-5.1">
+    <implemented-requirement uuid="6bd19e15-5977-4371-b020-0a1b73e4ee77" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="126052da-43b8-430c-8623-067ab0d5d51a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8995a5c1-5006-4188-b1c2-f42725e56dc7">
+      <statement statement-id="ma-5.1_stmt.a" uuid="6efc75bd-1995-4956-a7a6-f8b9441ca917">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bf26008a-ffba-4bbf-91a4-4a841edecce7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
 citizens is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="820b0920-3039-472a-a22e-6263c21c1b46">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="63fe81ce-b814-40a3-9f5b-1181763be7d1">
+      <statement statement-id="ma-5.1_stmt.b" uuid="f13ae1d9-6cef-4f5b-b42d-3e9b7fc55d64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3601f91b-d1db-4661-b309-affd6a7b63a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -4908,10 +4908,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9aab8a85-23de-47a7-ad9e-6f4087a7049c" control-id="ma-6">
+    <implemented-requirement uuid="92524567-89f1-420e-a36d-8a0f9e70e4e2" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="e6f9f7b0-6cbc-430a-b557-26079eac30d4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9d0d910a-463e-4171-9e21-e49bde868f14">
+      <statement statement-id="ma-6_stmt" uuid="13c5c4a9-5cd8-41b6-a32e-7d53ae01fd09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="525e2023-ea02-4cb1-b4c0-35a6e6a4d05b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization obtaining maintenance support and/or spare parts for
 organization-defined information system components within an organization-defined
@@ -4920,18 +4920,18 @@ of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e211d40-9915-420a-bf35-c90f3b92a179" control-id="mp-1">
+    <implemented-requirement uuid="aba94ad6-68f5-4410-b77d-4442e659c869" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="3539f785-bb6f-47b0-9d93-7c3b014356ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ca13d1e0-8ae3-4493-8809-e14817e66950">
+      <statement statement-id="mp-1_stmt.a" uuid="ae70b746-73d5-4cc1-b7d9-1c1425c563f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="c7dd2ac4-bb26-47b2-9df4-39c5023e97f8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="072fb469-4e77-4614-a14a-500684416927">
+      <statement statement-id="mp-1_stmt.b" uuid="9001b1b1-b946-4cbc-93aa-85d0e80b47c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -4939,28 +4939,28 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="427c0427-4f3a-45aa-9a25-384301abf90d" control-id="mp-2">
+    <implemented-requirement uuid="91730106-aecb-4b7f-97ae-54f8584ee6f6" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="3700d5da-ea5c-4477-b4bf-1c87a155e548">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2c852521-0c74-4f9d-8abe-6dd84bcfc1fe">
+      <statement statement-id="mp-2_stmt" uuid="eea31d1c-5a73-400d-afc9-be65544ec06b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bede0573-67bd-4ec1-a287-1b7bfde01a9e" control-id="mp-3">
+    <implemented-requirement uuid="9fb37b43-b174-4dc9-abed-cc660919b431" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="6a3127e3-81ad-4ee0-bac6-9ab08dddd182">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="93323abc-d5e8-456e-8682-3f19dd905f23">
+      <statement statement-id="mp-3_stmt.a" uuid="983f3fed-b8db-4b99-93d6-089028b950f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="de9ec1d7-56c0-41b0-9143-a277b0d199da">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a96ce9e7-75b6-44a8-96aa-bf572e35f837">
+      <statement statement-id="mp-3_stmt.b" uuid="7c06c13e-7049-41d2-8414-f7a3f49d662e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -4968,18 +4968,18 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05c4c4ff-5aa5-4447-b91f-00d228068824" control-id="mp-4">
+    <implemented-requirement uuid="e050ffab-48e6-474e-8aa7-743c0cae9ad0" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="ecde31ca-3640-459c-968f-3618322eb28b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="14de1b36-0a5b-4286-a8da-ee4744a57798">
+      <statement statement-id="mp-4_stmt.a" uuid="7a9dd7c8-e574-4881-aeb3-8526a42ca723">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="b51b136f-b0cd-47d3-9302-9e8452a1c13a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e5ce33f9-e6bf-487a-9c9b-af1938cb050e">
+      <statement statement-id="mp-4_stmt.b" uuid="5012554b-48ca-4f6b-bf11-392e650a6f35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -4987,34 +4987,34 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c9e3105-7495-464a-82cf-84c57691984a" control-id="mp-5">
+    <implemented-requirement uuid="5293ef06-ef10-4915-9a6b-7398fa6b52fa" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="3f2312bd-0e71-41a0-9989-0cf68a1ba044">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="33c45332-18c4-41aa-95af-125e64a1abee">
+      <statement statement-id="mp-5_stmt.a" uuid="e2da40e4-96a2-4de8-86bb-9d8e550a162a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="118ec08a-e660-468a-b119-75f4eef9cace">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6b0ee6fd-8f73-42d8-9b7c-6ba60f80e2a7">
+      <statement statement-id="mp-5_stmt.b" uuid="f102e259-62c0-4b9b-852d-7c2a921a6fa0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="4f5a5bb7-efbf-4501-8405-fb0a7ac2a0fb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="325ee141-f148-43ff-b474-f565ffeb7553">
+      <statement statement-id="mp-5_stmt.c" uuid="fd03c663-a259-4f0a-8ae1-71451a685f33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="a2fa170f-4b33-4bc0-989a-e8678e121699">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a8ea1121-998d-46dd-beb1-f36c32ae8204">
+      <statement statement-id="mp-5_stmt.d" uuid="e32304c6-ae95-44d8-aa24-7857f127c7d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5022,28 +5022,28 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcf5486d-357f-4155-ae83-e1c2c5079e2b" control-id="mp-5.4">
+    <implemented-requirement uuid="a10582c8-3aa5-42aa-95a1-b114422aabad" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="8e6307d5-6caf-4f90-858d-1192e47cb48b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="42b69cee-2157-469c-967e-68061d8b838a">
+      <statement statement-id="mp-5.4_stmt" uuid="f1c47367-a2aa-4ba0-9e87-b0c8eabe8923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="daf73f59-1e80-4949-bd35-1886a9342094" control-id="mp-6">
+    <implemented-requirement uuid="e6cb05be-04da-42b8-bc61-e73a3184da68" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="fa74aebe-24bd-434c-aa37-42b3b56c152a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="68cb543d-3d17-4bb4-b784-30851361fa1d">
+      <statement statement-id="mp-6_stmt.a" uuid="7704ff74-71f0-4992-bb95-0fc05c1b457c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="79f7f19c-979b-426a-acd5-b3bf867acf93">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f01a974f-b70f-4faf-8240-a7f76ed7df07">
+      <statement statement-id="mp-6_stmt.b" uuid="4b4b52f2-28fb-4b50-b6e2-63aa0383bfaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5051,20 +5051,20 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33435262-bcd0-4981-b9c9-a49c8854cdb2" control-id="mp-6.2">
+    <implemented-requirement uuid="19d5b1ef-4a99-4221-8802-ca284585ca11" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="ecb6c381-169b-4fc9-a69c-257096029742">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="20b485c8-135a-4eae-b40d-1be487fb00f0">
+      <statement statement-id="mp-6.2_stmt" uuid="b7efa870-c614-45c0-beb5-2f516baebb4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6df4c5b8-8286-44d4-84c1-af561006a6cc" control-id="mp-7">
+    <implemented-requirement uuid="76b89418-dd30-47b0-b610-232d0779620a" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="6555697d-889c-4d45-ac64-aa5e2a0f53d9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0937f3ea-4d46-4303-a57e-265c47ec9e61">
+      <statement statement-id="mp-7_stmt" uuid="c9cb4913-199e-4777-9977-90b733398721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12bd854e-d12b-466e-9a25-c3588d772f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes does not utilize or have access to media such as optical
 drives, USB devices, etc. Therefore, this control is not applicable to
@@ -5072,20 +5072,20 @@ Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1da2960-2b4d-4611-812c-3c95f9217e32" control-id="mp-7.1">
+    <implemented-requirement uuid="05cb6921-4efe-4157-9da7-01bb4dbee1dc" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="3f037a0e-7922-46dd-be04-19fc090a1e21">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d2b97d04-1b1c-414f-af56-cd7b9b4a1650">
+      <statement statement-id="mp-7.1_stmt" uuid="198189b2-294d-48ec-8eb3-c82910a87333">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e60d2fe3-eeb3-4f11-8547-2ae60f769032">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c07554cc-5441-4340-b87d-50500ce95764" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="4ed69920-9c03-4985-acb3-d6214d8d4051">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="176ef9c9-bcd4-400d-8673-d45737ec98c3">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5094,8 +5094,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="462a9bcb-2741-44ef-819c-8bd38f94fcc5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9c3f30b6-cbfd-496e-8d72-836051249aab">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5105,10 +5105,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9209ec2c-6108-43b3-a1db-7d2397ebc75e" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="0a79a1b3-2ec8-4fa7-9f5c-ef35d6e3ae67">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9a1c1f43-21c1-45f4-a858-0b65046383d1">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -5118,8 +5118,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="85402be2-f8f3-431a-82e4-05e754b2439e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="97e7d214-440f-4053-9755-d78f9f25e489">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -5127,8 +5127,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="c253edb2-4d6b-41b9-8e54-dfea6a342e95">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="47ca2aac-b99f-483f-b523-b90d7ce06239">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5137,8 +5137,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="46ec9d20-2d0d-46f7-afc6-66267353055e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2e5db1aa-f973-40fc-a082-1602d305bb87">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5147,10 +5147,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c8a60b2-fdb6-40d9-be50-2a8395795737" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="cd425250-2946-4044-a5f0-65d8acfebd3e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3ec80d57-39da-4783-803f-19e98a89426f">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5159,8 +5159,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="6f8cdc7d-950b-422a-8063-59eb5d47c76e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5ac778c2-55db-4826-87c4-1d900299b715">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5168,8 +5168,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="03923750-22b8-4f9a-a1dc-868396921b09">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a8398cf5-7a7e-421d-b8dc-6b988d548ff9">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5178,8 +5178,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="046663b0-2b04-404a-8632-115932760990">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fb7feb25-73c5-4032-9ed8-2e3ea9e006e6">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5188,8 +5188,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="b33df618-c304-455b-83fe-2e204a4630fa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="819bb650-c0bd-46bf-b895-b90a4ef9a5b5">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5197,8 +5197,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="79767d41-b5e9-46c2-a5b1-0940dfe9a494">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="afaba76e-911c-4be1-a9a8-830f27ab5264">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5207,8 +5207,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="e1d5b4a1-81ad-4c44-ad79-056d44cf7474">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d1f74df2-64ee-4660-a2c1-863c5671fc30">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5218,10 +5218,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4acdda79-7ffd-4110-83d0-c82a8547bd2c" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="602e8540-44e3-479d-8fa7-438e27ef32ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b1d28a87-5f2f-4d39-a915-4fee4d947f23">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -5232,10 +5232,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48e58e40-1461-47e4-b60b-8ff5b5cbc7ed" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="1926b777-93db-4086-9c4c-67c98ea9afd1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7a7e95a8-bbe9-4a58-afff-f009833f4c32">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -5245,10 +5245,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ca91247-b842-41c8-931f-0bc05e063ab3" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="e5595abc-f744-4acd-ab72-2206a723a8ba">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2be2995d-a6f4-4147-b943-a865b09349af">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -5257,8 +5257,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="f29c40e8-216a-4ffa-b54b-06cf18dc7de8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5a8c596f-f35e-4da6-a162-fb4ddc699e00">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -5268,8 +5268,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="5a6123fe-aef8-4f18-b0ad-49f2dbd5e261">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="13236583-3905-4951-aef9-1674fa555cc2">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -5279,10 +5279,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81e6e5ca-f053-4cfb-9af1-329c1eb0753d" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="154d2f70-10ea-40ae-84c0-18d420ad9f00">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6ab1d8a5-4404-4a6e-8ea4-d59353bdf5d4">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -5291,233 +5291,190 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39adb5d6-6d42-40aa-9460-879bdf940fd8" control-id="pe-8">
+    <implemented-requirement uuid="be5e63d0-4c48-419f-b1eb-56e1eeb86002" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="0e013453-d586-4fc7-ae97-fdfb302dc64c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ccfdfefb-d3a4-48ff-899e-4b33d0d6d9c5">
+      <statement statement-id="pe-8_stmt.a" uuid="60ece47a-8333-4136-bcee-0734c6bc9c01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="a0967980-1a98-488c-84b8-ec49d54273ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c4bebecc-56e0-4d0e-80a3-ea91c6a66755">
+      <statement statement-id="pe-8_stmt.b" uuid="280068ab-db1d-4d72-ae0a-03fafc30cdbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="020a15a7-0336-4208-af41-a842d3e97ebb" control-id="pe-9">
+    <implemented-requirement uuid="64951ba3-a1d6-4493-92b9-62998bedb132" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="f075feee-103d-49f2-ae26-b9d26e798ab0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d76d5b22-ed99-4da4-8aa6-7d59bcc204cf">
+      <statement statement-id="pe-9_stmt" uuid="3c5750f5-ddfb-461f-b02f-7558992d0b63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6672fa5-af3f-47a9-8a75-6189b03f6e09" control-id="pe-10">
+    <implemented-requirement uuid="e3e97c41-4934-4351-9a72-f6544b0f29b3" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="54d69523-c617-4e27-a569-46ee2a62f125">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5ffb44e6-4969-48bc-9f6e-81063122f04b">
+      <statement statement-id="pe-10_stmt.a" uuid="2fca9a05-980e-48b1-937d-8af177cf21b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="1c85ebeb-6eb0-47cf-891b-85b8a6debf7c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b348b406-1a32-4220-9df9-a82744abb43d">
+      <statement statement-id="pe-10_stmt.b" uuid="1a3e16fb-1780-4316-9faa-16c6b8cfa596">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="866b73c0-88a3-4021-8d89-8b011bfdc2e8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9623bb47-a5bf-452f-863c-5a4440edf867">
+      <statement statement-id="pe-10_stmt.c" uuid="2d3c89a8-5364-4d1d-80cb-11a8b0bf4470">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="991be779-39c1-4010-956c-750e8688ee75" control-id="pe-11">
+    <implemented-requirement uuid="a6501d1e-c89b-49b0-aa76-246a01a3f399" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="5b4896cd-3767-4bac-a39e-80f769c46c70">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3a82fd87-77a0-49f6-a7ae-66ba3150625c">
+      <statement statement-id="pe-11_stmt" uuid="6d26de0c-897e-4246-920a-94dcba8abb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09bf7574-c4af-453e-b15b-bb719a24291d" control-id="pe-12">
+    <implemented-requirement uuid="027e9b57-2ee6-41e4-ad65-395483a08ede" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="ebf81f4e-7b07-45eb-8f35-8d45bb31ca35">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="98d14e2f-1bd7-4ff4-b0ed-5403da7976e5">
+      <statement statement-id="pe-12_stmt" uuid="c0ee43af-659b-4222-a478-e26cf0209bd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4249d42-c56c-4cdc-b9a4-99576cada8a6" control-id="pe-13">
+    <implemented-requirement uuid="d2fc0a14-167b-4f40-8abd-16cb25ac7510" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="fe6554df-4976-46c5-b055-86b1d1399656">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aecf7175-e43d-48f1-9d98-4df07e1eb7ba">
+      <statement statement-id="pe-13_stmt" uuid="9c74e7b7-f0cd-4d18-8e72-9fb8bc120388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="987f61de-4ca5-4b72-8425-4324f9a4b121" control-id="pe-13.2">
+    <implemented-requirement uuid="d7af410e-bbd5-4309-9ed3-52811d7d0a35" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="2f14e80d-ec21-4c68-9bb1-b724fe5794a9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d1c65739-2c9d-445c-bc8c-92ac7fa859ab">
+      <statement statement-id="pe-13.2_stmt" uuid="54a5c536-db79-472b-9ec5-3b57ffea5125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6140533-ffdb-49d8-a1bc-1dfdbe2b82ac" control-id="pe-13.3">
+    <implemented-requirement uuid="5e77bdfe-feb4-40eb-8540-9cacaa1b4761" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="028cdcfa-3859-49c7-a530-e94c506f5bab">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="137ccbe3-f8cc-4e0e-a48c-779445b363dc">
+      <statement statement-id="pe-13.3_stmt" uuid="768bde08-904c-43be-9c7f-38ebb398f2dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd2d3773-9e89-40a8-91cf-aeb496e8af20" control-id="pe-14">
+    <implemented-requirement uuid="c3247981-3141-4ca8-a197-66f96605c590" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="c2c0058f-f4cd-414e-aeb8-6505362ec5d8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="edfa14fb-8d6b-4340-9968-b156494ec10e">
+      <statement statement-id="pe-14_stmt.a" uuid="da5e7fe4-059b-4812-8978-9ff93635078b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="7e886ec5-15c8-4c61-937f-578c0f40bef5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="74d5221b-acfb-4990-a41c-20102ea6f1a0">
+      <statement statement-id="pe-14_stmt.b" uuid="627443aa-6e05-457c-902c-be03161932de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b195270f-d802-411c-90a8-001b9e36fd5b" control-id="pe-14.2">
+    <implemented-requirement uuid="049ef29a-95e2-4fdc-add2-e4c5acf8ba69" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="4700ee38-5941-44b3-80a1-808b9ba6a196">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="026a7ed6-5756-47eb-a004-68e6e90ab4c6">
+      <statement statement-id="pe-14.2_stmt" uuid="430af539-e9c1-4ec8-a54f-c6b6fc8aba87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5cb4ef1b-4f96-43af-87f8-3d454aaa973d" control-id="pe-15">
+    <implemented-requirement uuid="e8adb6df-d83e-4c34-ab6d-ab53861166de" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="1207ae0d-a402-4c8c-860e-7b830e2fd747">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c2452039-7c9d-4668-ac8f-5b0d0ef6271c">
+      <statement statement-id="pe-15_stmt" uuid="645c4bc3-9242-4439-a386-eedc593005dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3065e7b8-cb12-4932-9c91-49e829bef7c5" control-id="pe-16">
+    <implemented-requirement uuid="21865d6e-01d9-4469-9a76-d11a53eeb03c" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="696e6f38-5c95-4638-bf90-8776113a5c06">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9292f24e-da9f-408c-930d-45cb843d3407">
+      <statement statement-id="pe-16_stmt" uuid="34f1d089-badb-4e0a-a76d-443fa1f19144">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd0d748b-f5aa-4474-877e-7e6778ede9df" control-id="pe-17">
+    <implemented-requirement uuid="8e1c4b1b-ee67-4f39-aab0-44d256e218f2" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="20dccf37-044f-46c8-aff3-912cd340af48">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="48bc3b27-8681-4a3e-9b7c-6b094f6082a6">
+      <statement statement-id="pe-17_stmt.a" uuid="edb010d7-e83e-46e2-8387-b8c87262fbd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="2ea1fee2-b485-4af7-bfed-733a62a9a30e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e43c91e4-20f0-429b-b2db-5f3522014ddb">
+      <statement statement-id="pe-17_stmt.b" uuid="42b6a63c-ce3e-442c-aaf8-7f8ec2e1ea0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="05d74277-fbfe-4bdb-85bd-97347045c19e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f6644a2c-3f29-4e0b-8f2c-02e6a0d75069">
+      <statement statement-id="pe-17_stmt.c" uuid="10e34321-922d-498a-81cd-93c63c185229">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e0065ffc-fa2b-409e-8e5d-67586fa89b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d637400c-50af-4d6a-a0c3-1195281db87a" control-id="pl-1">
+    <implemented-requirement uuid="84980f61-ea2a-4dd1-9376-298aa584f387" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="61d686a9-4a53-404c-87a7-9c7f40157749">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ba2362b9-0f64-4ef2-98de-9861d89652b2">
+      <statement statement-id="pl-1_stmt.a" uuid="382f60d8-c7d8-4ea8-b887-3746baf8da24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="835ab395-ebf8-491f-8a0b-cf315f92b5c7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="88b98041-59ee-4e59-ab89-0808eee072ae">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="87e79f7b-7d65-4376-93c4-cdb3949e9877" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="f845762d-ddfc-41fb-83dc-28ee206c14a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="165c0d26-aeb7-4b73-907a-2ccb9f37824e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="1981c3db-3323-44fc-97ae-cb8747dc175f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="53ab5e5e-243a-474c-aae9-c45f13f615ca">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="7d010355-6dba-45f5-a676-a632d6514faa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8919e91a-fa6b-4755-bca3-71029157ac3d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="d565d7c6-5d3f-4cc7-9989-5a84463383f2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="99ece84a-bdcd-4450-88ad-6b937d0792af">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="1a394a5e-aa17-4de7-9502-fe314bb6e640">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b9e88f2e-7d35-423b-9cbc-f1d598ae6bfb">
+      <statement statement-id="pl-1_stmt.b" uuid="baf019f2-5a26-4574-8b82-0084892b0836">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -5525,10 +5482,53 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0952710-0fc7-40f7-906c-26311b2662b9" control-id="pl-2.3">
+    <implemented-requirement uuid="b7012c99-7d97-4f34-8277-eebb08ad86d1" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="e6095d50-ec89-4ceb-b088-1671b26b889b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9d4ccc67-c708-467e-abdc-afe022a17286">
+      <statement statement-id="pl-2_stmt.a" uuid="8dca9505-1b6b-4ebc-bac1-1ed8021b7135">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="2fd6dab7-6837-44c7-bd51-a09128aba62e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d365ff4c-2321-4d03-b06d-2ff79db0d98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="3dcf454a-b8e0-468e-a875-949b94198f9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="a26940da-320e-4b28-b787-fe450c114570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="ba4c0c42-c439-47f4-9a47-da0bbe193a31" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="6e9f7be6-ee75-48d8-b03a-909f181c8c2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5536,34 +5536,34 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8210028b-93ed-4e0d-8482-a8ddc12050a7" control-id="pl-4">
+    <implemented-requirement uuid="cea646c8-94e0-4d09-a03b-bbd07071a4a6" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="eee7f583-e42e-4ccd-a050-745a6369ca30">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b9f773af-c04e-4e7d-aaa9-50fdf5c92097">
+      <statement statement-id="pl-4_stmt.a" uuid="880a0c86-f8b5-41d1-b61d-612794c15e5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="3ee9054a-fbb9-4a49-8dfa-b592e9c77376">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0e14456b-da49-4112-95f0-d30ad30419ed">
+      <statement statement-id="pl-4_stmt.b" uuid="b4352941-8475-48e3-b6bb-b4937fdfdec9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="b6f6d296-2681-4a89-a44f-42f648f93173">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8920f025-d55a-44d7-bb3e-cd4b6f2c3de7">
+      <statement statement-id="pl-4_stmt.c" uuid="ba9a5420-9b61-4fda-9a3e-6402d4e2751c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="b9636da6-601d-4a34-a642-d5796139537f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="44e630de-b372-477c-84ef-4d604da1a0a9">
+      <statement statement-id="pl-4_stmt.d" uuid="1f709031-5728-48b0-b2d4-3457e63abf85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -5571,10 +5571,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88eea2ba-e858-49ab-a617-dc5d660c7008" control-id="pl-4.1">
+    <implemented-requirement uuid="5ee6af21-f5f7-4800-bb79-b8fadb0c9e04" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="e77b0733-80fb-4295-bcfa-377407477d16">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cb9ec585-9976-4abc-87d2-d2394c4467a0">
+      <statement statement-id="pl-4.1_stmt" uuid="f5955a29-94f8-460b-a54c-e81940669b85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13468f4e-56d7-4984-a9eb-ca46b0293802">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5582,26 +5582,26 @@ applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1181c82-027d-4750-8459-d3ec80f60eae" control-id="pl-8">
+    <implemented-requirement uuid="71f516b3-5b86-4bad-a821-3c904d5d712a" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="04d1f1fd-a2df-4083-ab9e-519e499d50cb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c8ee8aa7-277c-48f9-8ed3-ceda65f41d52">
+      <statement statement-id="pl-8_stmt.a" uuid="d205c3cb-453f-4a05-936e-7692a784f8a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="9cb37748-e6fa-4113-b65e-7f693aa758a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="38061249-e3bd-454e-aeb9-0d21b4995c85">
+      <statement statement-id="pl-8_stmt.b" uuid="fea79ea1-083d-492e-8a11-ac40132bb69a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="b552b4eb-3c11-49dd-b0f5-255eb21e9913">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4452c3c3-8047-4628-bf1b-4c125cbd9c72">
+      <statement statement-id="pl-8_stmt.c" uuid="29ceaa21-6f9f-4be7-bf5a-61356d2855b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6799fde1-c55d-48c1-b7df-940bc4fff64f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
@@ -5609,10 +5609,10 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c097c662-fdd1-432c-8ac9-07f4d6deaeee" control-id="ps-1">
+    <implemented-requirement uuid="0509732b-28ff-4dce-8534-4a8d553e31cf" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="cf7c118d-d85a-4e33-953c-153be06b5d8d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="25e62ad0-0728-4586-94ee-e2340e6f04fb">
+      <statement statement-id="ps-1_stmt.a" uuid="8e69a681-7d8c-4c33-8fc1-09c277a7be63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5620,8 +5620,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="86d3afdd-6d24-4db8-8148-5347e52bfe0b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="439b0287-46a5-437d-aa67-27909f05b88e">
+      <statement statement-id="ps-1_stmt.a.1" uuid="08da0a83-64e2-4d6a-bbe3-4b8639dbe4b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5629,8 +5629,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="6001b477-5d19-48da-a0a3-c578e92c0e16">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6415c14f-8f06-4f04-9f33-cfd9d83c1bfc">
+      <statement statement-id="ps-1_stmt.a.2" uuid="9086085f-9d70-467a-ab6e-a8c7971fc63f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5638,8 +5638,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="4af1eb5b-bc6b-47ab-a0d7-143a81060ac5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2090f249-130a-4ff1-bc16-237a59205f06">
+      <statement statement-id="ps-1_stmt.b" uuid="d66da28b-8336-4182-87bd-83210fbd8a16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cae01e9c-41dd-49da-bc48-41712538a5a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -5647,8 +5647,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="b64883a4-05f8-4069-9f1b-2baeecd68366">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0116849c-7d62-46e6-9a76-fa4d59198b01">
+      <statement statement-id="ps-1_stmt.b.1" uuid="a4c57ab6-c597-4bf2-a004-175baea1e318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5656,8 +5656,8 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="20785cdb-73e8-455a-9dc9-9be51feda483">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4c1cac04-d912-4f07-a5fd-9884c72ff70f">
+      <statement statement-id="ps-1_stmt.b.2" uuid="025d26bb-f914-46f3-89fa-5e193f0cb358">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e040dfbc-cf0b-4cc1-a06a-3f8c68d5c568">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5666,18 +5666,18 @@ is outside the scope of Red Hat Advanced Cluster Management for Kubernetes confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e1cafb4-bcb6-43c7-8897-5c94b936b117" control-id="ps-2">
+    <implemented-requirement uuid="87c32fdb-ceea-43e8-8e1b-c66a7cb24bd7" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="98a2eabe-0f59-48a8-b6d6-557a7bb9de50">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5bf5ac2c-8717-4a47-8fd8-a8e13cb96f2a">
+      <statement statement-id="ps-2_stmt.a" uuid="d1ea0e64-8187-4df7-95a0-267fd3f13c0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a53b3b50-3dab-4be8-a8fc-e1957dc68954">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="440a0b38-510c-4b8f-84cc-2b49852c554a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="30b6844a-9a65-4555-9812-9ce32ed92d4e">
+      <statement statement-id="ps-2_stmt.b" uuid="87a70bf1-bb3e-4225-ad9e-d884e7e43e34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c1603b6-e20d-4245-8cca-589dae4ea801">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -5685,8 +5685,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="b31090ad-fc91-4af1-8c00-87d291972a3a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9cf3c8d1-9c71-4641-8c8b-be199fb9e3c6">
+      <statement statement-id="ps-2_stmt.c" uuid="f54131c2-6d5c-4b74-b75a-e146a00e040d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b22c353e-755b-4530-baba-c62897c0596f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -5695,10 +5695,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e096c060-a918-41fb-93f8-4ca1032bc6d1" control-id="ps-3">
+    <implemented-requirement uuid="7e38a1d2-2160-48f4-944c-318362f4f233" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="2ccb03a5-98f0-4e39-a82a-e81a255f7a6f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e09d42f4-d439-4be3-babd-dfc64a9b1c11">
+      <statement statement-id="ps-3_stmt.a" uuid="8ef2de60-c9fc-4743-9abc-bc839c975948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43bf671-6676-410e-9ec7-ab761cf5dd0d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -5706,8 +5706,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="8ee7305b-85ec-4dcb-b0e6-e470de33b19a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c7d1c981-f837-4d56-9f24-2172f026e6bc">
+      <statement statement-id="ps-3_stmt.b" uuid="4c0c480a-e013-43a0-bbbb-7457cf4ba5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4c2e15b-a2f8-4057-8132-53326f3f25ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -5718,10 +5718,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00adaa53-d279-4d80-9ae1-ce0b59c9a2df" control-id="ps-3.3">
+    <implemented-requirement uuid="dd80c2c1-fcf5-47f3-a2a7-7786ca02b264" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="f59280bb-530c-47fd-b573-2b8217857409">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="389d3677-67b3-405d-9856-c5e279ca0668">
+      <statement statement-id="ps-3.3_stmt.a" uuid="5357a4a4-af97-43b5-acf4-60ea83594215">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fdf2024a-f885-4f05-94b4-246a58c4ac89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5731,8 +5731,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="9344d309-f75d-4b09-94ef-0eb49ae58605">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1ec352e9-3577-4a9d-b4fd-c2f682f27376">
+      <statement statement-id="ps-3.3_stmt.b" uuid="d8cbd206-c7b6-4a81-82cd-0c25c586e079">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1af432e5-34ab-4653-96fa-b3d2434062ef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5743,10 +5743,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b968f003-b09e-4338-9ce4-0f419a31707b" control-id="ps-4">
+    <implemented-requirement uuid="93d688d1-a188-4a6c-857b-5ff45ff8bd5a" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="e6e10248-db14-46de-bf54-a4e217c612ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="52c2ac27-8437-4a2c-a2ef-992b793ef8fb">
+      <statement statement-id="ps-4_stmt.a" uuid="e8799de5-2c0e-44ed-b148-013e542d59b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33aeb54e-0472-45e8-89ec-ffd517fb4c90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -5755,8 +5755,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="4651213d-7f69-4c8f-ae78-7ab1bda4462f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="89b629c6-08ae-48bb-914f-8d6c09a35ee1">
+      <statement statement-id="ps-4_stmt.b" uuid="9034e4f7-d40a-4dab-9e94-aee7ea990d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42366338-6bf5-413f-af17-1ba8bd0c9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -5765,8 +5765,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="0457bf6c-43d9-4982-ad10-a570f05b8467">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ebf6ed09-4022-4677-b6c1-f3de7f0d5762">
+      <statement statement-id="ps-4_stmt.c" uuid="b0106692-4c65-404a-aefe-774beadb5ab4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d60b612-5b36-4216-b8fb-69e2b64a9f4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -5775,8 +5775,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="b2152609-762f-4240-95c6-f1f584afaf71">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7288f33f-1836-4fcb-a8a3-782ab96bdae8">
+      <statement statement-id="ps-4_stmt.d" uuid="a3a2bef0-9f94-4af3-ab52-fc4c4bd892f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3fecd8e-b4bd-4147-8b74-8c3b6faa2410">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -5785,8 +5785,8 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="597f4092-7b97-46f5-be07-b412e6898f9a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="31d9e854-73e1-4709-a469-c15af1f3ca3a">
+      <statement statement-id="ps-4_stmt.e" uuid="d1b7e6c8-a309-4603-bf7d-172dd9858328">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e8598f4-dcae-4101-be62-59f0c60d27c3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -5795,8 +5795,8 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="287591c8-7add-4f5a-bee2-376d55ef063b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="524d8507-c807-4020-ad56-f0ab27a37295">
+      <statement statement-id="ps-4_stmt.f" uuid="d9f86f5c-41ba-4235-bfa4-ee491660feab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e3fa770-31ec-412b-85e4-c42df7ec69d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -5806,10 +5806,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70b1ec2d-f6b3-4f2a-aebe-4ebf8f8b7843" control-id="ps-5">
+    <implemented-requirement uuid="530189ae-e0b0-4489-817e-68545a85fcb8" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="934386e8-727a-4ef3-8bb4-516807e9f087">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="40a26d97-9873-4267-953a-691851f75f73">
+      <statement statement-id="ps-5_stmt.a" uuid="d60d9065-eed8-454a-b65e-387181feb780">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="efe56d04-e15d-4bd6-b15a-0fec2acee727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -5819,8 +5819,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="0807edb8-422f-4ee5-99af-a663d7491ea4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dbc9c451-4308-4cba-8bb7-dcda865f18f9">
+      <statement statement-id="ps-5_stmt.b" uuid="b1c33cfc-5b1a-4c4a-9a1f-1b326d12b8bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="815501c8-e770-45c5-8421-cd2c1d2e1719">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -5829,8 +5829,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="515ee2c7-7928-4893-805b-0a04ca9c5eed">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="39e39043-3b59-4adf-b624-f3fdd317f901">
+      <statement statement-id="ps-5_stmt.c" uuid="6ef767a9-8e24-4146-a8ba-a16178901e3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3ef830a-c8b9-48d2-9f2f-22ffcbe98ccb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -5838,8 +5838,8 @@ or transfer are outside the scope of Red Hat Advanced Cluster Management for Kub
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="8aef755e-166f-4016-a7f8-999dc274a6a5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="325a27e6-9911-4d2c-afcf-0d38778cd2a5">
+      <statement statement-id="ps-5_stmt.d" uuid="8fa717b1-6194-46de-b1c1-8e9efa7d9024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58a7d968-8b64-442c-8cf8-6a1fb6f14c8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -5848,10 +5848,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="855b9a26-b4ca-4a18-886a-f5f9eb3fb65e" control-id="ps-6">
+    <implemented-requirement uuid="55212855-6b55-4446-894f-e8075367debf" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="40226717-9b40-4bea-9956-c4dac937edcc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e0ce6eb-a55c-4c63-9869-bc7af3d839d1">
+      <statement statement-id="ps-6_stmt.a" uuid="c0824464-d4c6-4217-9591-66c4979c214a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a87dde3-52c9-4aa1-b88a-5bf8a6716ff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -5859,8 +5859,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="bd685653-fbc9-4049-8fad-d012aaf37e2b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4fb871af-db8a-4d35-90d7-0d7217cbdd38">
+      <statement statement-id="ps-6_stmt.b" uuid="5f685e28-9d6a-471d-938e-237e539dc978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="82a00138-2407-4695-b3e6-59fe0dc8f35c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -5868,8 +5868,8 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="01a70bd6-d0d2-4157-9657-9ff2985113f3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="baa78695-07ed-48c2-a8ad-e15d55b26d58">
+      <statement statement-id="ps-6_stmt.c" uuid="be530178-263c-466a-9967-db94f8582011">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5877,8 +5877,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="39f15737-1081-49cb-b086-51e58d4ba4d6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="81abcdee-f58a-43f0-9100-daa2b77ba8c4">
+      <statement statement-id="ps-6_stmt.c.1" uuid="a8f518ca-e021-4e41-a0e8-5b044f14a24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5886,8 +5886,8 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="d5481f84-5e63-4fac-8b79-690d6350d1f1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1263aba6-4acb-4a22-a15a-86f79ccaba45">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d966152f-c1d4-4295-8eb6-fadbc32edbfb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e3c0463-9740-4554-ba16-ff2a8cc96320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5896,10 +5896,10 @@ access agreements are outside the scope of Red Hat Advanced Cluster Management f
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13897ec1-3535-4f0a-9d69-9990808350b5" control-id="ps-7">
+    <implemented-requirement uuid="9e92f0ba-f452-431a-85a5-a74cd7c4bc96" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="5932e3d2-2161-4f9c-b9dd-f4aa4fb7618a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="58e861ab-c673-48d5-85e0-88ccb47e1fe5">
+      <statement statement-id="ps-7_stmt.a" uuid="947bc933-387a-4d5d-bc1d-548d44c0489e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d1193a2-7742-4c6b-b661-478eb2347bfd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -5907,8 +5907,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="265c2ec1-db26-4846-b332-1aa1cdb1133e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="aac17edb-5ffe-44ca-be70-7f4717f77ddc">
+      <statement statement-id="ps-7_stmt.b" uuid="24b5dacf-7696-4efe-944c-6489e7ef86e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59e0633-2918-44a3-903e-4506e838ebcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -5916,16 +5916,16 @@ the organization are outside the scope of Red Hat Advanced Cluster Management fo
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="013415a4-d141-44bf-a8cc-0499eacd16cb">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="67514a18-7715-4724-a017-24ee693b33ba">
+      <statement statement-id="ps-7_stmt.c" uuid="e5009a10-28cc-4309-9c3c-f7aa4fa88e19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c862fe2-ab9f-4e92-b685-7e9769b97ddc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="a8b1c2d5-84bd-459f-ae83-f7290c9aa4ec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f92c621b-ae4c-4b08-8b04-c7a11c41b8f5">
+      <statement statement-id="ps-7_stmt.d" uuid="19524cc9-a1eb-4861-b73b-e596ec70eef4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5db9d0c1-73ad-4604-a0b5-124b1b0813d4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -5936,8 +5936,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="379b4eea-1196-4764-a24f-956cfca7b48c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="62452644-1b56-43b4-aa14-4b8a75e1f3f3">
+      <statement statement-id="ps-7_stmt.e" uuid="28eae6f7-79a1-481b-9044-61e2d75e108e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0fcff48-98f4-4c4e-894b-17089205806d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
@@ -5945,10 +5945,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3040a874-7c90-40e1-a0ce-19bd1405619d" control-id="ps-8">
+    <implemented-requirement uuid="51daba9a-e441-4a8a-9788-d76c1c1587c4" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="64380f41-60ec-4cfd-a35d-0665b78013f0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="00315759-b452-490a-b155-7ddca830f9e1">
+      <statement statement-id="ps-8_stmt.a" uuid="ae4c7e89-a6d2-4b61-8b0e-aabde6f59a4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0149ee0b-e7e3-4293-b9cb-889fbde710ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -5956,8 +5956,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="1f9dd980-b2c1-4a5b-b70b-678f173e18c7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="62d0aa9e-1cf4-479a-ab20-7bf6f7cedd17">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -5967,10 +5967,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f0d2bf4-e883-4cf8-a5c5-569c79ab51e8" control-id="ra-1">
+    <implemented-requirement uuid="6216d434-a474-42af-a2be-87332323c39e" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="0633fade-59a5-431d-908f-eb543574a145">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c1f2b273-0ab5-4ad7-abfd-d1c2fa8f7341">
+      <statement statement-id="ra-1_stmt.a" uuid="ba9a3d0a-1b84-474c-8589-1e19f8f59c78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5978,8 +5978,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="9609d4fe-5529-4a16-9e39-3862ef584aee">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c348c514-76a0-4cf1-99e7-44be810462e1">
+      <statement statement-id="ra-1_stmt.a.1" uuid="e8073210-6722-4f57-ba87-e52147b2afd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5987,8 +5987,8 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="924f186e-5817-44d5-8d6b-a94cedf593f3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="81f67b3c-fd45-4dcf-810b-5082023c491b">
+      <statement statement-id="ra-1_stmt.a.2" uuid="cca51aed-cfbf-44cc-9053-c1d1f769ad2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e275d924-ebe5-4564-a7c3-410c7100aa45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5996,24 +5996,24 @@ and procedures is outside the scope of Red Hat Advanced Cluster Management for K
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="ba73666d-af2c-43f6-aaff-0781bb5b6a53">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f978f91c-8855-438c-a465-295469c47adb">
+      <statement statement-id="ra-1_stmt.b" uuid="41fcfe11-8e26-454f-8590-a33e35c48c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="51865819-ac1b-44d2-89c4-af472ce3bf29">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e41858fb-4192-4ae4-aff4-40539c071204">
+      <statement statement-id="ra-1_stmt.b.1" uuid="6abad903-8168-4c9a-8415-b68e057853c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="963d8592-a772-4c4b-a5be-05a7c9267aa6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e1b3aadc-c269-466d-8300-81f915c72643">
+      <statement statement-id="ra-1_stmt.b.2" uuid="fc8da6e0-499d-4016-a8f8-fd4a5fc3c2c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14eb428e-e722-4eaf-8ece-03bccaf22ded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6021,10 +6021,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e20fdfee-7c62-4c31-b2f3-af60e2a9629e" control-id="ra-2">
+    <implemented-requirement uuid="5c418f41-5b8c-41e4-8aeb-04b1da9a75b1" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="77b8321a-8039-4ffa-8b80-f009d549e3b9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d4a423bc-b3fa-4190-a2e5-7dfd20f991a4">
+      <statement statement-id="ra-2_stmt.a" uuid="29b82483-d484-4ae1-9bda-11410dc737ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b8ec53-c18d-49e9-8dfb-f9cdff739bba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -6033,8 +6033,8 @@ guidance, are outside the scope of Red Hat Advanced Cluster Management for Kuber
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="55121832-d408-4e7b-91be-28ffd216ab59">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9bfe7348-7c96-4456-961f-8d89fcab1c20">
+      <statement statement-id="ra-2_stmt.b" uuid="d1ec18fb-30ba-4d31-8f13-2d53c896008f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8e73384-e452-4de5-8f4e-3904534bbd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -6042,8 +6042,8 @@ the information system are outside the scope of
 Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="84595f0e-0d12-4b4c-930e-48645709d035">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="339400db-dc8d-46fc-befc-46c1558384a0">
+      <statement statement-id="ra-2_stmt.c" uuid="41bf5a9c-a005-4633-a11a-548dc6388d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bd08efa-7eda-4b5c-90bf-4212008e6d51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -6052,10 +6052,10 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f44b0041-7e3b-4170-8867-118fbe23da3d" control-id="ra-3">
+    <implemented-requirement uuid="15b53a72-3910-4d35-a0a6-194aaa66d734" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="5d9e76a1-185f-494c-ac81-32dd65cae429">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ae7215ef-6308-40da-9bfb-0b7a394536ff">
+      <statement statement-id="ra-3_stmt.a" uuid="c158bdd6-f9d4-4807-ae30-105f4dbad6d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9e600a5-e75d-45be-a1b0-e134cc6ad299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -6065,8 +6065,8 @@ transmits, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="c01db0c9-5cad-4edf-ae06-fbdb35d23090">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cf782712-7b13-452f-9068-e9932a525048">
+      <statement statement-id="ra-3_stmt.b" uuid="6d5266e5-0cf6-41a6-a5e5-19dc40a4104d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08a69f48-635e-4c35-9c57-abef65f44bac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -6074,24 +6074,24 @@ documents, are outside the scope of Red Hat Advanced Cluster Management for Kube
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="f2e67a03-48e4-449f-ad55-5a3380f60d94">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9ff23c86-5524-42d4-b593-5e2960ff8ec8">
+      <statement statement-id="ra-3_stmt.c" uuid="3a949ca5-03dd-4da1-abf3-4964fb2f19dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e0ed2c-75a5-4b3e-85fe-af7dd3c33564">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="2027df33-a29c-4fed-b812-57b8f3f84630">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e457b9e1-89ac-4f60-b35f-3a8549ff917b">
+      <statement statement-id="ra-3_stmt.d" uuid="800d36e2-ebdc-4451-8b7a-b55a5d1521e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b31c816-14ea-442d-8c78-f53fefe80486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
 of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="926477b2-9291-4bc9-a1b4-5a5b14873e6d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="caa62816-3352-495d-b97c-e287b7e9fd87">
+      <statement statement-id="ra-3_stmt.e" uuid="666156ef-f85b-470d-aaf7-cf1a21d1f049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c4b4f59-53aa-4734-9668-258952461f13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -6102,17 +6102,17 @@ are outside the scope of Red Hat Advanced Cluster Management for Kubernetes conf
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce041fd9-6e72-41e0-a8dd-95af9260c12c" control-id="ra-5">
+    <implemented-requirement uuid="be9e3ae6-ee6b-4aa5-8d4c-c1d3b608406b" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="22193228-f8ac-4d26-92d4-bfc99a7abb3c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b8b54a27-8a64-44d3-9096-be1fc5e074a1">
+      <statement statement-id="ra-5_stmt.a" uuid="dccb79ef-09ee-4efb-939a-24bc0487e826">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="864bb24d-863b-4d49-9a6b-2f2226aa8790">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8634a6ac-e418-4882-8eff-df3268c6de6b">
+      <statement statement-id="ra-5_stmt.b" uuid="a99daa29-24eb-4b9c-8f88-042f70a8ac2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8e77ad9-cca6-42d8-bffe-2f62a993929e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing vulnerability scanning tools and techniques that facilitate
 interoperability among tools and automate parts of the vulnerability management process by
@@ -6127,16 +6127,16 @@ Documentation on how to create a security policy can be viewed at:
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="12f725ef-e29e-4ae5-8624-b0267fb04eb3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7d087f1a-0f79-44fb-ba31-cce99dae8630">
+      <statement statement-id="ra-5_stmt.c" uuid="900fe8d3-5443-4c5b-95a3-c19be1492b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38c9ad0f-841e-4ea9-b823-df5705054e7a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization analyzing vulnerability scan reports and results from security control
 assessments reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="1b26a5f3-0963-4819-b4d3-ef29eabc50ef">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e4038400-9016-46fc-974f-3f6493343fb0">
+      <statement statement-id="ra-5_stmt.d" uuid="1efab40a-9b23-4e20-8ea5-804c56098eb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce90a18b-e7b0-46a1-bea5-e49a4ee539ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization remediating legitimate vulnerabilities organization-defined response
 times in accordance with an organizational assessment of risk reflects organizational
@@ -6150,8 +6150,8 @@ via a security policy. Documentation on how to create a security policy can be v
 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="cb2cb872-2302-40ea-b128-99bf11d7f3ae">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b5b8787f-86c2-4f34-8576-e6f67e368b5a">
+      <statement statement-id="ra-5_stmt.e" uuid="37330ba6-07dc-4b51-8247-6cefa0718e1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9991d966-780d-4c2e-ac15-992b1775832a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -6162,10 +6162,10 @@ of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remark
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b92ad6eb-4734-4276-8477-4a36294bf9d2" control-id="ra-5.1">
+    <implemented-requirement uuid="b91bb912-26df-4bc5-a3ba-9a7a3f3cc9be" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="214bde27-b4f4-46be-a0b0-230dec3ea014">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bbc3b546-17a3-4ae8-9163-7c66ffdc1e87">
+      <statement statement-id="ra-5.1_stmt" uuid="d7217a8b-c3d1-4c98-b71f-14bf8270f9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ccdc896-ee97-4175-a453-b287e3acbb8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization determining what information about the information system is discoverable
 by adversaries and subsequently takes organization-defined corrective actions against
@@ -6174,30 +6174,30 @@ applicable to the configuration of Red Hat Advanced Cluster Management for Kuber
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb75cae7-3ae2-4a69-b60c-a6744b35e09b" control-id="ra-5.2">
+    <implemented-requirement uuid="c6949a3c-43fb-4149-b748-fd3fc0fb31f1" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="4dcda0d3-ba23-4753-9a90-5e41527db139">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bc24e9ef-8ffc-4e58-a8e3-4fdf4bdab0a3">
+      <statement statement-id="ra-5.2_stmt" uuid="30f80a77-17ec-4eac-9c5c-c9beb9de6e72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76cfcf47-3423-4b1a-a32c-357ed02ee25d" control-id="ra-5.3">
+    <implemented-requirement uuid="1f68bff4-c369-44e2-9c46-d446299c2bb3" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="0b51318b-7218-442b-9d69-a0a965c0dca5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="535de21b-06a3-4f7c-b809-f1e55d317320">
+      <statement statement-id="ra-5.3_stmt" uuid="b7c13b29-ed36-47cb-93fc-d90c28f1555e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b8b71ba-796f-41dc-9d7a-8dc92e8a7cbc" control-id="ra-5.5">
+    <implemented-requirement uuid="50a2816c-9bb6-4852-b778-5a03733ed359" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="f5af425c-6b63-436a-acc6-5d4f0128931c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1da8c015-940e-4288-98a0-8898a3ba3528">
+      <statement statement-id="ra-5.5_stmt" uuid="97aaba5d-c60d-4e2d-b70d-c933884a873b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1700163-85db-4331-8fe1-7a7558eb110e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system implementing privileged access authorization to
 organization-identified information system components for selected organization-defined
@@ -6209,10 +6209,10 @@ layer to provide and implement privileged access.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aed3bba-aa10-4334-a9e5-bb24d2801c26" control-id="ra-5.6">
+    <implemented-requirement uuid="20626d10-0b34-4ccb-aacb-b4a870726812" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="7cec31f1-1783-4de8-9099-7895c5a9fc72">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="499e0428-50d5-41c8-b38e-f8151a84f439">
+      <statement statement-id="ra-5.6_stmt" uuid="209a6a02-16c0-468e-bb8f-dce319fbf58c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79fa25c0-40af-4bb4-8492-d2f0c50a1a9b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization employing automated mechanisms to compare the results of vulnerability
 scans over time to determine trends in information system vulnerabilities is an
@@ -6221,10 +6221,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02f737d6-f9e7-4d59-a2f8-1c4712cff84a" control-id="ra-5.8">
+    <implemented-requirement uuid="4e055e52-d501-44f2-a717-138634b1c54b" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="7fd78d3e-b72c-45e4-82f8-1b6d5cbcf28f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e96afa4e-fd42-43c2-aa52-c9ef35e00ed9">
+      <statement statement-id="ra-5.8_stmt" uuid="2884be7a-4f0d-41d6-b00f-61f82e1b41d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="601da591-f584-4f91-83d7-ac2205cf1e83">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -6233,10 +6233,10 @@ Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ee4d930-9be4-4363-b2af-445b1e38eaf7" control-id="sa-1">
+    <implemented-requirement uuid="bef6edc6-6d64-47dd-8489-9a6e27d991c2" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="0eb69a20-98ce-4376-b6c6-e901c719d721">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="77113365-8ef0-4967-ad8d-6ce166ef13c9">
+      <statement statement-id="sa-1_stmt.a" uuid="028f5a03-49c2-4b53-a7cb-1785af084ad6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6244,8 +6244,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="cdf84ef9-5099-451a-82b1-67c8e61bfdc5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="805d1a1a-d86c-4f5c-adc5-2197fa136a04">
+      <statement statement-id="sa-1_stmt.a.1" uuid="19b9b625-8a58-40a1-9e80-83cddeae90b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6253,8 +6253,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="620d3fd9-497c-4b35-965d-825a33446ed9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="920c3eec-e87b-47ff-889b-2a51e1a8e57e">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2797b025-1caf-4640-b133-b5e5762e2982">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c6a19090-a6fa-49b6-8af1-13bf21af884b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6262,8 +6262,8 @@ acquisition policy is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="538f84fe-77ee-482d-b2b8-247a0023d294">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7eac248c-9f36-4dab-ac49-3dcfaa738a1d">
+      <statement statement-id="sa-1_stmt.b" uuid="d89d6bd3-82ec-4645-9fbf-fb91ecf0d243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6271,8 +6271,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="e294b850-5c2d-4ff1-96fe-7adbe400dbc9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ebde818d-f6f6-4694-880d-abeb89d36438">
+      <statement statement-id="sa-1_stmt.b.1" uuid="c38432aa-2db4-4d9f-8b38-599675772d61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6280,8 +6280,8 @@ is outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="deeb0a47-a51c-4233-98a8-17c6a47ca5f2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a9e6b600-b35f-445f-b8ad-f4b6a82d11df">
+      <statement statement-id="sa-1_stmt.b.2" uuid="16876a68-d462-4e48-b51b-467eea24dab2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e4b1486-f383-48cb-b8e2-eaa83e3936e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6290,10 +6290,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3364e983-f814-4050-b8d0-89f27f111c69" control-id="sa-2">
+    <implemented-requirement uuid="6964c443-11d8-4230-8f68-28dd5588b94c" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="6c580be6-705d-40e6-806a-6e77387b9eb5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a957d88a-bffe-47a5-91df-b06f6ccdc2b0">
+      <statement statement-id="sa-2_stmt.a" uuid="2e505351-afb0-46ec-829b-870b2fe94a7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d4b9c05-7564-44a9-aca9-fe352166d044">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -6301,8 +6301,8 @@ mission/business process planning are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="da5a68e5-c97c-4bfc-8e20-96d3acd21e17">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b6955808-cb9a-40bd-a1df-81ed57dec724">
+      <statement statement-id="sa-2_stmt.b" uuid="f8220ce3-ac39-4864-83f6-f270da1edf1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5fc173ed-aac2-473c-80a3-14d8ca2254cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -6311,8 +6311,8 @@ process are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="f242beef-ecae-40e5-ab3e-82203e69e9fa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f90da4d5-bd1b-440c-9a00-a5241a4bff5c">
+      <statement statement-id="sa-2_stmt.c" uuid="59308e73-1cc8-454a-af7f-74ef44846a9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d123c3-667e-4146-bf92-e0f3cd02938b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -6321,10 +6321,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="242b0bd6-0210-4bd5-b7f4-dd5814a163d9" control-id="sa-3">
+    <implemented-requirement uuid="499e5123-bce7-45ee-afd3-a841fc3c8b48" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="a7b4dbfe-4319-4aa2-af0a-d8af6d1a43d7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cf8ec17f-047d-45be-af3e-34f0bdfd0b7d">
+      <statement statement-id="sa-3_stmt.a" uuid="302872d8-fd9d-4cf2-82a0-7e28293d6287">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce685a8-c7a8-40d5-bffb-a711ad980341">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -6332,8 +6332,8 @@ information security considerations are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="3d303ecb-31f8-48c3-b8a3-9b216976fb49">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="27110cef-04ba-4b6f-8cd6-e78191cdab46">
+      <statement statement-id="sa-3_stmt.b" uuid="de1b1699-b5ca-4cc6-87f4-7897cf852320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb2cea8e-397e-4dc3-a732-f4ea8cc16dd3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development life cycle
@@ -6341,16 +6341,16 @@ are outside the scope of Red Hat Advanced Cluster Management for
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="c9d591fd-69f8-40c4-a095-301c29941c26">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ad26c0f2-f883-4d79-9ec2-8d51f1414cae">
+      <statement statement-id="sa-3_stmt.c" uuid="2050dd81-a765-4f5c-862a-6a9f35db0df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8283839f-f8b4-4736-8ed0-acad14cd7419">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="65dcfa67-36d4-446b-8118-26dc5d53c50d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e5acb43c-4f46-4a96-b3f8-3e8da1367c10">
+      <statement statement-id="sa-3_stmt.d" uuid="c8b2952a-7d4b-4096-872c-d5056996ffab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bdaaf3-c06a-4ead-9455-181fc42ab80a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -6359,42 +6359,42 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a0adb45-593b-4891-81c5-b67e4a3663e6" control-id="sa-4">
+    <implemented-requirement uuid="13e16672-ab35-4283-b047-0ddfae0a55fe" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="477d915a-5e8c-42cb-9f79-2320fc7d03f8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ff3dbcb5-fd82-4e89-9e2e-efcd46f94a34">
+      <statement statement-id="sa-4_stmt.a" uuid="739264ec-e883-4320-8ec7-5254f35496b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="195535e5-eff2-4172-8801-5e8a786a670a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="1187d522-5838-40c9-b03b-2cb05552beb1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="832b011f-2c4a-4101-9f2a-5aea09ba8766">
+      <statement statement-id="sa-4_stmt.b" uuid="9e4076e4-39dd-404c-bd0f-e6d62c71c87e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce554d87-8848-4201-bcbf-a5a3deb85d2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="93fd09e0-eabb-445d-8280-c4e2ff47f3d9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f4b66832-16c0-4fd3-b936-98c9be84b128">
+      <statement statement-id="sa-4_stmt.c" uuid="d4f5a970-6c0e-486e-bb78-97e25c18eefa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7e96d96-886f-4a58-b249-fc5ceb5d3acb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements in
 acquisition contracts are outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="44f1c4df-f2c5-4615-b389-c8a33164ca3a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="020f1b77-d733-4370-8b45-58f306d9a954">
+      <statement statement-id="sa-4_stmt.d" uuid="85d4555e-30c6-4760-b264-7532f915aee7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="916f3e52-34a3-445b-9b72-d122deb0afd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="db48667e-5c52-4f31-bdf5-cfceefd095e2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6f3c6c6c-d440-49da-85fe-8de10a4dd855">
+      <statement statement-id="sa-4_stmt.e" uuid="1655e4cb-492b-4bd3-9089-808252d01ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d76a02c8-d32b-4ce3-a42a-e90a15373882">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts are outside the
@@ -6402,8 +6402,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="03fdc830-fe74-4250-8d92-2efba79f9398">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ffbf4f7f-6b4b-41d7-acf7-5a133238d266">
+      <statement statement-id="sa-4_stmt.f" uuid="1eda4fcd-e205-498b-8423-b9957105e1ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a9cc39f-3256-4309-b8de-7d81b133ebf9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -6411,8 +6411,8 @@ intended to operate in acqusition contracts are outside the scope of Red
 Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="df2cbdf1-45bd-4d99-a358-87d22a2f1f0c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a90f183f-fa8e-423b-91e0-bb852c460875">
+      <statement statement-id="sa-4_stmt.g" uuid="ef890e3b-8c9f-4c7b-b5a8-b8e58ca7133a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72b142ea-c5ba-4f92-9019-96802ebb8ab9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in acqusition
 contracts are outside the scope of Red Hat Advanced Cluster Management
@@ -6420,30 +6420,30 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9c590d9-e7fb-4855-9046-2a5361417a22" control-id="sa-4.1">
+    <implemented-requirement uuid="7321ca74-e148-474e-94f8-a04964c037fb" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="d3a8f607-625e-4cee-8098-7bd77d6747ca">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8e0200e9-d148-4fef-ad1b-e5c54675e675">
+      <statement statement-id="sa-4.1_stmt" uuid="209afdb1-0dac-4e0f-b926-4d48ebfda0c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="396a34f2-b59d-4622-aaa7-317ddb07a610">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Official documentation is needed
 and is currently being worked.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acb1ad53-fe98-4bd7-baa6-44808976a3d2" control-id="sa-4.2">
+    <implemented-requirement uuid="3af98ccd-bcb3-4ec4-9ab5-f615bac80918" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="b7d8ee84-849a-48e8-ab16-f18493a6013e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7e5fdab6-f32c-4eba-8dd6-6c1b965b1b6f">
+      <statement statement-id="sa-4.2_stmt" uuid="2d9c3962-f6cd-4ffc-8e4e-c3243a618897">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="396a34f2-b59d-4622-aaa7-317ddb07a610">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Official documentation is needed
 and is currently being worked.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42b09844-7238-4261-bae4-15f5d76a0950" control-id="sa-4.8">
+    <implemented-requirement uuid="295d7c7e-344a-4e07-bd3c-ad0317bf6ad5" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="753e7f98-8dfa-42ac-ba66-ab21c3edaafa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b6a8d35e-1b14-427d-bff7-36e32e35cd0e">
+      <statement statement-id="sa-4.8_stmt" uuid="e7c6a491-2819-43b3-a2e5-1ff9f28377f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79d192da-1b65-4775-9d6e-edfc880fcb97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -6453,10 +6453,10 @@ https://issues.redhat.com/browse/ACM-455</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abc9de7e-ba41-4da7-aa0a-5efb46c8a067" control-id="sa-4.9">
+    <implemented-requirement uuid="a7b398aa-7c24-4d88-8c0d-6cc942cb6d7c" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="b95b16e0-658c-4d21-9cc6-8c8c6f9df97d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3ac4ee3c-c944-45b7-b0a4-30322be364b9">
+      <statement statement-id="sa-4.9_stmt" uuid="8bbd2217-aa27-4acd-a9a3-cb000706c911">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ab34981-0568-4c3e-be31-4775bb96c832">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -6466,10 +6466,10 @@ https://issues.redhat.com/browse/ACM-377</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e5b43cf-c65b-415b-bcfb-193a330de7c6" control-id="sa-4.10">
+    <implemented-requirement uuid="a196beaf-b45c-4b19-8e7f-624f1e5c3339" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="eb978e69-edc3-42e6-a833-eea2388088e5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="086881f9-85e0-434a-a11f-2adfe7841d0f">
+      <statement statement-id="sa-4.10_stmt" uuid="41eb5975-a78e-430f-bcb5-abb0606affc5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6477,90 +6477,90 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3c9204b-926a-4958-a133-9e49ae160ae3" control-id="sa-5">
+    <implemented-requirement uuid="f822cd1b-379a-4c7b-ad53-f1e217a85b04" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="af21e318-ddf5-464b-9da7-b1a62a9aefef">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="cf3abd31-3086-46d0-811a-c323a8f93c85">
+      <statement statement-id="sa-5_stmt.a" uuid="b9f58e21-0fd2-4c7b-b4aa-f12cb4ea7309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="5221a8ed-c56d-43c2-ac9e-89eb8b187933">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c9981e44-15c9-4237-8722-6efc09d0787e">
+      <statement statement-id="sa-5_stmt.a.1" uuid="5678be5a-2a7e-46ba-93e8-de0b2f9e96f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="727f0d08-0584-46bf-bace-0f5ecf17084a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8791da06-6606-4e26-a101-87150d9651a9">
+      <statement statement-id="sa-5_stmt.a.2" uuid="e301d484-e461-46a6-b65f-302944eeff34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="ffc48b3f-d8d4-4768-91b3-1c296f9c4cf9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8fe35c97-285a-4c9a-a813-139d7fc2a8c6">
+      <statement statement-id="sa-5_stmt.a.3" uuid="4b02dc91-2d21-455f-a6c9-095af0426668">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="e690dd25-de9d-409f-bb1d-f46dec5999ec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="301178fc-b648-4fda-a410-8bc3105b16cc">
+      <statement statement-id="sa-5_stmt.b" uuid="16150061-93ad-48ca-a3bb-2d3c4da717fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="54fb1acf-4960-40f8-a056-1277b8efc1ce">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6591452a-e30e-45e9-9b6b-f5c1e38976ed">
+      <statement statement-id="sa-5_stmt.b.1" uuid="953f7b0b-89c7-4dad-9cef-3b651e3a402c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="01004ae7-a06d-4b3f-b830-aa1800b533c5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fb8d81ee-cadb-409d-8ddd-63700c2e0bfc">
+      <statement statement-id="sa-5_stmt.b.2" uuid="3cab31bc-a5ab-4408-b629-7447386c8035">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="611b4975-73c3-4674-b18e-f28ebb36f283">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b85ea5d3-b123-4991-8f52-8ae7e0381e30">
+      <statement statement-id="sa-5_stmt.b.3" uuid="2c38c229-d3a1-4a76-b42e-d2ef311f4e15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="453b0431-dc01-49a9-8799-f26d754f22ad">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d791d9cb-4ed3-4868-86ca-6731b42c6312">
+      <statement statement-id="sa-5_stmt.c" uuid="c7bbf9bd-1f61-4dc4-8ee2-f0f3b230081b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="f3dfa43f-9331-4ac3-9515-d8aa4c4cf9db">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="efe90ee9-cb4b-4026-8035-c4104116f1d4">
+      <statement statement-id="sa-5_stmt.d" uuid="e87a5f39-1929-43af-85fb-1ff5fd949fef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="524f13b3-f384-4f8c-a9e7-b8bf9621b138">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="465e4226-ac5f-499c-8c7b-e12483af9115">
+      <statement statement-id="sa-5_stmt.e" uuid="7cad6c74-4815-4ba7-94b0-dfae69599372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6568,10 +6568,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94be5e71-28c9-47ec-b5e4-c4e7c90af1d7" control-id="sa-8">
+    <implemented-requirement uuid="8c7e85b9-da64-4a6f-8ee7-c868643947d2" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="e70dc4fc-8320-4778-a9a7-6c6ae6988d7b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e5a0ebf1-0089-4c4b-adf4-99578ef00910">
+      <statement statement-id="sa-8_stmt" uuid="330eb71f-a093-4fbf-adff-60bd30b13dec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6579,26 +6579,26 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f26a2778-a9f8-4342-8512-ab3fb33e1555" control-id="sa-9">
+    <implemented-requirement uuid="661d2ffc-26a5-4c69-b185-ff60e64b76d2" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="59535ba5-72f9-43ab-a3ba-083d72eb90e9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d980be9c-5117-43be-9b33-8c829abf71a2">
+      <statement statement-id="sa-9_stmt.a" uuid="5f542c78-8954-48e3-818d-25b5d1ae6d82">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="2be9baba-ec24-446f-9b27-65545ebf622a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="58b54159-1df0-4f0f-a6f6-843b879cf19e">
+      <statement statement-id="sa-9_stmt.b" uuid="8cb867c1-31f2-4862-946c-378dd8307496">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="0a02cf68-9bf8-49d7-bb15-6480c81b07be">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="94606d97-8e55-433e-828f-b8a5cb3b5279">
+      <statement statement-id="sa-9_stmt.c" uuid="a7025379-d99a-4313-aaa0-ad70d2e34718">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6606,18 +6606,18 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1dcb76d8-f48a-41f2-8382-c966bb4ce820" control-id="sa-9.1">
+    <implemented-requirement uuid="d374372a-c466-4530-b2df-cfe59d66e943" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="bfd65836-b485-48b5-9a82-e0a5cb502b73">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f059c9a-afb4-4077-9d6c-88ea60ff1b61">
+      <statement statement-id="sa-9.1_stmt.a" uuid="a13cf2d6-1e4f-4d6c-a246-5539b67d3d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="2ddfeaa7-d74b-4739-bd87-0b1965c2c600">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ca01a2bb-3f28-4dee-838d-fbe90992153f">
+      <statement statement-id="sa-9.1_stmt.b" uuid="f79f60ba-031e-4b6f-a533-244df1db8001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6625,10 +6625,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a5d6596-7e46-46a3-9fe2-e41c66c7f247" control-id="sa-9.2">
+    <implemented-requirement uuid="05cca186-4c93-4554-b38a-cb0455cac705" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="0e386108-87bb-4afa-98ec-a7c3d7dfa5cf">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5d66b184-18df-4823-89ba-3a0a9293a947">
+      <statement statement-id="sa-9.2_stmt" uuid="e6e126af-e9ae-4ff8-a97f-410c9d6ca2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6636,10 +6636,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="586a9f17-f339-4743-a55a-eef19d49771c" control-id="sa-9.4">
+    <implemented-requirement uuid="2b246686-ca40-4e18-8a90-0ab9d8241c26" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="f629c1db-32bc-4e0e-a481-f6121f43a7b9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e8d6a125-dfb2-460e-8095-bf9b1bf6e844">
+      <statement statement-id="sa-9.4_stmt" uuid="f23f3eb6-2991-470d-bbfe-0e04cada3f50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6647,10 +6647,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78aa3878-8876-4944-85ad-8f53bf014be2" control-id="sa-9.5">
+    <implemented-requirement uuid="39c0c307-c6cc-489f-b3b1-e8fab2aabf04" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="f3295645-40db-4bba-9dc4-f8263139d91d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="16dd08c2-305e-48a6-959f-1869cbd89ac1">
+      <statement statement-id="sa-9.5_stmt" uuid="55f4568c-cd0c-44f9-abf9-e77ace1e5a71">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6658,10 +6658,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe2690e2-c64d-4d07-83b1-b8cbfca75685" control-id="sa-10">
+    <implemented-requirement uuid="7cbf2bd9-a9eb-40af-b1e0-a1585a7a4bca" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="6542fa9c-b646-48d9-9bc1-5d2a87ff5b8b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="33627e09-0baa-4631-b6bb-eea3ada7e6be">
+      <statement statement-id="sa-10_stmt.a" uuid="fd9e8657-5a44-45f4-ab60-93aaab932264">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="088b458a-7d1f-4ed0-8d97-62d27cf13c5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -6669,8 +6669,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="cfb1a892-db59-4f9b-be57-72d413b8b094">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f92b98f-2ade-435d-a4f3-3ad1e3be9712">
+      <statement statement-id="sa-10_stmt.b" uuid="46568e54-403e-4201-9a03-6fe10dd5ccff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cdd8f10-0af9-4344-b12c-fca87995ad08">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -6678,8 +6678,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="f154ce40-9226-4d9d-8854-d01170eb742e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="10ad170b-cc68-4925-a5d0-480623d268f3">
+      <statement statement-id="sa-10_stmt.c" uuid="b59f2c8f-a5aa-4444-9931-76f6979b7575">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b02aec24-7c7c-44f1-84b0-dec1cf004fab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -6687,8 +6687,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="c842be90-12f4-4843-8d5a-de7b19913c99">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b19ccf95-2f78-4d06-86f7-fe1a134d47d0">
+      <statement statement-id="sa-10_stmt.d" uuid="5057677b-e07c-42de-a498-e47de857c621">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bd4914a-69ad-4e12-886c-71a3999dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -6696,8 +6696,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="e4ba1e8b-e4e1-4f15-af3c-5d25317dc6ff">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="75602c3f-3f5a-4974-b720-e18d97a62dc0">
+      <statement statement-id="sa-10_stmt.e" uuid="a4af5b56-db83-48c0-9e07-ee41c95827e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abad8380-8fa7-4f57-bd9d-8fa81ad7e349">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -6706,10 +6706,10 @@ https://issues.redhat.com/browse/ACM-378</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="095d1226-de0c-4737-8004-c860c86b7d1a" control-id="sa-10.1">
+    <implemented-requirement uuid="7e811e3c-bc47-4f24-b66f-9a08fb53fc60" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="30461834-bce9-4665-bade-480dc9e28eae">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="af19bfc9-e819-4e9d-ada9-4713f513ddc6">
+      <statement statement-id="sa-10.1_stmt" uuid="4c7fdda1-0519-49dd-9c12-b944c6d0553a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94722784-2dad-42b5-b5af-0818b2cc1033">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Advanced Cluster Management for Kubernetes
@@ -6717,10 +6717,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35bc73c8-4838-42e0-a0c6-76043f135b00" control-id="sa-11">
+    <implemented-requirement uuid="4ba90207-b468-4f32-8ca2-ab7a72426bb4" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="ae5a6846-d445-46ed-89a7-018593e30b15">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3b4590bb-92e4-4543-87e6-488e9151198c">
+      <statement statement-id="sa-11_stmt.a" uuid="126b3d5b-7f8f-4d48-8ee7-89a1acd113db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78869988-a5b4-42b2-aaa5-6f9d6c1f8fb2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -6728,8 +6728,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="eebf2ddf-c818-4c67-a621-da8daccfc6f8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="411ccaa9-60f6-420e-a9c1-7b320c7d0b7b">
+      <statement statement-id="sa-11_stmt.b" uuid="f70ac29e-3b5b-4a9e-93c1-128a941c32b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fa0f19a7-52ad-40b8-8ebe-75ae3ddca053">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -6737,8 +6737,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="daf747fb-4287-478c-9b5f-de9741349a6d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="18745996-66f7-4885-9ef1-01e135447c83">
+      <statement statement-id="sa-11_stmt.c" uuid="2b88980e-09bc-4ec4-ac6f-5ec1cff4324b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04309885-08c4-431f-9715-4483a8d4700d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -6746,8 +6746,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="0f3479a5-f0b4-4b02-976d-25911307220e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="30014080-4cd2-474b-8d8e-c0a9d2a12610">
+      <statement statement-id="sa-11_stmt.d" uuid="e09cedf6-d5c6-4312-9dd6-f9af55e3f857">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fb3eeb2-af52-4205-ba3c-8b021a4039ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -6755,8 +6755,8 @@ can be tracked at:
 https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="77317c54-e03b-4079-913c-e4e54b8af527">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="841161be-ce42-4e50-9323-b712c37daccf">
+      <statement statement-id="sa-11_stmt.e" uuid="844d2ca3-7f60-4eeb-a114-f85a0893694f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2dc70364-a195-45e9-a3dd-6fd90aa3d069">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6765,10 +6765,10 @@ https://issues.redhat.com/browse/ACM-382</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26d33323-886c-480b-a8fd-4a6a7394914c" control-id="sa-11.1">
+    <implemented-requirement uuid="1688c6c8-e006-4864-b472-f2107ad16193" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="e74cac34-7630-4682-8e3a-efcb0b3acfc2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="abc42e29-a58f-4891-b319-b7b1189d1ef8">
+      <statement statement-id="sa-11.1_stmt" uuid="688c07be-68f8-4067-a0ab-853e5f5cabd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2611b8a-495c-40ec-a6fa-5b0e1a65ce2b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -6778,10 +6778,10 @@ https://issues.redhat.com/browse/ACM-459</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d348d60-c28f-4b9c-83f7-04f7edd3c596" control-id="sa-11.2">
+    <implemented-requirement uuid="631e878f-0cde-4d74-8e2b-ac56c1ff1605" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="ad5ea1e5-0bc6-4aaa-8bdd-e3ee63d82a33">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dbf0e98b-94f9-42dc-ab3e-664462c86316">
+      <statement statement-id="sa-11.2_stmt" uuid="b9a3c176-c156-4b7e-af54-b446cc227cf3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d8a7757e-bd17-47f8-9d8d-b83628ccfa5b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6790,10 +6790,10 @@ https://issues.redhat.com/browse/ACM-460</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="945ab388-6006-4cb4-8f9e-6f9f0bb35de0" control-id="sa-11.8">
+    <implemented-requirement uuid="b456393a-a4f3-405f-aaeb-8b4ca8c73c4f" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="0c6b7d53-a2a4-4f7d-b2bc-f568972a4b19">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d5e15ae0-7f52-492d-8fd5-0f586d1ab238">
+      <statement statement-id="sa-11.8_stmt" uuid="3f6b4669-9832-41ad-939e-8187217d66a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="926f69f0-f998-46da-87bd-ce533f93f463">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. To assist with this
 organizational control, documentation is being planned. Progress can be
@@ -6803,55 +6803,55 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b873c6e0-591a-489b-9559-374622161891" control-id="sc-1">
+    <implemented-requirement uuid="063e4e11-4214-4e9a-a375-4796714c910b" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="49cb100b-abbc-45c6-a997-b277984aab5f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="77a8384d-b004-4c64-86f0-6702e461113e">
+      <statement statement-id="sc-1_stmt.a" uuid="a12a93f1-5b0b-4786-aa28-143f30eb38d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.1" uuid="085c6464-8c20-4ca7-b16e-a2f312fb5d43">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8231de62-aaea-4ed5-a6a4-efdb39a5673c">
+      <statement statement-id="sc-1_stmt.a.1" uuid="45a41e0c-33f5-42c9-beb9-74f9f76e5038">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.a.2" uuid="02c83657-871b-4a9c-a56b-62879a0b0efa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f63b7ad6-6166-48f1-9973-a63b42c135b6">
+      <statement statement-id="sc-1_stmt.a.2" uuid="e7cf378c-c4c8-4a51-91e2-dde7481422aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="5bc2b6d8-eeac-47b5-8a3a-101b40a140fc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f90170dc-7b2f-4577-9708-8100b28c44d1">
+      <statement statement-id="sc-1_stmt.b" uuid="11034f66-c864-479c-9204-78d1cc94bf09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.1" uuid="1c697995-0e59-4b15-8376-48d3b950dffc">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="00b88f2a-2346-4139-aa1d-09534ac35de1">
+      <statement statement-id="sc-1_stmt.b.1" uuid="af7bc38e-b9c7-43e2-8eed-e0196d0fa0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b.2" uuid="2df100a8-6f5e-42a2-80dc-623ae2149875">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9e7a5323-dc91-497d-87f8-7c7fdc89d822">
+      <statement statement-id="sc-1_stmt.b.2" uuid="254e5f5f-0634-4de1-b144-7021e0e88822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="88e24f9b-5772-4ff2-98bc-1b51bc43252d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of OpenShift.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0167978-d5b0-41c1-aa4f-82882e96870f" control-id="sc-2">
+    <implemented-requirement uuid="059e4c90-bd86-4140-bf09-2d97a146ec61" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="4dc77d92-00e1-4dcf-8aa9-f33f33516f05">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bbbeca67-48ba-48d3-9c9a-b44879d9cfc5">
+      <statement statement-id="sc-2_stmt" uuid="36052b94-cf92-4613-a11f-cd2f24b72a52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ceb6221c-0fff-4bc4-bb3b-4b812d3e884d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -6860,10 +6860,10 @@ and management functionality access is separated.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4679a8f-fae1-4313-8daa-2a2449368576" control-id="sc-4">
+    <implemented-requirement uuid="2dfcfe4c-f6a9-499d-bb43-75cd582bdd9b" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="c2feae0c-ded9-4b88-b9c9-dc959826650e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d50e945c-929c-4398-96d2-6260fbc461da">
+      <statement statement-id="sc-4_stmt" uuid="8b093930-76e7-4b8e-8f0c-9bec74a320bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="10d1ee8e-592b-46d5-9ef1-b1c0e098d576">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -6878,10 +6878,10 @@ https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_managemen
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac9d8f75-e849-41fa-af51-ec77bbff3baa" control-id="sc-5">
+    <implemented-requirement uuid="5b576bcb-c919-40fd-bb67-5821d10a7345" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="11f6a449-8e39-4d12-960b-8bda7f3d82d0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1b242b1d-752b-41e1-a22b-6599e8264920">
+      <statement statement-id="sc-5_stmt" uuid="e548b1c4-6c2d-4cfe-bb0e-38075f414e38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2b1b6a-92b3-4d83-aca4-3e0256656908">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6890,10 +6890,10 @@ https://issues.redhat.com/browse/ACM-384</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8d233a4-79f2-4669-a853-2c1787170c6c" control-id="sc-6">
+    <implemented-requirement uuid="eaaa0023-3b4d-47a2-b4eb-563d4b1e4864" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="6cb3a17f-9298-4090-bafd-91e3aeca3cae">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f254a8b7-d9c0-4949-a47d-17cb0e6d1f15">
+      <statement statement-id="sc-6_stmt" uuid="65c95447-d9f2-43c8-89d8-e28dcb5b2293">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad52e261-46a9-4e0b-8d8f-4b805a9cd3aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes provides by default
 resource allocation.
@@ -6905,10 +6905,10 @@ https://issues.redhat.com/browse/ACM-491</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ee5b653-93ea-4b5e-9dc6-540b98950606" control-id="sc-7">
+    <implemented-requirement uuid="56f23e97-1252-4185-aaff-741dcf403498" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="496c1596-b98e-42bc-9055-ec684470d7b9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="db1c3e87-1de1-4235-9325-09c55d5a4ec5">
+      <statement statement-id="sc-7_stmt.a" uuid="13502385-9466-448b-9d7e-fc2841c74e66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de4b5a8f-71f7-41e8-a400-6ed93c1e6851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring and controlling communications at the external boundary of
 the system and at key internal boundaries within the system is outside
@@ -6916,8 +6916,8 @@ the scope of Red Hat Advanced Cluster Management for Kubernetes
 configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="9f526d94-196a-421a-8fc1-aee15ff607af">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d9e2faf6-4d42-4518-8e22-836d975c244d">
+      <statement statement-id="sc-7_stmt.b" uuid="87f66c85-c155-43f5-87dd-579923be77bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23fbdb9b-c426-4f48-a8cf-4b13cde82e04">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing subnetworks for publicly accessible system components that
 are either physically or logically separated from internal
@@ -6925,8 +6925,8 @@ organizational networks is outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="96009dd9-e154-4283-9cba-1436d3cb34d3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3121a288-497a-456d-9ff7-682f2da58cc1">
+      <statement statement-id="sc-7_stmt.c" uuid="67a90d86-423a-4b5d-ac1a-13bec42b5b4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f1301a0a-a911-43d5-86f8-94058c539d59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Connecting to external networks or information systems only through
 managed interfaces consisting of boundary protection devices arranged in
@@ -6936,10 +6936,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c30265a3-9b0e-42f1-b353-7c0accab3bef" control-id="sc-7.3">
+    <implemented-requirement uuid="615a5a86-f1fd-44b2-b001-ebf3fcbc9f2c" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="0a85936a-d36e-48f4-ba9e-aee52459aaf7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1af8e508-5bd3-4149-a656-ec664b3774fc">
+      <statement statement-id="sc-7.3_stmt" uuid="ba9923da-e4dd-43b2-a873-91b818bb5f66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5b6b357-2cd2-494e-a99c-23ceb5a7779f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -6952,10 +6952,10 @@ https://issues.redhat.com/browse/ACM-385</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e10a9bf-7988-47a9-943a-531af48be9f1" control-id="sc-7.4">
+    <implemented-requirement uuid="a882084f-2782-44f6-b805-2d45a77f29df" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="a9582796-993a-4c2f-979d-e6258dbafbd0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ea9dee8a-15e4-4ca7-89ed-d1765ce801b1">
+      <statement statement-id="sc-7.4_stmt.a" uuid="0cb84731-f9a9-43f0-b0f9-6a75c4ab103b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7edac91c-20b7-40b4-aa71-16ee1b3d8e53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing a managed interface for each external telecommunication
 service is addressed at the network infrastructure layer and is an
@@ -6963,8 +6963,8 @@ organizational control outside the scope of Red Hat Advanced Cluster
 Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="a079e94c-10e7-43cf-9be5-9812bf56e237">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6c9cf4ce-0beb-45a5-a454-1cff0e8bbb75">
+      <statement statement-id="sc-7.4_stmt.b" uuid="49f59666-aa21-47f8-b72d-2b4e9a7c7af0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="38feef40-0d21-467c-ab25-d63893b608a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a traffic flow policy for each managed interface for each
 external telecommuncation service is an organizational control outside
@@ -6973,8 +6973,8 @@ configuration and is typically handled at the network infrastructure
 layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="22eb7320-989e-4511-842b-521af644a4f0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e221ff7d-4cf5-4b97-8c12-d25392126745">
+      <statement statement-id="sc-7.4_stmt.c" uuid="5f95f49f-c3d1-4a69-a6d5-4722a0338cd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c1d1a6a-3294-4e7b-b40a-dea74e2d7579">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality and integrity of the information being
 transmitted across each interface is an organizational control outside
@@ -6983,8 +6983,8 @@ configuration and is typically handled at the network infrastructure
 layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="700bed49-2023-4d37-b344-15a451d4a17e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1a5262f0-81bd-4ad9-ae67-51d3c7c164ac">
+      <statement statement-id="sc-7.4_stmt.d" uuid="e9e71658-9af3-472e-bc42-cf64626b39cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21595205-efd2-44c0-9df9-ebccd2bd217b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documenting each exception to the traffic flow policy with a supporting
 mission/business need and duration of that need is an organizational
@@ -6993,8 +6993,8 @@ Kubernetes configuration and is typically handled at the network
 infrastructure layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="4c3bc183-9795-422c-a3ec-57fff8c88320">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d5cbc480-ebbc-4dab-a1dc-1ed590ea3ca5">
+      <statement statement-id="sc-7.4_stmt.e" uuid="e9160e3e-343d-44b5-b2a2-07f4b21b474b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4434ce6c-364a-40f7-9d18-d19fa4e19025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing exceptions to the traffic flow policy per the organizationally
 defined frequency and removing exceptions that are no longer supported
@@ -7005,10 +7005,10 @@ layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c26084c-c202-4f69-9ee9-a976338fe8e7" control-id="sc-7.5">
+    <implemented-requirement uuid="0374f80b-0d74-4552-ab33-2d898fe4543c" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="af248bc1-5736-4734-bc63-13937321fc2c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="189e84b8-0f5a-4725-88f4-c7aa91e22b02">
+      <statement statement-id="sc-7.5_stmt" uuid="0c412dca-b9bf-4c7b-a5b1-c65064bf205c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ae14af3-0e7a-4075-b379-fec38e0351d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -7021,10 +7021,10 @@ https://issues.redhat.com/browse/CMP-424</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c295c905-a36e-4d85-80e1-f2571d919e20" control-id="sc-7.7">
+    <implemented-requirement uuid="2721a473-4275-4b19-b59d-65c6e1d2c535" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="55d99337-610d-454a-afc0-b3c5233b814a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b1ad880f-4b7f-4a57-9cd3-e9ea1d8c1943">
+      <statement statement-id="sc-7.7_stmt" uuid="cd8b0cd6-b2fb-410d-b73e-042bfe844c97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7b8b8e6b-b7cb-4a1c-9659-f9deac17394c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>In conjunction with a remote device, prventing the device from
 simultaneously establishing non-remote connections with the system and
@@ -7034,10 +7034,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25f76551-4e17-4815-a16e-d719a117a696" control-id="sc-7.8">
+    <implemented-requirement uuid="5327d9dc-5d39-47f8-aa8b-97c65f5bac9a" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="e730a526-e6ea-4779-ad99-490c1b0ef058">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="88d3efaa-ba89-410d-ad44-2dc588cc07dd">
+      <statement statement-id="sc-7.8_stmt" uuid="b457520d-3ba8-49fe-9713-59a0435e2438">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c15c0d95-db47-45db-8fab-2334a0e079bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Routing organization-defined internal communications traffic to
 organization-defined external networks through authenticated proxy
@@ -7046,10 +7046,10 @@ Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c08357c-0c2b-41b2-9c4f-aff65023ac03" control-id="sc-7.12">
+    <implemented-requirement uuid="a53cb130-af00-4ecf-9fcb-42b5b3a284d7" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="6aee3df5-4b96-4c7f-aa2a-11e72fca69f1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="279fe40b-44af-4892-afab-0893a11e9fca">
+      <statement statement-id="sc-7.12_stmt" uuid="3d02f023-2c4f-43f8-a0c1-4de86f884706">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d29edd9-111b-4a3b-b9c4-6bf8e2e0cfb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined host-based boundary protection
 mechanisms at organization-defined information system components is
@@ -7058,10 +7058,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea49ae67-0eca-425f-a01b-bfaa622089c1" control-id="sc-7.13">
+    <implemented-requirement uuid="9c1ac441-82b0-4da6-9fb9-cf8ce288a719" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="10b98351-1868-4736-bcea-5c903fc2f70d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="71e8f3ea-cf2a-474a-8d4d-6c656a0b84e6">
+      <statement statement-id="sc-7.13_stmt" uuid="cbf60374-942c-4837-b9bb-dd1f1f3f7f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f40708a-e612-483f-b517-e43f329e0aef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Isolating organization-defined information security tools, mechanisms,
 and support components from other internal information system components
@@ -7071,10 +7071,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a55aadd-41a7-4236-841a-2352e4787698" control-id="sc-7.18">
+    <implemented-requirement uuid="4f45c786-a981-4163-a62e-b611986c2fc1" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="f3d521c1-72ae-4b29-aaf5-0142874d6512">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9d7a2e3a-121a-4bd4-8464-c48c738da114">
+      <statement statement-id="sc-7.18_stmt" uuid="c1a3c1d6-1ce9-4576-a5c8-d64cd5dfddaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c792010c-269f-4dcf-b31c-c50a716923e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Failing securely in the event of an operational failure of a boundary
 protection device is outside the scope of Red Hat Advanced Cluster
@@ -7082,10 +7082,10 @@ Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2cc7abe-0741-4ce4-993a-1b0093e06502" control-id="sc-8">
+    <implemented-requirement uuid="76a8a755-ff71-492b-80d8-3ffaef117e3c" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="ce0f8d07-3b56-4801-858f-3e40a25285da">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="067128a4-74ac-4bd5-89cb-7f09f6c3780a">
+      <statement statement-id="sc-8_stmt" uuid="b3d27a6f-fd58-4a8d-8807-863eb3e77e79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84e096c7-b33a-4e05-a3c1-eb9baf19b49f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for configuring TLS for transmitted
 information.
@@ -7097,10 +7097,10 @@ https://issues.redhat.com/browse/ACM-386</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="374b2d07-df13-4f4c-9fba-993a3ab39228" control-id="sc-8.1">
+    <implemented-requirement uuid="82f2ac7f-81ce-47fd-989f-ecd8a1527f06" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="301973a7-8bc9-479d-ab6c-8432b8bfb17c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="c731c452-ac44-4a6e-9768-084ca4156187">
+      <statement statement-id="sc-8.1_stmt" uuid="939e04d4-0206-4eb7-ab21-50098faa8523">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d6aca3a-8a0d-46dc-a215-fb60ab74be7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing cryptographic mechanisms during transmission unless
 otherwise protected by organization-defined alternative physical
@@ -7109,10 +7109,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="411b923b-89fe-4d00-9b49-eeb211674944" control-id="sc-10">
+    <implemented-requirement uuid="c5e04792-80e3-47d1-bdce-638bb888ab02" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="3dcf895a-097b-4d85-9dae-9feea16d8365">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7df19262-cd13-4011-82b7-019916cb962b">
+      <statement statement-id="sc-10_stmt" uuid="abe54df5-bf79-4a71-b90c-009432798a35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e66c2b0-387f-44da-8064-74d9c8673208">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -7121,10 +7121,10 @@ means on how this is established.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a11132d-1bf5-47b9-8290-19f01f648fc8" control-id="sc-12">
+    <implemented-requirement uuid="f4a51580-1504-444f-8cb6-eca35566cd21" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="54e513d1-a766-470b-9b05-775b004b1c8c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="612aef81-2263-41d0-b79e-2a498e465054">
+      <statement statement-id="sc-12_stmt" uuid="01a81a53-f306-4a28-b642-fd8e42b313a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed54e6a1-6659-41a3-bfeb-bab90f16b829">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing and manages cryptographic keys for required cryptography
 employed within the information system in accordance with
@@ -7134,10 +7134,10 @@ Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7a232d9-e605-4c6d-9870-1dd2a35b1a04" control-id="sc-12.2">
+    <implemented-requirement uuid="48e0f6c7-bd57-4ea2-a463-7a376c429c4c" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="3c77d33e-8a55-420c-8d5f-da6468cc9f2a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a9036d8b-7074-4281-a5ba-b988ed33015f">
+      <statement statement-id="sc-12.2_stmt" uuid="8e9624b0-0547-47bc-bea7-02ef42bdac01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="daa96f4d-60e9-47a5-8488-04b648ca158f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Producing, controlling, and distributing symmetric cryptographic keys
 using NIST FIPS-compliant or NSA-approved key management technology and
@@ -7146,10 +7146,10 @@ for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="062ddf92-70be-411f-b7a2-352272394ca9" control-id="sc-12.3">
+    <implemented-requirement uuid="3a9eca27-4398-4781-86cd-0aec0a4fbac9" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="bf0b4e4d-8cad-45fc-8ffa-31bb03543a0a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="8128317c-c74c-40f7-b667-6efd79fd7b9f">
+      <statement statement-id="sc-12.3_stmt" uuid="ff8137ad-b4cc-4ff1-8901-ba3a90e3e5ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95ed6489-1734-438d-b0a4-392b344c8792">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Producing, controlling, and distributing asymmetric cryptographic keys
 using NSA-approved key management technology and processes is outside
@@ -7158,10 +7158,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0efa2fe4-cce1-40fc-ab41-05b8fa9a472f" control-id="sc-13">
+    <implemented-requirement uuid="3fd47604-a913-403b-bb68-ccd137bfa211" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="74f9ce46-262e-4d73-9f89-90fdab042b97">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e22bfdc2-d79b-4dab-96bb-8cb1fa48402f">
+      <statement statement-id="sc-13_stmt" uuid="5f71cac8-d81c-4210-81cc-56f35b49cf0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9015bd23-0bf4-4d39-86d7-b1372a363320">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organization-defined cryptographic uses and type of
 cryptography required for each use in accordance with applicable federal
@@ -7171,10 +7171,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="518e5047-7344-4224-acb1-02cbb4dfe9c2" control-id="sc-15">
+    <implemented-requirement uuid="60c39bf5-9dd5-4a4f-9d65-86b4ba78a77b" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="0574ad8b-c873-498b-8ec7-9fff564880c0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b06c53e3-919d-48dd-b42a-6fec2e360e1c">
+      <statement statement-id="sc-15_stmt.a" uuid="c17cc0dd-de75-4336-b4ea-b5ac72074452">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -7182,8 +7182,8 @@ not applicable because Red Hat Advanced Cluster Management for
 Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="b103fd9a-046d-4ef3-b6b7-a829d69cda41">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="224d053d-0831-470b-991c-5bb14f240cb6">
+      <statement statement-id="sc-15_stmt.b" uuid="82026196-8890-49df-811a-e0c6edb6bedb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d86768-b618-4908-bf50-ca2c21115d8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control is
@@ -7192,10 +7192,10 @@ Kubernetes is not a collaborative computing device.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3704f865-527e-4aeb-8e5c-7f1afcc80544" control-id="sc-17">
+    <implemented-requirement uuid="adaf211f-cea1-4950-9f0c-fc4a92d4e5bd" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="5ab26d96-01f4-41bc-a118-37648f544ca0">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="57cade84-348a-4e2b-ad3e-ff92ac3cc8a2">
+      <statement statement-id="sc-17_stmt" uuid="f2e84a5b-21e8-45ed-b978-6f20c4fa4be4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2da496cb-e8b3-4222-8990-f4fc3cd51aa2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -7204,10 +7204,10 @@ https://issues.redhat.com/browse/ACM-387</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="945bebf8-5c9e-4862-99c5-81ebc9c72f88" control-id="sc-18">
+    <implemented-requirement uuid="b1529437-35a7-4899-a9e8-34c10a2e639c" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="d61c0008-df08-4171-b343-db1504db89d1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e629a582-aa2b-4244-b8ba-1154c7801248">
+      <statement statement-id="sc-18_stmt.a" uuid="7670ab9c-52d1-49f4-87cc-9516c4126d85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -7215,8 +7215,8 @@ planned. Progress can be tracked via:
 https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="b511dec2-a5ff-43bc-8b39-f3b287239e85">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9bb8c746-75cf-46db-81b6-285447402a4a">
+      <statement statement-id="sc-18_stmt.b" uuid="41c8ab76-2048-4d02-8f51-4576ce47c200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -7224,8 +7224,8 @@ planned. Progress can be tracked via:
 https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="12e44296-f190-4140-abf9-a86b9e0cfe6d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9bf7736d-e63d-402f-b031-022e83bd44d2">
+      <statement statement-id="sc-18_stmt.c" uuid="39b64d86-886d-483e-8de2-423feb732958">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42889d72-bd1c-4e04-b2e6-4d27368957a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -7234,18 +7234,18 @@ https://issues.redhat.com/browse/ACM-388</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02bfe37d-ddb1-4875-8ac8-eb1c6fa9163e" control-id="sc-19">
+    <implemented-requirement uuid="8883a25b-61d0-434c-9bbe-e948f9a773d5" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="56a7994b-c28a-4231-9764-5bb6306a2d68">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d1cce9a3-5031-4aea-a161-559752d79880">
+      <statement statement-id="sc-19_stmt.a" uuid="5797fb17-4fd2-47a8-9915-2fee3956c60c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7a2647d-4a45-47c8-8fab-e3d58a5a98b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management
 for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="dafc93ab-b7ba-4aca-a30e-f4f2827b3a6a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5433bcb2-0169-483d-9f06-4e167e9b75e0">
+      <statement statement-id="sc-19_stmt.b" uuid="ff2c71bb-f02b-42f2-a9ae-e63fb1f3cef1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7a2647d-4a45-47c8-8fab-e3d58a5a98b2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management
@@ -7253,10 +7253,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04250734-ed22-4d3b-826c-eab91dec56e3" control-id="sc-20">
+    <implemented-requirement uuid="23dd3257-e41c-46b7-b50f-224e0ece8433" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="bd28ebcf-0efd-410e-a5f2-2e38cd1d036d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="fb40a188-7459-4d8d-bdf2-ad3f1f04824f">
+      <statement statement-id="sc-20_stmt.a" uuid="74b46734-23e3-40a1-86f4-e151498e8daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b06f186-06b1-4420-84c3-5562c998e3ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing additional data origin authentication and integrity
 verification artifacts along with the authoritative name resolution data
@@ -7268,8 +7268,8 @@ Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
 for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="cf76957a-1cfa-466f-a897-014929b148c7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7d4a6afe-1c2c-4fef-87f2-46e6e52891e8">
+      <statement statement-id="sc-20_stmt.b" uuid="584e9542-8ea8-49d1-b9ed-4061ffb3e388">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="04c15b7f-aaf5-4aad-9468-3ec78c5f0d68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing the means to indicate the security status of child zones and
 (if the child supports secure resolution services) to enable
@@ -7282,10 +7282,10 @@ for secure name and dns enforcement.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71b13f3b-90ae-47d1-9da8-d6f052017df2" control-id="sc-21">
+    <implemented-requirement uuid="284c92b1-ee3d-4f5e-934d-f4e46f765513" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="5889108b-ab3c-402c-97be-818c2113aa25">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a2953eec-bda4-40e7-bf5a-50b0bd3b710b">
+      <statement statement-id="sc-21_stmt" uuid="1237c951-198d-425c-bbf0-3f7cb2c85b11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d804e87-282d-46fd-b73c-7c83cb92348e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requesting and performs data origin authentication and data integrity
 verification on the name/address resolution responses the system
@@ -7294,10 +7294,10 @@ Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8330dd73-8242-40aa-b3d4-28eff45dfa00" control-id="sc-22">
+    <implemented-requirement uuid="a1fd2e32-64d0-46f8-a9d2-089b11bd5cb1" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="614fbacf-c3c4-4ba9-8666-6408229f0be5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b8783651-7557-468f-ad62-272aa67fc38e">
+      <statement statement-id="sc-22_stmt" uuid="68ca8a26-b035-470b-a730-35e3f5212d29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcd37744-2fde-4ebb-8cd1-6cbd7ce478b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Collectively providing name/address resolution service for an
 organization are fault-tolerant and implement internal/external role
@@ -7306,10 +7306,10 @@ for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2010f372-052a-49a4-a245-d133201b61ad" control-id="sc-23">
+    <implemented-requirement uuid="86e0c946-574f-481c-87c7-c7bd81e996a6" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="90498730-a777-4516-8cac-52d190dcbcd5">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ab5b9305-4ed0-4f5e-886a-1fcbec4ac276">
+      <statement statement-id="sc-23_stmt" uuid="7464d79e-1b64-4f76-9fbc-5c4919f35900">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee83d187-f7c6-4afd-91c2-4eb3aa554c65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -7325,10 +7325,10 @@ https://issues.redhat.com/browse/ACM-407</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7b2a5ce-e897-41e1-ad8a-4337dd028b9d" control-id="sc-28">
+    <implemented-requirement uuid="61eac231-50f1-4024-9218-d9e72ee28960" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="f7cd3333-73a1-41f5-976b-a344d42d6281">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3bfd5bf5-dc4f-41f7-8bab-670556dca845">
+      <statement statement-id="sc-28_stmt" uuid="82300480-58d9-4dbd-af4f-40c0c33db823">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f8f00c6a-2844-4a15-9a2c-640757a6145d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting the confidentiality or integrity of organization-defined
 information at rest is outside the scope of Red Hat Advanced Cluster
@@ -7336,10 +7336,10 @@ Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7f72bb6-dd3c-4889-889a-c9f27f735049" control-id="sc-28.1">
+    <implemented-requirement uuid="5b2102c1-6120-4713-ae07-93d4294e8a6c" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="0019bc0a-5d5e-4725-bdc8-a52797e61a84">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="04f1ae73-1d58-4e8d-82c3-72a94a3659a4">
+      <statement statement-id="sc-28.1_stmt" uuid="b480bace-0ade-4d36-afa6-fc45be3099e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96252d26-9075-4864-9b3a-9d44b90d1345">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -7349,10 +7349,10 @@ transport.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0861e00a-bfc7-4e88-926e-bd01329d886c" control-id="sc-39">
+    <implemented-requirement uuid="06047ebf-250e-4bc2-8889-294df634a49c" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="74ba8d7d-7d90-43ff-85fb-0a0cc7e173ac">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b7fca0ac-ef77-40a8-99f3-2fb50ed42612">
+      <statement statement-id="sc-39_stmt" uuid="45056cf1-b025-4ef6-857b-25e11139281a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="905ec3ac-6de3-40b5-abfa-45041060bccd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining a separate execution domain for each executing process is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes
@@ -7360,55 +7360,55 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62fae359-88b9-47b0-9a52-b981e45c9013" control-id="si-1">
+    <implemented-requirement uuid="1ac57cb5-e0eb-49d1-8ae6-31169fd834b4" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="f1e01947-d907-4687-940b-bce956cffd38">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5d6bdfa7-5eab-4479-8764-892b8c265472">
+      <statement statement-id="si-1_stmt.a" uuid="e9254d38-f6e2-41ff-aad0-6e9e07d1c09d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="c41677d2-a678-473a-8ad1-4c7aca68bfec">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="058762f0-4fa5-4b8c-938d-a318702b0365">
+      <statement statement-id="si-1_stmt.a.1" uuid="3e00a5d5-ce55-45f6-8aac-56a15fb5d9b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="d72f08b5-638f-4b7e-942a-1f39c9eafc37">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4998dffb-7319-4f97-8b09-ff030888e82c">
+      <statement statement-id="si-1_stmt.a.2" uuid="c7d2bf00-f2d1-42b0-92ad-eb30eb27d02a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="3d0c7e6b-37f4-40b1-ab97-c7f00cb323b1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="3f0cde92-2bbe-422a-a1ad-05c12c940e16">
+      <statement statement-id="si-1_stmt.b" uuid="24f5c308-d85d-437d-9246-e67792f05101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="f89ad25c-f150-47d6-84f9-27bcdad016ea">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6b16d976-a11d-4bca-b1be-1e3e58f67f67">
+      <statement statement-id="si-1_stmt.b.1" uuid="7f50bdcb-e683-423b-8ec4-c40a04d2f4ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="e2af6f2e-fa16-4bdf-81a1-9b71d0fbb93e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e48dd56f-6852-4712-a817-6e1c15ab11bc">
+      <statement statement-id="si-1_stmt.b.2" uuid="f590ce87-15aa-4188-badb-1c64dc28365f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="890d7461-64ae-4d29-bdff-9375838344f1" control-id="si-2">
+    <implemented-requirement uuid="ba0844fb-4f55-4ccb-9350-65001c226036" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="679ad9d4-f16f-47b2-aa97-5925683123f3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ddfd4283-a6ed-47f4-a04a-9905ebd00c8c">
+      <statement statement-id="si-2_stmt.a" uuid="8fe5873f-4410-4b49-b0a1-39acae3c6973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d82e347-ad53-4671-b12a-7fa613597f98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Advanced Cluster Management
 for Kubernetes deployment for flaws, reporting on those flaws, and correcting them. A
@@ -7417,8 +7417,8 @@ discovered and remediated, as well as tools that are used to assist in detection
 remediation.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="ec1fe208-9102-41e7-a276-9b4eddd6397c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="674bae07-c2df-4605-892c-5cf7e7a48c5c">
+      <statement statement-id="si-2_stmt.b" uuid="376ff04a-f459-444f-aca7-68c33bc958b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54df072f-e685-4337-8829-049d63b612e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Advanced Cluster Management for
 Kubernetes updates related to flaw remediation prior to installation. A successful control
@@ -7426,25 +7426,25 @@ response will discuss the testing process (e.g. the nature of the test environme
 types of testing performed, the tools in testing, etc.).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="19c53b9e-3235-4513-976c-268668dfa56c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2aed23ef-55af-475b-bec5-4c6246d3ad78">
+      <statement statement-id="si-2_stmt.c" uuid="f3546051-4f29-4055-8e73-2bc44e58c533">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="b0ef18ac-674d-4847-8d7e-a5e5d6a9312d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="440010d3-4a56-490d-b6d5-24899dfabe03">
+      <statement statement-id="si-2_stmt.d" uuid="6b511da2-09d7-44b2-a2e3-8c2a07b01922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0835546a-46d3-4b0e-a69d-6ab697079e33" control-id="si-2.2">
+    <implemented-requirement uuid="e11aee77-2dde-4d21-81e2-f08972504493" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="056965b2-6f1d-43ae-968d-9d8861fc9091">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ca386157-0900-4577-99e6-654d5f543ff7">
+      <statement statement-id="si-2.2_stmt" uuid="183255ab-7418-4705-9a34-ea3d032f6ffd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80a45e58-0de6-429a-b7f1-aac42d1b1351">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms per an
 organizational-defined frequency to determine the state of information system components
@@ -7460,10 +7460,10 @@ remediation.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56559786-d73a-4283-b2a5-e9865a95d6e6" control-id="si-2.3">
+    <implemented-requirement uuid="b76323ea-cbcc-4fdb-82bc-237f53c61852" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="eff72372-f0aa-476a-8ea5-a83c22561927">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="af16ea0a-7e86-4805-9d90-0c51e0039e71">
+      <statement statement-id="si-2.3_stmt.a" uuid="b78b08f8-f505-4781-8609-e69e5d0908e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f027844-481b-4e3a-9503-758b2b4d49f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -7473,8 +7473,8 @@ remediation using timestamps and calculates the time elapsed
 difference.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="8573b9c5-cd09-49af-9a1f-1ea6996a25d4">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="5c6a1a7a-1bf9-45f6-b80e-85276bbf2662">
+      <statement statement-id="si-2.3_stmt.b" uuid="04ea7b38-be21-40c3-a9e2-34dfe3656c43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5efc2319-b920-4bb3-8f63-c96f7afe6e7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -7485,10 +7485,10 @@ customer defined period after a flaws discovery.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a49599d0-c60b-4193-89a0-db7c70a06d04" control-id="si-3">
+    <implemented-requirement uuid="c4c53f67-ef6a-46b6-af85-f8628d279672" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="bb95dc48-87f2-490c-9f40-59b6981bb68a">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1ab1cb0c-e0f2-4d49-a5d9-b16c364735c2">
+      <statement statement-id="si-3_stmt.a" uuid="c9a78034-edec-4d05-bd0c-63e1d22f5549">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aad7e803-63d3-428c-897b-f3e6c876d05e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious code protection at
 information system entry, and exit points to detect and eradicate malicious code. A
@@ -7498,8 +7498,8 @@ scripts). In regards to Red Hat Advanced Cluster Management for Kubernetes, this
 generally through the use of third party tools.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="5b7b1f99-21b6-4a57-a834-e8bb6148f196">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6203dbe7-311e-4a38-a7b2-628a773d21f9">
+      <statement statement-id="si-3_stmt.b" uuid="9e354838-03da-492b-9122-03257ea75bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="210a2511-c79d-417a-9918-37a176cef03a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Updating malicious code protection mechanisms whenever new releases
 are available in accordance with organizational configuration
@@ -7507,15 +7507,15 @@ management policy and procedures is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="feda4e73-27f2-4720-8eae-43bd060bf1e2">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dfca0dce-e34d-4496-b206-f76b76439546">
+      <statement statement-id="si-3_stmt.c" uuid="18d03ef9-86d5-48b3-ab0e-42b0f75db078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2caa1d9-ef0f-467a-b427-cda36c3c95bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuring malicious code protection mechanisms is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="dc413761-867d-4ada-818f-8328f889a77b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="57764394-3acb-465a-b663-fbf9cd4d9fc3">
+      <statement statement-id="si-3_stmt.c.1" uuid="b84429c3-26de-4de0-8205-aebee6408335">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42a678a9-b637-471c-8b9c-b022ad140114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Performing periodic scans of the information system per organization-defined frequency
 and real-time scans of files from external sources via endpoints or network entry/exit
@@ -7524,8 +7524,8 @@ security policy is an organizational control outside
 the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="2612c138-1297-4943-84e4-9a45a92fd6d1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="f9bdab1b-df3f-445f-86b2-73b452625f3f">
+      <statement statement-id="si-3_stmt.c.2" uuid="be7da617-432e-438a-afc1-d74bd9291a7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723d2a9f-9964-4c4d-8df2-d0904f80d4f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
 some other organization-defined action in response to malicious code detection is an
@@ -7533,8 +7533,8 @@ organizational control outside the scope of Red Hat Advanced Cluster Management 
 Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="6686efea-7048-4182-b46f-8e0b09f0cd78">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="77b97844-6081-4c9f-840e-73e0679c0783">
+      <statement statement-id="si-3_stmt.d" uuid="427c4401-59c6-4c80-b8f3-2448c94585f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4d4652d-b87f-4963-ab15-232536b7d509">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Addressing the receipt of false positives during malicious code detection and eradication
 and the resulting potential impact on the availability of the information system is an
@@ -7543,10 +7543,10 @@ Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="615991cf-e656-4f73-966a-76e6fe944eac" control-id="si-3.1">
+    <implemented-requirement uuid="cc1129cc-aefa-4012-89e5-1acef7b0d53a" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="f72e3120-1b94-45db-9783-62e1b90b4095">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ad22e62b-0c3d-43b4-9f24-dfce7166e503">
+      <statement statement-id="si-3.1_stmt" uuid="f9f6e5cf-08e3-4a67-8af0-7b28703f8a5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00658baf-6614-48de-b4ef-2422d0e0b1d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -7556,10 +7556,10 @@ protection mechanism is centered in one location.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a6de963-2be6-4668-aabd-4de8c45ac7c7" control-id="si-3.2">
+    <implemented-requirement uuid="25d410dc-01f7-4446-bba6-47347f365abc" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="64457db3-1ffc-4105-89a4-94532fcb626f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="85b9d4c7-4289-47ef-a38e-345c87498ad2">
+      <statement statement-id="si-3.2_stmt" uuid="222ec5c0-526b-42c0-8ad2-ee599fb2a9d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ab0afd2-1a93-4315-be52-14c1dd0fd34c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -7569,10 +7569,10 @@ mechanisms definitions are configured to be updated automatically.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36c08d41-3247-4f33-87cf-fa1a9de56b8c" control-id="si-3.7">
+    <implemented-requirement uuid="43e85563-c3d6-4a65-817c-37eef06356ee" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="2dc03337-1e8a-4269-b094-1f6a90e04495">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="7682ace3-d4ae-4502-97b7-44a7d3ebfccf">
+      <statement statement-id="si-3.7_stmt" uuid="87741b84-52d4-4ab7-92aa-ee49d3e50eb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53ae9636-4fcb-4810-b789-4bdd780cb24c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -7584,24 +7584,24 @@ do not yet exist.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f83329ba-7abd-42dd-a4b9-d0cad31bd1b1" control-id="si-4">
+    <implemented-requirement uuid="b77472be-ee4b-4cc6-a1f1-76fee3f8749d" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="291ccfd0-10c6-4dc6-9e2a-9c888789edaa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bd7d9c46-d64a-48c6-8425-e5cb67ea7d1e">
+      <statement statement-id="si-4_stmt.a" uuid="e06f9d1c-ebe0-496d-8603-066fa2b282f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="3c5fcdac-926a-4ca4-a018-c6cd76577e6c">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="99a1d285-71ce-4f43-b4eb-345b62f95ae6">
+      <statement statement-id="si-4_stmt.a.1" uuid="c5488e87-5971-47c5-84e7-b10a62142a95">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="336614d5-4fee-4bc3-97af-964f8c38bb5e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="bd538d80-00c5-4dc6-b5ab-633301ff96a3">
+      <statement statement-id="si-4_stmt.a.2" uuid="4ba6ecd1-1581-4cad-965d-3bb5040ffd58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="201402b4-6cb9-4705-ab64-3be7e6f0bad7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring the system to detect unauthorized local, network, and remote connections is an
 organizational control outside the scope of Red Hat Advanced Cluster Management for
@@ -7609,8 +7609,8 @@ Kubernetes configuration. Functionality to meet this control can be provided by 
 party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="c7446558-744f-47ae-9122-c25d94434d80">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ea208773-5b1d-4010-9f9f-c7ece2659895">
+      <statement statement-id="si-4_stmt.b" uuid="30ba8a4b-7359-4609-a0a4-50da18a179ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="839816c6-ec65-4e84-afd9-398166749d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identifying unauthorized use of the information system through organization-defined
 techniques and methods is an organizational control outside the scope of Red Hat Advanced
@@ -7618,16 +7618,16 @@ Cluster Management for Kubernetes configuration. Functionality to meet this cont
 provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="2dcc3e0a-c80a-4f6e-ba72-55eb70f59724">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6024512c-b02d-404a-88f9-2dffcc558fee">
+      <statement statement-id="si-4_stmt.c" uuid="0cd49d2f-114c-4414-944c-faddf2e30fc4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="370fd0b3-f1a9-4e99-9133-431c67d824dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices is an organizational control outside the scope of Red Hat
 Advanced Cluster Management for Kubernetes configuration. Functionality to meet this
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="07e5061a-f63a-4de1-9a43-3bc81ab5e9d7">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="9e1ce338-7476-4b9c-9366-028eb13311f8">
+      <statement statement-id="si-4_stmt.c.1" uuid="077aadd6-ed2f-4f7d-b6a2-7c067cedac63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23939e4e-ab8e-46ef-aeee-f23facfdf1ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices strategically within the information system to collect
 organization-determined essential information is an organizational control outside the
@@ -7635,8 +7635,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="abb4777e-b91b-42af-b95a-de2848cef386">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1c146032-978b-49f0-8a9c-a3197f35af45">
+      <statement statement-id="si-4_stmt.c.2" uuid="268e71da-855c-4f6d-849d-a4f0958b0884">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0efbfba9-8414-4e18-ae9d-27b0c6324809">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Deploying monitoring devices at ad hoc locations within the system to track specific types
 of transactions of interest to the organization is an organizational control outside the
@@ -7644,8 +7644,8 @@ scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Funct
 meet this control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="265d7c3c-725d-4a22-b4d3-e5c85102206b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="600dc4d8-8d70-411b-8955-6bcd54b4be0b">
+      <statement statement-id="si-4_stmt.d" uuid="ca1cfc9e-26bb-4cc7-9555-01e010b5b1b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0249159-9b9f-4fd1-83ee-3234a37ae777">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protecting information obtained from intrusion-monitoring tools from unauthorized access,
 modification, and deletion is an organizational control outside the scope of Red Hat
@@ -7653,32 +7653,32 @@ Advanced Cluster Management for Kubernetes configuration. Functionality to meet 
 control can be provided by a third party vendor.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="a251ad3b-4bfa-4ed2-b94f-95e2f5eeabb3">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="382e6b92-5289-460d-819d-357bd68df991">
+      <statement statement-id="si-4_stmt.e" uuid="40798e3b-3e4c-4c93-8b60-f0208c2461d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="375d6b53-9859-453c-8efd-1cdfe6e867fa">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="07b0a4da-e2c6-4e41-902e-b786aed4cf65">
+      <statement statement-id="si-4_stmt.f" uuid="8adc244d-9602-4c86-a355-3aaee407d3f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="a60b3a5d-70b1-4b28-a7b8-861440e8b0e8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0282892e-5728-4a8e-909c-00a2135933a5">
+      <statement statement-id="si-4_stmt.g" uuid="52c9cdad-4eee-4f34-a375-7b2bf80f656a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5b2751c1-2b83-42fd-8a3c-a7ade6ae3a64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ec00791-c0ac-4913-a7c2-11cedc9d6b1d" control-id="si-4.1">
+    <implemented-requirement uuid="ffd3bfb4-78e9-450d-965f-96856862f408" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="331a134a-cfb7-431a-9913-88c8cbd1d045">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="522bad1a-d3cb-4262-be9e-cab0a1b7bb7d">
+      <statement statement-id="si-4.1_stmt" uuid="16afa9b2-20e3-4ba1-bcd2-8098cc67cf64">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75f50e55-c553-45db-bb8c-30361e73d6c7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection tools into the Red Hat
 Advanced Cluster Management for Kubernetes environment, and documenting how this capability
@@ -7688,10 +7688,10 @@ intrusion detection systems.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ff1c143-a441-43f1-a400-43abcfb817fa" control-id="si-4.2">
+    <implemented-requirement uuid="c31976d1-1871-421b-8e96-69220dab9a1e" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="580ef26c-164e-4690-8175-4ce87fe77e43">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="37195117-d492-483b-96c4-1597e003c444">
+      <statement statement-id="si-4.2_stmt" uuid="c7e73141-2c8f-4676-89e5-070980b98710">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d64a6302-9767-4def-a28a-5c4adce87eb9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -7704,10 +7704,10 @@ analysis of events.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="867c18db-42a9-41d8-8520-5131e9160ecc" control-id="si-4.4">
+    <implemented-requirement uuid="a0f9e3fc-0011-4b97-992c-3921c5775276" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="735163f2-9748-413d-ae1c-14fc5b573f33">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="2ce64ef2-a258-41e7-89a1-44e3fc3a7ab6">
+      <statement statement-id="si-4.4_stmt" uuid="ce5ff580-45da-48aa-bcb3-9069b7aa1ae5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29ed9044-d16e-4a98-92d8-975eb8efa59d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored. Frequently this control
@@ -7718,10 +7718,10 @@ not, how network traffic is continuously monitored.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50a45a3f-e112-46f2-94d7-34da9bb17d99" control-id="si-4.5">
+    <implemented-requirement uuid="aa6078a3-0537-4df2-aea6-19f07d576df9" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="716cb518-6d38-44a0-b772-9b0011697076">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="dfbcfec1-75ab-43a7-bdd5-b6d00c12453d">
+      <statement statement-id="si-4.5_stmt" uuid="f8ba4da5-bf97-4f88-adc9-9a33152faa79">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a945f5d-16d7-4dae-a509-4bd705f164a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -7732,20 +7732,20 @@ the notification.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="884531d0-56fd-445b-841d-47be121ee717" control-id="si-4.14">
+    <implemented-requirement uuid="b905cef1-dbb1-48fb-a2dc-3bbce0ccb46e" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="24c60217-d702-40c8-b107-289e97f2e911">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a943ad38-1e9f-4bca-806d-ac1b016fdd69">
+      <statement statement-id="si-4.14_stmt" uuid="5dabb2d8-b6be-40bd-a302-fbc631b4fef1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="348ac440-2934-46a4-93a3-1d4eab3ff590">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Advanced Cluster Management for Kubernetes infrastructure does not have wireless
 capabilities.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="847eb286-00a8-48f1-88c4-05c6741f4257" control-id="si-4.16">
+    <implemented-requirement uuid="6e9e4e24-e18e-4d4f-89d0-58241619c30b" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="17cd5d39-c294-4c54-8a61-4abc0d8031be">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a5cbd489-b023-4ce8-b70b-dcf69445ee9f">
+      <statement statement-id="si-4.16_stmt" uuid="74d9bf36-b9ba-4314-abbe-c8e488027922">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31a90a61-6e68-45f2-ae8d-38329d2b5957">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating information from
 monitoring tools, for multiple system components. This is frequently accomplished with
@@ -7755,10 +7755,10 @@ OpenShift layer or a third party product.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d8279c0-81d9-4f04-a87c-1787483c5e34" control-id="si-4.23">
+    <implemented-requirement uuid="afb5860c-50b3-444e-a2e3-08dd642fcc0e" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="0ea1dc46-1849-4a87-bb76-62ab648e30fe">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="13454fd4-0413-49c8-a45e-d64d45ec33d6">
+      <statement statement-id="si-4.23_stmt" uuid="43e85834-a3ce-4203-a851-f9e56c595598">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a9a25e07-6617-4bf8-9474-a63300b8407e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring mechanisms which is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
@@ -7766,10 +7766,10 @@ is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ffe5e5d-b33e-495f-8bdc-d4d0a9078409" control-id="si-5">
+    <implemented-requirement uuid="481d74f3-9023-4094-878d-88853a0e4a08" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="28752bf4-6e8f-4cda-b71a-d92856f05853">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="4ad9a9a4-060e-4e3b-b6e4-4835b011212b">
+      <statement statement-id="si-5_stmt.a" uuid="a92b6b92-db21-47e7-ac94-6997c9d82245">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c0f4359-ac0a-46be-84f6-5db0aa230901">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Receiving information system security alerts, advisories, and directives from
 organization-defined external organizations on an ongoing basis is an organizational
@@ -7782,16 +7782,16 @@ Hat specific products can be accomplished following the following documentation:
 https://access.redhat.com/security/updates/advisory</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="ca221d1d-ca38-4780-9c6f-7dc5869eb19e">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="e75d2dec-4a26-4ceb-a95a-d6be34ed87dd">
+      <statement statement-id="si-5_stmt.b" uuid="38658151-0557-406c-93de-a0a33b31ca75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c81518b-42bc-47eb-87e1-ecbd3b59996e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization generating internal security alerts, advisories, and directives as deemed
 necessary is an organizational procedures/policies outside the scope of Red Hat Advanced
 Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="8fae0df4-3a44-46b9-9ce0-03777366855d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ad2e64c5-71d0-4509-8c48-7f3c49a8ae5e">
+      <statement statement-id="si-5_stmt.c" uuid="61adc42a-b045-4ab4-9041-2f6349f10343">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc7940a6-7fec-4aad-b086-5e8792390249">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Disseminating security alerts, advisories, and directives to organization-defined personnel
 or roles, organization-defined elements within the organization, organization-defined
@@ -7799,8 +7799,8 @@ external organizations are organizational procedures/policies outside the scope 
 Advanced Cluster Management for Kubernetes configuration.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="20f9f784-c66b-4d3b-b0bc-983318706bb6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b35d809f-a684-4fdd-b709-d62bcf38f301">
+      <statement statement-id="si-5_stmt.d" uuid="b69855b2-331c-4eb5-9cd5-1fee573661f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c96147-de3d-4927-b91f-70aef285a171">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing security directives in accordance with established time frames or notifying
 the issuing organization of the degree of noncompliance is an organizational
@@ -7809,10 +7809,10 @@ configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e58b9639-4856-49d0-af8b-c3aa870b85cd" control-id="si-6">
+    <implemented-requirement uuid="e789018f-9aa3-4578-a2d0-bcfdad5ed8fd" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="3bf2b253-e83f-41cf-9b7d-b6398b828d9f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="96a31295-62b3-4faa-9dde-e9495577b24f">
+      <statement statement-id="si-6_stmt.a" uuid="a96e2d51-4254-4af9-935e-832019c57447">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4564a29-cdb2-4912-bf3d-a30d174bc75d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -7821,8 +7821,8 @@ security functions deemed necessary to verify, as well as the means
 for testing the correct operation and resolving any issues found.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="f48c2dea-c6f2-4993-938c-9ab80502ccff">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a3ce792b-3c44-4b32-aec0-ad6a1f9a59af">
+      <statement statement-id="si-6_stmt.b" uuid="c0fe2cf2-fa37-4cda-9071-1c74d8467c8f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4be5c4cf-a5c1-4fd4-8c6f-337797193d62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing security function
 verification at customer-specified frequencies and under
@@ -7832,8 +7832,8 @@ rationale for selection of the specific frequency and circumstances
 of security function verification.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="9d4982fe-6731-4ee8-a748-a2669498e2a6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="b4b1a8af-8fba-4eab-9152-e0640bce6271">
+      <statement statement-id="si-6_stmt.c" uuid="8a98bff7-b0e7-4a69-b224-dfa650a70213">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befdfd8e-f236-4a0a-b767-d7239209650f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for notifying appropriate personnel
 of failed security verification tests. A successful control response
@@ -7841,8 +7841,8 @@ will need to outline the personnel or roles selected (to include
 system administrators and security personnel as required by FedRAMP).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="f9b7bed0-0712-4923-87ad-a00565ff26e1">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1334d2fb-bfb4-47b2-bf0b-12844477224a">
+      <statement statement-id="si-6_stmt.d" uuid="a24e40cd-5934-48c2-8a05-4ad2b17db488">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab599b72-785f-486e-8436-d1efdb42643a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing appropriate actions
 in response to anomalies in security unction verifiation. A successful
@@ -7853,10 +7853,10 @@ actions.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b181311-9790-4cca-b8a4-003c1c5317e3" control-id="si-7">
+    <implemented-requirement uuid="7b0f9b85-31fd-442a-8e3a-991b9c495d85" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7_stmt" uuid="42b67037-700d-4763-8a12-96b601fea339">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6e606177-14fc-40b7-a129-ea1d4192feca">
+      <statement statement-id="si-7_stmt" uuid="439ed4fb-b18e-48d4-bcf1-f8e4a6d168c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1eff74f2-3641-4150-b9ca-e391f4f73fce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -7865,10 +7865,10 @@ the integrity-checking mechanisms these tools employ.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dea4fbe0-8528-421d-922c-51f411bddfc4" control-id="si-7.1">
+    <implemented-requirement uuid="c3ed22dc-a6ed-4d4e-9265-c1f1413d205b" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="3dd003be-2955-436d-a44a-ed7dff30bad6">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6aefc335-ea4c-4c19-9117-2dce9f256d7c">
+      <statement statement-id="si-7.1_stmt" uuid="0f8ac069-b5e3-4629-ac05-19924c496242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0dd3c6ff-0d3f-48be-8c8e-8bebb092b61d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -7879,10 +7879,10 @@ for selecting those criteria.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f09fa25-36cf-48d1-a3e4-b9be80d7eaa0" control-id="si-7.7">
+    <implemented-requirement uuid="9531851a-263d-4d69-a3b4-b14a7165e828" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="be10dc47-5ec6-4cbf-aa34-47b06bdc529d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="6337986f-8b79-4a7d-991a-1d00695b8343">
+      <statement statement-id="si-7.7_stmt" uuid="cffcaa9f-aa52-457f-af9d-1243539d45db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ce820e4-fe1e-4eb9-80a4-b7926317c692">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -7893,47 +7893,47 @@ capability is invoked when needed.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b39380c-e676-4bb7-b9d8-0abb3c235634" control-id="si-8">
+    <implemented-requirement uuid="1e3c35ca-17eb-489e-a181-896c419bb51f" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="7ae66911-ebe6-4afe-b130-2acb42c00603">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="49399c59-3c3a-4bad-8e24-5bbc435f9e6d">
+      <statement statement-id="si-8_stmt.a" uuid="369f401b-bd4e-4968-9394-e46031c15872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="9793963a-29f2-4fd4-9e99-ff9af5af102f">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="da01342d-53eb-43fc-8754-84ae9201708f">
+      <statement statement-id="si-8_stmt.b" uuid="25e05593-0d8e-440a-b4f9-0f74f1ca8fd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b2b01df-55e2-40fa-ad49-9ab534ff625f" control-id="si-8.1">
+    <implemented-requirement uuid="aa300855-c275-4494-90c4-e5612bc78f50" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="e2d6a3d4-94ad-47b6-86ad-afb45a954f96">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="69cef481-ce20-4ae8-a36d-d8d060bd069e">
+      <statement statement-id="si-8.1_stmt" uuid="6a02e17d-ff0c-4259-b890-2c76e9cbc397">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41ee5343-4b97-418a-906f-e23c81bab6e1" control-id="si-8.2">
+    <implemented-requirement uuid="cc7d9720-c210-4c72-a15c-952c494b276c" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="025e4f62-9a3c-4cb0-b457-7ee3740a3af8">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="a1ff45d9-7890-423f-85af-8d6c7237dabb">
+      <statement statement-id="si-8.2_stmt" uuid="4f6fa2f6-a52e-4e95-8631-1faa8e089bf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2363d5a-204d-4f98-bb6d-abf1651acec4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that are not applicable to the
 configuration of Red Hat Advanced Cluster Management for Kubernetes.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7730a112-2bd7-40ac-b27e-94a1f8471122" control-id="si-10">
+    <implemented-requirement uuid="e9607c12-c170-43fd-bf41-21e266b84b5c" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="2ca9a4ed-7b17-495a-b46c-94ab1ade2c18">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="1a3e9caa-753c-456c-8a7d-f587fd393ddf">
+      <statement statement-id="si-10_stmt" uuid="9ef61e9a-c8e8-479c-8d54-f8de2d543839">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bd8abe4-c17d-4fb2-8ffe-1308d874d38b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-10 is planned. Engineering progress can be
 tracked via:
@@ -7942,10 +7942,10 @@ https://issues.redhat.com/browse/ACM-408</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a839c76-06fb-4f86-aa38-9a6b03dc4c55" control-id="si-11">
+    <implemented-requirement uuid="3690ed91-498f-413f-989f-401d583daa67" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="ecbbd151-4f7e-4c0e-b7ac-fd47ebc695fd">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="ebb08e9d-f77c-4fd4-b352-a03a4ac9c2f1">
+      <statement statement-id="si-11_stmt.a" uuid="9b23aa69-1b7e-4dbb-9851-20f4abf25f52">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="865e1508-b7b1-4441-98ee-5926017f013a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system generating error messages that provide information necessary for
 corrective actions without revealing information that could be exploited by adversaries is
@@ -7953,8 +7953,8 @@ outside the scope of Red Hat Advanced Cluster Management for Kubernetes configur
 is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="0862ffe5-66d2-46ae-8aa3-e488ca4907c9">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="0e3e0c6c-684e-4399-b663-7fae0c2c427f">
+      <statement statement-id="si-11_stmt.b" uuid="272ef5c4-ac80-4ca7-9805-d316b28a2cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48ad5d86-2a5f-4351-934f-cbe96f6e857c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system revealing error messages only to organization-defined personnel is
 outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
@@ -7962,10 +7962,10 @@ is the responsiblity of the underlying OpenShift layer.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cb9a5a6-36fa-4bd7-87c6-6f2bf9bd1da2" control-id="si-12">
+    <implemented-requirement uuid="7205643c-3fde-44cd-89f2-51341494df7b" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-12_stmt" uuid="1382233b-0afe-4a71-bf76-b4b2782d7b1b">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="43af6bb7-40e8-4a25-b006-aedd51eb434d">
+      <statement statement-id="si-12_stmt" uuid="61bd108a-4e6b-4c39-b959-4c294686cc5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="571f3030-adbd-47fb-ae1d-3e65521060c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Advanced Cluster Management for Kubernetes in
@@ -7978,10 +7978,10 @@ are met.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffa0c473-1715-4506-a940-adb1cde4ca63" control-id="si-16">
+    <implemented-requirement uuid="a61b9e66-5638-4db3-bcd4-fcc71083a1b5" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="bf7db819-ead8-4998-8c22-2e3e2816d27d">
-        <by-component component-uuid="7bce0871-4ff9-4139-8c1c-956da3377590" uuid="d476fb23-0dd0-4d01-93c6-1b0d5b2e2851">
+      <statement statement-id="si-16_stmt" uuid="11a543ef-80bd-47a9-b814-d2fd1ffbb3df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe9d115-183d-4519-9da9-7bd79a8b9842">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The information system implementing organization-defined security safeguards to protect its
 memory from unauthorized code execution is outside the scope of Red Hat Advanced Cluster

--- a/xml/rhel-7-fedramp-High.xml
+++ b/xml/rhel-7-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="5f2d15b4-9c54-45fd-b8fb-7796685b0cd8">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="d8c42f89-26fc-461e-a3b1-548042249405">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.56+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.59+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="3cd5b545-11ac-4189-86ca-2b668bc41a7e">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="e66e1864-42f6-4721-95f3-73651b987c44" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="f747d0cc-b5a5-45a3-9c9c-b6b20b120fec" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="ecc7e9a5-f2ad-47e9-80ea-4924f4600bb8">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="af33841e-ebb9-4dbe-b646-4e5f8387f8cd">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="74268262-e18a-4894-b34d-501873b299d1">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="2238c08b-2d9b-42c1-940c-ba2db5b25e50">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f26dad2a-1931-4220-a7c4-3813a9313e00" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="29b8c1b6-9c72-45d1-a66f-6e911d7f4f6f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="020335ce-52fb-428c-ab39-df6d77baf822">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="f6e6784f-c274-44c0-a879-43b28b0f5735">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="de5284c1-642a-40ee-853a-31e7bbb771f0">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="9acc76c8-b302-421c-8a6e-356c2e3c03d6">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="45d7711c-768c-44c7-9795-69f449491c29">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,10 +530,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dfba643-2e38-4400-b831-e2a62be1c385" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="3cf9e2e9-0214-46fe-bccc-3f7795f57558">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="49ccb1e3-3a44-4826-a90d-5a6bac36f144">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -541,37 +541,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1d6f416-0a98-440d-bf84-18254d77f043" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="d7413583-e5e9-4b5b-aae6-0e99e4aba200">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="75f1f524-eb55-42ac-b10e-4548ff5acda7">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="1c499d82-c398-4d16-9244-102d84a6388a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="fdc4a11d-d634-4839-9af8-bbd7be79cfad">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="2c2b8a6d-4d0d-4f7f-b287-ec856f61f106">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="30024d11-a0b1-4dbd-97d0-9874f0594cb1">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8f867f22-5ceb-44d6-9f74-8ca9819031e0" control-id="at-3.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="b37299c9-8e4f-4a82-99cb-3574193b7f3a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="4ec17acc-b571-41a1-ae7a-e84e0a976d3c">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -579,10 +568,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bb0fb29-dcc8-43f3-8c30-42c5d2ca2a12" control-id="at-3.4">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="6ec7e055-509c-41e6-ba78-f9c407b1aefe">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="85aae850-9e2f-4591-ba30-f0cd74a4c4b4">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -590,18 +579,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b874cb1-c72c-48da-9a0d-df555642733d" control-id="at-4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="07e98d09-a314-4f7f-9c26-20d5e9f01fd0">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="59b5fdb4-6169-45eb-aa4b-a4c5241aeb52">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="26c272ac-cfaf-430f-b58e-37f8a3f9c0cd">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e38be6a6-81b6-4765-a230-515579f45dc9">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -609,50 +590,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ea1cdfc-3567-41cb-aa20-2744afaaf10f" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="ba21adc0-eeec-4790-abef-ab9db1e9eb24">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ec75d7bb-f279-4a42-b088-d0c85100c141">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="bb232e37-5f66-46f3-806a-98172d7afe8c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="75ce633e-16f8-40c1-b462-d1534b9eec12">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="fe39bd32-bad4-410d-949a-c5007bade2e9">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="a581c91f-f022-4bd4-8bf8-6263189c784d">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="282768b7-4274-4845-9862-7a5c232538e9">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3f520b72-4097-43bc-9e5e-3916f58ed061">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="5c5858a6-1a03-48cb-8510-5955f9f4a594">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3bc5f422-27d1-4552-9c8b-287aeeeea244">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="74f44f64-f986-4d5f-9a7e-fdcd107fb225">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="a44d48a5-8e43-471e-add1-6ab5c8bb21a8">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -660,26 +660,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7c41ed2-9876-447a-b646-9a57252e4890" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="b987fdec-20ae-4dd2-9696-36ff8728668d">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="09324f95-43e9-45c1-9633-16f248e24167">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="ff53ce41-8f39-41d1-abab-e04e8f3cb425">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1edfb901-9d97-40d8-8c4e-9a68f550ec32">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="ff07a02a-6a87-4705-9819-fa9af71a8462">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="2092cbe7-16a1-4a3b-ac85-fc7620c6bf15">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -687,10 +687,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3460e0b3-1404-4bea-8a93-b9d713ee2623" control-id="ir-2.1">
+    <implemented-requirement uuid="b8a42e25-33ea-48f7-8636-c4dc638c8dd5" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="3d995506-0e46-438e-9292-5e5edef32260">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8ae12d6a-1e22-4791-a4bc-08b3cf493c68">
+      <statement statement-id="ir-2.1_stmt" uuid="70b8f46d-e881-4a8b-8e60-5307a87a785a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -698,10 +698,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d9c428a-fb9b-4aec-9a61-f1501329e8e5" control-id="ir-2.2">
+    <implemented-requirement uuid="37391bc4-53e0-4236-8e44-0e0d825177a3" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="dbd9527c-4f23-493f-b0c0-bb7db6de8a2a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="14fb79ea-432c-4d5f-90b0-72f012b10d5c">
+      <statement statement-id="ir-2.2_stmt" uuid="a85b68a6-8ae0-41e1-9b14-875498165386">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -709,10 +709,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="373e2eb0-f608-46b5-9005-520992ca54e4" control-id="ir-3">
+    <implemented-requirement uuid="534c3783-f194-4e6d-bce8-f673cd7876a9" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="06e84246-4626-46e0-8f55-5653862c916f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="dc11bb16-65c4-446b-8a94-eecb8a4c65cc">
+      <statement statement-id="ir-3_stmt" uuid="b08ef514-12d3-49de-9430-8bd0081b6d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -720,10 +720,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34564574-3490-4673-8e30-ae7540eb8530" control-id="ir-3.2">
+    <implemented-requirement uuid="cd2b8dea-d475-4536-810f-4cb8840225a1" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="14e4b48f-5bcb-4f33-b6e1-11c078598454">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8fbfd1f5-a6fd-4999-9979-4fbba63210cd">
+      <statement statement-id="ir-3.2_stmt" uuid="228b2851-d621-491a-99b4-011447d2e390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -731,26 +731,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db6c5486-e3d6-4ab5-a0e7-90c1d8452a0e" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="c3550876-fd6b-4746-a9bb-fcb31cbb89a4">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="2f176505-a067-4431-ba3c-70fa2bb1314f">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="b7acee8d-89f7-411c-95c6-21679f1f6a2f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1e50495b-11a7-4459-97e1-ec412fb175cc">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="5565be1c-330a-4e62-9612-2b3c9f00328a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="2963df01-9c23-43d4-b5a8-0bdc03db905d">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -758,10 +758,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40b89e65-e50b-47f9-b58f-3956009e8475" control-id="ir-4.1">
+    <implemented-requirement uuid="51142785-d1e4-4886-b642-592d35b71e70" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="7b721a85-fabd-4e5d-abf5-0dcf93da604c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="9f78de81-606b-4274-8128-7f14f4aea7c8">
+      <statement statement-id="ir-4.1_stmt" uuid="12a7343e-93c9-41a0-922b-eac846bcb671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -769,10 +769,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63300008-9453-4b77-a6e8-d329a4a384d1" control-id="ir-4.2">
+    <implemented-requirement uuid="8ee0c424-a9d0-46a8-b5d5-7a47e1ed622a" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="8b5910d8-8f3e-4e74-9c03-26686ee939a4">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="d82abcef-8a98-4016-b772-b8015cff41b1">
+      <statement statement-id="ir-4.2_stmt" uuid="cb1a61a3-9d00-4e80-9a56-ddf8135425af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -780,10 +780,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2468cc1-2c04-4535-988d-63084f27a368" control-id="ir-4.3">
+    <implemented-requirement uuid="bb7b4e46-e393-4a60-9b1e-55a08e8639d8" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="4717c01b-b013-430c-b4b2-941682d61d5e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3d561503-9c39-44e7-8293-a25e74aa1b51">
+      <statement statement-id="ir-4.3_stmt" uuid="7c9a0d7a-bd4b-4613-92ea-1916c2285841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -791,10 +791,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04e856a9-9e01-4c45-a97e-decb7f826fd4" control-id="ir-4.4">
+    <implemented-requirement uuid="49785cc2-49b5-473f-9d73-7cda245d08ad" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="781e6ce7-8fdd-4285-b672-570541f42bec">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7b5f6f48-6fcb-4593-bfb1-3b9c83e56d5f">
+      <statement statement-id="ir-4.4_stmt" uuid="e8f86a45-aba2-4d10-b48b-ce60ebbc0bff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -802,10 +802,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8e5b759-cfe1-4b14-8f29-79f5f972478e" control-id="ir-4.6">
+    <implemented-requirement uuid="ccbe2177-2354-43c4-96ff-825626571315" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="bc414eac-db2c-4b25-ac49-24912cabc0d3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="188b94f1-7b57-4b1b-bf22-29dbeddf0277">
+      <statement statement-id="ir-4.6_stmt" uuid="34db7a41-1695-4729-ac23-f7336e158a1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -813,10 +813,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71d6c893-2813-4711-a5fa-4d199d672a60" control-id="ir-4.8">
+    <implemented-requirement uuid="ec5e92ad-bd5f-4af5-90ce-e08156a52be0" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="16f88c29-3552-48a9-91e6-6870e39dada5">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3a9463ae-e4b7-48c8-82f4-fd095b2615b9">
+      <statement statement-id="ir-4.8_stmt" uuid="921039ab-2d45-4951-9be6-0106bcfce3ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -824,10 +824,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f16d6b33-c122-4f5d-bd7a-1e13ceb20df9" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="5b49e306-35c0-4449-9bad-5f51a2d09e9e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="71f63963-5d36-4144-8dd3-c0755ade1238">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -835,10 +835,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eee98247-904f-47e0-91ac-23a9c8dbb303" control-id="ir-5.1">
+    <implemented-requirement uuid="6e53c00b-4ce3-4992-a0fc-4cba0a780287" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="ad6d61ab-02c1-41f1-949b-f5ab46a8938b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="0a0f9e2a-9e6a-4857-acbe-23f73e7a8d9f">
+      <statement statement-id="ir-5.1_stmt" uuid="d661f626-6658-407e-845c-1334ce9e6f31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -846,18 +846,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5560a63-cfb5-46b8-b87a-6af3366ecde5" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="92976640-f9af-4e5e-92a0-43cfd323a230">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="65161b8b-66e1-488f-b085-5fcdf9e669b5">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="f5b9b0ea-79d7-4ac9-8873-25ff9e02f31e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="b98d1c6b-c5c3-4eaf-9509-e1881770a101">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -865,10 +865,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3aa25a32-3648-4a83-90d8-24ab1b40bc12" control-id="ir-6.1">
+    <implemented-requirement uuid="abbf5ca4-c37f-4e55-be38-e0fb78d98b6d" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="8062066a-4752-4e33-a8d7-d172765926e3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="d721220d-6d8c-4da9-8ba0-01228341367c">
+      <statement statement-id="ir-6.1_stmt" uuid="bff866ee-07a1-48e0-bff5-677bbab030e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -876,10 +876,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9627272b-0646-4c4d-a051-dc331ee5c788" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="7e043287-bf75-4937-ab4e-baad022e4bfd">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="cd3d39b8-cde7-420c-816d-6e5e9d0d7f10">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -887,10 +887,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61fab390-e634-4176-8485-ddf6b4d3a33e" control-id="ir-7.1">
+    <implemented-requirement uuid="1e7dfee4-59e7-4258-a21b-252a865c51a8" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="87feaa96-723b-423e-85fc-95a8657b1abb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e617b0b3-024e-4d65-a454-c18ec0392e02">
+      <statement statement-id="ir-7.1_stmt" uuid="6aea26c2-e075-4c68-8b42-d974cef94703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -898,18 +898,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af11aba8-94ff-4853-a499-6b691f52ff56" control-id="ir-7.2">
+    <implemented-requirement uuid="b0e1ca1a-d05a-4e97-891c-242848ed917e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="99024ac4-da7c-4843-891a-0c442b198b26">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3adb2104-53d1-446c-90d6-9b51109c450d">
+      <statement statement-id="ir-7.2_stmt.a" uuid="0205e4dc-efcc-405b-b919-c8d96b200b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="85043438-9a25-4c17-aec5-0be309b22346">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="15dd4e89-05a4-40d2-b01d-3996efb1e910">
+      <statement statement-id="ir-7.2_stmt.b" uuid="71973ea4-e082-42b8-b2c1-59894f32f069">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -917,114 +917,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b7f5596-ccbb-4678-848d-9381406a4dda" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="a0a184ae-51ca-47ad-997d-aa04c1f517a2">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="6fea6919-90bd-4843-be8d-2d05b1ed5653">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="9fb3f6d1-cce8-43bc-9b6b-17db16435deb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c751ef65-4948-4dc1-a7a0-77a9f650f7a0">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="f40ffc86-0f4d-43a0-a782-887a79605c3c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7b058b07-4317-4202-b9b6-b7f8675a4ffc">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="4be04f01-e085-4364-9cf4-4c74b07e3ccf">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="06894d03-d876-4e8b-9b1f-68f0eead3d87">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="e21c7bb9-99aa-4252-ad67-f1b66f583b99">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7d9d8483-f870-410d-ac4d-9018ed782d2d">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="aa9f1b66-c664-428c-afbd-47cee9c2a43c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="9eff04dc-b1b2-4d6d-aafb-eea0e6f9db31">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="64ee4e0f-6f32-4f06-8810-2912c332f488">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7b282167-ab9d-4605-bf4a-37f7bea9131f">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="05dc50a2-8d1d-4011-9a28-a3680fa7db22">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ebc25ab9-c6a3-4120-9c6e-3c3cc02a4a38">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="2db36c2e-2de2-4266-9919-71f29baa3fae">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="6164cccf-682b-4fc1-b9e0-e9dacd21ac29">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="6a70691d-9fa8-4ef8-81da-e587bb10a332">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="977611ec-68f9-4aa1-983e-246e2f025676">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="5f3b6c77-13ea-4957-b354-2d8374153e16">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="dcd3eb2c-2e4f-4ec6-92e3-88455d3267a0">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="4b4a8ce7-0960-47aa-83b1-fe779ef5476a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="98c02b97-d62c-457b-b419-ba213cc4193d">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="74dd1d94-3ed7-46e2-9a7d-dac676c75fdf">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="30ac4e11-9a10-472a-bb5e-7e22f7e5a27f">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="a50a7fda-2c9f-4e7a-b97d-67f9fc0ebf3c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="a4772d2f-47f2-4ded-8af8-65b4865b85ce">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1032,50 +1032,50 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c5bbc79-3290-4638-8ec6-0de9e1ee2509" control-id="ir-9">
+    <implemented-requirement uuid="bcf3f3da-6836-477e-a2f9-7d4c2782c738" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="18c4ebc1-b962-490f-a4f8-cd467be9141e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="042bd152-befc-4275-a362-023cd92b794f">
+      <statement statement-id="ir-9_stmt.a" uuid="02df5246-c9a1-48c3-b3da-7603a39cdb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="eb57f596-1f07-4af1-aaca-521417dbdb9b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="2d4792d7-c53e-451a-ae3d-c0ff66bee080">
+      <statement statement-id="ir-9_stmt.b" uuid="7661656b-02d7-4f24-8543-2ab420fd420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="13d8bf8f-7cf6-4df8-87c6-e03c1593748f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c8ab0b54-b822-45ac-b549-aa292e66a779">
+      <statement statement-id="ir-9_stmt.c" uuid="163ad426-d038-4abf-a55a-cb9f0b6a5721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="c581496c-b6d2-4490-9b6a-897356c3a80b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="5688e556-8de9-4b96-a4e6-f0f714ad1197">
+      <statement statement-id="ir-9_stmt.d" uuid="8808f90b-b6a0-46a6-8342-0a3dbda1d754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="af135198-8316-42fa-99ca-c8e7fe202387">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1fade035-eea7-4a61-8616-9769fe5f6f7c">
+      <statement statement-id="ir-9_stmt.e" uuid="3085e8b1-08c5-4b1a-997d-a0d3f7ef4a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="b1073efc-8f36-48e9-84d0-da7dd477c1e9">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="bdd93a9a-a74b-48ae-91f3-92596808e8b4">
+      <statement statement-id="ir-9_stmt.f" uuid="13ae73bc-6bed-4a1c-96a2-401a1538d7ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1083,10 +1083,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdb7848d-a324-4288-abd7-5074a67cb138" control-id="ir-9.1">
+    <implemented-requirement uuid="d32202a4-71c3-4e5b-86bb-b799a06c6389" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="3af506aa-b375-4dac-87b1-22b757a7bd11">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c0a72446-6b37-4d77-9ffa-5ed0d2d3be1e">
+      <statement statement-id="ir-9.1_stmt" uuid="e360dc90-aa12-4097-b259-8b605b99154a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1094,10 +1094,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="978e1c82-71a3-46e9-ba17-ead865973cb4" control-id="ir-9.2">
+    <implemented-requirement uuid="562b61fc-ccbb-408a-9c03-08aef03f0615" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="d6a79da9-18b6-4bdc-b551-d344b724a60d">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c251a5f8-a320-4ab6-9373-f62f6deec1f9">
+      <statement statement-id="ir-9.2_stmt" uuid="4aeeb1f5-3b39-4d64-a261-220ab7f8a37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1105,10 +1105,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f98b17ac-f33f-4271-8533-ff6c4379f235" control-id="ir-9.3">
+    <implemented-requirement uuid="8677d99b-d58e-462b-83b5-5d7283825a99" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="5de03d34-ca6c-4536-aed4-68dd4d795b80">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e60c6e46-2ac6-4b29-a246-8dd47bba3637">
+      <statement statement-id="ir-9.3_stmt" uuid="e527df40-341b-4109-8975-29f039c56cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1116,10 +1116,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27c97347-8a16-4f52-be83-4f9680cbaa1d" control-id="ir-9.4">
+    <implemented-requirement uuid="38421d01-5e3e-4eab-8293-0686e2181441" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="e55100cf-f84e-4c9d-bbf9-c630a2b228c7">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="560a7379-2eb6-4b79-a03b-0444a15b9756">
+      <statement statement-id="ir-9.4_stmt" uuid="38221d3e-2bfe-450f-9a8f-0c88f2860012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1127,10 +1127,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50cb07a0-5a8c-4e3a-8dc2-046d44bbded4" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="0964a60f-4b88-4f1e-8439-933494145f07">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="66729d28-dc4f-4a5b-bcfe-6f90185fb0bb">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -1139,8 +1139,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="5fd4ccd9-3771-4d06-abdb-127090f75f51">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c50d8220-9705-498a-80c1-af42dc113c8e">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -1150,10 +1150,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e6d5c66-3b23-4726-8fe2-b6faaeafc2e5" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="16777016-664d-4b42-8bc1-e2dd3526980e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="4df64851-5c95-4872-a04b-04860353638d">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -1163,8 +1163,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="a660ec16-2233-4b7b-ae02-8343b53e158a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="604e97ba-73ca-441e-9748-4c8be80ea8d9">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -1172,8 +1172,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="b5b5a0c0-48dd-45d3-a1e3-94331fddb097">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="06876bc6-0e7b-4812-af19-601dffd815b0">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -1182,8 +1182,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="db56d215-35e2-4f52-b3e1-ab57f7d3e9c8">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="83463ac7-c024-4cc9-974d-285555e83316">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -1192,10 +1192,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f648d407-01b9-4d25-be47-18ac3567878c" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="0a81eca9-0f8b-4d31-9eb8-89fce383a5cc">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e8f977f8-31e3-4596-b307-996b12975358">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -1204,8 +1204,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="879e1733-d14c-44db-820d-1836bc0e1ae8">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="58e0e072-5ac4-43d8-894e-6a7aa3f8d4cd">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -1213,8 +1213,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="57fd4985-d532-494c-9455-a7f738b9421e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="cb2f1b42-6fda-41a4-b475-c232a743fcff">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -1223,8 +1223,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="722a74d8-1c7a-48f1-a74b-a50644e14cd3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="720bfc98-4316-429f-a1ce-cfb778e9a1fd">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -1233,8 +1233,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="cab9333a-e124-4502-90f3-49e259f37794">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="daf36ab5-f4f4-4274-a412-66c24a586b3f">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -1242,8 +1242,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="c36fd098-665d-463b-823f-4cf858174b57">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="55e79de9-2a40-4e14-b527-e19b43d7edcd">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -1252,8 +1252,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="c9d36fc3-3eb3-4367-a34e-7de9d2810d2a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="38cdf26b-3c2f-4120-8637-45b5c4fac4cb">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -1263,10 +1263,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e83e1464-af0e-4db8-ac3d-a47167be770f" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="95a92a6a-23cf-4aad-9f47-54703e4ecc53">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="006f7fad-68bb-4aca-bd7c-a1e14ce233df">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -1277,10 +1277,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bcb6df52-05c7-42b6-ba39-d4e099f39cd4" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="84a8bafd-14b0-4b42-9599-0a901de59ce4">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="6f2b8b78-0e9a-49b0-aa7d-989aec84997c">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -1291,10 +1291,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="544a755a-be80-4950-a5a9-3f94e01b82e3" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="342db189-3546-4b33-b35f-2fa04c74c5c2">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="cf493edd-b42e-4f8b-b74b-731db6e3f9c0">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -1304,10 +1304,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e33a3d04-7b35-4261-8edc-f7a14a3aeb75" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="19d12b11-5a2e-41eb-a378-cf7b08a087e7">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ba6eefb1-660a-4685-8010-b517201aee3c">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -1316,8 +1316,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="69531b3a-8fec-4196-8461-b125ecbfab87">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="b0ead8e0-c507-40d7-a4f9-715e2e19d183">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -1327,8 +1327,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="07ef52fb-e447-4939-9653-2a0f9424bade">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7e9ea412-7c90-42e3-be68-5597a835efbe">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1338,10 +1338,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64fbde1d-683c-4118-9aef-4982a218145f" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="10cd3d07-7a6d-465b-b9ac-941105ba8ad9">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e513dbff-001a-413f-b7c8-e6310e21b681">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -1350,293 +1350,250 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0fea8e3-e754-43b7-87f1-e29bb8a2ef01" control-id="pe-6.4">
+    <implemented-requirement uuid="6039d4cd-6f4f-4ab3-9ab4-8fe4db6cfa1a" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="cc248675-0855-4880-a623-28135cfd19eb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="192d1697-213b-4b70-8c17-f88b92eceffe">
+      <statement statement-id="pe-6.4_stmt" uuid="92f4bec1-a907-445b-a447-5a23b28698c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b84c4929-6721-417b-8d80-3e18d6b7b38d" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="d0396823-80a4-4812-a233-09cc9c01dbfb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="b5faa1b5-8280-46c9-9e99-275d9eb6bcd9">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="c06609d0-260b-4324-b3d3-c982fd8f1002">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="10863dad-3309-4e7a-8658-f1c9545d25f3">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afbb5603-1176-4ee7-a7b4-7eeaa12d90f3" control-id="pe-8.1">
+    <implemented-requirement uuid="89185b64-4241-4cc1-b99e-0fd4611379c9" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="707b0d41-a50b-469a-93d7-b0f7783d5acb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="48e8f9e2-d7e9-4de5-a807-620548e57241">
+      <statement statement-id="pe-8.1_stmt" uuid="7e29b876-5b35-4b33-b2c7-2599c8dccf92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="683aafc6-4ccf-471c-936e-a1eb33aea34b" control-id="pe-9">
+    <implemented-requirement uuid="d09ba053-a392-4fce-9d48-2650bbe51d68" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="eff6283c-8bca-4fb8-a7fa-958274a6676d">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="f9336934-ecd5-40d7-8a48-be447009bef4">
+      <statement statement-id="pe-9_stmt" uuid="af932a4a-e681-44b8-b559-7f4bae228387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d11add4-e67d-42b6-b36a-9926f9a8d309" control-id="pe-10">
+    <implemented-requirement uuid="a00714fb-0cff-453b-a86c-7123f5a5af8f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="9a003a72-d69f-416d-93a9-33bc7ff2ec28">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="98c1f9df-58b4-4652-ad21-eea882b9e590">
+      <statement statement-id="pe-10_stmt.a" uuid="f82a835d-0e45-447e-8cf6-e6a35c1e3060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="bcc49f26-10a9-4ad1-a982-985278db0fda">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8b8205da-45c8-4f35-8859-e3c8cf62eb46">
+      <statement statement-id="pe-10_stmt.b" uuid="b84f3c3e-161c-4083-9cf6-9bfdb8187570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="7e32c529-6659-40b8-9614-460c3fdc73e6">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="faef2f75-acc2-4025-8f57-57883e5f55e2">
+      <statement statement-id="pe-10_stmt.c" uuid="8c8049ef-779b-42d9-ba34-d24838950330">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3887faaa-358e-4740-a1fd-701fd0c8f5ad" control-id="pe-11">
+    <implemented-requirement uuid="667ed986-a1ea-4a5b-a836-1ef848a2d405" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="8df0ccb5-5b1e-4043-9478-a361ff81debd">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="80c37efd-8704-4d79-ae16-f5377fec304e">
+      <statement statement-id="pe-11_stmt" uuid="1bc8ee94-7662-43a7-8b6b-53bb4f6e9fa9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4663423-b36f-417c-bff2-4c891a818821" control-id="pe-11.1">
+    <implemented-requirement uuid="2ac139bd-067d-49a3-8cc1-e6c0ee845310" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="23332c73-25d3-4c3a-8417-02c5f58a9b0c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="17fb9410-3d36-49a2-82bb-e4b857bc1c17">
+      <statement statement-id="pe-11.1_stmt" uuid="8bcd7752-2be0-432a-a939-ef6cc5ef4da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0ae69fa-d461-4af5-8b26-c0402533a2cb" control-id="pe-12">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="38c81313-0530-4713-87f4-d787e8f38bcb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="471432f0-66c4-44ed-a2b7-72f8d046b9c6">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bec54fa1-e289-4c3c-8ef5-1b56010e3586" control-id="pe-13">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d770f4d6-6610-479d-851c-cd0dae57bbcb">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="18590589-6246-47b7-92d7-1b402a32cb7b">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19672a01-52fb-454c-93a3-9aaeeca9713a" control-id="pe-13.1">
+    <implemented-requirement uuid="c0a49647-2ecf-426d-8a0d-cc03b586ee60" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="93f336e0-fadd-43d0-96b0-e1addffb0d4c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="717d871f-6b8b-42ff-bd04-e292b75d2d69">
+      <statement statement-id="pe-13.1_stmt" uuid="63dc1e82-21c0-46cb-81c5-a1380d588d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcc95df2-1ee7-478e-8465-56c05fd71fb6" control-id="pe-13.2">
+    <implemented-requirement uuid="e61b56eb-502e-48d0-8dea-dd329df1444f" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="47d929c2-06cb-4eb0-977c-a8690304dfb8">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e376742c-4264-4333-b699-6af705177455">
+      <statement statement-id="pe-13.2_stmt" uuid="d20d68b1-605b-4789-a71d-0302341a68e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e426756a-db62-44c0-a768-a255ddb24ef1" control-id="pe-13.3">
+    <implemented-requirement uuid="ed45689d-2e14-4612-a688-ed8bacf22fd6" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="38712f06-de90-4c8d-9268-41e38024f99f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="d4cfff0f-7563-4939-85e7-465e4d515392">
+      <statement statement-id="pe-13.3_stmt" uuid="99caa78c-7757-4d63-a13d-cb0e57aff9ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95888c2a-8db6-470a-9eaf-ad09ac750d07" control-id="pe-14">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="c0584e53-5146-4efa-9dee-f9f84d7b3636">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="5235d72f-e94b-4a81-8e6c-5cd94afc9bc7">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="a61c17db-4aca-4d78-9f97-3123aec7164a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="93f0b305-a932-439a-a30b-4fc054ff0c8f">
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86f70cd0-6275-47d6-b8b1-923def95dfb6" control-id="pe-14.2">
+    <implemented-requirement uuid="c4d47a12-0052-49da-a5a8-b3852d8e8c00" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="b5aa50ab-5ce9-4c2a-9ad9-a98b9ef2dd45">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="109decd0-e13e-4a85-b174-001bb54b881f">
+      <statement statement-id="pe-14.2_stmt" uuid="b1069fc2-cf93-4ebc-951c-c7b8e46001cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe608abf-c642-441b-87e8-b7b2bb78a451" control-id="pe-15">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="d0c5f46b-bc0b-4820-ace7-af57c5989a83">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="a7ba52b5-851a-4f54-9957-2dd72782370a">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75fcedef-a794-441c-be54-ed4dedf6c892" control-id="pe-15.1">
+    <implemented-requirement uuid="02bd1e2e-c144-4c61-a041-9577c29aa0b8" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="a547a89c-da19-43c2-9960-5bd1fb161301">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="5f3ca0ca-54a0-4a84-9df4-cb7453d15c69">
+      <statement statement-id="pe-15.1_stmt" uuid="b219e010-a9cd-4505-a8c6-ceff54b9fd2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e20d66dd-4690-472c-8b6c-414da8aa5916" control-id="pe-16">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="95cbadd0-eb24-4706-aa6b-6f2d8c747119">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="73ca6a36-f622-497e-9434-d87e8ccd3bfa">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe6afa82-8bfb-44f6-8c1e-db4717b6c9cd" control-id="pe-17">
+    <implemented-requirement uuid="4d8e695f-6725-4dfc-a388-a629ab9aa7eb" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="53ad5d1c-b7fb-459d-815d-2048861b98f0">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c22e9cc9-96dc-4947-a188-7fa0365b9053">
+      <statement statement-id="pe-17_stmt.a" uuid="e750901a-4d28-4c37-bed5-3563e37933e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="2a41d419-b0fe-46bb-b622-69a258e6482c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1e9f6b46-d731-4b03-8b0b-8e95c041f422">
+      <statement statement-id="pe-17_stmt.b" uuid="a9dd49bb-c3da-4d5e-858b-3c0f480131f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="ab7d6ae5-47da-4bb1-9610-bfde9026e548">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="b074c11d-f455-48f2-8a89-aea28addd40c">
+      <statement statement-id="pe-17_stmt.c" uuid="e012ea43-db85-46c0-8920-fa79191734d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c80213bf-d651-451d-b1ae-717bf7014fa7" control-id="pe-18">
+    <implemented-requirement uuid="ef8324ba-51bd-46ca-8dcc-4f8ff4335588" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="c6b348fd-4a51-4f7a-80eb-9d3a60d238a5">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ab620dea-f1e5-4431-ac56-701267b3379c">
+      <statement statement-id="pe-18_stmt" uuid="2b1af852-47b4-4a7e-b90f-ac74f16d0812">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d9c7060-6ecb-4346-9e82-9ccd6f51dc70" control-id="pl-1">
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="1973ee92-08c4-4940-9dcf-7395995a938e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e75d339d-7cfb-452f-9e98-b9e7bbcb2a60">
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="3abaac07-9aef-4e68-87d1-284b1a6f28a5">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="4d250ccf-7ed5-4b95-bad7-589990ad07e5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="82abbe94-40ba-45db-853b-dd133b4cd2f3" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="88045def-73c4-4cc1-b8a4-a3f6263b0fba">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ef0977ca-0364-43ba-9e99-c37efc9d49f9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="d7f29a2e-dce9-4ffd-9f41-3a2ec33faeed">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="04c7863c-8e32-4702-8ca2-4ff094631b9a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="60f50707-bc47-487a-b59b-cfdfe9ed79d8">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="bfe87dc9-9081-48f9-a4b1-f75640312887">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="bae76255-d76f-4826-a159-cbbefd6503c5">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="209bf92e-2440-4815-8ec8-4d54971e1485">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="e53da3d0-4abf-4950-9279-b434e13209d3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ff67752c-48f0-4e6d-b155-084d86e0cad3">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1644,10 +1601,53 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b79d5fa-5bd6-4b41-b359-d68ebd3c9dec" control-id="pl-2.3">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="f6895b24-859c-40c7-a290-e9d84cf94b14">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3d217863-ba9b-4850-96b2-553d4d625d7d">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9d5246a3-4521-4c59-8205-516f2577541d" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="d6f42931-4074-4ff2-b339-9a5fcf43a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1655,34 +1655,34 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64f5e213-f2a8-4ef5-9014-7c823817a4e1" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="7c3eb1b6-72b0-4ab1-87ab-d1ebc3227677">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e19f9b56-d970-4df0-8b85-cb1a3f46e3dd">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="47d47610-4dbc-49b9-8967-5493034f22b4">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="4925ec1e-9337-444e-84b6-814a2837629b">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="72aa982e-9c50-4184-92dd-261c1b304a4f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="f27891cc-3a2c-4bca-99eb-118d68caac0c">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="f7fabc7e-e2e8-4497-a71d-d119ab769730">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c6d584d4-140e-4df1-a414-6adc6f2b4505">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1690,10 +1690,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e097c19-eb9a-4ffe-b789-65edf1e6b5e9" control-id="pl-4.1">
+    <implemented-requirement uuid="befdd6de-025b-45b9-bb1d-1904009c1805" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="4e8384b6-d47a-44bc-9253-f07063b161cd">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="b34e6695-9bbe-4e09-8d41-427b796bb355">
+      <statement statement-id="pl-4.1_stmt" uuid="2b440776-5d21-4e64-8135-54ff7feffdd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1701,26 +1701,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="784be4b1-5580-41c9-9ac0-671c4abc0ca9" control-id="pl-8">
+    <implemented-requirement uuid="d36b86a7-bf0a-4413-bb8b-b9fc088f748f" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="528651ec-d617-4bbb-be00-7bb48c61555b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="05c670f6-2e3f-4f57-a4a8-f2fa00d94adc">
+      <statement statement-id="pl-8_stmt.a" uuid="28433225-ecd9-4fbb-ad7b-f3440807c5cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="49b17285-cf72-4239-a4e0-d69da5b53cd7">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="fc83954b-5676-4c66-90a5-61e26263503c">
+      <statement statement-id="pl-8_stmt.b" uuid="79100567-b6d1-4a03-870a-6dcdfd334078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="00f88fc2-5ddd-496d-9460-3b8aded7cc9e">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7107ea5a-c8c1-4697-8c75-9a07bc68acf7">
+      <statement statement-id="pl-8_stmt.c" uuid="28d8ca15-8a90-4601-99a2-be94f976857e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1728,10 +1728,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d860312-38bf-49f3-b913-1d932394498d" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="0bddd1ae-9a90-46d6-85cd-d08efe526e1b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8f490136-5421-415e-9d2f-d7bedacb7694">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1739,8 +1739,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="96011630-cc29-4ce9-9969-36bace297657">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="87c97f88-5c13-4ded-b777-92157b7cc8ac">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1748,8 +1748,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="0a9cea96-e260-48d5-9fdb-9e7d14c6b98f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="f0839800-0bc6-4cde-937e-a2f78feef088">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1757,8 +1757,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="477b0e07-f3bc-48c5-8302-996ef0328e12">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8307b7db-e07d-490a-a37f-ee5271fc01b5">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1766,8 +1766,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="a85c471c-108c-403a-b6f2-85ad230bd30c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="604b6d4b-0c5a-42a7-b68e-774e8ef2781f">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1775,8 +1775,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="782e4725-5ce3-4a5f-acb4-5ee77c8e6e4d">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="799e05d8-0eef-4631-965a-2f8613440e21">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1785,18 +1785,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9212f631-8333-4005-956b-c27a0329fd3f" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="dd9089db-5853-4304-9a1f-1f37cf4909a0">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="66df961b-a4e4-4d25-9b26-fe2c94d6f323">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="c94a82a4-954c-48fd-bb39-3d76f3d176cf">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3e43ca5d-d7b2-4612-bf60-9e557892236e">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1804,8 +1804,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="64be2703-8097-4187-a029-6cca338cd3f5">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="90dc8b5b-5a25-4553-bf3e-60d8859d8a3e">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1814,10 +1814,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eef4ff77-df2b-44f6-9c23-53117a369b23" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="998ee95f-4727-4a7a-ad12-7542b29e46ca">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3dbd1daf-eb96-4bc1-8150-9a7e9ed0f842">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1825,8 +1825,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="85b4ad7e-23b1-43a6-b9a3-65bc3bedaf0b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="90ffd12a-4df1-4c4a-a3e4-14a7c72feb7c">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1837,10 +1837,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef859423-0683-4c0c-a918-f255e5d2119e" control-id="ps-3.3">
+    <implemented-requirement uuid="3959ccbc-54ed-4af9-9c1b-d819ab34008c" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="b34e2b0f-debb-4c22-b32d-de836152faf3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="04f2c8f9-379e-4bd9-9c2c-bffc8c97b5ba">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2cc3204c-5d15-4f86-bc80-67ef31dfdd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4149b12e-25db-459f-920b-dd7c6cc1d6fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1850,8 +1850,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="038a6e8f-20d9-4cfb-af2f-9880cea83004">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="54565d2f-e981-4df8-9a95-8e69a80dc410">
+      <statement statement-id="ps-3.3_stmt.b" uuid="4993cea3-da26-44a3-aa3b-d596533cc62d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7e0d2c3-63eb-4bad-85b8-e6e8a1437fc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1862,10 +1862,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb26bd08-7f73-48b7-a01c-321389de8f81" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="918999e9-223d-46d9-a14d-3d500c6b2f2d">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="af8548a8-9092-4696-9304-97879799372c">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1874,8 +1874,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="2eb11ff5-c8ed-4ad3-b783-3ba35248bc88">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="6a7fcf59-5388-4e7d-94dc-ec34ce585fe5">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1884,8 +1884,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="fe4a7730-67aa-440d-8374-eec3c6d6e244">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="21869c49-e701-4781-9cf5-9231f2dc0abe">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1894,8 +1894,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="dedbfe18-649a-4afe-93bc-d0c8e5b39dbd">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1f74d16d-ff17-411e-9c37-c9930fc6a968">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1904,8 +1904,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="ac9b8760-3e34-497c-ae2c-c0beea74fb1a">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="0999516f-a199-47ac-a78f-c41bcbf598ff">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1914,8 +1914,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="fbb8de51-6e86-4b0e-9b20-9b11658ef457">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="1218a177-5c17-4b28-b257-4c8717d84564">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1925,10 +1925,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="233aa458-c0d7-4f94-9657-622a1c557b6e" control-id="ps-4.2">
+    <implemented-requirement uuid="f2c61442-1b14-4a10-96c3-d0ba8c4659ec" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="0cb7cdb6-d0f8-4110-9140-fe6b3c424661">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="490eb735-045c-4e81-b90a-7e494396f293">
+      <statement statement-id="ps-4.2_stmt" uuid="eb569d00-deee-46c3-9cac-a0880b547c74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7158c5f2-fe50-427b-ae5d-93b17fd0666a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -1938,10 +1938,10 @@ Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66269764-e952-4e2e-a48b-185d4f6f07b1" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="63d70530-338b-40ff-b055-ac4ede5be96f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="086bc6b1-529e-403d-98bd-b564cae225e2">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1951,8 +1951,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="6efb812c-de57-4cf6-accf-230e6a27109f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c335fb99-3042-4605-a797-32a8ffc0e2f1">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1961,8 +1961,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="9926696d-c6c8-45d3-a317-9ee5568bc18f">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="f0abe0c4-da75-4d1c-9560-1c83535119e2">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1970,8 +1970,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="b12ae9bb-915d-483d-9e0c-aa2054600119">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="9c2d8fea-d00e-4d37-b63f-c3180be8cd2a">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1980,10 +1980,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f5c6bf6-a326-49cf-aefa-379e38d33a3b" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="878fc837-6cbf-4640-8758-6fd36b7ae3e4">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="8335cc60-9b12-4390-be13-780c2bb55257">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1991,8 +1991,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="c121ecad-8ebf-470c-b318-8cffa12013ca">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="c289163f-9796-443c-84d9-1abd000f5081">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -2000,8 +2000,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="8049bff0-8bd8-4a98-8b11-e2f97486e0b2">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="9d7bdf02-8c77-4b72-aae1-0b4e27ef8aa8">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2009,8 +2009,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="6c819234-301d-4aa0-b403-8a8b33c5456b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="f35ec60b-0de1-4cd3-a4d9-721001e107a5">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2018,8 +2018,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="d03f7abb-12ea-4bab-a633-aa0628d80d5b">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="3b905298-e861-4429-b04e-b74248fba0d3">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2028,10 +2028,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f6018f3-24eb-4e62-804a-4dd01b24f495" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="9664b258-cb0c-455b-86f7-2254d72b3564">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="7fe6b1b9-2660-4a0b-9219-e363073b136c">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -2039,8 +2039,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="502b1fea-23e3-475b-ae45-b71a8e66ed02">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="e2c4db7f-ceb6-416a-9e51-8c14f090c518">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -2048,16 +2048,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="87b42189-d9b7-4875-8c84-a545f70f1318">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="20c6b8df-97b5-4345-90a6-c3375191470a">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="b7ca2763-e44d-477d-a51c-aa7cf6474b18">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="6731e695-fed4-450c-959d-dda150b4a25d">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -2068,8 +2068,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="f6be882d-c95d-4ca2-9f00-c4eaef1055e3">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="ae5d77e9-31eb-483a-b8cd-1585e9a21b8c">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -2077,10 +2077,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d2e7f78-0fd6-4e7a-a129-7013bde361be" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="32e9fcd9-7534-4ad7-8493-5cb58d64f35c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="d71edd76-a143-4497-bd90-ce550b11e463">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -2088,8 +2088,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="03928b24-2200-4fbb-b97c-687c81da320c">
-        <by-component component-uuid="e66e1864-42f6-4721-95f3-73651b987c44" uuid="098e9485-cb0b-4013-a4f5-3e02356d415e">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/rhel-7-fedramp-Low.xml
+++ b/xml/rhel-7-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="6b152405-875d-4cdc-b9c6-173995a9bc2e">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="82068145-fb83-452c-949c-ba3572cd741a">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.49+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.50+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="7b5c0778-0482-41a1-9462-777fb1f7d981">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="a3397737-4954-4c0f-9e81-90523f4b299e" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="20b6ec35-96b7-4efd-9d4b-6c7872a5a141">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="6ef8058f-0883-40ba-a058-59d45f0c4395">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="efb3cd86-eb35-4328-82cd-5c35dcfd1362">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="d1683e2d-bd6d-4b89-a189-facdecdde7d0">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13c9b7b6-e584-4fba-959f-f9ba4ee8e75f" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="46e90cb5-1be1-4a5b-8e3b-7262b62331c9">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="24887d25-2b05-4642-aee7-9f92467ce515">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="87a51b3d-c203-4528-a6fc-4d408f82c047">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="ab8168cb-94c2-4da2-8576-ef4e01028bb8">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="12c12e89-5ad9-4f71-8ffb-d6cd786a04f9">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="a003e65c-4e3d-4420-9641-c4d9c2aa877d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,45 +530,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2af76d6-b996-4dc5-b00a-f3f19ee68614" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="0aa8ec65-534a-4dd1-9002-08b8344b42d1">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="37e19422-4b0e-4dd7-bcc4-e6027bf3dd4e">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="f13ce628-6ce7-4fa6-9fea-34d9612ff96e">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="491ec890-f191-4eda-b0db-583425cc46cc">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="9e742710-3e4e-46df-a974-86c65665ec53">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="e7454098-b47b-4e2d-8284-a99912c13f12">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="13420bff-20ff-4609-907b-cb292d2f1c82" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="d7855b2c-97bd-422f-9b80-b88a9e404b02">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="00cc3fb7-8206-4a47-9c56-522ce1a9cf51">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="bddfe9f2-4202-40a6-8576-b798bf2d060a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="2a576605-90da-48dd-b383-4a8b8ff19dac">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -576,50 +557,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d660d01-bc74-425f-98bd-5e3982e14272" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="54fca1de-883f-4be9-8c5a-6db926990c7d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b27856fd-56c1-4d01-9d49-81a2ef60946c">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="844b5bbc-2c00-4aed-b0de-acaea692f9c3">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="603a92da-daec-4193-b5aa-06b48f6bb18a">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="012deb9b-f90a-48e1-9ef7-06c45ee64f90">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="787ce3d6-b671-4a7f-a9d0-92cea9812c86">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="4a12a0a9-e0f7-41c4-aba7-6bb051d9d018">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="19242022-2303-4448-a8fb-e1a03b2b9051">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="94341700-fa07-499c-bb69-3243dc2685cb">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="f14a7fd9-3d61-44f3-97c9-298ed9e8788a">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="79f747e5-230b-4c2c-9cc9-637812b293a9">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c8ec240a-29c1-4d73-9056-92568cc981cc">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -627,26 +627,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="973244cc-156e-47f2-bd16-ac13c9ed1251" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="bc41379c-502a-4be5-89c2-445328699dd8">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="7ce3b1e7-b4b5-4ee5-8248-689161fd09fb">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="765d803c-18ef-477e-9478-3cedf851a703">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b01768ec-9140-4fef-9c18-4d26fceb60fa">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="2201a5d9-5fa8-4d63-8d57-4d4061b6913a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="1e801969-a5df-4c4d-893c-468ac8dc6517">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -654,26 +654,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49bffbfd-35a6-4f7a-962c-7d007b55e125" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="a7814894-a458-4a03-ae5c-0e204ce7452c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="ae7ab368-d709-4ecb-bb2e-6409ba2682dd">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="962a6994-e54c-4bbb-866d-aa93fbb27022">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="61045472-baa6-47ad-b502-9ed254e28ad2">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="44ecb0bc-7fe6-4dac-959a-7b6ee5380e96">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="ae6a34fb-3d34-4eff-a597-3c06f65f3067">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -681,10 +681,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b10b5aa-5384-4f6f-81b6-a81b33b1385a" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="5b5e10c6-120d-4bd4-9d78-731285a59275">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="cf863586-5a5b-48d0-b103-5be87e34121b">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -692,18 +692,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e1c9f5d-a74c-4905-89db-d26cbc3bb2b9" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="536f49f2-e633-4c97-b33f-e5457562cc42">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="0a1537fa-1a80-4f88-a779-02f6aa35e68e">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="b3e36990-c235-4d75-be56-8d34d4d61901">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c317d1b0-4db9-4aa8-9507-d81f9d73a26d">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -711,10 +711,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a89215d2-75a3-4100-b8e9-797ba0c6ac56" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="b4eab6fd-b922-4b79-9926-b09be7ebdcfd">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="05da937c-5cea-4ec3-9a42-ac163069b32d">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -722,114 +722,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fca14a0-e9a0-4d05-998b-239860aba73a" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="a3820356-5472-4426-ac02-866e84cf62d6">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="514a6047-3299-48d9-a37d-da1b45d30d25">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="e971bd75-0ea7-4c0b-87d9-0d6ad07ad581">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="8b7da1df-0fa6-435f-be7c-c81f79d2b854">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="f87ad62d-6d7b-4787-8000-003eea548479">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="86226888-08cd-46c0-a66c-ec28e71d9ae4">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="709220ff-0dba-4835-afe4-600222fbacda">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="d1454c90-5fe2-4ff3-8b61-ddf30f878224">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="1cff4ec8-e816-48dd-9ba2-69ca8b6174a5">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="acd30061-bf2b-4c29-a587-0851a9e5325e">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="8dc93acd-b43d-468c-91d0-4e28a8b7a43a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c3271e95-ab4b-43a0-b09e-aca07272e9bb">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="2b4fb7ce-416b-4c66-9a69-0533eec8ca39">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="d28a295e-74fc-4605-842b-24d87c8b7dea">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="be866039-cbd0-4d95-9cbe-a784840b513c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="3cbc9900-e997-47c8-b67d-6785b21b6d02">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="7af2fc17-047d-46ee-8b54-e9f5584f4dc2">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="5f58c86c-434e-4099-bbf7-a901cae9039d">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="34b1a03d-b54b-4dc8-a43f-9bf1906cda57">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="596003fe-01a6-4264-a039-5c48b55d8e98">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="52bd156d-c6bf-4041-8bf0-d5c81e2fa7fa">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="33804888-3068-49ed-a9c6-9796ea06f49a">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="6f15d41b-a5a2-41f1-8f82-5200208755d9">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="e86ba14a-1109-4542-927b-8eacfab506fa">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="c857b51b-ce67-44be-9222-0f780730ca68">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="4645504c-e4be-47b5-92d9-58cbc72eea45">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="74ab1a63-78b8-4ece-9193-9f0b9a1c23da">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b27cc872-9898-488c-9ebc-9a733120df53">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -837,10 +837,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5816ca3f-1771-43fa-b635-62f8b4d36585" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="4d178106-a914-4f44-87a6-5f2bf1fe7422">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="193966da-ce90-4801-9214-1625b0cc16d6">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -849,8 +849,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="6e6bdc43-8e51-418c-93ba-a8d65e8a1a79">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="be61e858-94b1-4fef-854a-6b58dbe6530f">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -860,10 +860,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e2f667a-a43b-4568-bf6e-da3f3587b842" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="1975c6ad-b945-42b2-9998-acbfefe9ee3d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="89eed227-89ed-4c18-bc85-288eecd2918f">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -873,8 +873,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="78c9572e-d406-42f0-8878-6e6e3fcfe086">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="efad84fb-51f0-4801-bf67-2d5de3f46a6b">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -882,8 +882,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="bcd47d42-6620-4694-9f69-f0a46bb1361d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="d4ce6ee6-45ea-4a8c-9909-938debd27062">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -892,8 +892,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="639803f2-3fb5-4357-8229-2843f99c5539">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="9232f455-ff62-4806-8708-addccae0a365">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -902,10 +902,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb24990c-0ff1-460e-bf90-304d07f37b05" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="cf04db88-34af-47cf-86b8-10e185224d05">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="04d7de2b-9f69-4fd7-a37a-38b19e8b910c">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -914,8 +914,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="4216dd5d-7c3c-4796-ba0c-58318e334175">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="ebaf2429-ae49-4c79-9984-30e57bcb0b96">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -923,8 +923,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="bec0ac49-4cc0-42e9-b407-d45280cb3549">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c9555786-e1da-4196-a52e-4b86ad81bda4">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -933,8 +933,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="8d7a9ca2-9e83-4343-83bb-f0a9f3718613">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="8ae21281-05ae-481f-b4f1-f27e7c4028cd">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -943,8 +943,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="53e93825-59e3-4d05-b142-8850f0e700c2">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="d0063242-dfa4-4c44-8d0c-179ffc103da5">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -952,8 +952,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="21059b16-1a61-4955-903d-d7df199fb7aa">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="7776a18a-065a-4a6b-8937-e5103f707d4e">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -962,8 +962,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="a5a5c46b-f1c5-4150-89ac-697936146907">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="785ede16-f9a7-4ed7-8c6b-26bd73ae7464">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -973,10 +973,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16061584-a6b2-42c8-a91e-abb5e9274b75" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="ab23d67e-0ab2-4b60-b23f-e2ec997b4712">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c1cb1e28-a818-448f-b8b7-699d23f5af71">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -985,8 +985,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="d668540e-7a9c-4e9e-9010-6f4310b8b2e0">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="ffa78285-4449-4c4f-87e2-088456867275">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -996,8 +996,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="e82fb3e1-28a0-4cd2-91d5-4f19cece6671">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b9a58aa4-2700-4f6c-83f4-236890e6e0a1">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1007,92 +1007,92 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="644eefab-260d-47f0-9110-e5087b045587" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="3f96aaed-5608-4536-9db7-02b23212e8d6">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="51864d59-0680-4c8d-b563-a8afee515ea3">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="89a875db-5c15-4f30-b9a6-f1975fad7f62">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c3a1fd62-fc78-49ff-8459-16172456933a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="fd2ba834-6d11-4fc1-9f27-2a351192957e" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="1383f40f-6069-4156-baba-db3deae40cb2">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="7123043a-7fe9-46b3-91b0-ccf9da10d742">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecc1ac10-0f36-46a1-b88c-1eac0539210f" control-id="pe-13">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="c89a3bc0-968d-4f84-9881-9f12c8e6c7e2">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="724ca797-9a2e-4ba4-9c40-871bbe215031">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3457bbfc-898a-4497-a23b-a3835f3f921b" control-id="pe-14">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="13aa83bb-58ff-4e79-a1ed-132a00147b78">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="880dbd40-f4fd-4e56-9ef6-1b14f9793033">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="4b7ed18f-94f9-4017-bb8c-a30b29283025">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c2f2e13e-0275-435c-9841-2f94e4081a8b">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f90b958-afe7-4ad7-80ce-ce30ac23edee" control-id="pe-15">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="ac8743ad-7878-4452-bcce-3d4c2fcfce34">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b562c479-907d-44bc-8dee-21d7ee80429a">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e678e77-c355-4498-b216-eaba995a84fc" control-id="pe-16">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="3e1fdb4d-2852-4c8f-8103-c21b059772c5">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="a0c607bd-a929-4489-9fe7-8fa6dbe042c7">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec8ca2ca-c3bb-484f-9ca7-0fe4cf3893d3" control-id="pl-1">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="5c16cf70-e8ef-459b-927e-b3fe4ad61d9c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="1315129e-df19-44ea-853f-53242d926fbc">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="5c2cd1f5-afa6-4acc-81e5-dfab8db619f3">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="067d7572-c928-48ef-876c-105d562e6564">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1100,42 +1100,42 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c75f18c-e050-43b9-8611-bc5f9d7b9a1a" control-id="pl-2">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="7da973e3-e3fa-402a-9f79-2b5d5b14c763">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="9d87681e-503b-4e81-b11b-7609a7d41ea0">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="347e51e6-52a7-4dd5-8bc0-8e6c460d6c5d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="a9cdfb68-0b48-49a6-99b3-500500d4a7c2">
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="2fe370f5-5e80-484e-91dc-d07aa8a4520d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="7d7c3c4f-9744-4da4-9614-1d1b215c0c3b">
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="d2dca009-dc6f-43c1-87c7-200fd4721bfc">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="32cf34c2-a08f-432d-a6e3-5804733b0511">
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="d0621934-9e5d-4ffc-ace4-c15783ac6cac">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="5574148f-8eaa-45a2-8be0-1ace28babf4d">
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1143,34 +1143,34 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="46290862-ffc6-4d2d-89f3-a402daa69ccb" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="82b207c7-602c-4e01-a8eb-32faa58c0448">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="af313b91-968e-4e51-b4d8-f53319cb0069">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="14ef6ad1-e9c6-4a38-8fe5-1d328df525de">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="5e2e8472-368a-4ea6-8574-03a246e0bd5c">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="e9d42e22-8fe8-44ea-8f6e-6a643eaf02bc">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="67511de5-e46a-46d1-a586-fcff79187fe8">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="71fc0f3b-1abf-43f5-b838-5f3e4f33b64a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="04622a1b-8d31-4ac6-97ea-2abd304b5567">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1178,10 +1178,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f943777b-6de3-4e12-b834-c754e43b130d" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="7c0bd194-ae77-4a24-b642-2d30c49fcccc">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="2607df40-7af5-4731-89be-017086596686">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1189,8 +1189,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="faf85aeb-a795-4dcb-b656-c153c61628f8">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="013c041b-38dc-4f3f-bf90-f0278bf1700d">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1198,8 +1198,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="496f28d7-bd4b-4a9e-b1fe-26580432796c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b59fbc12-6b42-4fc3-a1dc-2caae09ad117">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1207,8 +1207,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="bc35e739-cc12-4871-9cc0-80d1a207ef9c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="668bc6a9-7332-44c2-bdb8-29134214206f">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1216,8 +1216,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="615614bf-3848-4583-8549-e4310e56618d">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="370e55bd-08a3-4b73-be06-58b53afac5c4">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1225,8 +1225,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="7550636d-3f8e-4853-85bd-cffef3f7cde0">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="341e64ab-58ec-4666-a177-2769ac2b4cee">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1235,18 +1235,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0667368-3c92-4275-8406-cd6f62a4cb55" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="003a670f-1bac-4c53-8d4d-43228000cc8e">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="3c3fd4d4-8095-491c-9050-c719f9ed0b27">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="2cb540f1-b61f-455f-bb50-4ba900ff700c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="147abd05-e4d9-46fc-a60c-7abee4430fe7">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1254,8 +1254,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="cd9528cb-2a46-455b-8119-f5c7693ed8c6">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="a9209323-2480-4890-8194-958db634748d">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1264,10 +1264,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0a69165-1d23-4f41-a6bf-cc1ca148ffa7" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="d39e4273-e255-47a9-b0ff-e58d27ccb1c5">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="dee8038f-8188-4346-8ecb-ffeb09007e19">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1275,8 +1275,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="d844e8d2-2e58-4dd9-a72b-9b14573699ca">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="0a78d92b-c3b8-4458-b893-dfacd5902ebb">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1287,10 +1287,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00afeda6-7f85-41ad-a592-69a8c5df668c" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="02a30283-1a6a-4365-b41f-92aff43b47fb">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="55d542ec-77ae-4d4e-a106-81a8720009b9">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1299,8 +1299,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="217b4b56-39e5-4c3d-a454-ef38244f3695">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c82fe5c7-2b59-4aff-b54d-953cf0ee92ca">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1309,8 +1309,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="89ca03da-0334-46df-9788-c3ba5ac99e5b">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="1c053442-cb87-416c-8620-efe6f2a49989">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1319,8 +1319,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="6d3405df-c08a-41b2-bffc-9ee47a7f7e0a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="e76e2c25-2479-45db-a8ca-a625c5bf5d66">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1329,8 +1329,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="1ba5b031-9989-4b45-808b-c495d2bd7db0">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="8c0d722c-40da-4e42-a95f-f9d6b5939b94">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1339,8 +1339,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="67444c0e-1e55-4d30-983e-c78b29500a60">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="7c34918b-9aac-46bb-a839-d4767e7a2e0f">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1350,10 +1350,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97fb93b2-4662-4c8f-810a-74974e97eb3b" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="4ed361fb-9cf6-4b40-80f8-93ac8d5b980a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c0adc0e9-5f68-4985-9532-bb17735238dc">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1363,8 +1363,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="04d55335-ab03-414e-8613-0a717a742e86">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="b52bbaaa-6715-4369-9b19-56232dca813d">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1373,8 +1373,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="002b093d-6a84-402b-8c3d-3356bf5f2196">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="f07fff0e-05fd-44ae-bee9-246bb868fe30">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1382,8 +1382,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="1c8215fd-4788-4fc8-9d5e-b9a54024924c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="26509287-a586-47e1-a4c7-9801c0106070">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1392,10 +1392,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ff48d52-1e05-4618-af4b-f1e63238f317" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="b288c13a-011c-42ad-b080-addabb0d0d1a">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="574cefa6-06d7-413e-bff9-364ba1cbc70e">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1403,8 +1403,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="05771002-03b8-422b-9909-397d8285b079">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="fa38ba51-6fe1-4503-a040-15521d6c07ff">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -1412,8 +1412,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="cab95ead-385f-483c-84c9-32d312b4caaa">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="1a213ae3-707e-4260-84f1-a065c647cadf">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1421,8 +1421,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="13c28605-c82f-416c-906a-d0f05121deda">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="f30315c8-15a7-4aa2-8566-36b7b3d73999">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1430,8 +1430,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="890c65d6-73b2-41ff-a3b8-e2ff780c9f45">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c3e00df0-c316-425e-9996-9542374759d3">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1440,10 +1440,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23d37085-8dfe-4cdf-9362-186ef1555b9e" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="40a24215-36ec-4382-b704-657a3c70fe8c">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="1e9f7b94-3c88-4d2b-8479-29db32048456">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -1451,8 +1451,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="ba90da8b-039a-425d-89bf-260821270bb0">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="246fecbc-c4b2-4431-948a-95ea095c53bc">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -1460,16 +1460,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="da6c53d1-7569-40c5-b5ef-fa94c3ecf256">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="0a8b514c-258c-477c-8716-640d46b6cb1e">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="d7339dde-25c9-496b-a685-6bbf08d0cf3b">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="6c8f5b48-d10f-4ee3-90d6-60104e817a48">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -1480,8 +1480,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="14efbfb3-9b43-4094-95bf-acbcbab35cc7">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="49a2a675-7a89-4207-8d6a-976183d4ad62">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -1489,10 +1489,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96955bbd-f16b-46f6-bbc6-0fedf2aa11bb" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="53abb2d0-97e7-4dc9-b652-2b0b5abf17d7">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="c85952e5-98e4-4e69-88e7-26139ddb5a6b">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -1500,8 +1500,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="8cab2fd2-0a4a-4d13-b800-d6f6e82a6120">
-        <by-component component-uuid="fa7513f4-1d6c-4c16-b619-de31f54b3dae" uuid="45effc28-ef73-4982-82d9-25d6607e733e">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/rhel-7-fedramp-Moderate.xml
+++ b/xml/rhel-7-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="6d05d03d-1b7f-404b-93cb-cf2cb0ef3e56">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="07982263-ccea-40ab-aeb5-a1f2b878f11b">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.52+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.54+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="4d578b51-bb72-457d-8406-2e1609555f30">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="8a2fae19-841e-41f4-b2b5-34daefa52f1c" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="9c1c9bfb-cf0f-40fd-b830-ba74f64f432c">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="3d09c178-5618-46aa-be0b-c0e09a3ba1bc">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="edc441ee-cbba-4bd2-a3aa-81f8ed1f929a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="db726b11-10f1-4fa1-be6e-5e6a9ec5a29f">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d516de4-ab95-407c-9ffe-b7f807cc87ac" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="daa9637b-bf0b-4999-bef6-afd84dc30ecf">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="72a8a1d6-4760-440f-a1d3-afb15cd912e3">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="fabce487-fb5c-4db1-824f-2e355a734bab">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f0e967ea-c3f0-4801-b37e-7d6cfdbfe6b4">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="029140ec-0c5f-456a-9718-c69dc297baec">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="72bd09a7-4d38-452f-b6e2-32507e3274f8">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,10 +530,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a64f7701-442c-44d4-bde4-159b3d3c7422" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="1ec54153-09b8-4676-9531-6973a49a2bf4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="8c7bbb5f-7ce4-4dc5-b3d4-ccfe1a82342a">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -541,45 +541,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bae79472-d319-44aa-b4bf-9e066f338bc8" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="1484b92e-5051-4c0d-85fd-c90b7a0c70d3">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="764ba8af-2ffa-49b0-8ad5-e8e91c9b01ff">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="8cb758c9-b9c9-45e9-9b9d-5ae121e917e9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ac33508a-6400-455f-8b8d-a2a03925afe3">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="1896d22c-1da6-4f4f-91ac-92ff6bf26187">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="37720d7c-fce9-4ee8-9bbd-eebb68016035">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="36beae33-422b-476c-8034-cb5ca241b23d" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="38190850-e323-45b8-90bf-fe959950490a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fdebd7d0-d1d5-48e1-bccc-2a7376d7717f">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="fb0bb5e4-e8e7-472a-8003-acc262c6db51">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="b0cec655-6569-4234-a5c4-0267d34b00a1">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -587,50 +568,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62bc5f67-60d7-4143-85ab-71d1c4f8c16a" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="c5cb7e0c-a580-4500-bac1-68faf57f2c7f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="c9fd1fa8-8797-46cf-b4df-f200ce9b65c3">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="7b9a26c9-65c2-4cd0-a804-2260afcdcd4e">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="46d60d72-732b-4845-9ba3-46c8503f1903">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="02967529-1f72-415f-817f-4362c7d53a8b">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="6f121930-a3ae-4666-88b5-92afa5f1eca2">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="376c7afd-2810-463b-b567-21ece38e131a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="efd015df-c12d-4db5-a671-1c3de5ec100e">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="81cb4e1a-a609-4e0c-a24e-c83a0147a28f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="1633a466-2f0f-4753-b44a-00bc1d782cea">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="5ffa09cf-d9b6-4453-9e3f-09351605c058">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="bd224dc8-7c8b-42c0-972e-467dcdfbd8c4">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -638,26 +638,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bbc3357-cee5-451c-9f43-564e81d0ecea" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="7f6d38da-0f7c-4b17-ba01-8060c0410948">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="d5d1d765-bfb1-4d93-8fc4-c5a46bdc42b0">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="91f50540-7af8-4dbb-8d82-df8abbbdcc9d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="97dce59c-3eeb-4a45-890e-fe56ba516303">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="b1d07b31-528a-444b-a913-3353986da2e7">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="6703f7fd-33b2-413e-8b77-c77d7c9f7b0a">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -665,10 +665,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5255915-fe2a-4c71-94de-4a3574f110d3" control-id="ir-3">
+    <implemented-requirement uuid="534c3783-f194-4e6d-bce8-f673cd7876a9" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="88a03f8a-f1f8-42c2-abc7-0903784780ab">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a6226ad5-5f94-4593-aca4-0baee91da48a">
+      <statement statement-id="ir-3_stmt" uuid="b08ef514-12d3-49de-9430-8bd0081b6d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -676,10 +676,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c5e14e7-5e91-4cb2-8f36-23c1d201e079" control-id="ir-3.2">
+    <implemented-requirement uuid="cd2b8dea-d475-4536-810f-4cb8840225a1" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="fd7b0455-0542-4e23-bb1d-130b5bba6e7c">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9e8414f8-2782-410b-bb0e-42feb5c17cd3">
+      <statement statement-id="ir-3.2_stmt" uuid="228b2851-d621-491a-99b4-011447d2e390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -687,26 +687,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb1f34ad-0c91-4e68-bdc0-bfbaf2e20de5" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="385c1c5e-73a3-4943-af90-8ecd6b579679">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f8252c73-f01a-4063-baeb-c46ab5154218">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="7552e70a-1e84-4c6f-b7d7-61c5912a87c4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="73716eda-0902-47cc-a57a-8957241d65f0">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="5f5f4fc6-e65e-4d61-a6be-66ddb5679819">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9891c8f9-bc2e-4978-82b9-10fc91b7e801">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -714,10 +714,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4afba5cd-9687-46af-8110-dd5aab40bbee" control-id="ir-4.1">
+    <implemented-requirement uuid="51142785-d1e4-4886-b642-592d35b71e70" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="b1fba731-85e7-4719-8de5-95628348aa55">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="685df7ad-7ffe-41c5-aa67-445830374294">
+      <statement statement-id="ir-4.1_stmt" uuid="12a7343e-93c9-41a0-922b-eac846bcb671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -725,10 +725,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc5ba1e2-53ea-435f-8773-3a03fc9dfd77" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="4137bf77-e64c-4a26-95e5-e47b3813d1c8">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e790614c-f6bc-45a3-b940-1e0bef030cbb">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -736,18 +736,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a7697bf-481d-4930-94e4-3daa7f33809a" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="e7fb9ce4-45e6-41dc-8001-9e7aae39351e">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="81157a2f-5b2d-4906-8b7f-602e89a9b77a">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="6fd9c258-2c2a-487d-b9e8-e899d401c45c">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="b9dbd706-025f-4873-b526-7b666d1dba3c">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -755,10 +755,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="459a06e7-67a2-44f8-b653-793356d5de5f" control-id="ir-6.1">
+    <implemented-requirement uuid="abbf5ca4-c37f-4e55-be38-e0fb78d98b6d" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="8f0f5500-4902-4256-b60e-1f903cf7dd48">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="24e5f3a0-aa10-44a2-af53-a8d46c6bee9e">
+      <statement statement-id="ir-6.1_stmt" uuid="bff866ee-07a1-48e0-bff5-677bbab030e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -766,10 +766,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bfc5877-5110-4293-a92b-4ba5b89f62ab" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="50f92872-f5ff-4b99-9538-79db2ad84e41">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ecf8b2b9-7628-4a9c-81fb-cc9f865a7d78">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -777,10 +777,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b61b5842-7450-41e9-ba22-babab8c1ddc3" control-id="ir-7.1">
+    <implemented-requirement uuid="1e7dfee4-59e7-4258-a21b-252a865c51a8" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="960ae33d-1f46-4585-ba8e-4db0a222b1b4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f7e69779-e0a6-4927-90f2-3fbd0a605ab2">
+      <statement statement-id="ir-7.1_stmt" uuid="6aea26c2-e075-4c68-8b42-d974cef94703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -788,18 +788,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2be34a9-3a63-40e0-a780-210090a51d6f" control-id="ir-7.2">
+    <implemented-requirement uuid="b0e1ca1a-d05a-4e97-891c-242848ed917e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="2a57cb14-d58d-42fa-8438-8c8621fcc8e9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ac8c4d24-c26d-4e4b-983f-44abb907bd3d">
+      <statement statement-id="ir-7.2_stmt.a" uuid="0205e4dc-efcc-405b-b919-c8d96b200b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="d72da27d-c9c3-4f82-9864-e40c8f5a9222">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="c403ee6e-1cd1-4a93-91af-ab350cc72590">
+      <statement statement-id="ir-7.2_stmt.b" uuid="71973ea4-e082-42b8-b2c1-59894f32f069">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -807,114 +807,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eaa76ce5-fa2c-423c-9989-2880a9ae39aa" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="b626ec01-4421-4b77-962f-26b110755efb">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fe0385d4-9a2f-4141-b55b-338ca2d6aeb5">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="58c0396c-1230-492b-9c13-9cfafe03d8d6">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="78e93660-940a-4f20-bdb1-b27042cd1990">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="053dd21f-548e-4857-b21e-0bcca7a04fcc">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="567e6e8d-1d7c-4025-bd7b-34336d0a7979">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="cf9b5aa1-5f80-42f7-bbc7-7f7163904f2b">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="81b86084-56a3-4ae0-8969-446a9f1b73e1">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="15f0bc26-0560-4156-9f22-7dbc5dc30d73">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="b802c6f5-9c71-480c-860b-1ef063b9c78c">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="0d207867-469a-4e27-9266-17dfb34e19b6">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ff8c4b7e-86c7-49d2-beab-162ae0c9fb8b">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="3137b080-02e7-4b08-bb53-a6f0d5475935">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ae5bc230-9694-48bf-b735-52d17bb2f7e7">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="86081c98-3f5f-4535-bcb0-89d99ad856ce">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f9ac7d3d-5cbb-4199-9a48-e829b4521a09">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="9d18d7c7-0c4c-4402-a7e6-451e72180cb1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="860b409b-7a19-4c01-b455-0bf81039ad56">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="01fb6250-d5da-46f7-be9b-c659e0f37c48">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f6504ed2-9e42-4648-a6ab-964c98c49814">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="e485d2ef-3876-40cf-bb59-5332ee29f4df">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="0cc4357c-d295-453f-80d4-43128ebff0f2">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="fda9b00a-d51d-4579-ab1a-082fd2b70cf0">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="98879df5-6b7d-4070-9c16-cddda15b68d2">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="69ba3f24-0087-4d2c-be43-e933b12181bd">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="b9e3fdf3-1551-46a0-8a93-631f89369db0">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="4b66e2a2-c9cc-4503-afd2-7fa293d63955">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="5c0a73e7-b60d-4fe2-9fbb-eba677c51368">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -922,50 +922,50 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a51c4c2e-8403-492e-a001-e53ab5f873c2" control-id="ir-9">
+    <implemented-requirement uuid="bcf3f3da-6836-477e-a2f9-7d4c2782c738" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="b65122c8-18bc-447d-aef5-5f2dad8d0457">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e5d85d88-58e4-440f-a115-a7017c501460">
+      <statement statement-id="ir-9_stmt.a" uuid="02df5246-c9a1-48c3-b3da-7603a39cdb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="e1548a16-1550-4376-a8ea-3da8b96670e5">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="1711b711-7122-470c-8baa-bcf14caecbee">
+      <statement statement-id="ir-9_stmt.b" uuid="7661656b-02d7-4f24-8543-2ab420fd420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="448afc23-d830-4357-a2fa-380c9fa28b6a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="54f1f2c7-7952-4475-a668-547b7adb01b1">
+      <statement statement-id="ir-9_stmt.c" uuid="163ad426-d038-4abf-a55a-cb9f0b6a5721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="efd1768f-7432-4acc-b0a4-1a018e078388">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="880a73f4-0760-49f7-bac2-e33daf032559">
+      <statement statement-id="ir-9_stmt.d" uuid="8808f90b-b6a0-46a6-8342-0a3dbda1d754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="134588f8-e738-44a6-9ff6-5137a6cae00a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="59bea3f5-3a76-4ea5-89e3-509a249d199b">
+      <statement statement-id="ir-9_stmt.e" uuid="3085e8b1-08c5-4b1a-997d-a0d3f7ef4a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="cfd1a397-1b1c-417c-9953-cbb89fd5ffa4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="c04a844e-0a03-447b-8539-8b7af824d977">
+      <statement statement-id="ir-9_stmt.f" uuid="13ae73bc-6bed-4a1c-96a2-401a1538d7ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -973,10 +973,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fbeb148-468f-4c81-b0de-5b7ab21e6428" control-id="ir-9.1">
+    <implemented-requirement uuid="d32202a4-71c3-4e5b-86bb-b799a06c6389" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="5fa9e36f-40dd-4ee0-abe3-dd3a70916d76">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a1af3729-d80c-4030-bee0-f8d006432c3f">
+      <statement statement-id="ir-9.1_stmt" uuid="e360dc90-aa12-4097-b259-8b605b99154a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -984,10 +984,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ded1913-e01d-4b3b-ba4d-a74a608449f6" control-id="ir-9.2">
+    <implemented-requirement uuid="562b61fc-ccbb-408a-9c03-08aef03f0615" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="8fd0eabb-c5a2-4a02-bf0c-4a80cd41dc91">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="0fdea45d-30b3-4dfd-928f-03ad80e14081">
+      <statement statement-id="ir-9.2_stmt" uuid="4aeeb1f5-3b39-4d64-a261-220ab7f8a37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -995,10 +995,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8ac4e46-ec18-48c6-9dc3-dd8dd250e362" control-id="ir-9.3">
+    <implemented-requirement uuid="8677d99b-d58e-462b-83b5-5d7283825a99" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="40e4f1c9-e362-49e0-a83f-6f5a8e747280">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ff12d276-f49e-4484-a27b-64228e10f45e">
+      <statement statement-id="ir-9.3_stmt" uuid="e527df40-341b-4109-8975-29f039c56cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1006,10 +1006,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e107d4e-87b0-4473-8029-ca14d03bf6c9" control-id="ir-9.4">
+    <implemented-requirement uuid="38421d01-5e3e-4eab-8293-0686e2181441" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="e4edbec9-f0fb-492d-859e-af7aacc93172">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="6bdf7e97-9e62-4a33-af55-636ea2add1d7">
+      <statement statement-id="ir-9.4_stmt" uuid="38221d3e-2bfe-450f-9a8f-0c88f2860012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1017,10 +1017,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12b0c725-e5a5-4ec0-b7db-81354f2458b3" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="fe7f886e-9bf0-4ca6-8619-0b5d576389c1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="7bbc94e1-70a9-44bc-b589-ed7d79302c00">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -1029,8 +1029,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="b334fed9-483f-4406-a03f-38522f394b0d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="c2351cdb-5468-440c-bc92-b973fb30e605">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -1040,10 +1040,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31b1dbbe-bb6c-4c41-acac-77727dea5b15" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="cd46f554-546b-4d87-939c-ea483001a8a1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="84422243-a91a-437a-a1b6-0696f845fcdb">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -1053,8 +1053,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="4c74d9ab-5984-462c-962a-e03e081b7dfb">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="23f0682a-0161-49ed-8084-f6684a1c95fd">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -1062,8 +1062,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="59de1e19-59ef-4922-90f5-d8fa701fd377">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a24b7cb0-30b7-4c34-bb27-0ad4f4d1e388">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -1072,8 +1072,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="2e28ff8f-6372-4728-a0b7-be62d559195b">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="ed83ba77-a7f1-4146-a873-6612c4906b56">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -1082,10 +1082,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1fd1a43-1bfc-4f66-a2d7-40695bbbd6a7" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="587d3a73-00d9-4781-8852-544571a1ab9d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="79e825e9-fc16-4929-8687-d89b6de7b194">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -1094,8 +1094,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="1a210b86-c3dc-4054-a45b-d927a6f5cd36">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="1a155af4-3f24-4acc-8c0b-34eaa1c11e4f">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -1103,8 +1103,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="a46468e3-44a9-4b32-b825-a09da30f8b37">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fca6f88a-ebd2-4535-9023-6781190bb114">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -1113,8 +1113,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="7903599c-4f78-41c9-9fd3-c618ab6018e0">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="d264f04e-7aae-4da5-938f-70072da70fb9">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -1123,8 +1123,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="85b49ec1-858a-4f9e-ab43-67e737f9d65f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="d02fc186-871f-4469-bdcd-e6d3c8e25450">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -1132,8 +1132,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="5ed38677-c826-4084-be03-39432f36a534">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="bf623fcb-ade5-4e99-ac98-aa12ccf2302d">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -1142,8 +1142,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="e5bb9b20-3cc7-4fc5-a371-37a0a47bf5a2">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="4cafcd6f-213d-44be-902b-32374b0455da">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -1153,10 +1153,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3387d8b3-890c-4871-ac4f-a206fc9fa183" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="1add9a73-193d-46a0-9ce4-e81edec28c3f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="bfea1be1-e894-45a6-ac85-34d7077f4b7d">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -1167,10 +1167,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4fc1682a-71f4-412a-9d38-d4a03ecf3306" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="fccfb970-b826-4e95-a4df-e23d9395b030">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="33e075b5-e5ec-4fdd-870d-bde4a416d40e">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -1180,10 +1180,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="550b4b67-57b9-4bbe-a932-bbe4fbc49008" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="55da62b4-2a9c-4704-880e-e63e14d7e192">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a41b80ee-ec84-48fd-9d88-fb73f270826a">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -1192,8 +1192,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="f099a137-71a6-4696-8789-c076c8647479">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e3f20bd3-3f8c-4765-9807-ccebf3e78855">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -1203,8 +1203,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="6b0efcb0-729f-496b-ac53-ddb3c6c7f807">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="2150fad3-f84f-49d7-86ab-4e46e4956bcd">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1214,10 +1214,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="634456c3-1907-4ef5-8c7c-6233a760aaa4" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="b9a6ec4c-cbf0-4f7e-b977-d7ed4db27372">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f397b4fa-9c12-487f-b638-0e256d8fd8a6">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -1226,233 +1226,190 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="777e3449-4871-4f16-a4d5-677b6bb966d4" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="64381777-c820-4762-8af6-28202f42f222">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9e6ad090-d8cf-4b7a-ba78-78d1954dd0e5">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="2e0ebfbe-7c80-49b5-bac5-ea1596649d20">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="498d6d55-c8bc-4e06-a8d6-7c3d81030431">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="641ec73c-2dea-47f9-a794-e52d6223a79f" control-id="pe-9">
+    <implemented-requirement uuid="d09ba053-a392-4fce-9d48-2650bbe51d68" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="6db0743d-702a-4657-9929-3f2cce490436">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9cc71db4-3df6-4d30-966e-94772e95400e">
+      <statement statement-id="pe-9_stmt" uuid="af932a4a-e681-44b8-b559-7f4bae228387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb49bcf2-0c55-46f5-b1a1-1b401c2c28c1" control-id="pe-10">
+    <implemented-requirement uuid="a00714fb-0cff-453b-a86c-7123f5a5af8f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="7a585f84-94e3-4472-9015-917521b2a916">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="2135d2e7-c8a6-4ef8-b5b4-c8c5d44c28c6">
+      <statement statement-id="pe-10_stmt.a" uuid="f82a835d-0e45-447e-8cf6-e6a35c1e3060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="1a610158-e96d-4ff1-8019-fac09fcc554f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="507bddc2-a36a-4289-b48c-b36fa9aa6493">
+      <statement statement-id="pe-10_stmt.b" uuid="b84f3c3e-161c-4083-9cf6-9bfdb8187570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="ba3ce968-aed2-456a-86a5-47f77151a348">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="55fe7858-aeb5-487c-95cd-d0e41815c5d4">
+      <statement statement-id="pe-10_stmt.c" uuid="8c8049ef-779b-42d9-ba34-d24838950330">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23c5fd3b-8879-48ce-9901-cd2aa509a487" control-id="pe-11">
+    <implemented-requirement uuid="667ed986-a1ea-4a5b-a836-1ef848a2d405" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="e3448ee6-b33c-4fa8-8de7-6a97575febf5">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="10bb406d-0622-438a-a13d-b20b16f7877b">
+      <statement statement-id="pe-11_stmt" uuid="1bc8ee94-7662-43a7-8b6b-53bb4f6e9fa9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e01ba10e-c4d7-4419-b023-b2f920fe7eb6" control-id="pe-12">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="16952a1d-5c5d-482a-9215-04f01a4f4555">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="df501c38-91e7-421c-86d4-fab7d81e2a7a">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e5fe549-f2b2-4f5a-8570-6cb83d7e7d1f" control-id="pe-13">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="63b1a2de-58ea-4de5-a30d-85ea287cfd28">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="c57ffad4-b9b4-420f-9c60-21098a299820">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b04bf6b5-1eda-4eef-9e50-ef58eff7fda2" control-id="pe-13.2">
+    <implemented-requirement uuid="e61b56eb-502e-48d0-8dea-dd329df1444f" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="543e8e89-e452-4c49-84c2-29a3095f4ea3">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="989df6bb-4146-45e0-8e98-baba2d34dd04">
+      <statement statement-id="pe-13.2_stmt" uuid="d20d68b1-605b-4789-a71d-0302341a68e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4452269-e4ee-4e89-a696-a6ce0f2a4026" control-id="pe-13.3">
+    <implemented-requirement uuid="ed45689d-2e14-4612-a688-ed8bacf22fd6" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="add17ed5-86e2-45e1-a76e-3de02ca4f78a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="4cdde3e8-d070-454a-bb19-c93622021db9">
+      <statement statement-id="pe-13.3_stmt" uuid="99caa78c-7757-4d63-a13d-cb0e57aff9ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b79870a8-5f71-4d3e-bf6b-27c257687cce" control-id="pe-14">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="4779dcb3-1765-4c26-9333-cebe19b2d5a3">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="73e4aa68-48c4-407b-9e29-f0bda4cff90c">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="21095654-c3fe-4711-9757-e6f3c06901f5">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fd266388-6241-4dd5-be65-bbc4fe9ed918">
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="383bf978-6ed3-48be-a6ba-e3bf3b977720" control-id="pe-14.2">
+    <implemented-requirement uuid="c4d47a12-0052-49da-a5a8-b3852d8e8c00" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="263aa2a7-57b5-4b94-a6a6-4a99fb2001fd">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="2b16d577-124e-4f6b-81fa-36385ba33954">
+      <statement statement-id="pe-14.2_stmt" uuid="b1069fc2-cf93-4ebc-951c-c7b8e46001cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4505f420-759e-4e39-a33d-1e54f863c80a" control-id="pe-15">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="c64add1c-88b6-41ce-aa70-713a0fef4266">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="911c44ac-915a-48d9-b413-35eb2185fd48">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d33896d1-18bb-460f-92df-337a0c44e88c" control-id="pe-16">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="ddf0943a-bb6c-471f-a044-0925aa0e920c">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="3b76c336-385f-482a-a691-25a89ed5985e">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="474f01d1-f362-4f02-948a-db202ef0e427" control-id="pe-17">
+    <implemented-requirement uuid="4d8e695f-6725-4dfc-a388-a629ab9aa7eb" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="da4e6d38-19e4-4a6f-9cc4-3a5b167062af">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a9cdf55c-9474-42ee-8740-fd7407ed2e37">
+      <statement statement-id="pe-17_stmt.a" uuid="e750901a-4d28-4c37-bed5-3563e37933e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="b4adfdf7-ab10-4009-88a7-07af08cb3717">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="1fef3813-4399-4612-879b-837067d704c4">
+      <statement statement-id="pe-17_stmt.b" uuid="a9dd49bb-c3da-4d5e-858b-3c0f480131f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="312cc4e0-1e8a-43d4-b791-89ed05e47857">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="8c32e0fb-9309-48d0-8b26-cf91a35363b7">
+      <statement statement-id="pe-17_stmt.c" uuid="e012ea43-db85-46c0-8920-fa79191734d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63fc8cbd-8df7-4f2b-b45d-aa495a2ed44c" control-id="pl-1">
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="30bb0858-4455-41aa-812d-a5e3dbbabc5e">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e0d95016-348b-48d0-9871-a05defda03ef">
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="3b5319cc-35dd-4918-a046-4d6d319923da">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="702e6767-95b2-42f7-b1ab-b66cbd66300a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="c8bd7085-990f-4feb-b174-60dd2cb4a0d1" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="c7b6b445-fc93-43b6-9087-25cd90a8fb07">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9191a61d-98ab-4de8-a3ec-236d4f446212">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="2e71ba31-ab74-49f9-8a4c-b3ba7d3c3614">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="47705194-ee82-4889-bbc3-ecdc7cdeaea5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="3e2d4e1b-447d-4b2d-8be5-72a7427e7507">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="b2a8fef0-4851-485d-a2e6-a6584b5740f9">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="0317cdf5-3e7a-47ca-88b8-6e38654a56b8">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a673902c-c14c-4857-b34c-20e97b9cb92d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="e85481e9-b544-4e6c-a809-41ea217dc7d9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="bc7101d2-63ab-42b2-be7b-6bb3aa21f7f7">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1460,10 +1417,53 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98bb8331-60e6-4f6c-941d-091354c89983" control-id="pl-2.3">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="81f823bf-d979-4ffa-b01c-07e0f047c234">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="eac32dc9-51f0-4916-af1e-81481870e92b">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9d5246a3-4521-4c59-8205-516f2577541d" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="d6f42931-4074-4ff2-b339-9a5fcf43a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1471,34 +1471,34 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d47d137-50de-4b33-bcc3-c7d923e06647" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="5e1ebccc-5760-49ee-ade2-605a90e9f030">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="7df04983-e766-483d-84b9-18191697354a">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="74873510-d9f5-4793-b449-3dfff47a244b">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="48bf8816-62a1-4ef9-b4c8-da62111747ae">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="42844670-79e7-4eab-8380-275feea90488">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f3043df7-fbb2-4589-a387-7e4c272178b0">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="512ff234-1b7a-4a92-97e5-b7f7c0fc21a9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="37630075-0929-40aa-b7ed-9b51c7db5b79">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1506,10 +1506,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="457aac76-28b6-451e-b5e2-bdb748d5f1f9" control-id="pl-4.1">
+    <implemented-requirement uuid="befdd6de-025b-45b9-bb1d-1904009c1805" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="02628533-f880-4f8c-8ec1-d643bfcfd0f9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="140a97e4-8ba7-4b1b-9566-94d70eafe32f">
+      <statement statement-id="pl-4.1_stmt" uuid="2b440776-5d21-4e64-8135-54ff7feffdd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1517,26 +1517,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69a8c3a0-c04a-45eb-a932-417fe56f2580" control-id="pl-8">
+    <implemented-requirement uuid="d36b86a7-bf0a-4413-bb8b-b9fc088f748f" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="7ae25f12-e2be-454a-96dd-0f4d461b71f1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="6656c8d3-dcca-4c1d-a36d-04b2c0762181">
+      <statement statement-id="pl-8_stmt.a" uuid="28433225-ecd9-4fbb-ad7b-f3440807c5cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="d3c1c374-5d80-4ab5-a9d1-f67bf4a7bba1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9b6eece0-4cc8-4d71-8d76-602a186a13f9">
+      <statement statement-id="pl-8_stmt.b" uuid="79100567-b6d1-4a03-870a-6dcdfd334078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="511068c7-e269-4d9d-bab7-09e8004de8e0">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="7fd4970d-8f2c-4051-8019-eaf27af81862">
+      <statement statement-id="pl-8_stmt.c" uuid="28d8ca15-8a90-4601-99a2-be94f976857e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1544,10 +1544,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="956cbf34-5487-4f04-a4ce-7b56fd0c4903" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="ba0bea94-9cb6-4f93-a153-241a2c444111">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a21253ec-93cc-4d85-be96-f373d1bf3cdd">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1555,8 +1555,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="50b61c37-7263-4ad2-a207-6581d269fbd4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="38c7b7d0-affe-404c-80b1-b511e80cb84d">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1564,8 +1564,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="fe944918-d6e6-44f7-9a48-18040fcb4f24">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="a87044b1-3e9e-4733-aba4-2a269a07c82e">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1573,8 +1573,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="4ed0634f-c9ea-4a7c-ae87-42d80b8fd076">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="efdc3b59-baf8-4d09-98ff-f790d7b48877">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1582,8 +1582,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="43987f3a-56e8-4ac2-908f-b2d38d294d47">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="aab590ee-7246-4fc5-8fc2-ea59077c9906">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1591,8 +1591,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="546dcf71-1cc2-41ee-a7e4-11c7ec392edd">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="3947b80e-f56d-44d2-ba44-297979288f35">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1601,18 +1601,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b573b7e-367b-448e-8501-dc8798bca6af" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="bc71c524-4324-48b1-bfec-1a99261a3b44">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="167a0927-9434-45c4-8e41-76ca1a8ecb27">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="bd26414c-835a-4d71-9138-7c54dd590dcc">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="114019ba-5dc3-45c4-a9da-b7b3c2d1b0a9">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1620,8 +1620,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="375e97c3-bd2f-473b-a7f9-2a04a1b7657d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="5a52e421-dd86-4ac0-97ef-e4e23ee89bbe">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1630,10 +1630,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="701fcfd7-6b51-4a0d-952e-52cd3f8440d7" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="fbc6f9d0-8472-474a-ab27-2b2767e82710">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="2133d422-0c70-4877-8270-8469868c7390">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1641,8 +1641,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="091a1794-035d-4d3a-bd62-205f4f5a76ee">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="dbff5496-700b-4318-810c-4a41150ac45e">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1653,10 +1653,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e905a67f-89d6-4e89-9770-5e01ca276086" control-id="ps-3.3">
+    <implemented-requirement uuid="3959ccbc-54ed-4af9-9c1b-d819ab34008c" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="04a80d36-c989-4817-bcd6-de433f8d9d23">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fe709cd4-f50e-48ab-ac5e-835693a4d1b4">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2cc3204c-5d15-4f86-bc80-67ef31dfdd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4149b12e-25db-459f-920b-dd7c6cc1d6fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1666,8 +1666,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="a6f5bc8c-657c-4c90-a64c-52704076e6fc">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="cd49048a-6221-4639-9a4d-25a78ddff80c">
+      <statement statement-id="ps-3.3_stmt.b" uuid="4993cea3-da26-44a3-aa3b-d596533cc62d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7e0d2c3-63eb-4bad-85b8-e6e8a1437fc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1678,10 +1678,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="953c1b2d-a2e9-4983-af18-eba28c2450bf" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="2d4a4224-6170-4bdf-8ee0-313fd54121aa">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f13b695e-a951-4d7d-a1bb-f9b504769495">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1690,8 +1690,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="440404ef-ba1d-462b-9336-82690a8ea02c">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="8805007b-a4c4-4907-881d-9af27ee37d2a">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1700,8 +1700,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="54eb6a44-fa81-4cbf-8081-73646e3068a9">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="5383f098-a3c0-4c32-8eb5-0a13aef1e7d5">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1710,8 +1710,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="2f9cd130-6837-4f7c-b2fc-2135bc86c608">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="1e00e389-bbf6-45fe-a068-410e216072ae">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1720,8 +1720,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="bdda7872-2602-47c9-ac79-a8589191fe7a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e04042fc-85ec-42ca-a72b-9d01ab426460">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1730,8 +1730,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="4066ddde-5df5-41dd-a2bf-003a4fc7adac">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="d9448018-c013-4ae8-a142-3aeab934adf7">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1741,10 +1741,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3e00b46-9326-4bec-9110-db01f65ca32f" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="68c4fcf8-2ce6-4cfe-97df-d9a5f93cfb04">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="7ba97a6f-54b7-40d1-bf06-47d165f6d232">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1754,8 +1754,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="00a1fc89-16a0-4155-915e-9bdb56880732">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9ecf9061-3edb-4e00-b766-6bc1634fdc1d">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1764,8 +1764,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="02070922-e2e8-4ea9-b477-c91ed35f2b5a">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="9c6cf4ac-4bd3-4ed5-8934-5cd927699788">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1773,8 +1773,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="52b63a94-ab3c-463d-8fee-736b9df19645">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="14246ca4-05a3-4bad-857e-27cfeb97515a">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1783,10 +1783,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef6a3ca4-3aa9-4e95-93a1-7b2f9c78851d" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="44facbcf-ab3d-47c9-a849-225dc7d84c21">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="382db204-68e3-4da9-82f1-9c4cc1837640">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1794,8 +1794,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="4391213f-0582-476a-8704-dcb80c44782f">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="0cfcf5b9-ad54-4c87-ae9d-eff8ea7f19b7">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -1803,8 +1803,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="f4990804-3d13-44ee-b745-73390a13b2f4">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="877f7b90-a501-45fa-b3f1-c6e49f97d09f">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1812,8 +1812,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="42444bb0-4147-45de-b494-a156b52a340e">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="fb811ce9-ca41-41c0-9bb6-bd8fb97f1b41">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1821,8 +1821,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="a7ec5647-9cd3-414a-97e4-11fb3fe364c7">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="0f43d31f-48b5-46ee-8073-63dfec96a2cd">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1831,10 +1831,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c70c90c6-8ed0-4da8-8aec-7681bacd926d" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="ee9e243d-ae68-4ede-b28e-35d9667b2835">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="dbd15ceb-f7a3-47d3-846e-46bea04a6ec4">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -1842,8 +1842,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="9cede278-5511-43f9-9c3f-d18d5121187d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="f5406fc7-cadc-4c06-9263-827e40e6da30">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -1851,16 +1851,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="f9ef2e08-3b47-482e-bb93-9bf0438558fd">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="aa524570-5ee0-471b-9d28-177c22afa30f">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="37c66304-06e2-43d8-82a9-8a6e005e992b">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="7aa34b8e-8f79-4455-9720-cec12d60d2b5">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -1871,8 +1871,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="e3d8d74a-5e8b-43ec-b058-ff24009492e1">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="e65bdf3d-6f6b-4477-b87a-5e3fca783b60">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -1880,10 +1880,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b26df15-9401-4e7d-bd22-85a725da8c90" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="53505b56-bac3-4494-9eea-5a37b632d96d">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="55980235-c989-43eb-a614-75d059736ff3">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -1891,8 +1891,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="5535cbaf-97dc-43bd-91a1-9cd0e8469c58">
-        <by-component component-uuid="c4b2ecfc-1b19-4531-9a6a-5e51034d87cc" uuid="41ccab22-28ad-40be-b91b-cfb8728274ce">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/rhel-8-fedramp-High.xml
+++ b/xml/rhel-8-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="8f8ce9d2-87d5-40ac-b584-dbe3b409ce58">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="e77770e9-d9e8-40ad-aab0-799b66031018">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.65+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.73+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="730a863e-13f6-459f-89a4-df22cc3557f7">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="3c4e5f54-bdee-4921-bb39-7361af5df606" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="6ad462bc-f37c-443d-af11-2d076a2070ae">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="df1f14e8-5ce6-4939-8fde-72a2c0cc7a45">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="db2522af-4424-4adb-af3e-3c172b8e652b">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="451004d4-77d8-4021-a943-09a98871917b">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6df3946f-0092-41da-910f-19e44a5166d1" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="2237d822-1383-4b5a-b055-d32ef26340f1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="7cf9d7ff-2f8d-422d-ac66-032b3cbd5e18">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="1dcdf14f-a300-44e3-999d-f22cccedca91">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="8fb742d6-b740-4050-8ad4-bfe1feaf1abe">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="e55c5b26-7ff1-4733-b8d0-c59a0d4e99aa">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e28b8ca7-6d7e-4da9-a69c-206141da6918">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,10 +530,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbd88f58-3ed0-4fa6-bf91-83696f3e34cb" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="d1ba8ba4-760f-4731-9b99-c52c5e54ccfb">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="95a0016f-d3c2-48f9-88c6-8b9f295926fe">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -541,37 +541,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40c08dd2-7993-4258-b01a-dfc05335e4e8" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="fc073d43-3b8a-4d04-a986-112cdbb9883d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b00ec52f-ca10-493d-b2b4-0046fc1852dc">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="ba3baac4-5a8c-4f27-a804-a29d62cee688">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="339b9cd0-7d4a-420a-aca1-7561ba7c9353">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="d5c0fcaa-ef19-4609-b596-3fca06673490">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="9dc71251-93b0-4830-aaa9-d5423aaf8547">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="39f71600-adfd-4bbf-8f1c-4e7195c0392f" control-id="at-3.3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="cd23df93-0f8b-4eda-98be-a1c16ff70759">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="57aebd60-912e-40ed-a3a1-0bbb1c2bdad1">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -579,10 +568,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49a37d59-fa45-47b1-bc99-16e375aeae3d" control-id="at-3.4">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="553e49b4-01bc-4be6-a024-f2fb54b12432">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="81563525-5f2f-4e8a-943c-c155ee4e3840">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -590,18 +579,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a628f04d-9563-40b1-807a-78175eb2901a" control-id="at-4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="4fc27876-efba-4ee2-9c74-02630e7f94a3">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1c0a6b3e-ebd6-4dd9-a7fe-e8ae592dc20c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="9258a7bd-ab7f-4010-b048-62c1eaa3a809">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e5d5c19a-1f6f-45ee-9a88-3b115071557c">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -609,50 +590,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1c3f7cd-c3e0-4e50-a9f8-c49bc18184a9" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="0fb704e7-bf1b-48dd-a5d0-3800ecc1e021">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="6977a43d-bf4a-4e3b-bcbb-e3bb2f59a68f">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="34e7f845-8af5-46a0-b15e-7f15a228edb1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4819c231-2b0b-4d9b-94aa-d9227307da0c">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="82d6d774-b293-4b82-a14b-ef73e4037bc8">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="6a3220e3-6d18-4830-8e1d-61d3a4e03df5">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="8a249413-4e3e-4256-add9-c88186c4bd21">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="83724fc4-5c8e-4d91-9e55-0a8456ec034f">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="e96ce909-ed54-448e-b763-73eed8bd26d8">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="70b9ad85-7068-479f-83c0-460116a1d6ba">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="5aa76643-06a7-4421-a22a-fe0ba13272ce">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="9ffe4ea7-519a-48b9-b365-86dce1315c54">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -660,26 +660,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6398ca0b-a5ab-423a-9223-1843e606b324" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="c766fa91-2c63-4ff4-97ab-90065d9f006b">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ae5b949b-2929-40d0-8881-5b2d1fffd613">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="1ecb547c-6883-49da-98f9-b178d7d59b64">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="3bf358a9-b894-4e9c-a224-0cc706a15291">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="10403ff3-89b3-4208-bf4b-fa93f4489194">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e58f4046-1a44-4db9-8a63-98cd58a21c35">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -687,10 +687,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f0c34975-6cd0-4d29-a0c1-0676bc4ffcf4" control-id="ir-2.1">
+    <implemented-requirement uuid="b8a42e25-33ea-48f7-8636-c4dc638c8dd5" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="4dd459bb-1fed-4cea-a3b8-8a9be862d3f7">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="df2636ac-fe06-406f-a4d6-53fe6a9d1da6">
+      <statement statement-id="ir-2.1_stmt" uuid="70b8f46d-e881-4a8b-8e60-5307a87a785a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -698,10 +698,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="451996a9-ac85-4e3d-8dfd-593feda9ce93" control-id="ir-2.2">
+    <implemented-requirement uuid="37391bc4-53e0-4236-8e44-0e0d825177a3" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="79cfea00-b6a2-4631-936e-6bfc46d28379">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="87029ff7-e6a2-449e-82d0-7d901d9ba2f4">
+      <statement statement-id="ir-2.2_stmt" uuid="a85b68a6-8ae0-41e1-9b14-875498165386">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -709,10 +709,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8103d453-7db7-48fe-9fcc-3976281db3b8" control-id="ir-3">
+    <implemented-requirement uuid="534c3783-f194-4e6d-bce8-f673cd7876a9" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="b49cf15b-05dd-4ddf-8403-f81ae1d0d209">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="47905024-c063-413b-ab3d-99328ad726b7">
+      <statement statement-id="ir-3_stmt" uuid="b08ef514-12d3-49de-9430-8bd0081b6d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -720,10 +720,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a1e1e47-b937-4895-a861-b454bac7735b" control-id="ir-3.2">
+    <implemented-requirement uuid="cd2b8dea-d475-4536-810f-4cb8840225a1" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="b3cff051-eff9-488b-8f07-3ecb66ffe1ee">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="298d6f15-29d9-45a3-8e6c-ca9776c53bcb">
+      <statement statement-id="ir-3.2_stmt" uuid="228b2851-d621-491a-99b4-011447d2e390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -731,26 +731,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93359e16-cee7-4890-b1aa-36803a4a14de" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="bcc80668-54ce-4c05-a120-bbdf16de7a9a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="3645e72c-08aa-492b-bb43-700943a5c38b">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="604ca35a-e504-46da-a8f8-79caf9223ddd">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ad01db17-17a4-45e7-87e9-0eecd3f2a32b">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="29fb830e-182b-49b9-9461-848eab95ad1f">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="bdd527c4-6a53-45b3-84fc-ab221a7ba235">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -758,10 +758,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e9182a4-0b59-44dc-aaf0-0d6350e35acd" control-id="ir-4.1">
+    <implemented-requirement uuid="51142785-d1e4-4886-b642-592d35b71e70" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="7c59eded-e785-4728-a224-124c76340975">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="99d44d39-365b-4300-8925-438be14ae30c">
+      <statement statement-id="ir-4.1_stmt" uuid="12a7343e-93c9-41a0-922b-eac846bcb671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -769,10 +769,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9eb8ad8-42fe-4f28-ab8a-d43c67119f43" control-id="ir-4.2">
+    <implemented-requirement uuid="8ee0c424-a9d0-46a8-b5d5-7a47e1ed622a" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="9183a118-20c5-4491-a6d6-da9ce82bedee">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="a9c372e9-e902-4e32-8a17-984961654b8f">
+      <statement statement-id="ir-4.2_stmt" uuid="cb1a61a3-9d00-4e80-9a56-ddf8135425af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -780,10 +780,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87b2c32c-73f9-491f-aa0f-2f6632abb98d" control-id="ir-4.3">
+    <implemented-requirement uuid="bb7b4e46-e393-4a60-9b1e-55a08e8639d8" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="5136b887-bd63-4a77-8b6c-62442945cc25">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4fe568bd-10eb-47fd-8630-e57477621345">
+      <statement statement-id="ir-4.3_stmt" uuid="7c9a0d7a-bd4b-4613-92ea-1916c2285841">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -791,10 +791,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df7c92fd-e0e8-4c96-a1bb-6892ccebbab4" control-id="ir-4.4">
+    <implemented-requirement uuid="49785cc2-49b5-473f-9d73-7cda245d08ad" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="bb790666-c275-4d21-a9b0-32e04c906d6e">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="917935b8-2da6-49b3-9165-43c9f30c5660">
+      <statement statement-id="ir-4.4_stmt" uuid="e8f86a45-aba2-4d10-b48b-ce60ebbc0bff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -802,10 +802,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7dcf83d-3e85-4c71-bf62-dc1f939cf762" control-id="ir-4.6">
+    <implemented-requirement uuid="ccbe2177-2354-43c4-96ff-825626571315" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="ac62e889-5f2f-4e6b-9df6-23253fca4bf1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1a737b7e-a779-4d2e-bdd1-67341a0ad938">
+      <statement statement-id="ir-4.6_stmt" uuid="34db7a41-1695-4729-ac23-f7336e158a1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -813,10 +813,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2c9a5f5-8f36-4875-afa2-5121ff682d14" control-id="ir-4.8">
+    <implemented-requirement uuid="ec5e92ad-bd5f-4af5-90ce-e08156a52be0" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="23326009-4cc8-48a0-a106-9dd5b5e3d9ba">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="989b6d48-d77d-46fa-90ae-ac01839f7f8c">
+      <statement statement-id="ir-4.8_stmt" uuid="921039ab-2d45-4951-9be6-0106bcfce3ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -824,10 +824,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef287271-1fda-4f98-b1e4-94306449d6e9" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="ce3145e7-e022-49be-b0db-2709c0b4233c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ed767cdd-d781-48a1-a299-c010569caea2">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -835,10 +835,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fc2cd1fc-7ded-44f5-993f-5fb129b90040" control-id="ir-5.1">
+    <implemented-requirement uuid="6e53c00b-4ce3-4992-a0fc-4cba0a780287" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="fc56ae2f-6c79-427b-9451-bb1e24c4368d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1944f446-9f14-46a5-8d62-912ec666118d">
+      <statement statement-id="ir-5.1_stmt" uuid="d661f626-6658-407e-845c-1334ce9e6f31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -846,18 +846,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cd01d78-f0ec-4997-9a45-4d868818a5c3" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="b024d1ac-5b44-4004-9e42-028a831b7f5f">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c59cbcb4-8439-41bd-9a02-24ac45d35af7">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="0915f7d8-4f98-4722-9764-dbca68c36bf6">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="11842407-72d5-4178-98f0-147d9aaa9dde">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -865,10 +865,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd0ce5d3-f58b-48c5-b0d5-5e0f0bf46a4e" control-id="ir-6.1">
+    <implemented-requirement uuid="abbf5ca4-c37f-4e55-be38-e0fb78d98b6d" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="a27de4e1-3b64-46d5-a062-691d2fbad207">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="cd424b14-b0c8-4fa0-9706-e57c20ad689a">
+      <statement statement-id="ir-6.1_stmt" uuid="bff866ee-07a1-48e0-bff5-677bbab030e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -876,10 +876,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd42387f-61d4-4382-81d0-a7ce590b225f" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="3ba8684f-6dd7-47ed-bf29-dcf0e0ad7869">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="237c1cab-4f01-443b-91c7-785df9fd77be">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -887,10 +887,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84913b86-e256-435e-a9c3-9767b0f6804e" control-id="ir-7.1">
+    <implemented-requirement uuid="1e7dfee4-59e7-4258-a21b-252a865c51a8" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="a9cccc93-b01e-4ed3-9fea-a09ea839ec7a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e62b2a0b-d86f-4bbe-94ad-0bf903f66e2f">
+      <statement statement-id="ir-7.1_stmt" uuid="6aea26c2-e075-4c68-8b42-d974cef94703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -898,18 +898,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65b57b6e-1121-4e94-b155-e1236a567fb7" control-id="ir-7.2">
+    <implemented-requirement uuid="b0e1ca1a-d05a-4e97-891c-242848ed917e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="febce2e7-4b9a-4ca9-9a41-f8a0bd2f395d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="26e665f3-ddef-4d22-986a-15ac725928bb">
+      <statement statement-id="ir-7.2_stmt.a" uuid="0205e4dc-efcc-405b-b919-c8d96b200b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="1059bdb8-f4f6-4ace-9dcd-f8af7e968b2c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="053cac10-6857-4414-aca9-51774e2ea1dd">
+      <statement statement-id="ir-7.2_stmt.b" uuid="71973ea4-e082-42b8-b2c1-59894f32f069">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -917,114 +917,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="705d56b6-add5-4fa7-8fdb-9808c8a1fd50" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="0220366f-4b2b-4765-a62a-30fb174ad0de">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4d9cd033-bd09-43dd-887e-0173baee30f0">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="383a81fb-1222-42f2-82d6-4fdc6fd0645a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="84391aba-d988-4154-9fe1-6942461ec892">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="d3c06241-cc6f-4b4f-a7ec-9dc6b5afe4aa">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1ddfee8e-37fa-4669-9caa-f2e8f4acc989">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="940cb85c-f452-4521-815a-bf27a94f4c89">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="38eba6d1-4ad7-4e44-83fd-e54bb1949a40">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="286d4a4b-d773-477d-9224-887c67c35ed1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="606c171a-9960-4af9-ab4a-91d37b9ead35">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="3bdde5d6-a9e6-4dba-85f9-16d5c0c28e8c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ac553dc8-7e28-4cd7-9d7a-11536e0e942c">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="b95fe026-cdb5-4f54-8be5-fdbd8f07c938">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="75202729-1735-4dc3-96c7-b9d9382d4565">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="4c73530c-0769-4c6a-8942-4e86bc6f80e1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="82c4bd3f-4c99-47c0-b6c5-ba9c0cc4a65a">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="c725c835-e223-4263-8931-2b55567c9bde">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="6dec257f-99af-462e-8e29-a1ac365e35c6">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="9fbea045-d29b-4ad5-80c6-bfb1f2210b4d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4006d955-014e-4683-946f-7988bbcf2178">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="cd72dd4f-c585-48b4-a863-e07d87f5d57c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="698b1b9a-1c10-42e0-805c-2e99979ebc57">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="92c58106-5c5d-405b-8296-784d90ca10be">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="cf5b994f-2ba4-4987-9dc0-ff67fb729e41">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="b09fce0e-c1af-4c1b-b21c-743eca07c2ab">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="da1ccc7e-35fe-42ef-833a-3ad1c1c4e383">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="96c1ebf9-d0f8-4373-b30b-1f1cb961fd57">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ac846433-81ed-45db-bd1a-e11770df8ef5">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1032,50 +1032,50 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7be38ea6-5eae-412e-8ecc-0cb1172dbc46" control-id="ir-9">
+    <implemented-requirement uuid="bcf3f3da-6836-477e-a2f9-7d4c2782c738" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="3e183506-0ddc-4cbc-a294-ae2cb1e95c04">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="3280bec9-9503-4b1b-bce4-3d6218c2ad1d">
+      <statement statement-id="ir-9_stmt.a" uuid="02df5246-c9a1-48c3-b3da-7603a39cdb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="c4de7bf5-1c1b-442b-adc1-8203da7822d3">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c9550ae8-985d-418c-a8db-35b3c134fbfb">
+      <statement statement-id="ir-9_stmt.b" uuid="7661656b-02d7-4f24-8543-2ab420fd420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="9fe6a36f-4019-4ed0-a5af-fe7e7eb4082c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ae97e73a-ff09-4265-898d-1319139cf4d8">
+      <statement statement-id="ir-9_stmt.c" uuid="163ad426-d038-4abf-a55a-cb9f0b6a5721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="414dd13e-6c69-41bd-b564-067d576b69e9">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="37ea8cb2-da3f-4a44-a938-180b95d8a004">
+      <statement statement-id="ir-9_stmt.d" uuid="8808f90b-b6a0-46a6-8342-0a3dbda1d754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="a481a8a9-5007-47ae-b928-1cd4a8698f30">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="021de48d-ace0-461f-b9a7-a22d9486a14a">
+      <statement statement-id="ir-9_stmt.e" uuid="3085e8b1-08c5-4b1a-997d-a0d3f7ef4a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="8c0062cb-36d4-4435-9ded-f6b9988177f1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b429c2ff-571d-413d-8f01-7975321c6605">
+      <statement statement-id="ir-9_stmt.f" uuid="13ae73bc-6bed-4a1c-96a2-401a1538d7ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1083,10 +1083,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3eaee0c7-80d4-4c88-ab7a-737e3b0c92da" control-id="ir-9.1">
+    <implemented-requirement uuid="d32202a4-71c3-4e5b-86bb-b799a06c6389" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="22c3efda-9242-4b15-b639-5bdd54c1a760">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="bbb5ba38-c4f7-4ada-a914-73d9494a20b8">
+      <statement statement-id="ir-9.1_stmt" uuid="e360dc90-aa12-4097-b259-8b605b99154a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1094,10 +1094,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51d29257-d89f-4096-b195-dcc57c313d21" control-id="ir-9.2">
+    <implemented-requirement uuid="562b61fc-ccbb-408a-9c03-08aef03f0615" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="1faf4157-7be7-401e-9919-cca64e4ed75e">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="230d7b05-11b3-4ba7-9f14-c1068d8881c4">
+      <statement statement-id="ir-9.2_stmt" uuid="4aeeb1f5-3b39-4d64-a261-220ab7f8a37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1105,10 +1105,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e791726-131f-4b63-bf30-270ae5d61766" control-id="ir-9.3">
+    <implemented-requirement uuid="8677d99b-d58e-462b-83b5-5d7283825a99" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="59fc0fe2-1e2f-4521-9816-2f7c5a360372">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5c4e1d4d-3490-498f-848f-b4231b1b177a">
+      <statement statement-id="ir-9.3_stmt" uuid="e527df40-341b-4109-8975-29f039c56cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1116,10 +1116,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a7b8ff6-80ac-46a8-9026-d28d9c7e63a9" control-id="ir-9.4">
+    <implemented-requirement uuid="38421d01-5e3e-4eab-8293-0686e2181441" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="42b4f230-836b-4c5c-81f7-5cbfc1d92d3a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="526c71d7-68e9-47b2-8185-e6f8d4e870d0">
+      <statement statement-id="ir-9.4_stmt" uuid="38221d3e-2bfe-450f-9a8f-0c88f2860012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1127,10 +1127,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a003c21a-fdfb-4249-a8a2-2bc232cbbbdc" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="c0fd5179-1c42-4dbb-9dc4-93750c9990a5">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="703e5020-39d3-485c-98bd-425f26c7bf83">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -1139,8 +1139,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="422c3d0c-fa20-47cc-85a3-e3c7ec7a612b">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c9dc475a-cffe-4877-a4fd-d59df6ca67fe">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -1150,10 +1150,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d6cac34-660d-48f3-afb7-af57f6665bc9" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="6a600c2c-3b41-48a8-b94e-ad909cc9b675">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="61ff67db-b667-4afd-88a5-0d3520368991">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -1163,8 +1163,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="790dc9e4-39ce-47ea-bfa8-7dc0f6ce8c0b">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d5cf9aaa-cee1-488f-8ddc-ed37dc84caeb">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -1172,8 +1172,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="2daf0564-2a07-405a-928e-9c8bf6aa9d5c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="29518d72-92e9-4532-8a1c-d727ed365679">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -1182,8 +1182,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="cf6f79db-58b7-42e7-81ac-b678b4e6e081">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="32d089b6-0097-4e11-bac3-12d626a75552">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -1192,10 +1192,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e1f1a26-5ea5-45ce-9249-ff60b8161994" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="b587557c-6072-48de-822b-7739fd993089">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="14861fc2-c6a9-45b7-bb92-829568fce8ec">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -1204,8 +1204,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="32e332f3-cb33-4700-a518-44e5e327553a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c4ce5694-9452-496b-a37f-21daf707de62">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -1213,8 +1213,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="84f27c1d-78a3-4321-a911-7e35682bc5ce">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5c7c0a67-520a-4707-97a0-85e1628dc7d7">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -1223,8 +1223,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="b82bf881-2d65-47da-8566-b403a429bd26">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1deeaf90-d735-49bd-bdec-d20515a5611c">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -1233,8 +1233,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="f765b7d4-81fd-49c7-bcd0-8be0cbbc8a11">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ce412ca5-4443-4f9a-a8b2-a21b08fa786b">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -1242,8 +1242,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="47fe5651-8bcb-448d-9e94-27aae585d36c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="caaad83c-e85c-4f93-94b1-07e84ae2600e">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -1252,8 +1252,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="cddd1e68-7447-400a-928d-0316a7d27583">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="451b1333-9107-4dc9-ae81-62f9a68d0c0c">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -1263,10 +1263,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f7b836d-cc5d-4dd3-94d9-14dfdcc3ca6c" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="06f6cc44-a0c8-4f4e-8bc7-06e7c5ad8031">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="fef00c25-1824-425a-ad84-94fea76bdb30">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -1277,10 +1277,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afc3ead6-7efe-4dba-9623-ee1bc063d657" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="cef57dae-9e6a-4b5a-b47b-059c78030078">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="945708cc-1d1d-467d-8aca-3786b593ebc2">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -1291,10 +1291,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="909014a3-f228-459d-afee-f1a999d1a4a8" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="f6feca99-ef6c-409a-b2e2-7ead9be27fb4">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="501011fe-75a1-4149-bc4c-eb31d04b8612">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -1304,10 +1304,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd296f03-ae8d-4d91-8750-589e40928fa3" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="5f2e8a91-b501-45cb-855c-bc489d362a21">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ceeaa559-7d86-41f2-84b4-9ef4df265f67">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -1316,8 +1316,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="c9c04de5-f539-420a-80a7-b3bc501963ce">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4fba1361-f232-46e4-8dac-979362f74aa0">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -1327,8 +1327,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="a09dbad7-a31f-4cf1-83d2-3379d90db95c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="9db9f338-dca8-4c10-b41a-3b37f41af1a6">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1338,10 +1338,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="640fd61a-6761-4f45-8395-7f550c2658b3" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="6aa5da8a-a119-4772-af6a-0c10963b52ae">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="bcf9d1a7-b228-4ad9-a1e1-e98df53e7886">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -1350,293 +1350,250 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74e0987d-9c6b-43e3-a750-60008de3dba4" control-id="pe-6.4">
+    <implemented-requirement uuid="6039d4cd-6f4f-4ab3-9ab4-8fe4db6cfa1a" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="02f9a0e2-c118-4e54-9b38-395aa930a1e9">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="42510767-cc70-4d52-8a6a-b16d12452fb7">
+      <statement statement-id="pe-6.4_stmt" uuid="92f4bec1-a907-445b-a447-5a23b28698c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="630ef718-1b6a-4f58-9d68-491bd5494bd5" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="0f18d2ce-732b-4a0d-8e42-7326477f04f7">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4dd66a8f-a1fe-4bbd-a5a3-16df618cab27">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="9c108c1e-b975-4684-82de-349634ccb135">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5029d138-9fdf-4a4f-af0f-97d0bd18b032">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0684ecf8-24f6-465f-a566-8b8f69cfbd70" control-id="pe-8.1">
+    <implemented-requirement uuid="89185b64-4241-4cc1-b99e-0fd4611379c9" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="a8dc813a-b8eb-4310-8c7f-3887c856a005">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="6ff882db-284b-4412-9a15-8178b11ae2c9">
+      <statement statement-id="pe-8.1_stmt" uuid="7e29b876-5b35-4b33-b2c7-2599c8dccf92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa643f03-87f8-43a2-9f68-b5148c065816" control-id="pe-9">
+    <implemented-requirement uuid="d09ba053-a392-4fce-9d48-2650bbe51d68" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="2fa78927-accd-4e29-9ce2-403f976bd2b2">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="775b6b9f-9f69-4a03-8cc5-bd7886580bcc">
+      <statement statement-id="pe-9_stmt" uuid="af932a4a-e681-44b8-b559-7f4bae228387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f28a1e7d-f6e5-4871-9a89-326215eec09b" control-id="pe-10">
+    <implemented-requirement uuid="a00714fb-0cff-453b-a86c-7123f5a5af8f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="dafc7674-e8a7-4be1-a974-2e2a573ca4b4">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="90fbf56b-886b-4bae-a6a5-4321a742f451">
+      <statement statement-id="pe-10_stmt.a" uuid="f82a835d-0e45-447e-8cf6-e6a35c1e3060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="d5ca10a8-b19a-40eb-b70b-fff216221f72">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="24d2f13f-09b8-470c-b249-3deaefea06ae">
+      <statement statement-id="pe-10_stmt.b" uuid="b84f3c3e-161c-4083-9cf6-9bfdb8187570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="39744264-bfc3-419d-86d8-72ee76fcba06">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="82d3e460-9c0e-45a6-b364-22b705727bd9">
+      <statement statement-id="pe-10_stmt.c" uuid="8c8049ef-779b-42d9-ba34-d24838950330">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a84f12a4-ec70-4aa1-802a-68947c81c0cc" control-id="pe-11">
+    <implemented-requirement uuid="667ed986-a1ea-4a5b-a836-1ef848a2d405" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="05f4f61c-fe75-4481-87de-beae151d16c0">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="fde081eb-c033-4908-a7ad-fbd47c55a394">
+      <statement statement-id="pe-11_stmt" uuid="1bc8ee94-7662-43a7-8b6b-53bb4f6e9fa9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4926e57-aad8-4713-8502-4f80450eadb9" control-id="pe-11.1">
+    <implemented-requirement uuid="2ac139bd-067d-49a3-8cc1-e6c0ee845310" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="2482dc34-7201-40e7-95f2-a00a389f6705">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="70cd3bf4-a466-4c65-9f3d-84947aadd624">
+      <statement statement-id="pe-11.1_stmt" uuid="8bcd7752-2be0-432a-a939-ef6cc5ef4da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a298e746-db8c-45de-b380-7d87d85d5835" control-id="pe-12">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="710b4a9f-8bb2-4581-9031-6f5ac986f322">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="af6956af-81d5-4f35-b3c6-be7b1c027101">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d83176ae-9275-452f-9bbf-dd55cbe6d420" control-id="pe-13">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="4595ba5d-a405-458a-886a-6fab6e319bad">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c513ea1a-7bf8-4aac-91e7-b09eef467927">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b3c36cd-bb7a-4576-9601-3c0614ed031e" control-id="pe-13.1">
+    <implemented-requirement uuid="c0a49647-2ecf-426d-8a0d-cc03b586ee60" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="1a460770-cd69-4cca-8c5d-50f068a5182a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="14318f77-df29-428e-9553-68a3ae06305f">
+      <statement statement-id="pe-13.1_stmt" uuid="63dc1e82-21c0-46cb-81c5-a1380d588d97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="734d7624-736b-4c46-afa7-5ed2505dc8e7" control-id="pe-13.2">
+    <implemented-requirement uuid="e61b56eb-502e-48d0-8dea-dd329df1444f" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="1cd50517-b406-4ca5-9e45-fd40d9d67c33">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5f16f837-2e94-4e63-a432-056ad8eb3e76">
+      <statement statement-id="pe-13.2_stmt" uuid="d20d68b1-605b-4789-a71d-0302341a68e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f8abc73-d83e-4eb0-997b-77579c863cc7" control-id="pe-13.3">
+    <implemented-requirement uuid="ed45689d-2e14-4612-a688-ed8bacf22fd6" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="edf85bc2-43db-445a-8546-4d054e3089d6">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c337d03f-4cd8-40c7-bf55-00eb048d8337">
+      <statement statement-id="pe-13.3_stmt" uuid="99caa78c-7757-4d63-a13d-cb0e57aff9ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b45cdf12-9bbe-44e3-9d6c-fa6c14198aec" control-id="pe-14">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="d1b046e6-7fb3-4755-bc3b-b9497c96c5eb">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="3d80fd4e-3e20-4c05-a207-90770d7986ed">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="9ac89b83-4ac1-4ecc-9af7-55c3a0ddedf4">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f18d44ea-356d-42c3-8d40-bf8ec5e07caa">
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c08fd771-04c1-4370-8078-c5bd42c7df00" control-id="pe-14.2">
+    <implemented-requirement uuid="c4d47a12-0052-49da-a5a8-b3852d8e8c00" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="bb0ac927-943f-48f4-950d-eb06d927c693">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="213700a6-a73b-4e8a-8e3f-e4d5c947a294">
+      <statement statement-id="pe-14.2_stmt" uuid="b1069fc2-cf93-4ebc-951c-c7b8e46001cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6133ccb-8b41-4420-b37c-65d2a64f46fa" control-id="pe-15">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="5eea7f2b-1e3a-4149-b42c-b05c6992dead">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="bc700675-c3c5-4c42-8105-1219152a7be0">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87491cac-b67c-4a03-9705-1dd6065adb0b" control-id="pe-15.1">
+    <implemented-requirement uuid="02bd1e2e-c144-4c61-a041-9577c29aa0b8" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="d8238c36-1968-435b-9338-1f55d16871f0">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="8e05ce30-de57-4ce5-958f-bad3e352a938">
+      <statement statement-id="pe-15.1_stmt" uuid="b219e010-a9cd-4505-a8c6-ceff54b9fd2c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4b6a0e9-252e-49f4-83f9-34582e67b937" control-id="pe-16">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="646655ec-270b-4616-8f1f-09691cd1ca9c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="73f0487e-db05-444f-9b77-8f3557d6b2b9">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="29144e89-5e45-4ad2-9923-a5d75603450c" control-id="pe-17">
+    <implemented-requirement uuid="4d8e695f-6725-4dfc-a388-a629ab9aa7eb" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="baf276f0-6bc7-40c5-8a49-d3aedca0feb7">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="bdb313ca-520c-42a7-aeb2-42b6a51c339c">
+      <statement statement-id="pe-17_stmt.a" uuid="e750901a-4d28-4c37-bed5-3563e37933e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="b721ee8f-8ceb-424b-b990-d296fa546078">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d7d52018-865a-49ce-aba3-03ce9942d1df">
+      <statement statement-id="pe-17_stmt.b" uuid="a9dd49bb-c3da-4d5e-858b-3c0f480131f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="a16574a1-470c-4f5f-8171-d6ab956f5336">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ea17f489-6c56-4680-83d1-691651908983">
+      <statement statement-id="pe-17_stmt.c" uuid="e012ea43-db85-46c0-8920-fa79191734d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e93d09bf-1e26-4a8b-b03e-3e3bb78aaa3b" control-id="pe-18">
+    <implemented-requirement uuid="ef8324ba-51bd-46ca-8dcc-4f8ff4335588" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="37879fa2-b49a-489e-b235-7ecad4ecb9c9">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="0144788b-55f9-487f-ada7-27904e52d8ef">
+      <statement statement-id="pe-18_stmt" uuid="2b1af852-47b4-4a7e-b90f-ac74f16d0812">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ebbbf01-8514-487f-8752-18a39e28b0f4" control-id="pl-1">
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="59b5faff-87e9-4ec9-a899-0770747b1bf5">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b0758498-ee19-49bf-b656-33f86087c712">
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="606d72d5-09f9-4c1b-89ab-6d51675df130">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5a527623-2a1b-4f8f-a127-439e444198a0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="b4de9aa2-312e-4f1a-bbbb-18cdbecfab2e" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="e6f16082-f1a3-4da8-81f4-94bddceeb756">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="2ba080fc-7fa0-471d-a601-4f4cc858a6b4">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="5b019a0c-b9a2-4441-83c6-1cbe50c4d1bc">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="49659711-b5f2-4f34-90de-e98cac800535">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="f1689e98-a338-41ff-8816-97673617f101">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e472dc5c-cb20-4735-86c6-c41b30fe07fb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="09bad097-708b-4e25-92dc-e87191908a74">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="3a46dc43-b963-4618-b92e-37ccfbded5f1">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="3fe5fb04-408d-43a2-bb6b-1e6a4504eb2d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e942280c-fabe-4809-b588-e59a0ce31505">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1644,10 +1601,53 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ea5b64d-cb68-4e30-a703-48a4f336c2b7" control-id="pl-2.3">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="c1d285e4-3e85-4e9f-979b-66ec73c85c0c">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c918ae01-cbe8-4db5-bd9b-7d9ec69eb171">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9d5246a3-4521-4c59-8205-516f2577541d" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="d6f42931-4074-4ff2-b339-9a5fcf43a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1655,34 +1655,34 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a55b58ee-0745-4a59-bea7-23e5f405e377" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="d013d519-718f-4738-9f1e-b9b026e1b045">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="e1fb83e6-ac39-44ad-9485-4240b8b940e0">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="2b2b0489-464d-45ec-817c-302625ba9540">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="9aaa1d62-4226-45f2-90cb-6bf7a5197286">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="c6987dcd-0cc6-4884-8571-0e44fb0b865a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="37eff22b-3c3b-4ee9-939f-e7abe8996140">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="9d4c64bb-772a-43e2-a8af-d7e609505a21">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="7e815c28-dc2f-443d-87c1-fede53597f82">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1690,10 +1690,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91fdd9f1-a50f-48bb-931d-1a449cb3a06f" control-id="pl-4.1">
+    <implemented-requirement uuid="befdd6de-025b-45b9-bb1d-1904009c1805" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="53f98072-bd08-4b8b-a993-4558eb0f1591">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d67379ea-9cbd-41f0-b6f4-772275205705">
+      <statement statement-id="pl-4.1_stmt" uuid="2b440776-5d21-4e64-8135-54ff7feffdd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1701,26 +1701,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="335608ea-997f-4393-a8e6-4b8495e46c39" control-id="pl-8">
+    <implemented-requirement uuid="d36b86a7-bf0a-4413-bb8b-b9fc088f748f" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="1842903f-20c0-4034-affb-8596b081e6b5">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ca14f3a7-70ea-413d-87b1-6ed1c1c6843d">
+      <statement statement-id="pl-8_stmt.a" uuid="28433225-ecd9-4fbb-ad7b-f3440807c5cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="2516851e-2723-4475-9665-a41ed093316d">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="ebd094b8-f277-40c6-ae4c-0b61e844d872">
+      <statement statement-id="pl-8_stmt.b" uuid="79100567-b6d1-4a03-870a-6dcdfd334078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="a2bb94b8-3ccb-4962-b76d-747d4e78e3ec">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="24c255b4-d6c6-4b03-8bb3-252e47254c30">
+      <statement statement-id="pl-8_stmt.c" uuid="28d8ca15-8a90-4601-99a2-be94f976857e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1728,10 +1728,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b45d33b4-a7aa-4c46-9472-00a651e9425e" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="b9348f08-d528-44a3-90c8-e0cb16052f9f">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="9cd7343b-cb52-443b-a9d5-7b24a98e70bc">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1739,8 +1739,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="ae1a3717-f882-4b92-bfda-699115247bbc">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="de6a12aa-1ba9-4cdc-bc63-5957ee62a10e">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1748,8 +1748,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="1b7f71ce-d105-4500-939a-a4dd62afaaac">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="a1f86d1d-ff67-44ae-bb94-50e4fffa2d3a">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1757,8 +1757,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="51d66b04-be33-4759-9fa9-a12dc56e7a2b">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="31d17220-98da-4dae-809a-aa7fecc1179a">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1766,8 +1766,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="47a11a7f-d08c-4844-9d15-a0e3d13853c3">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f6774742-e811-4110-96f4-8263263eb4d6">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1775,8 +1775,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="097918b0-b53f-408c-9dbd-a62669aa7040">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="180409a3-c81b-43b1-b3e1-507a57db1333">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1785,18 +1785,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccee51c2-0b44-4b23-8d80-fda71c355f99" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="f920a0eb-00cc-4d63-8752-1e17f1e4bcde">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d4ee819f-1854-44a3-93ec-73b5a9255ea8">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="fe327675-04a0-4b6e-9df0-1d3cf49cd4ba">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="5b4c2a69-3375-4f21-9e5d-3186e03d4f6f">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1804,8 +1804,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="af4df44f-7ca3-46d9-8baf-261ca466d248">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1abf7e3d-6d48-4355-8be3-285e6459e452">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1814,10 +1814,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="34b31c5e-2a25-4070-bdb4-72c709357e71" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="90607cd9-8a21-426c-b01a-5a71e5a1417a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="8abd1b34-ee62-4965-ba09-22a6cd9d07e9">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1825,8 +1825,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="92c57689-4b7f-4f19-b18c-5fe51e785391">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="1588cfef-9337-436d-a4f0-b352a8a88dff">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1837,10 +1837,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b5bf5ed-8f1d-4751-8021-06b2b462899e" control-id="ps-3.3">
+    <implemented-requirement uuid="3959ccbc-54ed-4af9-9c1b-d819ab34008c" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="a7f9b7ca-df60-4c2e-b30b-a5dd4014f68e">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b8b6ad0d-b2ba-4f0d-a3a4-69d77b4cc1cf">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2cc3204c-5d15-4f86-bc80-67ef31dfdd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4149b12e-25db-459f-920b-dd7c6cc1d6fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1850,8 +1850,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="e4c7b28d-e044-43a3-82d6-d73afd8608ff">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f52818d5-5c27-4aff-9903-0241394498f0">
+      <statement statement-id="ps-3.3_stmt.b" uuid="4993cea3-da26-44a3-aa3b-d596533cc62d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7e0d2c3-63eb-4bad-85b8-e6e8a1437fc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1862,10 +1862,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6bf892f1-4dbb-4b00-ae14-1bf9f54d8641" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="9c63bb0c-4185-4e57-863f-fe1d690cc5ad">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d406bda4-23b7-42e2-9f77-894ad727d793">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1874,8 +1874,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="f74e5a68-b92b-45d7-9554-4f459f091ef9">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="56ce0717-eaae-484c-a0e8-ebdc539031f2">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1884,8 +1884,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="c3fa2d36-5efd-4f79-b792-4d46aed9b4fa">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="178e0e3e-7739-412f-b48b-b62b4c3f4fa8">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1894,8 +1894,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="8ebaf4fe-44a9-48e8-b806-f9305b6a7853">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="538e1a5a-7bb9-4360-a979-fc40259b8256">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1904,8 +1904,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="e7db1f1a-0797-45b3-8c3b-77b11da4a935">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="61470d44-306b-4988-a6d1-620d60f4c1a7">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1914,8 +1914,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="a6216b08-c753-42b8-ab30-181e7d4ff2a5">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b4e829d4-d23d-4f1b-a623-b294c97cb6fd">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1925,10 +1925,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f782e154-214f-408c-b922-9114273a1201" control-id="ps-4.2">
+    <implemented-requirement uuid="f2c61442-1b14-4a10-96c3-d0ba8c4659ec" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="2a6998ec-121f-436d-9f80-9cb0aebc0e25">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="38eaf6c9-3581-4fb3-bc9f-721a6c2f9359">
+      <statement statement-id="ps-4.2_stmt" uuid="eb569d00-deee-46c3-9cac-a0880b547c74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7158c5f2-fe50-427b-ae5d-93b17fd0666a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -1938,10 +1938,10 @@ Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0fef97a8-bf80-4727-9586-db7d3bb99155" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="8c21ee2c-3f7a-4a26-bcd7-619302c7a4eb">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="05a13570-2bdd-43eb-ba49-68a6b0fe246b">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1951,8 +1951,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="898ff7cc-ff19-47ee-ae7b-b6326b993d59">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="068a3143-ec05-4860-aec1-5ad857db9de3">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1961,8 +1961,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="1763c00c-209f-4be0-8bbb-e4a09d40f521">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="c936bfce-86ea-4959-81cc-e554a12c0609">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1970,8 +1970,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="3c1d7c19-360b-444e-bfb0-3ffcfe1748b1">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="49c8dd3c-8c62-4e22-aa41-649d284e306e">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1980,10 +1980,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6816e814-e8c0-4360-a793-749d0923444e" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="d517fe0b-4532-4a0e-a0e3-1b090752e002">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="0ed9f053-e12e-49e5-bfe4-4932010c8d0a">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1991,8 +1991,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="cb97452e-69bc-49fc-80a9-c86ae9ca497a">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="d7ba3feb-6631-468f-9fa7-2fcf17bc99bc">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -2000,8 +2000,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="c3fa4a4a-07b7-4376-8954-2cb8004bcff0">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f942abb0-08ec-4bd0-bd2f-ebc038ce9923">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2009,8 +2009,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="b4ec4da0-4977-4c8a-bda0-37e65bd56766">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="b5d0d401-e063-4373-9839-957d95534ec2">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2018,8 +2018,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="fca70982-a731-4348-8e7c-cb9621a4caf5">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f5f8c285-3cdd-407a-bf3e-494b04667a29">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -2028,10 +2028,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50d06ce7-b551-454e-99cc-b016cc85b7d0" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="450809dc-b972-4557-a058-0b898fde97b8">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="25c5fb4a-30af-4f06-a8df-b59dba0013b5">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -2039,8 +2039,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="51a9db1b-1c17-4faf-bf06-bae73b0b45a9">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="6b504e93-84a8-46cb-bf67-2ab3721236d4">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -2048,16 +2048,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="433b43c8-514f-4eac-ad32-64cdf947b7d8">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="4b2bee7f-ba33-4a2c-901c-322d9a231ca3">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="d3f9505d-4bbe-47bf-9993-6493517242af">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="dc20a7d7-c145-4f4a-b929-db333efafa71">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -2068,8 +2068,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="dcbdf3c0-76ec-4f99-b811-12e1af86fff6">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="f498ec34-e9f8-48cf-bd28-7fff26e769ea">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -2077,10 +2077,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4cb0799-dcbe-49ee-bd16-9f2aae8c5941" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="51d05b62-d630-4181-b398-4c0dc2200a01">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="98532f8b-3879-4a5e-86c0-8979306007b5">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -2088,8 +2088,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="a64068bd-24f4-4348-a051-1e4e902e3052">
-        <by-component component-uuid="2c600ab5-9cdb-42e5-83bd-d848e7ba0e81" uuid="acfd42f0-ef50-40be-8112-3a4364c92d71">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/rhel-8-fedramp-Low.xml
+++ b/xml/rhel-8-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="6294165b-76d3-4c4d-9c25-61c4d9e890ea">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="0492065b-daeb-45f5-806b-f54e8cbe47de">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.59+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.64+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="f7eae4a1-e600-44a7-9df3-c6de3baae3c1">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="96a6f984-2664-4887-91f4-6aacede0dc63" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="909feb3d-5886-410c-96b5-399935c7d240" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="9ee514fd-c092-4cc6-8d58-0710e6fd3c8a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="7e9eebfd-87b3-46f1-9a58-969110cee639">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="5bf9d668-9adb-43a7-9f54-02d8d4aaf57e">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="c5b3d232-8057-4e0a-9428-daf460754ad1">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7856a2c5-4b51-498b-9d82-da85fddd44a7" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="5eb32dfa-76e1-4714-8774-b41aa2911001">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="765d30ac-b4f7-4322-a2f9-eb3ab6751a07">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="9d06db7a-0b14-407b-8301-38db5a5028e4">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="6c39f89e-95d3-4da8-bd3d-2c579a038a04">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="cd5c24ad-b7cf-4fc8-a25f-4c4ee20bfc28">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="08c6c7af-248c-49ba-a45e-c7e70b94e22d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,45 +530,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="555b2625-2451-4990-b59f-b91d4b718ffe" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="acd322a8-54ab-4fd8-9eae-93fe91f040a8">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="4726de66-54f3-4428-b7ac-d2bd28ac2af6">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="55560bad-4621-4f86-986a-59563c714e05">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="72645919-6a24-43f6-baa9-b3b161cc94b7">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="bf13cfed-f378-4744-929a-4fc8a2622209">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="954ab3c8-0dae-4337-8c4f-215105a2cf98">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="21231ae7-a74b-4800-b787-5d67c335a7e7" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="29f242e9-0484-4df7-ad5f-eba3c4965077">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="73d138a8-f79a-4c95-97d6-717dda375afe">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="de9713f3-236b-48ed-b5e3-4a17df3ec638">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="4a76e7d9-2223-4cdd-ba8a-1b8ccbbdd76a">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -576,50 +557,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8294057d-f308-4fd0-8c02-9333cf5e215d" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="98bad09c-4cb0-4ce6-8a9d-b67ab5a88c84">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d5069500-1364-4860-b67a-a64f9300ab07">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="3c65fe51-776c-4740-8847-def8a0827154">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d1dd264d-083f-4afd-941e-59514e87d3e0">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="deadbcf1-265b-4d1c-abb3-190a747838bb">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="31a00960-4227-40e5-9a9d-e33e40a357b7">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="b09e2232-bd28-4b54-a491-6a518941aad8">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="052dc142-d6d5-4f0f-8794-c8afd9379d61">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="ad4051db-d7bd-444a-b393-ef9b4a606815">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="11355c95-11db-45d2-86ac-d148650dd04b">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="e90900b9-518b-4cf7-85bb-abb3b6916c85">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="7491f6f3-cd36-4033-af30-ee3a4a6d6131">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -627,26 +627,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="660466cb-0c0a-417f-9ae5-812e466fb38b" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="ebec601c-df8e-4fc7-8dc4-404182d5284f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="fa998e5e-25f6-451d-ba24-224de986007b">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="c0a1e561-3762-46be-83ad-12eb3b296ee6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="7b59dc02-5ad1-4408-bbc1-4d5b5b279453">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="1dba0927-e24e-4ae7-9cf8-c1874e4cc3fe">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f0896553-006a-4e79-a140-f2f217fdf757">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -654,26 +654,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcd72d8d-a53a-48b7-820d-f18f13dc5f8e" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="ce83e711-89c4-435a-9a47-6cf9db89ee66">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="24a8c100-40ad-457b-87e5-f4d4c68e65b5">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="d1c602df-ad39-452f-b4e0-80b91d9037c6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="57afd716-3b2c-4c6e-a89f-eccbb374bc43">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="77d268c0-f27b-4650-83ce-3e919550359c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="76d52213-96cc-4553-bc6c-aa379a9049d4">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -681,10 +681,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e648ea0-9f22-4956-b657-3b0a3eb22d96" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="6e0a59c9-2ee4-4e75-a9a5-4d745dd2f1b0">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="968f8f3a-3468-4415-9266-0a92771b67b8">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -692,18 +692,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3948e163-f201-4056-86d2-6306e7458f20" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="1e155f99-45ff-4a02-a128-7906fcbc7c76">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="4078fa62-c197-4418-9600-4cd174fa20fb">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="489e160e-32e7-480c-878c-0b10402a3ce6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="59c1f4e4-eb07-4d7d-8b4f-0571a3e91b9c">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -711,10 +711,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="71feb87c-a249-4ebb-a598-7314600a67f5" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="61d4ff77-f53f-44dd-a12a-d5f8262179ae">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="1c62eabe-c0a5-4496-9080-e7bd901ec795">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -722,114 +722,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b75d6c7-85fd-492e-99d7-253e602afbb8" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="100f989e-3b26-4207-b328-c419b892194f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="02ad4a81-b242-46e6-84fc-9fc332bc40db">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="d986e1a2-6690-41ab-9614-48058bc89b58">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ca924dc9-28d2-4230-a73d-f97e6ee899f6">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="aea72eb8-2e9f-44c3-9570-8175134599b7">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="844f63c9-a4ba-46e1-976d-b3686c8981f3">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="b0db56bc-32a1-4cbd-a676-35b6362d5c07">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="2991cbea-036e-4d3e-959a-9eebd7814b71">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="4b6e3750-4e43-4262-9911-f724e81b9abc">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d040c894-1627-472e-8208-4d796a4c8acf">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="ac19524f-52fa-44c7-9aad-a389ab1e32e4">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="fe6d07b2-b628-4ce6-ae22-7b883c942c15">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="97946b3f-2c07-47d7-bb6f-5cb6878afc17">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="a83cd8ce-1003-4c2a-ae45-bb1ed25cdb4c">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="c85dc47b-125f-4893-bdac-88cfd9b2a683">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="08bbe015-22bf-4b99-b4df-e4f5b4a0de46">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="3469008e-4552-4c87-9d7b-2a6098b837a1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="4ef95702-8d81-4024-8eb5-addd8f56ea8d">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="a134fa98-2d5c-4831-8de6-4ba8cad64944">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ad58615f-6d9c-42c1-a4b9-73ad78792239">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="fced0c07-59fc-4796-807f-76385f61cb2a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="1ee36d94-307e-43cf-8283-528222b661e5">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="a82afdb9-695e-4422-9a1f-f969d9c2ecb1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="33994217-2cbe-413f-b433-28825084f70b">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="f80ff4ab-d229-44e6-afea-19c45e865aed">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="5ca35187-2d5f-48db-b3d5-2612a98b30e4">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="a5d8b3a9-92b2-4edf-9255-4ab82170092f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="28e13d01-4dfb-4b09-b8e9-3c1acfd7558a">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -837,10 +837,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="396b524c-b77f-4735-88a5-5c7fcbcf2c17" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="042df830-101f-48a4-9ae3-9020a9e19e58">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="5ca93fb0-4b88-4498-974c-7a47b1732f20">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -849,8 +849,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="5ecb5de9-c080-493c-8d9b-70931405584a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ef6fc79c-67aa-4a80-b346-43b1947f57cb">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -860,10 +860,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14f9b252-06cc-499c-b678-2516c9f01dd2" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="b0433cc9-7e1b-4f26-8c59-b7b6cba9b4ec">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="70aec272-f6f7-4859-9c63-60cb8b36f848">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -873,8 +873,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="2c06d566-7357-4495-b613-760a6a041dec">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f4ed610d-18c2-4c32-983f-37178ffe4650">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -882,8 +882,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="bd89bdff-a7e0-4aad-b00f-fbec9258d040">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="5eccf831-6c39-4349-a3b2-b2de78a00712">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -892,8 +892,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="7912a54f-f851-42d3-8bad-b6edfa7f19b3">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="71a13240-29c9-4e8e-9c4e-a6b17a1a6adb">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -902,10 +902,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8625f22-aa35-4500-a299-21a2629df466" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="be6a4f06-d423-434c-a2c9-4d9e3c4312e3">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="10c4b27f-5b42-4739-9a41-fb739a8d57bc">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -914,8 +914,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="a7c58422-6054-49fe-86dd-7c017c30d54c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="2311bffc-8e4d-42b0-9a5a-45156e1decf8">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -923,8 +923,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="d7d3b7fd-f4c9-461b-b4c0-ec67ea007f02">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="01cd88a4-19eb-4688-b054-183c9fc72195">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -933,8 +933,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="80a8e770-934b-40eb-ba65-a26d55eca0db">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="23f4eab8-a8d5-4a7e-99ff-9228c9d78c2a">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -943,8 +943,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="7c3e831c-9a63-4c76-b1f8-33012572e118">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="32452a43-09b2-44f6-87c2-3d269d2df57a">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -952,8 +952,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="2aae1adf-f7bb-411e-bd20-d28da373fef1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ca19d7ef-379d-4ac6-8cb5-288921738971">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -962,8 +962,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="7b08cafb-cf5a-4a6d-b70e-b04dade0419a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="a708ca27-8fa9-462c-b12f-a97b6d2a666f">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -973,10 +973,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="716ac07f-63ec-44c6-98b0-3b24656c3288" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="54ed48e1-69e3-45f2-a88d-9759ab4fdb7d">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="dda6e414-2430-406f-a0b6-f0690c9cd798">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -985,8 +985,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="7277a753-965c-4f2e-8ff1-3dd9cbe6aa95">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="95cb6062-d313-4940-9067-ca56314fa32f">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -996,8 +996,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="f6a077f9-b0ef-4984-a61c-e6f92f4c7579">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="85c4f7af-4748-4375-a040-5cde53d2d845">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1007,92 +1007,92 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28786616-46f8-4dcd-9866-71480664355a" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="c1fc3fa6-6195-421b-98b3-9490ec60f9d6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d0f1414e-adbb-4fd6-b6a2-704476a17ab1">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="64330f3f-77c2-4828-9443-c6dccb0a61a5">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3f268ab9-05b9-4169-b8a6-e7fd2c5a76b0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="57829dd7-8e2b-4406-8ca2-f81e8f336ac5" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="2a50f999-1b32-445d-99a4-6e462a5a2fba">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="1f308e6f-8fc7-408b-814c-2eb9508cddf0">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d0a8eb1-0e72-4d43-a6fa-1152eeebfbe0" control-id="pe-13">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="4ffb5b26-83fe-4207-83de-766248a6cdd3">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f392b10d-b454-49cb-97ff-073b08390e67">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="789d4729-9050-4bc5-9f49-93fe62e19203" control-id="pe-14">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="573180de-06e9-4cde-b383-05e00a72b0e6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="53748ff3-6abd-4596-a83e-a1fcad7d4964">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="729bbef0-e8f0-491f-9944-5788440def41">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="273456cb-a870-47f3-9992-222626e534d4">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30e59954-cf20-4a7b-83c6-292838cfaa10" control-id="pe-15">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="ffc5293a-cd6d-44bd-9217-5a628ca85d9e">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="da73dd3d-d123-4c94-bec7-a0c48e1870fb">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44f2c0b2-722c-4eb4-9372-a8764f6e689e" control-id="pe-16">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="a08e6c2f-64e3-4937-8edd-4956065cced1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="bea84840-f7c5-4664-910b-05555f33c52e">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2d729ff-2707-412f-9042-0c1726f2fb93" control-id="pl-1">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="5f38662b-0763-4aa0-a571-4ca506a7dd4d">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="094afc00-f0bd-4f47-934f-a38d61822c3f">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="38423838-6171-4405-98bb-8f957300549a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="4aa19316-a243-4501-8692-7aaacb01e396">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1100,42 +1100,42 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be883aea-42a5-4455-9be7-8a6bfddb8042" control-id="pl-2">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="2b21aec0-44c5-4db3-b405-b2102acf0392">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d263125c-a315-440b-9c0f-fe1084bee9c2">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="62ca940b-76f7-4178-affc-f978f1a8bc7b">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="9e18a6bf-2737-4b68-989b-0f80ac8409e4">
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="da353d37-270a-4c22-ad7e-17738839e84c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="21f1c105-178d-427a-a998-fb3c5ec176de">
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="d2fc04f1-852e-4a4b-b5c8-ebfd5c2cc686">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="72b58e62-2277-422b-a055-6421d20ac4ee">
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="a4ab3ba3-fd88-49a1-b835-961ce90dbba2">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="9a9b709b-efec-46d3-abd4-af3844dbde0c">
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1143,34 +1143,34 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6a24af5-e0b6-43fb-8c41-b1cfe43417fb" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="d8534789-9da3-4894-af94-41d59061eca5">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3efba6fd-5b20-4e48-a1fe-56826d86017d">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="393b5ead-7c89-443a-b152-a196d96e4618">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="354d1335-878d-4062-8a08-794378231db5">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="edce95c6-1fbd-450c-a31a-10a53b15271c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="570c2f67-889d-4fc4-99d4-d20209d9ae9e">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="69e02f96-2cb9-4367-b388-029afc1871c1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f0a4d9e0-8dab-411a-b686-1ecb56f49ece">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1178,10 +1178,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1368ba99-17d9-407a-896a-285bb3ae043a" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="78fa74ad-f04c-47a6-8f88-798222d6276c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="a14522f0-0d10-4ed9-a876-d040abb6b574">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1189,8 +1189,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="64da8922-b588-427f-b82e-a92368f0f3f0">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3181f4da-e80b-4a82-a870-266ddbd1cc11">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1198,8 +1198,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="e9d7bea4-5b1a-419c-8196-654cc3f1e5e1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="5741c84a-0517-4ddb-a922-a244b2d53e2a">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1207,8 +1207,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="1fc47f64-f5de-4120-8204-f353f35c112d">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="67a489da-d836-4818-a8a0-0b1c3249c760">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1216,8 +1216,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="e8be79ac-4350-4d0d-9817-c62b27417de6">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f7e4bd7f-9267-4a23-aae0-facd06af55ec">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1225,8 +1225,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="38b0819b-b7c2-4c49-b689-e46a875985d7">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="82bdd8c7-7b60-40ec-b8dd-91b1343037a7">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1235,18 +1235,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d40a6fe8-28e0-4cab-bdbd-d7aa5d237737" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="9e86bd52-868b-4839-ab5d-970618ab771f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3471f10b-a15c-4447-8075-c21ed1550c26">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="4e6abb91-4705-449d-b6dd-4a8b240802b4">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3141a3c6-1538-4c77-aa1c-303d8a85b69f">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1254,8 +1254,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="734d9b8f-d340-4b16-8ee6-5c976a18ed47">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="d0fc0139-0089-4b4d-879a-e632906846ae">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1264,10 +1264,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62217604-ed4c-4f9f-8f52-0fdc9c634f50" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="3a47cecf-527d-45e7-9fd1-97726ceb4769">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="0b173ae6-a094-4bb7-8af5-81480489da6b">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1275,8 +1275,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="bcfb2c37-5117-4ef5-9ab5-b04dda8fa5d5">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="99ea7619-2bd9-4bc3-81af-b93177177c60">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1287,10 +1287,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="306d8e5a-4e9e-42d6-ae0a-93d38883de36" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="2550d76c-8726-4ac5-a469-6c3aee7ea3f4">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="73c5fc7c-3a71-4515-8e06-266ed7c9f2ea">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1299,8 +1299,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="d95b8eee-fdf5-48ce-95f3-de7b71ff149e">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ae93fefe-0615-4d25-8a70-0cd531423503">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1309,8 +1309,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="62f065bf-369d-4d2e-bc94-a9e2975ae7bd">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="325ffd3c-060a-49ea-8c27-774e4b36c6a5">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1319,8 +1319,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="e4d9271d-7028-4dac-af32-46f276a3059a">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="19ac4e8a-df6b-4e7e-8289-e95883b1688e">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1329,8 +1329,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="cc4d66f0-d2cf-4bb9-9001-14d4f3c10caa">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="9fde8bdf-d735-489d-8e34-4653950898c5">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1339,8 +1339,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="8479ed77-d0d5-4dec-ac83-d714a68887fb">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="48ab191a-556b-4307-bd52-47f44764e196">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1350,10 +1350,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3572b945-377f-4aed-9904-06e5caf49fed" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="5d39068a-37ac-4a5a-b91a-c0dc598db42c">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="af529a9c-cc85-4866-90cb-9b8afd8e1704">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1363,8 +1363,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="eec6e3c5-4a38-4f31-a086-bcffa34ef5e9">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3e51d848-96ea-4367-b5fa-6dc4fb324493">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1373,8 +1373,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="75326ff7-d067-4cce-902d-8adeede5d024">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="de68af02-755e-4780-b323-983587c26f56">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1382,8 +1382,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="7554b0ca-f657-4213-9609-073f488c7c23">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ac142551-f67a-458f-b314-e987e3483eb7">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1392,10 +1392,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51c3b4ca-439b-4887-8684-a9fac594ecf3" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="c5dde6ed-181e-4e24-b118-42382281cb77">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="3330777a-1619-46b1-9f82-f1df2830102b">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1403,8 +1403,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="235dbd0b-0e90-40bd-8f72-d94dae019631">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="9ee55a2d-9cfd-4abf-be7c-89c6cc7b7716">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -1412,8 +1412,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="04fec197-78e0-49af-ba07-5416c15d871f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="0428e15a-b5cb-440a-8a1b-8bba2cc60a15">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1421,8 +1421,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="6df03c4d-54a4-4e0e-ab4c-d25d686bee03">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="bd4da917-23f7-446a-a2bf-775acefdc245">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1430,8 +1430,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="c9acb67a-e9ca-47b5-9a68-c59cf7599e1f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="834a455c-7056-455b-8aa2-0781331bd289">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1440,10 +1440,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee700567-5de7-4f64-bffc-f0ea5b2cdf40" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="2dffed7e-acee-4b04-8eda-4adaba450213">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="46dae894-afe2-403d-87d3-ecde0ab2b1ad">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -1451,8 +1451,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="8037bbaf-979f-4f66-adff-120cb6448daf">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="006ef0ce-aca0-45c2-bb44-bea141ab42a6">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -1460,16 +1460,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="e0a5dd6f-1fd1-4027-a336-050f5639a38f">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="172e72cc-3229-4d41-8007-ffa91ee5b9af">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="b03ae730-f55e-4876-9953-c6873bf7b152">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="1831cf56-7cf1-457c-9b07-43b16314624e">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -1480,8 +1480,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="07122caf-8e67-4742-b6d9-8d4caedc2bc1">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="ca059b24-15e8-4aae-9316-668dca2a0b14">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -1489,10 +1489,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64519311-6a90-4c45-9bb8-2c900f8b1ea0" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="05a2d0be-45fc-4e68-82b1-c265d3911f7d">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="36304755-d9dd-47bf-ba60-41932a014717">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -1500,8 +1500,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="34883e40-d77a-4756-b9d1-7f3c72621e5e">
-        <by-component component-uuid="96a6f984-2664-4887-91f4-6aacede0dc63" uuid="f0c47abc-99f9-4fb0-bb29-1c01a7ae88f9">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/rhel-8-fedramp-Moderate.xml
+++ b/xml/rhel-8-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="cade25cb-385c-4f5e-a8d8-334f06a6b5e0">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="3d9e6574-ee20-42fe-adb3-40d2510eefdc">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.62+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.68+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="0a79dc62-2634-4623-aedd-81d14d5945b2">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="17264c11-5b53-4a3d-9d07-640215a87278" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,18 +484,18 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="376407e5-975b-4a7d-a61a-137f80904c7f" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="83315e58-b6cb-4cde-bf55-f09f97d0246c">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="bb263526-8a8b-4588-8dea-851fbffdf9bd">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="8c3f3317-7232-48a5-aba0-9030ae47a8f1">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1f7808ca-8c27-461e-a22e-67c0b58e19c5">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -503,26 +503,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f649cd7-fa14-4ed2-b4ae-cb06c10c5a82" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="fb75971b-056d-4d2d-8dc6-06f535beb2f9">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="8f067ede-ba9e-4771-9533-ba9a2545a6e4">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="3eb4e400-0360-4866-97be-cca3c30e3d84">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b037a554-00c0-4274-8b9b-c1a02aebeaaa">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="43b1cf64-94f1-417d-95d3-6e4dd81a0119">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d7ecca73-f677-4dca-9688-c829f20b0144">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -530,10 +530,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a36069a2-8fa9-41a1-a775-88e6e7e9f6eb" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="5def1b1a-c49f-49b4-80e7-074627cbb1d0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="7e802caa-c9d6-4d8c-aaf1-42062ed89573">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -541,45 +541,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c57e9da1-41b4-429e-9f3e-6d81723e7e75" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="e459a43a-105d-4229-b2c1-395979773f1b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="a415619a-21df-40d0-9e68-c7fb218b15cf">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="2cf81a6b-d444-417b-a0fb-4d5d59ddefbf">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="c69d94c9-0769-4a7a-bc38-18270ab7c1e4">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="efcff6ce-eb11-4bd7-a47f-2f143aa36476">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="79bdfe98-ce72-49e3-a60d-1c5840b188d6">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="4bfeb587-bb99-47d7-8d13-1d94e5df2262" control-id="at-4">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="d11d5ff0-4fe1-46ff-a4cd-e2631a155bec">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ae38179e-da36-40e6-829a-5345f577bd73">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to component-level configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="at-4_stmt.b" uuid="d9e74d30-35ad-4e18-8a82-69f8ba3eaf9d">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d5260505-1a05-4a4d-b55a-911b758f9e1e">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -587,50 +568,69 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a0b42d7-d071-4020-b56b-c5f9f88a2485" control-id="ir-1">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="0c699331-a771-48e1-b196-475044962d25">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="cfd7d4dc-b6e1-4978-bcb0-327d2e1e3c8c">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to component-level configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b2074ca2-3314-40e0-a322-f76401c98bfa" control-id="ir-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ir-1_stmt.a" uuid="ed383cd8-fcef-44ad-940f-ea4fc52b0aa2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="9fdc52a5-fa1a-4825-b83a-2675c6586692">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="97f97d46-31c7-429b-878d-8d7fde3afd47">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a3341e3c-19c6-4b0b-b637-9735c61cc5f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="96cfec18-8ea4-49ee-bd93-1fc5e5caff10">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="c0f2967a-7fbb-49c9-a1eb-0f2406f8ed04">
+      <statement statement-id="ir-1_stmt.a.2" uuid="e91da04a-dbf5-4de9-b6e9-746ea1986315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="a04f9e9e-8a9a-491f-989e-5d641e4a7cfc">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="88fc63e0-8b7f-46b1-b763-aabab85664e6">
+      <statement statement-id="ir-1_stmt.b" uuid="f045f5f3-7433-450a-8514-a5d958b6f756">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="0bac12de-22a8-4bdb-a87b-92729bfd276b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="7494ffc1-4481-4ab3-9e3c-b0404fa01381">
+      <statement statement-id="ir-1_stmt.b.1" uuid="2cee221e-32d8-4226-a9f9-301ed97dd459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="5c277e98-4d7e-4ea6-9fe7-a20995116aa8">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="c0ae1ef3-a35f-462b-aa71-06f0c8c91f75">
+      <statement statement-id="ir-1_stmt.b.2" uuid="fa61c208-6617-4235-b59c-eca7c1a95820">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -638,26 +638,26 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd6da950-d6c4-4e14-ad5b-9d6732c9574d" control-id="ir-2">
+    <implemented-requirement uuid="0a75b64e-e699-48d4-8f39-5739080a53eb" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="22ac3e06-faba-44d2-b09c-f208802cb5a3">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="461d2356-8b4a-4859-8ea4-dee6486b7854">
+      <statement statement-id="ir-2_stmt.a" uuid="fb410b5c-35f6-43a9-bc42-1eb15f6561a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="82ff1dbf-bd12-4f6a-b196-c31362a2ab25">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0d2d6b2f-48b1-4c54-8c21-03714612ff92">
+      <statement statement-id="ir-2_stmt.b" uuid="7503c5a4-5d5e-4dc7-8423-09cfaaed0c90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="4585f16e-bc1c-4db5-b567-4c62ed7c1931">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="97128d30-1d22-4527-b879-322b2d5ec7cf">
+      <statement statement-id="ir-2_stmt.c" uuid="eae5a6d6-5743-4c18-a1ff-417213648ba8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -665,10 +665,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3aed915-4de1-4f92-bffa-13b59ff66b4f" control-id="ir-3">
+    <implemented-requirement uuid="534c3783-f194-4e6d-bce8-f673cd7876a9" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="7f71a174-cb8b-42b5-8630-6c8f153ea46d">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="06ad9f51-ba2d-4b18-822e-ed37330a0501">
+      <statement statement-id="ir-3_stmt" uuid="b08ef514-12d3-49de-9430-8bd0081b6d34">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -676,10 +676,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cb32eb0-b3de-496b-92c8-ebb5f4fa212b" control-id="ir-3.2">
+    <implemented-requirement uuid="cd2b8dea-d475-4536-810f-4cb8840225a1" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="e9e8cd4d-2ecc-4796-a255-72f1fbc98bfd">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="2f631833-1a48-4d3b-8139-d0cdda467834">
+      <statement statement-id="ir-3.2_stmt" uuid="228b2851-d621-491a-99b4-011447d2e390">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -687,26 +687,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14b709bd-5e58-4a49-a696-c42ed10077bf" control-id="ir-4">
+    <implemented-requirement uuid="d5f43da4-0738-4742-b982-9078b37c5e7a" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="a0ebf022-a012-45c1-90ac-9bd803413f90">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b8d056ae-661c-4577-ac86-7a9be10d3710">
+      <statement statement-id="ir-4_stmt.a" uuid="df767cc6-026f-47e6-b828-78dde7ffea92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="a20791e4-4fdd-4f4e-9ca0-86bde9ca7658">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1e5ccba0-b201-4bd0-b973-5fb3006a2245">
+      <statement statement-id="ir-4_stmt.b" uuid="a776cf6b-5456-46a0-8971-aea647e59336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="e506bea1-17be-4e05-a953-274f9e5e93a2">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="7cf24bb8-d0ff-4ba2-920f-cb2bf4da40c7">
+      <statement statement-id="ir-4_stmt.c" uuid="f50b8c8c-add4-42c9-8c3b-c2a614a4652b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -714,10 +714,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caaf3d58-53fe-4651-8639-66626f0cad22" control-id="ir-4.1">
+    <implemented-requirement uuid="51142785-d1e4-4886-b642-592d35b71e70" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="8e90a8b2-a226-4d7d-8aeb-88bdb7ed418a">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="5a6b04d4-ee5f-417b-a3c5-ced5d7a0920a">
+      <statement statement-id="ir-4.1_stmt" uuid="12a7343e-93c9-41a0-922b-eac846bcb671">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -725,10 +725,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4881e2c2-f004-4c29-9523-097a27fb2042" control-id="ir-5">
+    <implemented-requirement uuid="fb3375f1-e4be-45d8-98a3-89897298fca4" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="25846e01-aa94-4801-8fc2-2b00862a95fa">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="2a14b371-d1a6-4b4d-9615-5647c99eccf7">
+      <statement statement-id="ir-5_stmt" uuid="5e6ba516-299c-4800-a996-f5a5d9edbb09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f064814e-36c6-448e-8f0d-4eca9db77025">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -736,18 +736,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8fcd72b-8912-4d36-a20b-0a8e0d947ff8" control-id="ir-6">
+    <implemented-requirement uuid="655e23ea-73f9-42c9-b7d4-3a94e7a2ad57" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="46b77b77-106a-4ae2-a2e7-a0ddf12189b3">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="459d5ac9-0ad3-44f8-b91d-03a4ed6f07bb">
+      <statement statement-id="ir-6_stmt.a" uuid="40d636d6-6964-4610-aa7c-d86737531f1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="718a5821-bb7b-4887-b2e5-fcb3a7dd2054">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3010c8f5-ab1e-4be5-838c-4d77658a3c01">
+      <statement statement-id="ir-6_stmt.b" uuid="9a1f52a2-b2a3-42dd-9f4e-07b0a9e5562a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -755,10 +755,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49858394-9710-4af8-af38-1c20bb143a11" control-id="ir-6.1">
+    <implemented-requirement uuid="abbf5ca4-c37f-4e55-be38-e0fb78d98b6d" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="1bed9fd9-a501-4c1f-96a3-37e31adce962">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="5496fce2-6467-4f73-a69d-103e4306a57f">
+      <statement statement-id="ir-6.1_stmt" uuid="bff866ee-07a1-48e0-bff5-677bbab030e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -766,10 +766,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fbbdcc5-c9a3-4712-b9fb-13b715afbffd" control-id="ir-7">
+    <implemented-requirement uuid="3e04a01d-4a41-444a-bdc8-bb8ddeb427e9" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="8203c26c-884b-47ba-9be4-842ede9f2eb0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ecca5c9e-7bbf-4c11-93f4-ccec0e932640">
+      <statement statement-id="ir-7_stmt" uuid="1defce0f-835b-45b2-a8b4-0bbf79eb06a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -777,10 +777,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28967264-83a1-4fe9-9438-dd525ee51624" control-id="ir-7.1">
+    <implemented-requirement uuid="1e7dfee4-59e7-4258-a21b-252a865c51a8" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="9d080cf2-d8f7-41fd-b95a-7179868f1026">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="a788560b-4433-4ad4-979d-16636f4bb2c4">
+      <statement statement-id="ir-7.1_stmt" uuid="6aea26c2-e075-4c68-8b42-d974cef94703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -788,18 +788,18 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1eb7894-1a86-492d-973e-0f08c039da99" control-id="ir-7.2">
+    <implemented-requirement uuid="b0e1ca1a-d05a-4e97-891c-242848ed917e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="054de582-3f00-4d66-87be-b5dda06b7f56">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="4c68c918-50c4-4b21-9f11-1027bb46081a">
+      <statement statement-id="ir-7.2_stmt.a" uuid="0205e4dc-efcc-405b-b919-c8d96b200b01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="12f908ed-bbd3-4b80-8697-f82480c2dfe2">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="6ea38aa4-c234-47a9-8af2-e18bb099ba77">
+      <statement statement-id="ir-7.2_stmt.b" uuid="71973ea4-e082-42b8-b2c1-59894f32f069">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -807,114 +807,114 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c181c41-0296-4c60-9e30-30ac8a4eb766" control-id="ir-8">
+    <implemented-requirement uuid="98e7a79d-ec6b-4253-a247-3dfa3a97f274" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="0acaa493-f0a4-46d0-b99b-ba076e1a6ab8">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="2d836004-80dd-446c-9d0e-3be0277f9437">
+      <statement statement-id="ir-8_stmt.a" uuid="f226ef5d-c4e5-453e-8f06-806363fc976a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="771786d9-917f-4f06-b3e9-4ae2fb65f41f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b946b7a5-272f-485f-8ad2-dad096482dbf">
+      <statement statement-id="ir-8_stmt.a.1" uuid="a45f4789-b326-476a-873c-2c0f287832d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="93ec9880-ff05-49fc-868f-c765460cfebb">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="2ad80db5-7c81-48a1-9c5d-b79e68a7312e">
+      <statement statement-id="ir-8_stmt.a.2" uuid="813f981f-6923-4235-a648-7b076ee3eea6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="2c06b9a3-fc7f-489e-869f-2704d1ce63e3">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="7264df71-ad46-42ac-8f48-b461be9dff2a">
+      <statement statement-id="ir-8_stmt.a.3" uuid="30328a20-0b4a-46b8-8f1a-7ba21adae16c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="f54d1b61-c260-4938-865f-171ef44e5204">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="4b4b26d6-ff1b-43ea-803c-63ae0c4e87fe">
+      <statement statement-id="ir-8_stmt.a.4" uuid="df0171a6-7b99-4a7d-94b4-05f839870539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="bfa2f086-d3df-495c-9792-23261a26918c">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b18d95f6-c673-4f1e-9457-5a83b504eacd">
+      <statement statement-id="ir-8_stmt.a.5" uuid="0f112da4-8f39-4059-9b59-5e79408d6400">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="c5ca0e9b-9d0e-4b60-ad81-8824226aecf9">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="063da2a0-d528-4762-a349-dae14685ca99">
+      <statement statement-id="ir-8_stmt.a.6" uuid="c5f5033e-b926-4c39-8ed6-ce6973cf1003">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="2eacaf96-cd99-46fb-9acf-9f19134214a4">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="bb21ac6f-bce2-49ea-b944-da334a798cf1">
+      <statement statement-id="ir-8_stmt.a.7" uuid="7165cc37-0212-473c-b692-b82782d977cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="c474c63d-a5be-48c7-b881-2a21b7a2daf6">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="52614524-8639-4c99-afa6-aca929ead14f">
+      <statement statement-id="ir-8_stmt.a.8" uuid="d9359977-60b1-407b-b570-0a5f1196cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="b83590bf-08a9-4404-b526-43bd3ad70498">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b44d709f-3829-4688-bbaa-904354f73bd2">
+      <statement statement-id="ir-8_stmt.b" uuid="0a5d4e19-2307-43f4-bc0b-8e40d51b1709">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="beb056ef-bcde-4789-997b-91eeea896803">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0ea4db88-f81e-4b2f-960c-70b5fd09fc9a">
+      <statement statement-id="ir-8_stmt.c" uuid="410ad22d-49e8-4aa4-89cf-ba7d90b82231">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="56b1a964-58fa-44e9-bf50-eedf59231509">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="60074077-4c69-4d86-b133-78247f416383">
+      <statement statement-id="ir-8_stmt.d" uuid="b8b6ffaa-f874-46b5-a0e8-919d4d22db03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="23b0f66d-1a17-4683-88e3-dc04f5603f5f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="fbfcf8a8-8192-487b-9bd6-d96ae8f718ed">
+      <statement statement-id="ir-8_stmt.e" uuid="987ad1c7-67d9-44bb-9bdf-070d5bef811c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="5c6b8f94-abe5-44a4-95d3-c011eb0022bd">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="06ffca24-282b-4d37-b470-ea31816fd4e7">
+      <statement statement-id="ir-8_stmt.f" uuid="78a2096f-5c01-4a63-a51b-4652d85f1821">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -922,50 +922,50 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3325053a-3221-409b-b8cb-2030fa7dc5ec" control-id="ir-9">
+    <implemented-requirement uuid="bcf3f3da-6836-477e-a2f9-7d4c2782c738" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="7c800d0e-da57-42d4-a48a-3837f96b1a18">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="85be3b59-2969-4885-b6c7-9f910e17eb41">
+      <statement statement-id="ir-9_stmt.a" uuid="02df5246-c9a1-48c3-b3da-7603a39cdb7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="ea6f9068-bb7d-40f8-909d-66f5cb13c601">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="f1326c05-b509-4785-9d08-2a25362c7171">
+      <statement statement-id="ir-9_stmt.b" uuid="7661656b-02d7-4f24-8543-2ab420fd420b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="b156205b-5455-45b0-bbe5-8b12b6f9b14a">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d2aa447e-229e-4ed4-9167-b5df251987ea">
+      <statement statement-id="ir-9_stmt.c" uuid="163ad426-d038-4abf-a55a-cb9f0b6a5721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="c2f6f647-04f8-474d-bcfc-f0af9df27a70">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="86ddb3dd-6dcf-42a5-bcd2-cdb500e8ab80">
+      <statement statement-id="ir-9_stmt.d" uuid="8808f90b-b6a0-46a6-8342-0a3dbda1d754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="e6c59834-55d4-4ebe-b144-24d3c5cdee19">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="8417df0b-33dc-4a72-96f3-0a56b38e4442">
+      <statement statement-id="ir-9_stmt.e" uuid="3085e8b1-08c5-4b1a-997d-a0d3f7ef4a5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="a3cc2166-7de6-4c79-b35a-f96cc2dc5263">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="616a7ca1-f618-4e78-86b3-5727386eddea">
+      <statement statement-id="ir-9_stmt.f" uuid="13ae73bc-6bed-4a1c-96a2-401a1538d7ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -973,10 +973,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02945992-71e2-460c-93c4-b29da2bcee11" control-id="ir-9.1">
+    <implemented-requirement uuid="d32202a4-71c3-4e5b-86bb-b799a06c6389" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="868348a4-77c8-40fa-8408-a03372ffa393">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1e6eceed-00e1-49ca-b07c-1323106f4664">
+      <statement statement-id="ir-9.1_stmt" uuid="e360dc90-aa12-4097-b259-8b605b99154a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -984,10 +984,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3aaebc95-1bca-4d0d-8d5e-89b4bd26353e" control-id="ir-9.2">
+    <implemented-requirement uuid="562b61fc-ccbb-408a-9c03-08aef03f0615" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="4ab63863-4d5c-4c7d-82bc-3d81167b3500">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="fc40ce31-3ab1-41ab-bbca-9a39fb6c2020">
+      <statement statement-id="ir-9.2_stmt" uuid="4aeeb1f5-3b39-4d64-a261-220ab7f8a37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -995,10 +995,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30b73215-6ff9-4dd4-969c-a7dd9eba0edc" control-id="ir-9.3">
+    <implemented-requirement uuid="8677d99b-d58e-462b-83b5-5d7283825a99" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="fed22246-feb8-4a88-b4f1-e2fbafa98b2b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d1059c17-f8b4-4c74-9352-7b67bb2fc377">
+      <statement statement-id="ir-9.3_stmt" uuid="e527df40-341b-4109-8975-29f039c56cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1006,10 +1006,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7a66116-c8e5-4f64-b50e-0210e0a45c00" control-id="ir-9.4">
+    <implemented-requirement uuid="38421d01-5e3e-4eab-8293-0686e2181441" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="171e2fa7-b55e-4449-a045-7e428fc75817">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3ba2409e-e961-4e5d-93b1-4cf6f0546579">
+      <statement statement-id="ir-9.4_stmt" uuid="38221d3e-2bfe-450f-9a8f-0c88f2860012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20e12e08-e93e-4178-bab1-0649101f2a59">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1017,10 +1017,10 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c76807cc-03d5-4cb7-96dd-e5b71d31d310" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="8c649e07-8c4d-4739-b843-d2121996cfd0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="93849662-1970-4ed4-a489-84215cf43354">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -1029,8 +1029,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="8b348a1b-03de-4ff2-aff5-1e4e79d851c0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="f86c4b8c-936a-4438-b875-6536a4b06c8f">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -1040,10 +1040,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92f3ac80-eb2f-48f9-b5c9-3eaee0d78eb6" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="9148e8bb-113d-43f7-8cad-2d6ec2f5fd05">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="6db8473e-ef6f-43e4-b9f6-cdb07ad4a93c">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -1053,8 +1053,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="b579ba8d-a3a4-440c-9d89-7d63b253c952">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="014495fe-ad93-424c-922a-7609bf25271d">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -1062,8 +1062,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="5ab96eba-a92b-4196-a0b1-28c475a1bc5b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="556ebd0e-eb65-4e4d-8771-a05cf9dd09af">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -1072,8 +1072,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="33089ce5-f123-4aa6-8f4b-e998108d28e6">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b398ab78-1aad-4eaf-94c7-b457cd5e6ff7">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -1082,10 +1082,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="039adbf6-b441-4e1d-9f31-2ef91214aef4" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="3dcc7b2c-1434-4710-b69e-3a2c437216c5">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="41e31208-bba0-4964-8773-791354967a2d">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -1094,8 +1094,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="26e57d39-e67b-44da-a3d6-6f48d4de9a4f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="30a31318-f042-4f82-9064-5d4616f5ee50">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -1103,8 +1103,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="8648db71-f0f1-44ac-975a-a012522050cd">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3ae18268-787a-42a2-9220-21577875f16a">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -1113,8 +1113,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="9bd8ac12-dca3-4993-b31d-6f99483e6e59">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="818aabec-be07-45d4-a148-f2d07d2b6e28">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -1123,8 +1123,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="dad7175b-b5aa-479f-bb27-2a0f1f071f24">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3fc06049-b7e5-40af-815b-cce3265f6f6b">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -1132,8 +1132,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="45268a3e-dfeb-46a7-ab27-0fb6022912a0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d75a8a04-06a4-4390-8000-f96eb0555fe1">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -1142,8 +1142,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="6c346be0-7a15-487d-a877-e53acd53d787">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0af4c6f3-a321-425d-a0a3-298c71431bfe">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -1153,10 +1153,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="613b3c6d-eaab-4612-ac0c-21fa0f685007" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="35f251a3-971f-4e6b-91d5-d08368284019">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="82ad93aa-275b-4e4e-b96f-ca82d8ad70a6">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -1167,10 +1167,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37b3d6a2-ed9b-47e9-b3cd-ad14c4cd3709" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="2b41316e-6e4b-4374-b15b-76c6fd536953">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="247575a1-8400-41d4-a9d4-975c58e9ea6b">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -1180,10 +1180,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15fb6263-58d6-4b71-8e6f-8c0c01669769" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="10169e94-8121-43c4-9d3e-5b3c7bf7d7e1">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="e40ddc00-cc10-4363-a98d-bb031a0e75d1">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -1192,8 +1192,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="0bfc7814-d9e1-418b-94cf-c281e12847fd">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="02acac86-4dc0-456c-bfad-1a2e744efcbe">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -1203,8 +1203,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="f1cb0946-2aac-4d20-9263-ff45f593f96d">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="9d565506-ece7-4570-9f9a-edef64ecc8c7">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -1214,10 +1214,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff5a88d3-9e29-4cd6-92d6-bbcc02bdd4f4" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="dba42e21-7805-4cc6-b287-a5554e927ad5">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="66741df0-5575-4673-9424-947681f7808d">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -1226,233 +1226,190 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8604e93e-da42-46a8-97b6-48649c3fb2be" control-id="pe-8">
+    <implemented-requirement uuid="e4329b69-a2bc-496f-aef9-60af3f2ba616" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="ec1e7cf5-806e-4d34-94ba-99f09229f579">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="4d12ba61-3313-46ec-9757-bd06d69d1e54">
+      <statement statement-id="pe-8_stmt.a" uuid="91b8d93b-c8fa-417c-ae8c-4951597fe883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="ec26b65e-b95d-4d76-9492-0c407f611f86">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="141b1ad9-f324-49d2-b98c-010a4795af8f">
+      <statement statement-id="pe-8_stmt.b" uuid="02093793-e0dd-4d1a-949f-013f040ae8a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d857339-fbd2-41b0-ab30-d7eca7a6b34a" control-id="pe-9">
+    <implemented-requirement uuid="d09ba053-a392-4fce-9d48-2650bbe51d68" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="28b1522a-e315-4629-ad0e-d350a4c25ffc">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="c04a3b2d-dc4d-4ef9-9f74-2f47622b93b7">
+      <statement statement-id="pe-9_stmt" uuid="af932a4a-e681-44b8-b559-7f4bae228387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b911627-9c21-4490-93d2-e754d29e9017" control-id="pe-10">
+    <implemented-requirement uuid="a00714fb-0cff-453b-a86c-7123f5a5af8f" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="c5d25281-39f4-41d4-a6aa-6c14cf686715">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="79f656e4-3d4c-4955-a233-6fb412e0be9c">
+      <statement statement-id="pe-10_stmt.a" uuid="f82a835d-0e45-447e-8cf6-e6a35c1e3060">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="d50ea7ee-5b17-4db2-9690-80affee51b6c">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="f8b2cf25-608d-4ceb-a17f-59e4aacddf7f">
+      <statement statement-id="pe-10_stmt.b" uuid="b84f3c3e-161c-4083-9cf6-9bfdb8187570">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="1c17a355-f4d8-451e-b855-85c71d2b0175">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d84004aa-6be7-4b9c-a490-963a8ffa41ab">
+      <statement statement-id="pe-10_stmt.c" uuid="8c8049ef-779b-42d9-ba34-d24838950330">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd07ba7f-3ab2-4d0c-9b5c-0f9b4c619cf7" control-id="pe-11">
+    <implemented-requirement uuid="667ed986-a1ea-4a5b-a836-1ef848a2d405" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="0bb3c3cf-a2e0-43a6-9269-a8b7695b63b9">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1b3a0a73-cd72-4af3-bd7b-d725106af4ed">
+      <statement statement-id="pe-11_stmt" uuid="1bc8ee94-7662-43a7-8b6b-53bb4f6e9fa9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d49023e-f6c8-4a50-8d7e-64777990bc3f" control-id="pe-12">
+    <implemented-requirement uuid="11b8b7ee-c378-4425-b296-6f56eb703c76" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="a2cc886e-2f00-4fe9-847d-65e61b809dbf">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="a4ff2d15-90a6-4573-b5de-728e5fb039ab">
+      <statement statement-id="pe-12_stmt" uuid="4845a568-565f-40f8-976c-5c1d1f1eb9ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ef9dc9b-40d1-4e7c-ae90-e0768ef4631b" control-id="pe-13">
+    <implemented-requirement uuid="6657211f-e3b9-43c5-9477-02767cef12b4" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="263f9583-5e57-434b-9484-f7839a2b6571">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1eeb162a-a9b2-4ca8-97bb-7fd338be889c">
+      <statement statement-id="pe-13_stmt" uuid="4c7ac6a7-5677-47f5-ad33-e8a4d982c01d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e64cb1d9-0fa9-498b-8b06-34867ff39211" control-id="pe-13.2">
+    <implemented-requirement uuid="e61b56eb-502e-48d0-8dea-dd329df1444f" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="9cee01d1-1221-43b9-982f-a0574552b884">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="064ed93b-d54d-4b63-beb2-287acee52296">
+      <statement statement-id="pe-13.2_stmt" uuid="d20d68b1-605b-4789-a71d-0302341a68e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abdc97bd-c342-4724-907d-58ec03f78d98" control-id="pe-13.3">
+    <implemented-requirement uuid="ed45689d-2e14-4612-a688-ed8bacf22fd6" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="3ad1433a-89ad-42a8-96f2-611219a976db">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="411e41dd-d74b-49ad-9738-1755cfa3ed5f">
+      <statement statement-id="pe-13.3_stmt" uuid="99caa78c-7757-4d63-a13d-cb0e57aff9ae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa2790ff-444f-4c6f-84bb-e7e83afb4127" control-id="pe-14">
+    <implemented-requirement uuid="4bf3d533-2f44-44d2-9003-a104380b30e9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="13aa273c-2fbc-42eb-8f6a-ebd259d68c71">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0c8c034f-5435-46c5-b675-d594f9f3b0a4">
+      <statement statement-id="pe-14_stmt.a" uuid="e2719a38-2d72-4d39-9c9f-344e9d3342b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="dc08ea16-a8d6-4444-861d-7014558dc143">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="aaefdf73-185b-4955-a919-90619ac5a53f">
+      <statement statement-id="pe-14_stmt.b" uuid="6b2d96a7-6a9d-4448-99d5-89a5443be73b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93d83d67-ac99-458b-b19e-1277e434e17a" control-id="pe-14.2">
+    <implemented-requirement uuid="c4d47a12-0052-49da-a5a8-b3852d8e8c00" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="027d348e-549f-4f19-938c-aa9ea8c3775f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="2d72be31-e033-40f9-90b3-2fed99b22dd5">
+      <statement statement-id="pe-14.2_stmt" uuid="b1069fc2-cf93-4ebc-951c-c7b8e46001cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68e4534b-b5ee-45da-9156-ac380a7b66f9" control-id="pe-15">
+    <implemented-requirement uuid="07a3be45-5937-4bfd-98b8-b8f9ea1b21a2" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="9793808e-8a6a-4717-af36-b1ecbee7b103">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="01557818-ab01-4680-b6bb-a79fa25ef93e">
+      <statement statement-id="pe-15_stmt" uuid="a6f71100-a32c-4b0b-bd03-ef3d792de1ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9cd358b-30fa-429c-ba24-686d07a4ca91" control-id="pe-16">
+    <implemented-requirement uuid="e9fecabe-ac5c-4e3c-9e8b-dcd8923787f8" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="00ccae96-059e-4e7f-91ab-e2ce9c154b8e">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="920e00f7-696d-43b1-b95d-6d555dc980aa">
+      <statement statement-id="pe-16_stmt" uuid="29136d47-d918-4593-8b2b-6516d3c01915">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8fe2e90-a97a-417a-85c8-bf3ffc6c1c7e" control-id="pe-17">
+    <implemented-requirement uuid="4d8e695f-6725-4dfc-a388-a629ab9aa7eb" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="da456f98-3703-4393-8050-fe7a6670da8f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="4ec8710f-34bd-4609-9b69-b5ebe54fbacf">
+      <statement statement-id="pe-17_stmt.a" uuid="e750901a-4d28-4c37-bed5-3563e37933e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="9a35cb1d-e364-4077-94a5-ce2fe5d1fe73">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3a7148f2-ad32-49a6-828d-a1c56c197d0d">
+      <statement statement-id="pe-17_stmt.b" uuid="a9dd49bb-c3da-4d5e-858b-3c0f480131f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="473d0b3b-aa4b-4552-a475-d63101ddfaa0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="089284af-08d1-48b5-b4fa-5701e792e731">
+      <statement statement-id="pe-17_stmt.c" uuid="e012ea43-db85-46c0-8920-fa79191734d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90eeb4a5-5f8d-4bee-9f00-0e22c33d8db6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="faa4f92a-2644-47b3-abbe-37e1b535f412" control-id="pl-1">
+    <implemented-requirement uuid="5a6a70cd-e241-4b52-bf70-dbb9f62a0c75" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="31f2d2fa-ef52-47f0-8917-151d58446a79">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="46918d92-e8e3-4ad4-ab00-abe205e3e1e0">
+      <statement statement-id="pl-1_stmt.a" uuid="094d50b5-ebc2-442d-9031-7bc8a1196c57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="776c8018-3313-48f5-8eee-0658f247321c">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="124b66f0-54c3-4aeb-9d58-976ae4fefedf">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="2578f88c-d39a-4ee8-a1b5-6c31d6420d5d" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="bbcc6686-09bf-4694-9432-7b0a6c31be33">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="43eeb4b1-da57-4eeb-b991-086d2f4b5431">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="da78a443-2b17-4ab1-a5c5-f6e40e2fae02">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="36322f90-60d5-43a0-88be-61bcb58a317c">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="b92b05bb-169a-4ffc-abff-f27d7874a285">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="86a5671d-d735-4203-89be-6c87efb6cf1a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="449c57ba-acea-4039-a4bd-6b9d753f67ca">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d7cb7ade-e5d9-4634-99c9-6b414b67248b">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Enterprise Linux.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="6d99dcca-f51e-4fdf-a50c-b8dfb252cac4">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="33505ffb-68b2-49f8-8243-91b8091a52c2">
+      <statement statement-id="pl-1_stmt.b" uuid="8a288e6e-1641-49e0-acf5-684f40de5b21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1460,10 +1417,53 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9774fbcf-4d55-41fe-8440-0b63a6241dfe" control-id="pl-2.3">
+    <implemented-requirement uuid="567a49c4-0184-47f0-854f-4ef1fb836ae8" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="9cf7d9fc-a606-4191-803c-df0aef81fde2">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="9c27113a-505f-461d-9cfb-44a8f6a559eb">
+      <statement statement-id="pl-2_stmt.a" uuid="b0c294fd-f8da-43a1-91a5-5a8f1ce16aa8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="0ae636b7-3308-4de6-985d-bee23fd586cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="d878723c-436f-4131-bcf9-a63cff332b30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="b4235c44-8baf-4bda-8d26-1e2fd25a910d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="0336a419-949e-41a7-9586-7844675ee2a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Enterprise Linux.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="9d5246a3-4521-4c59-8205-516f2577541d" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="d6f42931-4074-4ff2-b339-9a5fcf43a1da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1471,34 +1471,34 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8853437-f353-48e7-ad0d-fb144998c5b1" control-id="pl-4">
+    <implemented-requirement uuid="aa60b190-b436-428f-82d3-5e609134ce39" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="6d2650d7-77d1-4c6e-9b1e-6a314db1d4ce">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ccc125b7-bae8-4a29-96a8-14399f92a053">
+      <statement statement-id="pl-4_stmt.a" uuid="42ef50ea-2c10-46a2-9bdc-76d8adf7560c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="4d720341-2a6b-4344-b168-27d7e4cc0996">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="b443a2eb-dfb7-4eea-8269-266ef32a6c4f">
+      <statement statement-id="pl-4_stmt.b" uuid="c46e6105-5a63-49db-bf1f-73b389843af6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="5a66233c-cc85-4bfc-bc52-b59f563383f7">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="6dd59bb6-149a-437e-87a8-4a8197ac09a0">
+      <statement statement-id="pl-4_stmt.c" uuid="2f333acf-78a0-4ff4-b462-cff0758b291b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="b3241d22-cc73-4fb6-820b-7abf0a66683f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="635c3a76-7e3b-4fd6-b990-3657fecac793">
+      <statement statement-id="pl-4_stmt.d" uuid="4f93d123-f0b7-41ec-8ad8-3b8862704db2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1506,10 +1506,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c41299c-eb62-420f-9318-aed0dee5440a" control-id="pl-4.1">
+    <implemented-requirement uuid="befdd6de-025b-45b9-bb1d-1904009c1805" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="9cbae24a-5074-4f54-99e4-3056ed768ae5">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="db57595a-42d2-48fe-bf04-71a580d509c0">
+      <statement statement-id="pl-4.1_stmt" uuid="2b440776-5d21-4e64-8135-54ff7feffdd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17ac9647-3ab7-479b-8945-90c0e73b1faa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Enterprise Linux configuration.
@@ -1517,26 +1517,26 @@ applicable to Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba5bb884-1a91-4dfa-a2a0-e310fe82f4ff" control-id="pl-8">
+    <implemented-requirement uuid="d36b86a7-bf0a-4413-bb8b-b9fc088f748f" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="894a5eaa-3a20-40ec-8ea8-83050825a736">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="25184f18-5176-467e-9acc-92df52eb0715">
+      <statement statement-id="pl-8_stmt.a" uuid="28433225-ecd9-4fbb-ad7b-f3440807c5cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="21d976f0-fb0b-4660-9ef8-a0fa5cef97cf">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="20df0d46-d3ad-4860-84d5-f181ceae5c1c">
+      <statement statement-id="pl-8_stmt.b" uuid="79100567-b6d1-4a03-870a-6dcdfd334078">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="a28c51b1-c08f-406f-8065-def72b0cd345">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="e1fe192f-dcb5-41ee-a663-e0c26299e286">
+      <statement statement-id="pl-8_stmt.c" uuid="28d8ca15-8a90-4601-99a2-be94f976857e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a38c107-7dd3-417b-bd56-95c3002123b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Enterprise Linux.
@@ -1544,10 +1544,10 @@ applicable to the configuration of Red Hat Enterprise Linux.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95be86e2-0ca2-4ed3-83c7-7576f09bb214" control-id="ps-1">
+    <implemented-requirement uuid="c988b60d-465a-4ff5-b48a-725e3a78d86a" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="335be4ca-48aa-4d22-9310-b2d138ea1ae5">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="74a30d47-a25d-433b-a86a-1ae70ea5ad1c">
+      <statement statement-id="ps-1_stmt.a" uuid="0d51f17d-3553-4efc-8ffd-225ef6ca9909">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1555,8 +1555,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="73ad9b24-a9c0-40af-85a5-9e15f3b75afa">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="d4dd1edc-76f7-4d11-ab4e-4a7b21066035">
+      <statement statement-id="ps-1_stmt.a.1" uuid="0aa5b922-5a46-4e23-a13b-3c3dc4d2394e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1564,8 +1564,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="2ca60311-1059-466c-a193-69937c0a5108">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="dbb2d02c-8d92-44d6-b38b-b40e24337698">
+      <statement statement-id="ps-1_stmt.a.2" uuid="c46c9f16-3014-47ad-bcf4-7fe5b7f7eef3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1573,8 +1573,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="d76622b3-d29d-48a3-8d3c-ed9f810f618a">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3c5bf195-19c2-4b17-802a-275597877716">
+      <statement statement-id="ps-1_stmt.b" uuid="3b162d5f-320a-4980-96a4-827861f26603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e1a01d7-b935-4923-a72b-5fdab355ca76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -1582,8 +1582,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="559c8346-2293-46be-9daf-1f18902db86a">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="a31e89b5-4135-46d0-b96e-b7c9fef70d84">
+      <statement statement-id="ps-1_stmt.b.1" uuid="40256f60-3c90-424b-8d79-8a8be97a6d02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1591,8 +1591,8 @@ is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="b76427fc-507d-4d43-9756-4d194fcdd020">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="3d9cb216-a60e-4d8a-a43d-a322a2116764">
+      <statement statement-id="ps-1_stmt.b.2" uuid="390198da-0711-49ba-ba04-7e623e2f872f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f35720a2-4c26-47e0-b150-10fbdef09485">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -1601,18 +1601,18 @@ is outside the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3289a19c-b8a2-4c11-a26e-9f0c7832859a" control-id="ps-2">
+    <implemented-requirement uuid="4013a119-4669-4462-b32c-a13a61913347" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="bc8d913b-2648-4909-808a-006d357990b9">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="dd223f7a-5e90-4013-9cd2-20ffbb8386e9">
+      <statement statement-id="ps-2_stmt.a" uuid="1388f2d8-ae86-4819-97e2-5768ca9dc4b7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1f82811-f626-4ecb-9987-0e5c056a792f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="f6e4a8b1-46c9-4031-978c-d195614e5e78">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0db890fe-a3ab-4d43-9f32-7286e3ee5ab8">
+      <statement statement-id="ps-2_stmt.b" uuid="277a1997-199e-4df9-9aff-3a28c98b2569">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="76dc6db9-0389-4e6b-b889-0cfc81206704">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Enterprise Linux
@@ -1620,8 +1620,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="45dd3daa-8e76-4b39-bd7b-330b5c39cf1b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="e7083019-2fd3-45d7-bf6f-8db63e6d083f">
+      <statement statement-id="ps-2_stmt.c" uuid="421af13e-3066-4d91-89e9-3327af5f2d90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e37e2c3-8e83-48a9-a8f0-3e10cbda33b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -1630,10 +1630,10 @@ of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6268ccb2-dcc6-42a1-9913-bd01b5054bf8" control-id="ps-3">
+    <implemented-requirement uuid="f7be1dbd-86aa-41f8-b1d0-67ff78c56022" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="f276d245-3d78-4b95-a97d-5273970bd083">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="9305fcab-5253-4cf6-803a-f62e7d47fe34">
+      <statement statement-id="ps-3_stmt.a" uuid="4b0f8c16-3670-44f5-9304-3dfbb1e47801">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f5ce677b-00ef-4acd-a893-6a1108779fe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Enterprise Linux
@@ -1641,8 +1641,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="307d00aa-2cfe-4265-8ded-e68222571a1f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="8699fc58-5793-4dbf-a0e4-47bb59f8e3a8">
+      <statement statement-id="ps-3_stmt.b" uuid="94fdd023-e571-45e2-96ea-e752c9f6f201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4e0488e-a97a-4a7d-b05d-a628a196dcf4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -1653,10 +1653,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="293cf441-1501-457a-b972-8f297ca9c8c2" control-id="ps-3.3">
+    <implemented-requirement uuid="3959ccbc-54ed-4af9-9c1b-d819ab34008c" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="867127d1-0187-4396-a119-285f63775672">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="31c1c863-d3e8-48fa-b612-d1bb80c82a4c">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2cc3204c-5d15-4f86-bc80-67ef31dfdd43">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4149b12e-25db-459f-920b-dd7c6cc1d6fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1666,8 +1666,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="e9cf55a6-2eb6-45ce-a4d1-88f2dd758351">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="30a69b2e-da2c-44b6-b622-98b62fe519bf">
+      <statement statement-id="ps-3.3_stmt.b" uuid="4993cea3-da26-44a3-aa3b-d596533cc62d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7e0d2c3-63eb-4bad-85b8-e6e8a1437fc1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -1678,10 +1678,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2b8aaae-ec9d-4017-a0b7-935e9d4e5ed7" control-id="ps-4">
+    <implemented-requirement uuid="b4b68dad-4698-4307-b5d5-368927e4ca81" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="9fb17099-7826-4968-8223-78e99386f462">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ba8ff20d-c260-49e7-b0d2-4e9c1701aea2">
+      <statement statement-id="ps-4_stmt.a" uuid="e713072c-cd4d-4957-8a6a-89312c814a72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4131e0d9-2ae1-439c-9390-594d5fe724b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -1690,8 +1690,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="92b16698-741d-489c-ad8f-59f9423517f3">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="6b31fe41-f1b3-4fe6-a5a2-f09215bd0db0">
+      <statement statement-id="ps-4_stmt.b" uuid="82bbc369-291d-41ad-8142-adf503f51a3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="855c02d1-a80b-4fe4-9e88-b9f1541c7966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -1700,8 +1700,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="106b0334-a79c-4621-8521-1853ccdf0a32">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="858cc652-ce35-42cc-913d-ff09f22248d4">
+      <statement statement-id="ps-4_stmt.c" uuid="89d535f9-c9da-406c-89e0-4a5fdf524ef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe3d101-0b7e-4306-8a60-a83386d2902b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -1710,8 +1710,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="82ffca28-7ad2-48bf-851d-bc116c3fb080">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="776b5469-b144-44f2-96e4-cab28d754c77">
+      <statement statement-id="ps-4_stmt.d" uuid="e84edbfc-357a-4010-a60d-3d3a9101fb6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2fcf347-7359-4cb0-9b78-4495cb51f9fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -1720,8 +1720,8 @@ of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="4e258333-a52a-496b-965d-1e51e2705263">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="c76c8682-84f5-45a0-8fa2-e94e404a8057">
+      <statement statement-id="ps-4_stmt.e" uuid="3e3d11bc-4f79-45e6-a8c8-5027ae4fa3cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09c8db57-2a8e-432e-bfcf-7751092dc5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -1730,8 +1730,8 @@ are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="51a0f10c-5eaf-4629-b416-030fb9c74fe9">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="7cbbdb3e-90cc-49df-bfd9-4533e06bb18c">
+      <statement statement-id="ps-4_stmt.f" uuid="1dced8bb-23f9-4853-9127-e579658554b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0416027-169d-43e4-816d-a7d11f28ab5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -1741,10 +1741,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ab154c6-064e-4a55-ad21-8a983d5f9d65" control-id="ps-5">
+    <implemented-requirement uuid="c13693a6-8717-4c41-b9a5-4f30ce6f8101" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="e175d013-e1d3-4d5e-a682-b8b506eb9c8b">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="dd7bd459-66ba-4be6-963e-67992dd5efb4">
+      <statement statement-id="ps-5_stmt.a" uuid="e1489dc0-a117-42be-b778-82b7750998cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479491e8-8dea-4f0e-b7d3-ffd22903d2b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -1754,8 +1754,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="a278b921-3c98-4b10-983c-f603f7f1767f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="0383aa7d-fb3f-4859-b8d9-f97bb6b9dd65">
+      <statement statement-id="ps-5_stmt.b" uuid="4a9feaa8-de4f-4163-ade4-79cc444243ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4f79abd4-01cc-4a13-9688-27c5d024bfcb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -1764,8 +1764,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="595d8136-c04d-4cf6-8f72-0f61ff93356f">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="1fd75bd4-c7f8-4150-83eb-381c16ace9c2">
+      <statement statement-id="ps-5_stmt.c" uuid="dc70a4f1-e6f7-413e-b681-a8c1bc3c046e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e9e3993-12c2-4701-b54f-a4840a0c6bd7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -1773,8 +1773,8 @@ or transfer are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="b43d822c-620b-4d87-95ac-9a3a9c979cc0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ebc61d80-0e6c-49e8-9b8b-0bb949e48c20">
+      <statement statement-id="ps-5_stmt.d" uuid="1db9f2d5-379b-4c98-a6e4-00940b0e110f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5065e649-c75c-4114-b472-32d24cbfad15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -1783,10 +1783,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="594e9207-07f7-45cf-9450-7b5d05b8fe65" control-id="ps-6">
+    <implemented-requirement uuid="170cfb24-bb93-4702-90d1-8d17b5c354fd" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="2b136352-f0c5-42bd-a2dd-d1347ed0cf28">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="8400e1d0-6f1a-42c4-bcb7-35f2b6f65c23">
+      <statement statement-id="ps-6_stmt.a" uuid="2d92b85d-052e-41e8-a286-e555d06de10f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21e5d497-9123-4f23-8057-62ef9c31ccbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -1794,8 +1794,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="c9d726f7-c5e1-4de4-a1de-bfb6c0700fcf">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ea9eb9bf-6ece-440c-bd99-a0c7cd9f6320">
+      <statement statement-id="ps-6_stmt.b" uuid="4f3ef13a-e090-4d16-8b0c-9e889bae67db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="adb9b134-e07a-4289-b7d5-9b540c238761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -1803,8 +1803,8 @@ Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="d77bc97a-8816-439f-b581-201d4187ae62">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="f348c728-b3b0-4153-b7e4-abb6675aa683">
+      <statement statement-id="ps-6_stmt.c" uuid="32edf3e6-203c-4450-83ff-cf925412a8ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1812,8 +1812,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="0a3bbc1f-8aeb-4cfe-8a16-12e29f2dcfb0">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="17a8962c-b9a2-4c88-aff0-89b6f1ac16a5">
+      <statement statement-id="ps-6_stmt.c.1" uuid="0ec17fd5-01a5-418d-88b7-f844e61ca31b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1821,8 +1821,8 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="be81fc3a-5b30-4856-8bb7-47c523e29888">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="f34c4c7d-9c28-41d2-9d8a-52c43429bf97">
+      <statement statement-id="ps-6_stmt.c.2" uuid="085ff1ac-a28c-4d4d-ac7c-a9458cceb105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b16478ac-2be8-4826-a331-d89f1f9c817e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -1831,10 +1831,10 @@ access agreements are outside the scope of Red Hat Enterprise Linux configuratio
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d000a0d3-b86c-451e-84e3-840a3be77851" control-id="ps-7">
+    <implemented-requirement uuid="71d0c115-792b-462a-a349-f36740aa5544" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="b74fce62-074a-4f33-be39-ac4219569b14">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="e6c8737d-706a-4a83-8429-69a0ed47d890">
+      <statement statement-id="ps-7_stmt.a" uuid="0adf029f-4aec-4849-a44d-24e76dd274e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a6b68a7-216e-4f2d-a7d6-017baa605b65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -1842,8 +1842,8 @@ outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="c877222d-32ea-48e6-9deb-4b6ba50798af">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="4cb7ab83-8d22-4503-8612-d9d55652e926">
+      <statement statement-id="ps-7_stmt.b" uuid="d7de56d7-ee30-475c-99c9-c76655387b24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="72edc7fa-1400-43a6-a419-b63392aa46b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -1851,16 +1851,16 @@ the organization are outside the scope of Red Hat Enterprise Linux configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="1fe9f9c6-cfe7-450d-b54c-dad0101c517c">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="ded83ae6-e517-440d-811f-753019138877">
+      <statement statement-id="ps-7_stmt.c" uuid="c93764f1-b0bd-4889-bd27-cb577fb9109c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="71831662-dfd7-442f-8e95-0142f1d3c5c4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="c677a0e2-0449-4d89-94f3-fcec4ee2c1b6">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="fa7d1038-a3b3-4fde-a51e-3529cb818441">
+      <statement statement-id="ps-7_stmt.d" uuid="c6d320d9-3ce8-46fd-a00c-8963e666aee0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7757d8f6-0ae6-42b5-ae0f-9e3059c7efe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -1871,8 +1871,8 @@ scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="32202eac-772f-4886-8471-c99ec9bcbfbe">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="73315d83-bb0f-401c-9685-937d538acfd1">
+      <statement statement-id="ps-7_stmt.e" uuid="85911840-5a9f-4809-8966-3b61e611f684">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c5a474a-0081-488e-8770-80e2de25b009">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Enterprise Linux configuration.
@@ -1880,10 +1880,10 @@ the scope of Red Hat Enterprise Linux configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5841dfe8-1110-4a4f-8d97-913bf787dd4b" control-id="ps-8">
+    <implemented-requirement uuid="7a65e74d-e2e7-493a-a7ba-b05985a49cb2" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="f7db9aeb-cf40-424c-b873-92e1e9a3ed6a">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="dc3f320e-2290-498a-b74c-7fafb4ed04ce">
+      <statement statement-id="ps-8_stmt.a" uuid="53be986d-9088-4b95-a7f2-9920267fa519">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660bfa1c-231a-4b9c-9f2a-dbc99d75ef46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -1891,8 +1891,8 @@ and procedures is outside the scope of Red Hat Enterprise Linux configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="f0f9cbcc-d9ef-4688-a514-6ae7a4e98132">
-        <by-component component-uuid="17264c11-5b53-4a3d-9d07-640215a87278" uuid="a3021452-baa4-438c-ad38-b5526f416f28">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal

--- a/xml/virtualization-host-fedramp-High.xml
+++ b/xml/virtualization-host-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="7a2c6538-86e9-48f0-bfce-be0527d64599">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="2d260eed-b55b-431f-9f66-57c087e6c8e3">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.82+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:21.01+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="d4f2114e-a5ab-47c6-912d-3c3bf4c4bc69">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,69 +484,69 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="31f91227-29da-4897-b1b8-9faba32c3ce2" control-id="ac-1">
+    <implemented-requirement uuid="fa701737-9ee3-444f-a822-2d00abc0ce14" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="b4643a9a-6452-4344-b7f8-5b9254569b3e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0d06e820-84ea-4f56-bdba-cba6a37aff4a">
+      <statement statement-id="ac-1_stmt.a" uuid="e79f158e-6add-4530-8fae-a14530cd3213">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d5ec4f2-5bc7-4425-a8c6-db4371696baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="2c8d22b7-af57-41e4-a784-695420779b3d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fac0b3d1-6fc4-491e-aa6a-dd430d3e029c">
+      <statement statement-id="ac-1_stmt.b" uuid="383a924d-c22a-4209-a9e4-1d75bcaf3ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0128bd2-2067-4f52-91c3-7b52eb85b101">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc5b5ac6-c2d7-458d-8f06-41c6094e68e4" control-id="ac-2">
+    <implemented-requirement uuid="4fed2379-d30b-41d3-9ffa-9f8e4eb1489f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="e00ec1b4-a9ed-4775-b9a5-420693c90cda">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4c97297c-84d4-4539-b3b1-62db37851b16">
+      <statement statement-id="ac-2_stmt.a" uuid="bcd3cce4-0c2b-408a-80ec-da208033ff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="110cfea5-2aa5-4a93-8c1b-5063e328712c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="f3c3c9ad-34fd-4656-a517-6362aed23cad">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8cfeeea7-ddf9-47e7-b762-9409a8dbe23d">
+      <statement statement-id="ac-2_stmt.b" uuid="faab07b6-9814-477d-9601-7aa872c416a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc79e596-54a3-4f76-9f56-f82751e10396">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="6b9f3df1-2364-4028-96a4-a450fbf8ca3d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="172f4b4c-86e0-4203-ac6b-85cb09d2d6bc">
+      <statement statement-id="ac-2_stmt.c" uuid="167f867b-56bd-40bd-9249-0f5ab7f2a8d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f2a97ea-8b2b-4bda-ac51-fec3c2116e45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="b8697f81-535b-4875-956d-ad663882ea78">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0a809baf-9ad6-4f75-8224-344dec062b1f">
+      <statement statement-id="ac-2_stmt.d" uuid="4056bec3-4b46-4f62-bf68-ae47db08fa6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0597b132-ef8a-409d-bad0-3ad622e4ff0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="71653a01-856f-4280-ae92-bcb7383b180a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="77b6681c-beeb-405d-9dcd-c35f11030c68">
+      <statement statement-id="ac-2_stmt.e" uuid="198cda94-0fd7-45a6-b02a-1cec97445351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87a9cf41-a3c6-42c0-85e5-1579f696a03c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="87b9eb48-cc26-4bbb-af12-baae304e45c7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a7f4823d-81a3-4ac3-9db0-2c4ebb75888a">
+      <statement statement-id="ac-2_stmt.f" uuid="b9383762-ed06-4fa6-9168-aaf501bbbea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d33bdb-a014-43f9-aa39-4635db1660b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="6154c43d-9df8-4fd8-8bd3-f16eb886a403">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e047044d-e7fe-4f3c-8ac7-7604b83e108b">
+      <statement statement-id="ac-2_stmt.g" uuid="2448f24a-9cbf-49b0-9f0c-e9405e348158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb26ba54-f3ed-4d29-816a-1e4132fed948">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem must be enabled to ensure audit and monitoring
 of Red Hat Virtualization Host (RHVH) information system accounts.
@@ -560,39 +560,39 @@ events that the audit subsystem will be responsible for capturing.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="880b074b-916f-44e0-a15e-adefc2768c2c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="23f099fd-48ef-405a-b040-32ac3c7da66e">
+      <statement statement-id="ac-2_stmt.h" uuid="28c65170-7539-4b0a-8d70-9cc9ab7add25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fafd74a5-41c4-414e-8d9d-ba79a2bf4e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="21381bc8-0317-4e2b-9c7b-2b7e328200ee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3be859e3-7aba-42fc-b051-96785f2f5b22">
+      <statement statement-id="ac-2_stmt.i" uuid="f2517473-8de0-4df7-963e-6c0072e94b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aab400c6-783e-4b90-8b47-4c6df01cf2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="59fcdeb2-1bfc-44be-a009-d682f522b338">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="532d4d06-7717-417d-8b54-d3978a370bca">
+      <statement statement-id="ac-2_stmt.j" uuid="d011ba12-8d77-4068-8ea2-16b092b8341c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f829215-f634-4e0a-86e4-3ed5702c4780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="a616788a-1399-4608-b7a6-2675e27956b5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1e7b84c2-09f3-4333-9c50-400a6a319277">
+      <statement statement-id="ac-2_stmt.k" uuid="56388cd2-93d8-44d3-8dcd-4979ae202a2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bb7841-0542-4c4a-825d-a45e7a294b4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9b30c87-1bee-48e9-abc4-e8052ecb8398" control-id="ac-2.1">
+    <implemented-requirement uuid="8bab6c99-f7f1-4eec-8186-0b368e17e893" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="52635493-c1c7-42d9-8744-89d740b9e2db">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a2a88d9e-8c77-4bb2-812a-a4babba25c32">
+      <statement statement-id="ac-2.1_stmt" uuid="db4c5cea-a43c-4c9f-b35a-52ec0e9d75b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2835a50-2963-42d1-a2d1-be71091d9b4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) components of the system support automated
 management through monitoring of accounts and system
@@ -612,10 +612,10 @@ https://projects.engineering.redhat.com/browse/RHV-19937</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4e7bd2b-0259-4557-b776-1b3edcaef30f" control-id="ac-2.2">
+    <implemented-requirement uuid="e11fe50b-0289-44ce-b413-bbe5e6630e53" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="5616b870-4d73-4444-ae7c-fe8bb6301e78">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5b265d3a-bede-4ea2-bd32-dd85916bb1f0">
+      <statement statement-id="ac-2.2_stmt" uuid="4e6c903c-a518-4cb1-96fb-bf7f0be7fc33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aaf3fc9b-bcd2-4038-9483-f843224a1aa0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) does not have the capability to automatically
 delete guest/anonymous accounts or temporary accounts. Any
@@ -625,10 +625,10 @@ identity service (e.g. Active Directory, LDAP, etc.)</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac5509cf-872c-4ca9-b323-bf9b90f0031b" control-id="ac-2.3">
+    <implemented-requirement uuid="704d6fd5-d8b8-4452-9429-bcdc9d2d31e5" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="4dea5d19-e65c-4254-bef3-6fde490a0dee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="43d38b70-6401-40fd-b5d1-735c1e058678">
+      <statement statement-id="ac-2.3_stmt" uuid="2793ab65-312d-41bd-9540-f3525fc62391">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="381e0da0-8465-4ad2-ad7c-29ec45d6079f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -637,10 +637,10 @@ https://projects.engineering.redhat.com/browse/RHV-19938</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efa8560c-8397-455d-b69c-7b73533195a5" control-id="ac-2.4">
+    <implemented-requirement uuid="27d8f87a-5fc4-47af-8466-b3411e509250" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="938ed505-74ce-4fdf-9ea4-9b9f05aa466f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88f189fe-5da5-4f53-a1b1-b85e2eb8e6f6">
+      <statement statement-id="ac-2.4_stmt" uuid="eaebd66e-070e-4cd7-a27f-a1f698b92a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="beb2350c-a692-4a5a-8336-d126cb5462a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -649,10 +649,10 @@ https://projects.engineering.redhat.com/browse/RHV-19939</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4a8a89b-cace-4f47-9198-d3d8ad838423" control-id="ac-2.5">
+    <implemented-requirement uuid="dd5e5105-d2cd-4733-9fd5-fd3020397f4e" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="08e8e081-c144-4115-8f8b-81013abbba8b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e61c9313-5fc2-4208-bdf7-e5a803dd9ff6">
+      <statement statement-id="ac-2.5_stmt" uuid="3c6eb3c7-fc42-4181-a8ec-da4f7e3b6b9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2645dafa-cbbb-4d6a-84f0-4d1ce85741c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -661,10 +661,10 @@ https://projects.engineering.redhat.com/browse/RHV-19941</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bf72d96-6bd7-4c11-a015-32f4daf46ce0" control-id="ac-2.7">
+    <implemented-requirement uuid="59e36a09-44ce-40b8-9dca-b3fe96440226" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="7708db99-90fc-4f65-a1b0-59e1bd96341a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="aea16402-a22e-4e68-9b9c-e7b07d81a14c">
+      <statement statement-id="ac-2.7_stmt.a" uuid="f19cdaaf-9b1e-48e4-9b3d-2b356087abe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e056b0fb-5e60-4904-90b7-a7a6f3936b64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -672,25 +672,25 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-19943</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="b2dd7408-09c0-46c5-ad5a-26936eeac693">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="32a4291c-8970-4a69-9565-b10e4946171c">
+      <statement statement-id="ac-2.7_stmt.b" uuid="517d0a5f-ad8a-4807-bbc4-eba579cde3b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1a7c635-b639-43fc-86bd-302623c80dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Host (RHVH).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="a8b15949-0ce9-4b6a-b945-aad40f9a8156">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ba6093d6-43f9-4027-897b-660726720cfd">
+      <statement statement-id="ac-2.7_stmt.c" uuid="55917923-c220-4396-97c9-f3b6cc8873c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1a7c635-b639-43fc-86bd-302623c80dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Host (RHVH).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d57b58aa-0891-437e-96af-e21563a66645" control-id="ac-2.9">
+    <implemented-requirement uuid="1d86c2e4-5c81-4ea1-804a-9448299e4adc" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="7d21e3b1-784e-4352-8eaf-5e47012b9731">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d0bf6304-352d-4942-9c99-8a24d93bcc33">
+      <statement statement-id="ac-2.9_stmt" uuid="f8e4cf40-b558-4e82-8706-750ab1823701">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b54761c-9e15-4895-ac45-02ed31e96ffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -699,10 +699,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="455f1dd5-637d-4d35-987d-055228b983c8" control-id="ac-2.10">
+    <implemented-requirement uuid="c9c3bf55-612c-4339-9e25-aaf3b2dfcf53" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="16f8c442-4d02-40a1-84ff-bb445f4e1769">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="04caaa28-c354-449b-bb89-bcde88117f9a">
+      <statement statement-id="ac-2.10_stmt" uuid="852836c7-18b4-4191-a4a1-525e217c407f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b54761c-9e15-4895-ac45-02ed31e96ffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -711,10 +711,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df2d3f3a-3ab2-4e16-bcfe-23c3347a56d1" control-id="ac-2.11">
+    <implemented-requirement uuid="fc70d9c9-e756-44a7-a30d-d35546199359" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="36daacdd-3491-4495-93c8-36931216e366">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="72c434d2-44b3-4d38-ba21-b80b5f4c94ef">
+      <statement statement-id="ac-2.11_stmt" uuid="206b41d8-0aa3-4d1e-9ab4-c14bb493d908">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f9fadb0-2ae3-4603-af48-640a639f9981">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -723,10 +723,10 @@ https://projects.engineering.redhat.com/browse/RHV-19945</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c85ca04-162b-4090-93d7-27afa81f4d98" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="a7ab38d5-84a4-4fcd-be4b-5c0eec79b7af">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="04efa1e4-4a60-4928-9c33-435f860c47c4">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -734,8 +734,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="85890193-dd2f-4659-a12f-d61b26f63f1b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6afbde96-80fa-4ec0-820f-0c8229c0fa88">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -744,10 +744,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c1f22c6-bcca-4764-a789-32bf367b9386" control-id="ac-2.13">
+    <implemented-requirement uuid="9acf0cc8-f955-4bdc-b6ba-168f06052b5e" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="3187811c-1454-45b9-a30a-452e8a4a0d2e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dc0811f1-a93a-448b-abf4-7dd46220cb2b">
+      <statement statement-id="ac-2.13_stmt" uuid="f102a128-ddfb-41e6-b2d0-93af2e08babd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74cf5a18-ead4-4dc2-a5ef-b0e174d6435f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(13) is planned. Engineering
 progress can be tracked via:
@@ -756,10 +756,10 @@ https://issues.redhat.com/browse/CMP-211</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b8ea454-d457-4c93-b847-9ea9e0d085a3" control-id="ac-3">
+    <implemented-requirement uuid="291df6ca-5c31-48ec-a484-799392cc4d19" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="b8de8031-bb93-4b55-a9d9-4a8fddf7c3ab">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7c99b80d-1406-42da-a791-c8995f49780b">
+      <statement statement-id="ac-3_stmt" uuid="f358ffb9-7aaa-415b-8eb2-48fee861d62c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c28f339c-fbcf-4674-aedb-82d4be2d5649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) is capable of enforcing
@@ -791,10 +791,10 @@ approved authorizations for logical access:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2345e55d-b1ea-48da-861d-da89011d233b" control-id="ac-4">
+    <implemented-requirement uuid="fb206e6b-1e3e-463a-9813-1054cf5eb413" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="b7328c32-5ff6-4a58-87d8-59842eaf0db9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="72d28c8d-d139-48b5-8d1f-3643d79fc2a6">
+      <statement statement-id="ac-4_stmt" uuid="431a8b3f-25c1-44d5-b6bf-f6e13d08bf46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d03a35b-2b3c-46a6-934b-24d7d32561c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -803,10 +803,10 @@ https://projects.engineering.redhat.com/browse/RHV-19975</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14aa5049-9bec-4873-a381-1049db2866c5" control-id="ac-4.8">
+    <implemented-requirement uuid="b3434369-e9cc-4b1c-86fc-20dba450a462" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="1c924b81-ec7d-4899-bbf2-41143240430f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8077ac7e-734d-4163-9363-406d6c8a8633">
+      <statement statement-id="ac-4.8_stmt" uuid="7695bb28-9f62-4734-984f-ae6336dc9f1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13f7b221-9cc5-43d3-8086-48b4dbf97f53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -816,10 +816,10 @@ https://projects.engineering.redhat.com/browse/RHV-20076
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="424ea77d-78ec-41d3-8764-ed20fe16098e" control-id="ac-4.21">
+    <implemented-requirement uuid="552e2d31-d520-4e5f-bdf2-fa21f7df835e" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="5a691b47-393c-431a-8e2a-8ed5645507bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="612e4d40-773a-4ab3-a146-acfaab6ef100">
+      <statement statement-id="ac-4.21_stmt" uuid="a45d1455-852a-47aa-a2d0-c063b9663faf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314eeab2-b5af-48d9-a8d6-b30a00f379e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -834,10 +834,10 @@ https://projects.engineering.redhat.com/browse/RHV-20102</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88458cd3-0cc5-402a-ad74-f95bd61b1b72" control-id="ac-5">
+    <implemented-requirement uuid="58a6ee2c-595f-4f45-941f-9e0c16f6a5e2" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="372f84c9-efa3-4d41-8fe4-b97746932d0d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="886a6d7b-fb41-4b2d-806e-39b9af7b6b7d">
+      <statement statement-id="ac-5_stmt.a" uuid="da9cca65-af73-44f4-9bf6-1da00da0d3aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31feef7d-c449-48ac-ba1f-06b38f1488bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -848,8 +848,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="63d10d18-6c2b-47dd-a4f1-d5b228019694">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2669da0d-6d67-4bf3-b95f-a38371820224">
+      <statement statement-id="ac-5_stmt.b" uuid="fc671f60-3b5a-4937-9e6c-b5c5c936463d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30617341-8f13-48f3-9e3c-a123e8b5a4bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of Red Hat Virtualization Host (RHVH)
@@ -861,8 +861,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="4b397466-07fe-40c5-ac18-2610b4b2d72f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c9266f0f-cf9c-4fd9-adc7-4aacda6365cf">
+      <statement statement-id="ac-5_stmt.c" uuid="4928af4e-8ef5-4de7-8ca6-954f97575323">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393e6d1d-c15d-40ec-970d-c90308821e4a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -875,10 +875,10 @@ user is allowed to perform a given action.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2c48866-f25e-48b3-aeeb-8fc71707fb2e" control-id="ac-6">
+    <implemented-requirement uuid="cd068943-85d8-4507-bfc6-c1b5ac06fed1" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="30044703-5598-44c9-a711-3bdc1f651592">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fd55e3e4-a7fc-43ed-9262-bc704f087cd5">
+      <statement statement-id="ac-6_stmt" uuid="395124ff-7909-468c-8c26-9c019a94a445">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12714d47-155a-4a25-8adf-0c9fa759d3d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -888,10 +888,10 @@ https://projects.engineering.redhat.com/browse/RHV-20104
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d328a30-c44e-430f-af37-1e18786d2426" control-id="ac-6.1">
+    <implemented-requirement uuid="79009ec5-feda-41fd-9466-3d1170902932" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="2480264d-c51c-4cba-86a9-8aaa3aa42f27">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2e1394ac-75ad-4997-b5f4-ef9b61348358">
+      <statement statement-id="ac-6.1_stmt" uuid="bbedf025-0a76-4145-a3a8-e0772c011e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e72751f-1477-4bd5-9b86-4079f8d1c129">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -901,10 +901,10 @@ https://projects.engineering.redhat.com/browse/RHV-20105
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7176d96b-0b3a-4b5a-b208-ebe4a0ab2be3" control-id="ac-6.2">
+    <implemented-requirement uuid="438d7426-4873-4b73-bafa-335b630ea2dc" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="930713c5-7b06-4bac-b6f2-bc667fe796b5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="218dfffa-492f-463e-8dd4-5f1113e816f4">
+      <statement statement-id="ac-6.2_stmt" uuid="b74056ce-c15c-4104-bebc-7b5b288dcc66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="184f857d-53d1-4eda-bee3-b631152658d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -924,10 +924,10 @@ https://projects.engineering.redhat.com/browse/RHV-20126
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e393e306-bb82-43de-8e6a-08e24e068bea" control-id="ac-6.3">
+    <implemented-requirement uuid="62d6d75f-1ef7-43e7-be3a-407a04af09c6" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="30c49b9e-e8d1-4a0f-845e-a7eeb06072fd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f94effdf-bbe6-4b7e-b72b-74c5e4710c62">
+      <statement statement-id="ac-6.3_stmt" uuid="80514836-07d6-4043-9368-5da868c37e01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4da87f82-32b3-46e9-82fd-600ead90dad9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -937,10 +937,10 @@ https://projects.engineering.redhat.com/browse/RHV-20143
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4ce46034-0752-43b1-aba6-b4013813b3e6" control-id="ac-6.5">
+    <implemented-requirement uuid="2a1661e8-ae24-48b7-9cb5-8a9c7749ac0d" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="26ff86b5-c7a1-433e-ad43-ba6278bb2e8e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9a014be1-1b75-4074-bf3a-648c8237e397">
+      <statement statement-id="ac-6.5_stmt" uuid="29749905-8d71-49a1-8698-80d5f8c63afa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb127ed5-b226-47ac-9b29-fb68288063a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -955,10 +955,10 @@ and login with an account that has received appropriate RBAC rights.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aa3ae22b-5786-422f-9625-0a4c7ff2c231" control-id="ac-6.7">
+    <implemented-requirement uuid="2f7f5e51-312d-457e-a168-681432ec6666" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.7_stmt.a" uuid="e29b0c26-120c-41c7-8157-cb4b134c863a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="99d0f1b2-8999-496f-aafa-6d4dabad040d">
+      <statement statement-id="ac-6.7_stmt.a" uuid="7725e7ef-f7de-4335-a405-9da1e8dabbbd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45854c9d-1160-4c98-9707-ab9d45ca2d3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration. It is up to the organization
@@ -966,8 +966,8 @@ to review and validate users permissions and privileges.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-6.7_stmt.b" uuid="89fb98ef-4e52-4e77-8867-54d68db440ee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="536dba31-178b-4ca8-94c4-6318bec8540f">
+      <statement statement-id="ac-6.7_stmt.b" uuid="b1efb5cc-4792-4727-b54f-78912ae5899e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45854c9d-1160-4c98-9707-ab9d45ca2d3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration. It is up to the organization
@@ -976,10 +976,10 @@ to review and validate users permissions and privileges.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fc886c0-e0b7-4925-a767-e6c68a7e7891" control-id="ac-6.8">
+    <implemented-requirement uuid="3c24a783-e449-42b3-8784-1575ff12643e" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="63d91603-b56d-4dfe-8639-51f9f8f5ad85">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a3462d95-691a-42ba-80bf-5077b26d11b9">
+      <statement statement-id="ac-6.8_stmt" uuid="766832b9-f295-4797-bf46-43a31e220f63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31e2fe07-d678-489f-9b11-cbbe9bac93f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -989,10 +989,10 @@ https://projects.engineering.redhat.com/browse/RHV-20148
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98c86aa6-deaf-400c-a03a-143b132d9533" control-id="ac-6.9">
+    <implemented-requirement uuid="435c04e1-8c27-49fa-8e5a-112bf8ed04af" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="eca6ef10-369b-4bd9-9c3b-20b63396b6bd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2cc47a6d-e49d-470d-8047-ab43ae519dea">
+      <statement statement-id="ac-6.9_stmt" uuid="4dec473d-de52-4b32-b0d1-cad9f73f8cfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023ccb0e-4287-4b46-baf4-be96cd66a27f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -1007,10 +1007,10 @@ https://projects.engineering.redhat.com/browse/RHV-20149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e2c86c8-ec15-43df-aa24-710056b81c76" control-id="ac-6.10">
+    <implemented-requirement uuid="7949fd53-0e80-4c80-bb4b-9a7c96bf9e66" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="60418df0-3141-4e9a-a9a7-c1452620654b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0835a865-8fdc-4681-926f-2c92b11f32e8">
+      <statement statement-id="ac-6.10_stmt" uuid="f4f90226-de6b-4803-b91e-66e2e0913185">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d898ce-e363-48cc-87b7-0b6b804c10c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -1026,10 +1026,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2036d30c-8d17-474e-b433-ee5eaa9c6f58" control-id="ac-7">
+    <implemented-requirement uuid="bd4093af-1e69-4000-9685-fa2b09f1b859" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="2a7b49f0-ef97-4cda-9bad-1c22154bf358">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b00d6f84-90e9-4c9c-bc41-51a406fdff29">
+      <statement statement-id="ac-7_stmt.a" uuid="843757dc-c3bb-41bd-aa7e-23b34c22de8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4da5858-8f53-42dc-89eb-d0d477853378">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) enforces an organization-defined
@@ -1048,8 +1048,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="feeecd9c-3875-4ca9-a77a-919c79ac49b0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d8882b90-18b5-4d4b-bbca-3e2fcc47663d">
+      <statement statement-id="ac-7_stmt.b" uuid="1e1a552b-bb76-4aa0-a438-9a7c5faa9e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96ad9325-f04e-460e-b295-69b0b407ad00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to automatically
 lock an account for an organization-defined time period, or to lock
@@ -1073,10 +1073,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f46876b-290c-4d87-ac71-e29925fb65dc" control-id="ac-7.2">
+    <implemented-requirement uuid="58537ae8-2e1c-413e-b008-4d163126ac45" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="21fd408f-dd46-48d1-be36-b53cd2c37c4c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a36c7c93-e9e5-4eec-bebd-068f45aee8b7">
+      <statement statement-id="ac-7.2_stmt" uuid="875dce57-cdfa-4f6c-9eb0-9bfa84ff4406">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69382c1a-0bed-4e67-97f0-ad372cea1308">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Management of mobile devices is outside the scope
 of Red Hat Virtualization Host (RHVH) configuration.
@@ -1084,10 +1084,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b06c7d2c-a57a-47d2-a3c0-f3e78a033e01" control-id="ac-8">
+    <implemented-requirement uuid="8d430a33-8d65-4073-9a06-876dc1efd893" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="eb701e97-7f89-49a2-88f4-e269e53c2256">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e1946a14-999f-4cf0-982c-5ff68d0bb5ac">
+      <statement statement-id="ac-8_stmt.a" uuid="578d1f2a-3921-47fc-a4c9-139e07f251f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1104,8 +1104,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="adcef312-55ad-4e04-9a56-fb37ff9ddd68">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7a04792e-4516-4441-abb0-d34ab6a28905">
+      <statement statement-id="ac-8_stmt.a.1" uuid="fea04920-020d-4465-99d4-6abe68dc3e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1122,8 +1122,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="adbb24b2-8ca1-4677-8e23-41f0930f278b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="454dfc00-9b9a-43e5-a881-d77a2069f916">
+      <statement statement-id="ac-8_stmt.a.2" uuid="8c26f5fe-c79b-4706-9fc8-7146ef4c41b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1140,8 +1140,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="7dd03ca9-34f4-4692-af2d-cbea26e48f48">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="eb3ba1d5-2c4d-4049-b811-3804f7b75701">
+      <statement statement-id="ac-8_stmt.a.3" uuid="345e0b72-dd6c-4d69-831d-051c64fa77a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1158,8 +1158,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="919fa6ae-6a34-4653-81b5-cdd990eab436">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8a8982a2-c05a-4b02-bf78-0ad58401f81b">
+      <statement statement-id="ac-8_stmt.a.4" uuid="b225ff56-5766-44d2-ba08-7dbec06a10d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1176,8 +1176,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="c63d461b-1ede-45fb-9361-7397f3c98c91">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6c2cca5d-dd2b-4334-88ad-23b2949e3c0f">
+      <statement statement-id="ac-8_stmt.b" uuid="672f5f2f-425e-4146-bfd6-8c4b0b22ef9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="283a8a12-0912-4e76-bc7d-94300515179b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will retain the notification message
@@ -1191,8 +1191,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="17f938df-ffbb-4ed6-bd15-76480e0139f9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="369b2d0f-f0c6-484f-a832-52868bcb5809">
+      <statement statement-id="ac-8_stmt.c" uuid="6542b907-4c96-435b-9646-91e6183f9bcc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89177120-8793-4492-a6a2-cc3276d76459">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will display system use information
@@ -1205,8 +1205,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="e849a8d9-2311-49ed-85f9-724d5cba7ce8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d3af936d-05a7-4907-bd92-35d34a89d843">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -1218,8 +1218,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="acc384bd-4781-4e3b-aa19-e9fc284645a1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a86e85e1-5835-490b-9447-a8c8ff154f6c">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1232,8 +1232,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="3015b9c0-9615-4876-b6dc-258122ba86f6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f9cea2a9-6148-4538-917f-b3f1ff111367">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1249,10 +1249,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53201afa-044a-41a9-8614-241928df56b2" control-id="ac-10">
+    <implemented-requirement uuid="658dfd46-01b0-44b2-9e87-8b8c43b810fb" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="6378f090-7164-4b27-af59-282dcd6e4ddb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2f5a16b0-70cb-4bdd-b8ab-6c106d7961d6">
+      <statement statement-id="ac-10_stmt" uuid="77d6b558-3a40-4f35-b6ed-4d29c010404a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24c2c079-5b6d-4e1e-a549-72a4a6046ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1267,10 +1267,10 @@ https://projects.engineering.redhat.com/browse/RHV-20220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="894d69d0-ffe4-4709-8919-4ab8ecb21a0f" control-id="ac-11">
+    <implemented-requirement uuid="de47af6d-3ab2-4ccf-be56-0e9d1b328c6c" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="6825d97e-bcfd-4786-953f-fd1ac438e441">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b21b4193-b192-42ce-9c28-cc848d3c8ec5">
+      <statement statement-id="ac-11_stmt.a" uuid="4322b9cb-3cc1-4b1c-aa75-ee0f7d42d6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1279,8 +1279,8 @@ https://projects.engineering.redhat.com/browse/RHV-20311
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="eaa0d7c9-291f-4845-a46b-6c6d4b631743">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f42a8af0-2899-4fc8-8e81-f2d93a61bf97">
+      <statement statement-id="ac-11_stmt.b" uuid="afe463cd-920f-447c-8ef4-0c01bc1d59db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1290,10 +1290,10 @@ https://projects.engineering.redhat.com/browse/RHV-20311
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f18bb9c-75ab-4002-bda1-318ad42fc28a" control-id="ac-11.1">
+    <implemented-requirement uuid="9186ba2c-900a-4af7-b19f-bb180f5b2a76" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="8b3d3df3-68a6-4111-aa5d-420696b2279a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7fff49d7-8a79-4692-a2c5-93cf633cb5a4">
+      <statement statement-id="ac-11.1_stmt" uuid="9f71193c-566a-40c0-b07e-a386d1989365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33f20195-3d93-43ed-9b21-63e4c9107fd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1303,10 +1303,10 @@ https://projects.engineering.redhat.com/browse/RHV-20312
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7501ae3c-0e2c-490e-8d72-f6e4898c37cf" control-id="ac-12">
+    <implemented-requirement uuid="e31814b1-e9f1-4f64-803c-4d8a3773aeed" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="8190fe8d-6345-473d-b17c-1f1f2c89c9c7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e1e0d4f2-261b-47e5-81d6-6a4bc9c47eaa">
+      <statement statement-id="ac-12_stmt" uuid="90b59e85-2cd3-45ff-b096-a35056dd4d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b753ca6-6101-42a2-98ce-14b9560c501b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1322,10 +1322,10 @@ https://projects.engineering.redhat.com/browse/RHV-20313
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9038fac-1c89-4d8a-a285-c576fbec68f5" control-id="ac-12.1">
+    <implemented-requirement uuid="8b96ff26-c23b-40fc-b815-0251803b0720" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="973ff067-a26a-4fe5-b226-57ae1f6182e5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="29d082c9-8a2f-45b1-8ac6-482976fec51a">
+      <statement statement-id="ac-12.1_stmt.a" uuid="33c688ff-702f-4b79-95d9-c6b6f67c42f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b37a5084-c9ca-4c11-bb94-67b3383a8f00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1334,8 +1334,8 @@ https://projects.engineering.redhat.com/browse/RHV-20314
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="f096b290-5da0-4675-a715-e3b162c83ca8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="794c94c8-dd99-42a4-9dfd-69c60e1588aa">
+      <statement statement-id="ac-12.1_stmt.b" uuid="c91bb6bf-4780-4ca8-bb2d-7b774ba1aa6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58ff5eb8-9b58-4b37-93e1-a7cde0e44c0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1345,10 +1345,10 @@ https://projects.engineering.redhat.com/browse/RHV-20315
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe260017-4d45-4567-adbb-3b83a97b54da" control-id="ac-14">
+    <implemented-requirement uuid="684c2758-5cfd-459b-aa4f-5236451d89c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="2c9e39f8-39ac-446c-a4f0-70af1f75ae53">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="106a9910-3993-47af-b203-c87383b2aaa2">
+      <statement statement-id="ac-14_stmt" uuid="98fbea0c-7a97-49b7-ad10-d519e17504a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ade1f14-d64b-43c6-a3bc-4a09b37d14dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Host (RHVH) without identification
@@ -1358,10 +1358,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da0105ec-6a78-470e-bd2e-2a3b2c79fa27" control-id="ac-17">
+    <implemented-requirement uuid="00433395-fa1d-426b-ae24-19065a86ffd0" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="434a6f2f-dcf6-4927-9cdf-93e2a655154d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="00accbc4-e44b-41c1-ab42-5a3fb2dbe8ec">
+      <statement statement-id="ac-17_stmt.a" uuid="98e3a56b-95ee-40c7-9990-7fbcf14104e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d37e756d-8ef0-4b4f-8357-e22cb5bcb32e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Administrative connections to Red Hat Virtualization Host (RHVH)
 are performed over SSH. The following configuration checks are highly
@@ -1420,18 +1420,18 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="7dfc7a44-2b52-49b3-bf86-95d72f09e936">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9af93c7e-be1a-42e7-a374-ec2de07660d0">
+      <statement statement-id="ac-17_stmt.b" uuid="2a664edf-1c55-4227-85ef-fcd0664f7e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b03f6d3d-4fc8-472b-82bd-12186b5c307d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fdd52cd-11e6-46b3-863c-dcc11eae728b" control-id="ac-17.1">
+    <implemented-requirement uuid="2c168041-4ca0-48cd-9b1d-43827a6bfb6b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="29425916-6be2-43a6-85ab-0e5728e9583f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0f445f8d-68b0-4acd-a026-700c20de489c">
+      <statement statement-id="ac-17.1_stmt" uuid="779cdd50-e242-4ef3-8fca-6512a0d0b012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70e205b6-1bc3-463b-bc62-fe2f320ba8ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1441,10 +1441,10 @@ https://projects.engineering.redhat.com/browse/RHV-20373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f1b237e-68d2-46d1-a947-905bc07d2ba4" control-id="ac-17.2">
+    <implemented-requirement uuid="4ca77273-9117-40b2-983a-4dd5040356ce" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="e92f023d-adf0-47e0-9a5a-5e7b49bb9dc8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c19840ca-cd20-496f-b178-3053c7ecaf14">
+      <statement statement-id="ac-17.2_stmt" uuid="1ce07c9f-0df5-4991-b8fb-98fbac3b4bf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dce36b4a-1920-441f-80d1-3e68abe7fff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1454,10 +1454,10 @@ https://projects.engineering.redhat.com/browse/RHV-20374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="441ad2a4-973a-449d-85b2-95320c84e505" control-id="ac-17.3">
+    <implemented-requirement uuid="bc44a17a-d305-40bd-aa49-f123590cef90" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="cfd00cc6-5e64-4ba5-bf0d-1aa455bf2240">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="faea576a-53d5-48d1-b57c-c46b4843fcbc">
+      <statement statement-id="ac-17.3_stmt" uuid="42eb896e-2e27-499e-a0f0-578bb7b8ce33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d263384-2276-4a13-9725-cc474255f41e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1474,10 +1474,10 @@ https://projects.engineering.redhat.com/browse/RHV-20375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32bb555c-c22d-4663-81b7-8859d63a30a4" control-id="ac-17.4">
+    <implemented-requirement uuid="601d7507-7916-4d74-9366-bce72369763c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="9e007d1d-5b9f-4fd4-9189-cb4a7371080a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5a9d4527-f741-443f-b993-90c1ad1f8f34">
+      <statement statement-id="ac-17.4_stmt.a" uuid="e376c343-772b-42ff-9c33-17681b5bc45e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1486,8 +1486,8 @@ https://projects.engineering.redhat.com/browse/RHV-20376
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="b1345a23-d31b-4a3d-b07f-d19b6110728b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="29f3a812-5a4d-408a-a095-d8226bf2c431">
+      <statement statement-id="ac-17.4_stmt.b" uuid="4b4c9a85-6a8b-44e1-adca-dd63c6562b7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1497,10 +1497,10 @@ https://projects.engineering.redhat.com/browse/RHV-20376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67fa5300-da56-41fe-9185-7c6517d1563a" control-id="ac-17.9">
+    <implemented-requirement uuid="746dfdff-fe0a-4296-9d0a-755ef877cbea" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="b27ba6b4-a861-4147-91a9-fe56f9db4789">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0dfe9f37-70e5-45ce-a4c8-4ddb16b40a50">
+      <statement statement-id="ac-17.9_stmt" uuid="faf10f62-e49b-4ebc-a79d-896ae192f735">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e69aba8-9109-4efe-add3-4b09adcf574f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) utilizes the firewall technology named firewalld
 that allows a system administrator to configure host-based rules which take effect
@@ -1515,18 +1515,18 @@ https://projects.engineering.redhat.com/browse/RHV-20377
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="be3b3bd9-1b0d-4004-8899-be888fe5b944" control-id="ac-18">
+    <implemented-requirement uuid="cf94a9d2-9c80-4648-9d1a-8230c226c567" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="068d604f-9ea6-4eb7-a2e2-80a8b9ed49f0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0ed0344d-cfa0-4bbb-8471-1bceea27ba59">
+      <statement statement-id="ac-18_stmt.a" uuid="311da3f0-e4e8-4eb6-9608-0e07d6138736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0288252-f9e3-4799-b317-2eef7e56dc32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="ba056c1d-0efb-4c06-91c4-4a12c0d82521">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="672e85fb-3eb3-4ba1-8a83-cd1b49d1bdbe">
+      <statement statement-id="ac-18_stmt.b" uuid="e88d12f0-ed95-4bc1-aead-1a7618d5dee6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fca007b-4bd5-47fc-9d79-2e20f48e28a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1534,10 +1534,10 @@ system are outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d60e62e1-4a0e-4cef-b176-a9807fe5a1d4" control-id="ac-18.1">
+    <implemented-requirement uuid="1ac7f974-c33e-4090-931e-326fc42c39ba" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="864b5155-670f-4000-8907-7e1415037886">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b280a46a-7e7c-4e18-bbe9-7ef560d6b0cd">
+      <statement statement-id="ac-18.1_stmt" uuid="9c519ada-8b42-4a38-9112-f4a58ab56500">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626d3238-bb0a-4b52-b0bb-40ef55c29972">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -1545,10 +1545,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="734f537c-95f3-40a4-95bc-aaefa68a9fa0" control-id="ac-18.3">
+    <implemented-requirement uuid="2b43ef60-4dca-4d94-89ba-3ccc009a0696" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="b9beca0f-bbec-4c6e-8a01-bed253eb9ab7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0f88fa85-c412-4924-a328-2f865c2b3e00">
+      <statement statement-id="ac-18.3_stmt" uuid="1d9b2004-584b-4c37-905d-d7719cbdc1bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21fe04ee-3ecb-4bc9-a248-297883f0bd7d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Wireless networking in Red Hat Virtualization Host (RHVH) can be disabled with the following
 configuration checks:
@@ -1556,10 +1556,10 @@ configuration checks:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87566c3d-9328-4728-b5f2-ef85481c074b" control-id="ac-18.4">
+    <implemented-requirement uuid="ae6a3688-6284-4c9a-9d8a-9c2b5765860f" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="639ab9c2-f88f-436b-b98d-bcccd3b3be92">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dcaf9f9d-eedb-4094-a3d4-931943ce003e">
+      <statement statement-id="ac-18.4_stmt" uuid="b71c05be-3215-41d9-8df6-d922303c5ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3a0dc5f-241a-4c12-963f-109e8bc8d8b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing users from enabling Wireless networking in Red Hat Virtualization Host (RHVH)
 can be configured with the following configuration checks:
@@ -1572,10 +1572,10 @@ https://projects.engineering.redhat.com/browse/RHV-20378</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d42fe90-c1c9-403e-aa7e-f31fe58e1908" control-id="ac-18.5">
+    <implemented-requirement uuid="5fe67148-ff91-4f4c-a392-1932a8f04dab" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="cca8af97-2bf3-4f0a-b262-7178c71b9e83">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f2d0a59f-e55b-4598-92c9-0688a60028bd">
+      <statement statement-id="ac-18.5_stmt" uuid="d8edaa3a-e749-4aec-98b3-9a966254fece">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3f7eb945-a1c1-49bd-9f4e-7d934dbaeb10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Radio antenna selection and calibration is outside the scope
 of Red Hat Virtualization Host (RHVH) configuration.
@@ -1583,18 +1583,18 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99d63975-72e1-4ef3-8741-493d909aa1b0" control-id="ac-19">
+    <implemented-requirement uuid="78ab6b5d-0a11-4f22-9827-88750979254d" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="d0dde36c-6516-4f62-945f-f4582caac47d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="df9ebba3-4f2e-437a-b24d-bc156fa88a56">
+      <statement statement-id="ac-19_stmt.a" uuid="d8e4bd09-c320-4c5c-b376-bc6385f43bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ee6b0db-3fd5-4373-bf29-c4a426eb6884">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="d9837215-74c1-4f36-8981-c908cd99e826">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="417d59dc-e2f3-4ab4-8a07-4d548866f528">
+      <statement statement-id="ac-19_stmt.b" uuid="f00355c7-3b2a-4d78-8ff1-e8ba6eb677e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="206f5e0e-1f5a-44c8-9dd2-cb418965dded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Host (RHVH)
 configuration.
@@ -1602,10 +1602,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0120f93b-03df-43a7-8dfc-7a3f8a6c302e" control-id="ac-19.5">
+    <implemented-requirement uuid="6fcadec5-b100-4551-bc3b-7b2457202d73" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="da8a86f7-04a1-4684-9aa8-7c7faec5ed97">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b78e6092-3432-466b-9824-932d62c332fe">
+      <statement statement-id="ac-19.5_stmt" uuid="b62a8896-728f-48d3-8cda-6b6dfa3d2744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c083d4-929d-484e-9cf6-a288197475b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1613,10 +1613,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffabc13f-6750-4f5d-b780-6eeba1a849c3" control-id="ac-20">
+    <implemented-requirement uuid="3733ec6f-76d8-493f-9490-91a5c25ef3cd" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="71beaaed-95e5-4ec3-a77b-96c0c4e22db6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ba656045-0102-4322-8798-91bbe53c3b5a">
+      <statement statement-id="ac-20_stmt.a" uuid="3fdb7fae-e48a-45fe-a1e9-3fa009502b06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c64b1e2-40d3-4609-becd-e33f4f85d73d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1624,8 +1624,8 @@ systems is outside the scope of Red Hat Virtualization Host (RHVH) configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="241ef4ca-9e81-4827-a00c-9b63b1522b4a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d11fa56a-1de2-458a-81b9-699bd0dc28a5">
+      <statement statement-id="ac-20_stmt.b" uuid="a4eadd7c-a583-456e-bff8-69ecdd5903bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd3e1d9-c2ce-43aa-84b0-301c83bc8bf0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1635,18 +1635,18 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a795691-31e0-4e6c-88b5-04d3b8dacc2d" control-id="ac-20.1">
+    <implemented-requirement uuid="129d19dd-de95-44cc-908f-a9683baf6b8d" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="71c936c8-89a5-4500-94d9-9e013afe7b4a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3437e0a7-7ebb-4974-9021-e02c96b196bb">
+      <statement statement-id="ac-20.1_stmt.a" uuid="75ebfe9e-4e86-48f1-a243-0dec6785c09e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="579fc5d7-e56f-488f-bca1-7c0efa91ba4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="ab57f05e-5f12-4a3f-9d67-471ecfef45f3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fd516c04-2083-444d-9c7d-9e03d2bdfa65">
+      <statement statement-id="ac-20.1_stmt.b" uuid="4113f8aa-d44f-4639-8408-2fd8e1bd8e90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a3c899c-0be9-4500-8444-cd175fbb7b05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1655,10 +1655,10 @@ information system is outside the scope of Red Hat Virtualization Host (RHVH) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38ab521e-8039-49e5-9ea2-5e532b8d6c01" control-id="ac-20.2">
+    <implemented-requirement uuid="2faaba5f-004a-431a-b95f-a5eb3798d4af" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="d50532aa-0197-43e7-b5b3-2cfbbf6e1a81">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="140497aa-a107-4739-8f92-ecb5a384186c">
+      <statement statement-id="ac-20.2_stmt" uuid="f0957d50-acda-433f-9ca4-26e0159dd3b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2522cf64-2809-4a88-ae49-9de9191f7e71">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1668,18 +1668,18 @@ systems is outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="446a065b-378a-4e48-a863-64e822b076f8" control-id="ac-21">
+    <implemented-requirement uuid="0fb4e964-b620-433b-b065-e08292c9213b" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="d5cc123a-58d6-4040-a76b-9955875edf04">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2141a54-3ccb-4234-ab88-46ec4fb34094">
+      <statement statement-id="ac-21_stmt.a" uuid="51109e1d-c7a3-4f4e-9343-ba4e88c3c42b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c5f770-1ce7-441c-acc6-93b539c8ae58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="1e65631e-fe27-4197-a18e-6b68fb9794b1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="829e2c39-3ef9-49e8-90b9-cf70fe89662e">
+      <statement statement-id="ac-21_stmt.b" uuid="5183e867-8c2a-47a1-a08e-d4bd1c6c0e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd252304-5f89-435e-a48f-3251c8f16a63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1688,10 +1688,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="841478b9-1543-4274-8f76-753405d8847a" control-id="ac-22">
+    <implemented-requirement uuid="22d9b4d6-436a-4319-8f84-f356873d10df" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="9bda16be-45f8-463f-aff2-5c558e2d8623">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3b21dc33-0583-4b53-9964-1536eb343cef">
+      <statement statement-id="ac-22_stmt.a" uuid="6744af3f-1fc6-4bfd-b70a-86d731c3a9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="accc6867-088f-4fa0-a311-f8ec1625cde0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1699,8 +1699,8 @@ system is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="a28c884f-6b5f-4371-b17a-c5db2ff7eed8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="310242bd-fc75-4f97-8e64-6520aca567fa">
+      <statement statement-id="ac-22_stmt.b" uuid="11d537de-0e77-4a89-a424-2d313832e46e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e117711-d918-4757-9c53-cd8e925fb189">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1708,8 +1708,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="cf55d2aa-499e-439d-bc1f-d479089c14ad">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f0b3f736-c79e-4ceb-a577-05658bd63bf1">
+      <statement statement-id="ac-22_stmt.c" uuid="e9fc565e-5b3c-453d-bb6a-2c6be6f0e2c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4bf50a4-e6e4-4df8-9070-d3ee9420d06e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1718,8 +1718,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="8f8df335-b1f9-4c6b-8bda-86aafb600a72">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d6ac05de-5be8-4fce-83cc-1b35d928bebd">
+      <statement statement-id="ac-22_stmt.d" uuid="76c42769-386a-4002-9b56-dcfe271343fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80727243-4558-4500-9bbf-6b8567ebd9ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1729,18 +1729,18 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c7e9036-211e-437c-ae85-110952e413d9" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="2bd1d102-1c4c-4b05-a65b-f29336fb0fcd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e92ca94a-5b2f-4a3b-9790-1604edbce8eb">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="0649b309-46de-4f60-804b-7d5cd834530c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e974036a-1d53-44af-a8de-52d8f090951a">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1748,26 +1748,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd9cd4c6-9bc3-4153-adad-ba76e4a2d783" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="4e11415f-eefc-4060-9a41-96cb3a823fa5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ff155ad0-4f81-4ad8-a02e-1ad3ff4604f1">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="6217689d-3a24-4c34-89ab-ac31616e0033">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4fe69153-b607-47bf-8cbb-5be6712e9a03">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="b8f15576-cfb0-43d9-a9a0-221da13a78d2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8cc9f456-c162-4b96-b7e6-7f0579733f94">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1775,10 +1775,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="479c9014-106f-4d31-8fc0-5dcdcdba8ea6" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="22a664dc-683a-4c7c-9e49-5deb584029bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4d7527d2-d891-430d-bc92-1ebbf5196e24">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1786,26 +1786,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="455695e9-0e1a-4f3f-a0a9-fb6e2a0caf74" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="488cf74f-b84d-4f32-b5c0-beaa24f639e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="befbb36d-e8a0-4069-99e4-5325da46d45e">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="6427e3eb-7eb2-444f-86b8-e34b3b0a37e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d8a273fe-0573-467d-8ce7-69bb64cd254b">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="993cebb7-aa63-45a9-8dca-5f9786ac4f16">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="72757291-49d7-45d1-aa4b-a06966b9ec8f">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1813,10 +1813,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93918770-11c1-4738-a150-284bd17ba364" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="97572c61-fd91-43b5-8dba-d6686deff18e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2ade93a8-b2fb-4572-8dcd-28ef0be3209b">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1824,10 +1824,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="370b9114-1e27-4602-b00d-8246077f6866" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="5135e470-edb1-495f-85d9-d372921d63e9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="66d654c9-e5d4-40d0-87e6-39e0368e28ec">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1835,18 +1835,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08e808e6-645b-4d22-b1c2-29d57977dadf" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="58dfb1ea-07ed-4c5b-9713-85789117d633">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ff0fc0a2-eb90-48ba-b9c9-b17988d86592">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="c6c29efb-eef5-4c7b-bbe5-a532335971c5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0400f323-059b-4cd3-99fe-8ae03cece510">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1854,18 +1854,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b8fd284-8bda-4c98-b66f-e40b3de7d0bb" control-id="au-1">
+    <implemented-requirement uuid="9f3bbb92-4fd6-4f4f-a234-43e8b2f9d321" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="469b9efb-98da-4457-98d2-9653e5714468">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="015b32a0-a91e-4a2b-8301-ce7d51c855f9">
+      <statement statement-id="au-1_stmt.a" uuid="c2636108-0713-4727-908b-9d644f5ef47a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6d15083-8660-4473-bd76-f23f53dc412e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="2635a5b8-5f75-46c7-83c5-90942c6d5756">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="27c1723e-252f-4183-b2bd-19da53d26aea">
+      <statement statement-id="au-1_stmt.b" uuid="c63af622-3579-4f08-9ba4-caaac03fe2f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b09d43c2-ff7d-4474-9cf6-41f5b9827270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -1874,10 +1874,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63168626-40a0-4fe1-b229-27779b24c569" control-id="au-2">
+    <implemented-requirement uuid="b7db7dc9-b503-436a-8f61-937f91b306d6" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="a13cd5b6-565b-4260-ba29-fbba089f4f37">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6c4fc5e4-b73c-42d0-9302-6d16af4df924">
+      <statement statement-id="au-2_stmt.a" uuid="f4c58566-e8d5-4cb4-8d80-5814a9a4d258">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5dc2ddf-e441-4bad-bafb-d41bbd5dfa89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1909,8 +1909,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="60c573a7-2e10-417d-b016-151e22f7054a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="985b0c34-ad80-410e-9f68-11b5a98e7475">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1918,8 +1918,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="d9af162c-9064-4cd7-8f4f-7f1010e8f66a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="44683e33-f4e2-4870-b807-163915f3a393">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1928,8 +1928,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="2281f9ac-bbf5-4371-8c8e-f74b1fffed47">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2e396356-2ae9-4187-ae17-7d42eed9ca01">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1941,10 +1941,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed652e9c-1745-432e-917b-2cd405d1d7cc" control-id="au-2.3">
+    <implemented-requirement uuid="78e86d30-c64c-4d7b-9ca7-a86134553a4a" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="3a76e6ae-4754-4221-b896-727841a6e7cd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f7fc8461-3b1b-41e2-b192-9418cce812df">
+      <statement statement-id="au-2.3_stmt" uuid="3527cadf-7964-4181-ad84-4cda1f62949a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f0ba69-723c-4ee0-9f21-84503d026812">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1952,10 +1952,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fabc572-8e38-4662-be12-49ac10da5ce9" control-id="au-3">
+    <implemented-requirement uuid="8e3dae3b-dcbd-4acb-942c-254be196b09f" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="f5829b31-cde9-40cd-9ac0-72008bcaf009">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bdee5e8d-4238-4510-af63-04e31bb3b7cf">
+      <statement statement-id="au-3_stmt" uuid="3f79bc0f-b8c6-4846-804a-0ef92deae5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="602ba1d2-55b7-4547-a71c-79ef4acc3e2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) audit records contain
 the required information and cannot be configured to be out of
@@ -1963,10 +1963,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7100dd92-d5d2-46ad-83e0-479ddc4d8667" control-id="au-3.1">
+    <implemented-requirement uuid="be77b6c8-342f-4bc5-b488-a40884a0f1eb" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="fad7dfb3-a48f-4872-a87b-5ed893cca1fc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="117875ce-a887-496b-872d-df8a27ce9aa2">
+      <statement statement-id="au-3.1_stmt" uuid="f04ec7dd-9f1c-45e1-a32a-eb05a6a66d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1975,10 +1975,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d606c644-4413-43da-8286-a0ea2b63d298" control-id="au-3.2">
+    <implemented-requirement uuid="f82154b9-bdf4-4b76-8c2c-be7363a4a05d" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="43791d1f-fca2-464a-a367-dd7dfd41b151">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9d632262-0d03-4ead-b31a-b0cb5036cb4b">
+      <statement statement-id="au-3.2_stmt" uuid="cc7c27dc-4a84-4626-a76f-f4151896c73f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1987,10 +1987,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39bcc200-ac98-4a39-a632-8db0936afd74" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="f1fca939-be40-4282-9ba9-a4b11c63f4cf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3f1b27d5-25c4-41ac-8f36-4e03b10da50f">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1998,10 +1998,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b74ca134-3751-43ab-80b6-a10ab80ecca7" control-id="au-5">
+    <implemented-requirement uuid="5b395705-475e-447d-aadd-b8c26afedae6" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="a556c95f-97c9-4a31-a991-3477a3a5a110">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2c13fe09-dfd8-4a30-9114-0e2b710979cd">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -2012,8 +2012,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="f9eabaf4-2c31-43a3-b1ad-7501780417fc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="43745888-0947-4427-a480-b4580d28e215">
+      <statement statement-id="au-5_stmt.b" uuid="17101dc5-e63f-4235-9379-079def2556d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8322a91-fee3-4987-9b27-c869af08a5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To shutdown a Red Hat Virtualization Host (RHVH) node upon
 an audit processing failure, which includes software/hardware errors,
@@ -2035,10 +2035,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27166810-9d98-42af-b3d8-6c2213ed8661" control-id="au-5.1">
+    <implemented-requirement uuid="8c3d93b0-4822-4367-a117-91d11275e75d" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="6ee28614-0cc7-4de6-81b1-8abab3edf8c0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ebfaab6c-77c0-4a81-a30f-27654ece3ebb">
+      <statement statement-id="au-5.1_stmt" uuid="a7086d1e-a2ba-4be6-a457-74a656889790">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bd1204a-09ec-4c7c-b874-236b60988b7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2047,10 +2047,10 @@ https://projects.engineering.redhat.com/browse/RHV-20422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce2cd2d5-5e2b-4de3-af2b-6dad90fd2cb5" control-id="au-5.2">
+    <implemented-requirement uuid="81485c46-078e-41e9-bbce-bf9916b52681" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="1b73e1b0-a225-41a1-82bf-69541441f748">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4595a2e8-c387-4e55-a285-9743f9c28280">
+      <statement statement-id="au-5.2_stmt" uuid="4daad5ef-5158-4ff5-ad8c-e6e7a00e4107">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="040caf93-bdd7-4e33-88ff-7e4af1224149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2059,10 +2059,10 @@ https://projects.engineering.redhat.com/browse/RHV-20423
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe73f283-fea8-4250-85c9-b08d516023b5" control-id="au-6">
+    <implemented-requirement uuid="3444efd3-f653-41c7-be8d-b52fe68795ef" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="17890079-ab70-4947-bbaf-998428b7d561">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fa4b359f-9053-4a3c-b68f-6a63eff18040">
+      <statement statement-id="au-6_stmt.a" uuid="0a10e0d9-e8b3-4d8c-8a1d-21eb61c789e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7932186a-3291-4937-9080-1023ab875818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -2071,8 +2071,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="99c4b17e-97d6-4bf4-a0cf-e7418408ea95">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e13006fb-9612-4ce6-8405-dda3f9e3a877">
+      <statement statement-id="au-6_stmt.b" uuid="b514c067-55cf-486c-b3a5-74348c51c675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a00e37ab-b563-40d3-93f9-2ecf04468c31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -2081,10 +2081,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e97647c0-5404-43dd-9393-a92d7548c8b4" control-id="au-6.1">
+    <implemented-requirement uuid="37775031-a4ba-4fdb-bfe7-9ec860d0e643" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="ca9184f6-01ef-48c8-b155-d8ce174dbcce">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="81d1f807-9f1a-4312-b0ea-2385c94f7a79">
+      <statement statement-id="au-6.1_stmt" uuid="78fb7f25-7b92-4b0c-a04b-091352b690f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f159707a-684a-4f17-abcb-f8f7712921f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational use of automated mechanisms to integrate audit review,
 analysis, and reporting processes to support organizational processes for
@@ -2094,10 +2094,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4458d284-3d24-4a4e-b3a6-c96e0dae2cc3" control-id="au-6.3">
+    <implemented-requirement uuid="3b4c311b-089c-4fe1-a4c8-34497050d552" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="03df9098-d27d-440a-9688-32a6fea0bb0b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a1a8f7f4-3e29-4862-8653-117a11da9f01">
+      <statement statement-id="au-6.3_stmt" uuid="d90133a4-0ba1-4493-8283-8a40ebb3f97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c4da8b4-7a73-47ef-932c-d06f4353a56a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -2114,10 +2114,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3f69db9-91b9-4d83-a1e2-7c78650c85e9" control-id="au-6.4">
+    <implemented-requirement uuid="7ca53b90-b112-4aad-939f-a04e965da827" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="a39620c4-2ac2-4a2d-a38e-52d69dcd2135">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c19b3a80-42d4-4c98-8155-0568d862d0c3">
+      <statement statement-id="au-6.4_stmt" uuid="4b34e4fc-2bbf-4daa-a524-765519ac0ae9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d847793c-c3d2-4ca9-a48a-69a96c686f29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to centrally review and analyze
 audit records from multiple components within the system
@@ -2133,10 +2133,10 @@ applicable.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9466558-006a-4b9b-b74a-fa313a10b2e6" control-id="au-6.5">
+    <implemented-requirement uuid="5c029824-0827-4364-8cd9-c101b1048bf5" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="4960424b-764b-4fb4-afd6-d434c17260bd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="228e5dc2-876a-4691-866e-b39211ceadee">
+      <statement statement-id="au-6.5_stmt" uuid="f624b93b-4a32-45e5-878b-f00f58109123">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="86b87eae-734b-4313-a4e5-7daff001254c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to integrate analysis or audit
 records with analysis of additional organization-defined
@@ -2154,10 +2154,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cec9dcee-a2a4-474d-8917-1bf3a845edf3" control-id="au-6.6">
+    <implemented-requirement uuid="caf66726-c459-4e99-ba64-fedda24c7a5d" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="003fd934-6135-4224-90b5-70754b689dae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="81b1256b-ba76-4c63-9f86-739b8a67276f">
+      <statement statement-id="au-6.6_stmt" uuid="98325b0a-20f5-45c8-9ac6-69a33f054734">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5828217c-abb3-45e7-85e5-b5ac90a714da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to correlate information from
 Red Hat Virtualization Host (RHVH) audit records with information obtained from monitoring
@@ -2175,10 +2175,10 @@ logs with physical access data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="428befe3-71d2-439e-919a-6f11cb0dd17a" control-id="au-6.7">
+    <implemented-requirement uuid="5b1acc52-0cbc-496f-a964-971a537deee0" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="c5fe7ed0-257a-4a40-a86d-8b0ee5aa73f7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9d7a0ffa-e9cc-4d65-9be7-702b27869de1">
+      <statement statement-id="au-6.7_stmt" uuid="7295958a-ef9b-49e7-9559-8a0e8fbecf13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="faf1cb08-593b-4bf4-bd9c-f030c8abdbe9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational specification of permitted actions for
 information system processes, roles, and/or users, associated
@@ -2188,10 +2188,10 @@ information is outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5869b821-23f5-4104-bc48-3984e39bc16e" control-id="au-6.10">
+    <implemented-requirement uuid="2d576746-415b-4cdc-a895-43c4c6036fe3" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="07f05c42-0ab7-4653-9550-dd589ba5f6ff">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dbc78b6c-58b0-4129-8670-21c5e6393783">
+      <statement statement-id="au-6.10_stmt" uuid="cb1bc027-e557-44ee-ac45-2af1dc7da5b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2c8129e-5ac0-42bb-9caf-dff34806d003">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational adjustment of the level of audit review, analysis, and
 reporting within the information system when there is a change in risk
@@ -2202,10 +2202,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fedd1398-318c-4073-a51c-fc9310adc807" control-id="au-7">
+    <implemented-requirement uuid="9d404010-fdda-4aaf-883b-c36e2876d5c8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="696321c8-56a8-4ec3-b04e-9a5334b68523">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c20c981a-176e-4917-a3ed-eff52cdd97ca">
+      <statement statement-id="au-7_stmt.a" uuid="32c2238f-fc50-4cf0-8789-85635ac69e09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2213,8 +2213,8 @@ https://projects.engineering.redhat.com/browse/RHV-20424
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="9702f148-20e4-44de-b914-592d1cccb605">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e367684c-9dc6-409f-ac7b-71e704245b3d">
+      <statement statement-id="au-7_stmt.b" uuid="460204fa-d554-49cc-8aee-1e7b603104a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2223,10 +2223,10 @@ https://projects.engineering.redhat.com/browse/RHV-20424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5493b592-a407-44bd-90ee-3722fb345775" control-id="au-7.1">
+    <implemented-requirement uuid="b714e1ac-5385-47db-b004-f4538318cbd4" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="b2b580a7-4a8b-4d8d-9acd-246a126daf97">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="424e9e0f-3523-49f2-bdc8-46af99fe6638">
+      <statement statement-id="au-7.1_stmt" uuid="6b9632dd-07c3-406b-a28f-0dfdaf45a47b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34dc1b8b-6c3a-404f-aa23-7106d0a34670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2235,18 +2235,18 @@ https://projects.engineering.redhat.com/browse/RHV-20425
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea4c83ba-cde2-4245-8904-f5c18cbf8618" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="1e0914fe-9d6e-4728-be0d-eb67cf7224ac">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a7e8e9f5-b737-43a9-8e57-e58baf2c20a9">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="fe387755-0e90-4bdc-9daa-ccf4322945b1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f9ef01c1-fdea-4e2a-a42a-ff040b0f7f4c">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -2260,10 +2260,10 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c14aff3-ea78-4caa-85ae-df847e9c9366" control-id="au-8.1">
+    <implemented-requirement uuid="fe187a61-ea34-418a-b501-ca3011363641" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="66dbad0b-48e3-488f-9458-2d688fadf50f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="54e1c6d4-e6c0-40a4-8456-5588f35436ba">
+      <statement statement-id="au-8.1_stmt.a" uuid="2f91fcc4-cb3a-4c91-bb53-499978eaf621">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3051045-d17b-40c2-9797-1f75cd5a1b96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure that the Red Hat Virtualization Host (RHVH) syncs time
 with an authoritative time source:
@@ -2271,8 +2271,8 @@ with an authoritative time source:
 - CCE-82873-1: A remote time server for Chrony is configured</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="dd53b5ff-4197-4833-9639-f936edcd6240">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dc81032c-302a-47d7-ad65-1430b45c767c">
+      <statement statement-id="au-8.1_stmt.b" uuid="a4189d5e-78f5-4777-b6e4-72ad1ba68cbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6695c4ef-ccb7-4d44-8ef5-3f793411ff2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure that the Red Hat Virtualization Host (RHVH) syncs time
 with an authoritative time source at regular polling intervals:
@@ -2281,10 +2281,10 @@ with an authoritative time source at regular polling intervals:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5575367b-f972-4b12-b754-e1c92f83f72c" control-id="au-9">
+    <implemented-requirement uuid="9eec989b-e59f-4c58-bb64-15cd8b4cd415" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="d64f3303-b327-44c4-a008-4111b260155e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="646481e5-d6e3-4362-a43b-f78fa400e6c1">
+      <statement statement-id="au-9_stmt" uuid="2837780e-02a0-44ab-afb1-5c221e5f9f38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acfe3ec3-a01a-4943-b0cd-65e93a684b6f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure the audit records are
 protected by appropriate file permission, user, and group ownership settings:
@@ -2310,10 +2310,10 @@ been modified/tampered with:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62e864db-a833-4f4e-bf52-8376f49bd638" control-id="au-9.2">
+    <implemented-requirement uuid="b27e50b8-48b3-427c-b6f5-207314c09526" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="6bbe2ad7-c657-4e6f-bcb3-2ca4c0aefac1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="75c0662a-9791-4357-b9f7-e3e603035b87">
+      <statement statement-id="au-9.2_stmt" uuid="7ee18b7e-7ba1-48b1-9be0-e050275901dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89a9eb49-f787-4bdb-bbca-dff99867830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2324,10 +2324,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97ce5f88-f165-4e15-8f38-1c51e4b079d5" control-id="au-9.3">
+    <implemented-requirement uuid="19fe5e30-a455-458d-92fd-85ac20dcb9dc" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="ba57b488-d9fc-46aa-a046-ee76c65cc9cf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e0fa0bd-355e-423c-a35d-bcbb45c7be7e">
+      <statement statement-id="au-9.3_stmt" uuid="1dc35e48-2b59-4bc8-affe-3088d26648d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5de6f550-45fe-4ffa-9825-2b22be83c835">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcement of cryptographic protectionm is the responsibility of the centralized audit
 facility, and outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2335,10 +2335,10 @@ facility, and outside the scope of Red Hat Virtualization Host (RHVH) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c5866fd-bc7b-4d8d-97a2-b87fe6ad21b1" control-id="au-9.4">
+    <implemented-requirement uuid="a265c8f6-0497-4ffd-baa0-bd923d1b9308" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="38294cd9-b4fb-4535-8dc9-40017436b1bd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="63ce9ba0-dcfe-442b-abb2-0ae601fbe137">
+      <statement statement-id="au-9.4_stmt" uuid="9be4ed66-62d1-4775-aa28-bb2096f5649d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20adb15-f43b-4008-bf7e-2fc6ac84b3f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2348,10 +2348,10 @@ https://projects.engineering.redhat.com/browse/RHV-20506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e69b8b2-20c9-4b97-bd41-e6594b19a4ed" control-id="au-10">
+    <implemented-requirement uuid="f7d29850-e5e2-4981-9871-4cf543c9d84a" control-id="au-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-10_stmt" uuid="68ad83c9-782a-4690-9f5d-6990ef86ce49">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="75aa09a8-e0e2-4187-90b8-a52dd5706383">
+      <statement statement-id="au-10_stmt" uuid="50600659-6ac5-47da-995e-05004e011e8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ff78945-8e66-4f26-a163-481253a4dd3c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2361,10 +2361,10 @@ https://projects.engineering.redhat.com/browse/RHV-20507
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f1e20cc-b3fa-48ff-a7c4-8fc3986e7bba" control-id="au-11">
+    <implemented-requirement uuid="6b3bbfa4-14a0-4bc9-8576-b92c461c4150" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="1e0ba7f4-d300-4427-a5c9-6af016c8ea65">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="586680ad-2c63-489f-a2b5-c2ca7620798b">
+      <statement statement-id="au-11_stmt" uuid="30e22ec4-cc35-4140-a186-122b751ea450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98a9df94-f1be-4c9d-adc3-a34c9358b230">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2386,10 +2386,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9fed969-3b13-4aad-ab78-aff8fdf66a74" control-id="au-12">
+    <implemented-requirement uuid="6f8494bb-c00d-47f5-bda7-0ae955eb3822" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="714614a5-b915-4adb-9923-9105d0ceafe4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="16d312ef-96a2-4dae-b788-d27f330ad18b">
+      <statement statement-id="au-12_stmt.a" uuid="49b9b7a6-a777-4820-b4af-81b7817398a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05794480-06d3-4c97-a7ec-634d165fbc1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure Red Hat Virtualization Host (RHVH) nodes provide audit
 record generation capability, the underlying audit subsystem
@@ -2405,8 +2405,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="07bb151f-a7e5-4956-abef-e776e53441a6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a0c766fd-5147-4667-80e3-f8c0c1dda29c">
+      <statement statement-id="au-12_stmt.b" uuid="ae3d7411-b456-4b09-b30d-7b49f8d21f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="435db5cb-b92e-43d3-a0c5-1a103bc53163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>System administrators may customize audit rules by editing the
 appropriate files under /etc/audit/audit.d/.
@@ -2417,8 +2417,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="88b338c7-e35f-458c-b484-bfd5b28d226e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="48299acf-c5f6-4b67-b8bc-cdd901f6c482">
+      <statement statement-id="au-12_stmt.c" uuid="92631140-5b9a-497a-9a62-1fc88736cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8a1327c-6ca4-46a0-a0ac-cc2f87d19dcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks correlate to recommended
 audit events:
@@ -2553,10 +2553,10 @@ audit events:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e8020d8-9f73-498f-91bf-eacdfb33cffa" control-id="au-12.1">
+    <implemented-requirement uuid="3be7e549-d455-4b66-8e0d-ab8573b4b798" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="57f032ea-cc12-4de6-96af-8a797d6a1c31">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="76de0d29-dfdb-41ed-aa54-93b322fcad80">
+      <statement statement-id="au-12.1_stmt" uuid="9244732b-0047-4ecf-a489-f4a882799001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ab5fd37-9f44-4383-939b-e3ac2a6f0967">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2566,10 +2566,10 @@ https://projects.engineering.redhat.com/browse/RHV-20514
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d38734ae-bec6-49f5-907a-054bb01157a6" control-id="au-12.3">
+    <implemented-requirement uuid="97b0a277-679e-4c64-a1f0-4f4f51206520" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="65368b91-e2ee-4e37-8392-ccd3467ae12e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="92bd8aec-3519-4741-af75-ebc773e81e77">
+      <statement statement-id="au-12.3_stmt" uuid="bd2359c3-6887-48fe-b556-cacc6d6db85b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c2af807-7d1f-46ad-8096-0f23cf70ac35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2579,10 +2579,10 @@ https://projects.engineering.redhat.com/browse/RHV-20515
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63c46836-71ad-4ff3-a5a8-6e017d5fba6f" control-id="ca-1">
+    <implemented-requirement uuid="9f7998ec-517c-4f59-9cb3-183766cdc84d" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="d2d6bfd9-5b88-4acf-beb7-a350056632c3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2834595b-5a09-480e-a0a9-61cb9d903250">
+      <statement statement-id="ca-1_stmt.a" uuid="6e1cfd0a-61e2-45fb-beb1-ad29db0968af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2590,8 +2590,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="12fa9e9a-c1c0-4d1d-a189-626cd19803b4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="00d7484c-5858-47d4-8aa2-331d017b239e">
+      <statement statement-id="ca-1_stmt.b" uuid="3a2fae8e-3afa-43e4-a06e-9c493bee605f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2600,34 +2600,34 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a26eadea-a524-4522-ba25-930245c30cdc" control-id="ca-2">
+    <implemented-requirement uuid="289d60a5-96e0-4c8f-ba5c-ee51e290a842" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="219dad99-ece3-4844-9c78-49c793c4c6e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d53d2d10-89ac-4826-8909-14cdc4244686">
+      <statement statement-id="ca-2_stmt.a" uuid="a7abe116-eac2-4cdd-8d14-45471e54f6a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="8d6f53be-a09f-477c-8efc-94da68c40565">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ceba4f22-c47c-4b68-b0b4-e72be2d13ae6">
+      <statement statement-id="ca-2_stmt.b" uuid="d1dfb904-939b-4f78-b8ed-47b4f1c3116e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="7d424ac0-367c-4d67-adcf-f753ac429f4a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a3b87bdf-9789-4f1a-8fad-34f4ea07603c">
+      <statement statement-id="ca-2_stmt.c" uuid="f247ced2-eac6-4696-b78d-b0435339a085">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="d0f88b74-cf6c-43d6-b476-db981412eb22">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c4c1b6a0-af42-475a-8287-86dfae705a1d">
+      <statement statement-id="ca-2_stmt.d" uuid="ce26608e-47e4-4c3e-bd43-ce258ddb8254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2635,10 +2635,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d224fe0-8c5f-4422-b840-e681d959756a" control-id="ca-2.1">
+    <implemented-requirement uuid="6ef18e3d-dc28-49ad-8675-40ab7c85fcd9" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="b852badd-de4c-4f54-89de-28c971caf295">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b703ed74-9474-4e2b-80b1-9209f06115e9">
+      <statement statement-id="ca-2.1_stmt" uuid="57b3b99a-2df5-4fe7-ab08-9935ae4a4474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed1c9eea-65a1-42c1-bb95-e72a6403fea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2646,10 +2646,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbe4dd55-ebdb-40ef-adf7-865d3efe027a" control-id="ca-2.2">
+    <implemented-requirement uuid="b0f11a8c-fc09-485b-81f2-ec7431effba4" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="3942de97-076c-4ae0-a373-48a48fc5a0b9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2b49639c-bfd8-48f3-8fce-88647ddeda05">
+      <statement statement-id="ca-2.2_stmt" uuid="b5ec0373-2514-4ea6-a4d5-4358dd92c93b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7975cb57-e329-44d7-bbfc-fb4924829ae3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2657,10 +2657,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36d17cac-f834-4649-b23f-3d082519fdad" control-id="ca-2.3">
+    <implemented-requirement uuid="39142afe-1558-43e7-9c95-76cecd414cc3" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="21df017d-79ef-433b-956a-06aacb3e0769">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="193abe84-5d42-464f-b30a-225c20b58353">
+      <statement statement-id="ca-2.3_stmt" uuid="fb1d133b-3ada-4dcc-9195-1d9adbee0c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3f038e3-b26b-4790-a56c-3a1946d960ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2668,10 +2668,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6bfcfac-c589-469a-bf90-c45dd684e187" control-id="ca-3">
+    <implemented-requirement uuid="2cdfa14d-b733-4897-a340-b8e3f05bbec9" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="f7f970d1-c4db-46a5-8f27-917064a15d88">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4eaa4dd1-7d03-4588-87ac-97d173a3b329">
+      <statement statement-id="ca-3_stmt.a" uuid="38b26537-a0fb-491c-a6ec-4eba6cf219ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2679,8 +2679,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="d2068c1e-9f38-4f01-a119-4591f806e9c3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5542882b-e64e-4ccf-acf5-5842b1e00a63">
+      <statement statement-id="ca-3_stmt.b" uuid="8dbf9169-8348-4c89-847e-cbb73c852d62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0315457-27b4-46d2-b4a0-e26c51bc6331">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2699,8 +2699,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="1d189c59-970c-4a6c-a879-6d643568564a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2d8ef686-07ab-4179-8bdd-967ddd8379d7">
+      <statement statement-id="ca-3_stmt.c" uuid="0d1c4f9e-fff8-4cdd-a9f7-f66acd150010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2709,10 +2709,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21b71f8d-e6e0-4d9c-a6bc-f6d86f4c5b30" control-id="ca-3.3">
+    <implemented-requirement uuid="850a4ba4-82cf-4aad-9cf8-b8ebc65a9d3a" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="e182a580-acc3-481e-825f-13695f9c1cbd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3ac02728-7890-4f96-8e48-4742a81ea40b">
+      <statement statement-id="ca-3.3_stmt" uuid="b5c7d2a9-d912-4bdd-b25b-bc3b37149184">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b698b788-aff4-4227-9a0e-ecc3f1a85b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2720,10 +2720,10 @@ Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="337c50b7-d4f6-44e5-8ef1-0a58bcfc39fc" control-id="ca-3.5">
+    <implemented-requirement uuid="fedbf269-0f66-44c8-9e7f-25605d243263" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="1538b659-1aca-4603-9617-d684b21ef614">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="46789fa4-f228-43ea-be29-a2c09c95233d">
+      <statement statement-id="ca-3.5_stmt" uuid="f6abe9b9-631d-48f6-bb3e-625110996d75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="deb71040-a9e4-4609-b2b5-b473fc4ec3e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to Red Hat Virtualization Host (RHVH) and applicable
 through host-level firewall rules.
@@ -2735,10 +2735,10 @@ https://projects.engineering.redhat.com/browse/RHV-20516
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="45da4afb-0a4c-48fc-aa6a-4f98160ca210" control-id="ca-5">
+    <implemented-requirement uuid="86d74c00-0c31-4d76-b3fb-c0c9a65518da" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="612d59d9-d373-45bc-8aac-a2907f10cd02">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0afb8d90-de89-4945-bd36-61697dea9ff4">
+      <statement statement-id="ca-5_stmt.a" uuid="47df7fd2-84ab-40da-86ad-2af43e1230f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b013587-8b21-43ec-8ef6-0917e64a1462">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -2746,8 +2746,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="1f28a3e1-5866-4ca4-b6d5-e3b8ed249ae3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="32e79129-f53e-4e23-8e0a-2bd9df6c25fc">
+      <statement statement-id="ca-5_stmt.b" uuid="a48733c6-22f6-4c39-96c2-0b8738304727">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea64d27c-3385-4fa6-93d6-575913ac2533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2756,26 +2756,26 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration process
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36168af1-42cd-43e5-acad-6ac6c9fda5b8" control-id="ca-6">
+    <implemented-requirement uuid="f614a8be-533c-4f88-8721-e6069c1932e1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="929f6ab4-12f2-429d-afcb-a40404ed3450">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="384eaf3d-75fb-493e-bf29-2283617509a2">
+      <statement statement-id="ca-6_stmt.a" uuid="c0d2ca6f-e92a-46b9-9552-8403ee244e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="de2907f6-90a3-475d-a722-d95e7f2a57af">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ea503986-ef64-404a-a3e1-e42382d891f1">
+      <statement statement-id="ca-6_stmt.b" uuid="ee5d757d-b418-40c0-952b-1956499bcb08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="52d8a0e8-f9d5-494f-898c-0146bde01f38">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="471a0ef3-e0a8-4013-aa07-1522e7094f0d">
+      <statement statement-id="ca-6_stmt.c" uuid="504677fe-0e57-4537-9f05-b57d3833d732">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2783,10 +2783,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18b3c26f-3c39-4d60-b5ba-f369b837a92b" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="71d6b9fc-b5b9-44a8-b994-6bde470313d8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="694c876d-f2a9-4a46-b17b-80f59e6de82b">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2794,8 +2794,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="76b53b7a-f2b6-45bb-acfc-ce7601d31fa9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9e604b43-49f8-44c4-95a3-c8a1daf516e1">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2803,8 +2803,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="36d0a038-62c5-4f2d-837e-951ed9d65db8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0e5af2cb-dd32-414a-9f10-90c9deebf736">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2812,8 +2812,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="695da096-ef38-4cbd-a8a7-b59ea8b7646a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ab1fdcf-dc89-407e-922e-950ee90f4fb2">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2821,8 +2821,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="77f67fe1-85fd-4e3b-8549-91e61e7ac3ec">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3d7471c1-9777-4247-8fa1-6e8785ba82f0">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2830,8 +2830,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="e7206f38-851b-40af-ae1a-1824ba224b7e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8f75e688-3ba1-4652-b31e-b1563dbb46b3">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2839,8 +2839,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="ce691ce5-d99b-4fa7-be6b-9614a3f8d9c8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ea0318e2-7e71-4644-aaef-842da77f23d2">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2849,10 +2849,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04436bb9-1452-423c-988a-f20e15883bbc" control-id="ca-7.1">
+    <implemented-requirement uuid="9598c03f-f904-4244-9e36-c3c25ab93014" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="6f8adfd5-59b5-48a5-88a8-5ed538cb1378">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="491c5fa8-6e2e-403b-8688-73a5686759ef">
+      <statement statement-id="ca-7.1_stmt" uuid="502f4163-776b-40ca-9c81-0f094f7ba39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3d82404-c62d-4668-b25b-da4dc2a9baa7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2860,10 +2860,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af10367b-68fc-4591-a972-85d7ff675126" control-id="ca-7.3">
+    <implemented-requirement uuid="3bb1dd39-9535-4a91-8172-8693937f3798" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="69722549-b779-4f48-8c22-1492df1a0317">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7dc5e8e1-aac1-4ebd-b5bf-c91cbbddca3e">
+      <statement statement-id="ca-7.3_stmt" uuid="e775d900-3b4a-43bb-a43a-1e7963b62dc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4593ac-7e9a-40db-8f2f-002124c0c5af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational trend analyses processes are
 outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2871,10 +2871,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a57fbe25-e540-48d2-b569-81f64f9552a9" control-id="ca-8">
+    <implemented-requirement uuid="1dc4a76c-ce52-4b9c-860b-644bcd2d46b6" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="55870198-a1f3-450b-a5ff-8a4170c374ff">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ec50083d-cea5-4479-afa2-f94f8c342547">
+      <statement statement-id="ca-8_stmt" uuid="a940f98b-95e7-4673-b382-23ca28241bd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2d7b791-7b57-4b06-843f-8d36c82228dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2882,10 +2882,10 @@ Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f8a7b78-845e-44fb-8280-e1b7cb99c7e0" control-id="ca-8.1">
+    <implemented-requirement uuid="c24de900-2274-4748-ad30-9f7faaaeab8b" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="de586dcc-e86f-43f8-b5a1-f139f4ddb4ec">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="61488f4e-fdf2-4fb3-b2b9-c21400ac8ce5">
+      <statement statement-id="ca-8.1_stmt" uuid="e8122375-3c7b-4569-8076-3bbd87ba8309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbc2a29b-74d2-41de-95b5-76e6afa4615a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Virtualization Host (RHVH) configuration
@@ -2894,10 +2894,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5e66997-c49f-4377-8382-028f80b04bf5" control-id="ca-9">
+    <implemented-requirement uuid="81438902-6d72-48c6-bdef-512ce86f9cc8" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="2aa0719c-a849-4336-b971-06f155e8812e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c341add3-37f0-4f35-ad6c-50f091d3839e">
+      <statement statement-id="ca-9_stmt.a" uuid="37075470-ee1b-4d57-bd59-9e906f08185b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ba32062-5e14-4358-a282-0c161301fd23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -2915,8 +2915,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="b390144c-b9fd-4d94-a82d-5c739e30bd3d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f82b10b3-a8a3-4626-9576-a61b6f2acbc5">
+      <statement statement-id="ca-9_stmt.b" uuid="8757eaea-2bf1-4007-9b9c-1d12b7808641">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4085cf70-9957-47a4-9b8b-97caac2a5166">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -2936,18 +2936,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91e3dc57-9e47-4a2e-bf53-9527438bf7c0" control-id="cm-1">
+    <implemented-requirement uuid="cfdc0ca1-6cef-42e4-8d4d-ed3938123b40" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="8c8cfe65-8e85-41b9-a608-cac0e2398511">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6d67f735-4bdc-4a53-a863-4bb73d98a258">
+      <statement statement-id="cm-1_stmt.a" uuid="8e9e428c-067e-47be-81a9-5bea33a7a446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08f31ac0-12ba-44af-a682-36187123d8c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="aa183b41-c66f-4cbb-bd65-7f3a659eeded">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9c88500c-f4fc-4c18-8fd5-ce1c8bf32a5e">
+      <statement statement-id="cm-1_stmt.b" uuid="05595bed-e10d-4ed8-b954-b8e07ca96a22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27ae912-1014-4d2a-b6c7-32a644fe6dad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2955,10 +2955,10 @@ management policy is outside the scope of Red Hat Virtualization Host (RHVH) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85ac35a0-db1e-477a-9d17-030186e27591" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="69b3bdf3-5e11-4e3d-806e-a762432d7fec">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="925de0a6-c251-4c7f-b1d3-7fafc8ea60bf">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2968,10 +2968,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eebc6cb8-f607-4c99-9953-ad9a68fb78fc" control-id="cm-2.1">
+    <implemented-requirement uuid="1175aab2-b8fe-4b48-a82a-54c02ce8b030" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="c262451a-2f3e-4f8d-9317-40b7d7949202">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ad3f5b0c-dd3b-42ce-9457-2fd7b38598f8">
+      <statement statement-id="cm-2.1_stmt.a" uuid="c70cb871-7647-4a19-9e18-25d13e0c8134">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2980,8 +2980,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="fbac52af-8fb6-401e-a9d1-e5d5fde88c15">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7cf96a1b-be5c-48d1-b3a8-c9734c93487a">
+      <statement statement-id="cm-2.1_stmt.b" uuid="02f6ac89-58fc-4803-9ca7-d8ba052bdb7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2990,8 +2990,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="9fa73a5a-b92e-4222-b443-ae715163bde0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6e71d639-d04d-471b-8cb2-ad26398d9c4f">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5c60f968-1ec3-4d42-a3d5-6506b6229de3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3001,10 +3001,10 @@ https://projects.engineering.redhat.com/browse/RHV-20520
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6128593b-2a96-49a6-8ac4-766926850842" control-id="cm-2.2">
+    <implemented-requirement uuid="70c0fb30-fa81-406d-9884-90eda4617fae" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="dd45101a-256d-48f7-a2eb-73afafeaa3bd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="20fdf1b1-72bb-4a64-9993-08118af66aff">
+      <statement statement-id="cm-2.2_stmt" uuid="ad22cfd3-c298-49b0-abc1-f14139cb228d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c82280c-9d27-4e3c-bfcd-2cf177e34ba4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3014,10 +3014,10 @@ https://projects.engineering.redhat.com/browse/RHV-20521
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fab2e160-c110-457e-b875-15012a3abe21" control-id="cm-2.3">
+    <implemented-requirement uuid="25e98aef-d677-4c77-9d54-2973e72f1750" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="295d6ded-ac8a-4485-90ec-bfef99915aa3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8036ac7b-df6a-472b-8f3f-f50e56ee9ff6">
+      <statement statement-id="cm-2.3_stmt" uuid="9120376e-fb5f-4f88-84f4-5bd32d647c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d33969d0-128b-432f-b439-dc4f470e4466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3027,10 +3027,10 @@ https://projects.engineering.redhat.com/browse/RHV-20522
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1352aa4-2fc3-473d-b29e-04c0d06b71e8" control-id="cm-2.7">
+    <implemented-requirement uuid="9ded0ea3-4568-4ab3-901b-eb03cffea7a0" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="52f93a73-37f9-46e7-9863-f53c7e97faa1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a2da03ae-7e59-45a9-9db5-0e0af2370edb">
+      <statement statement-id="cm-2.7_stmt.a" uuid="971b43bf-62cb-4fad-9519-4aa739eb1469">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="543efe33-8d56-411f-8838-6712a0af2fc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -3040,8 +3040,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="512692f2-ae57-4f1b-b6cc-a167c2101605">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4605b431-eff6-41e4-9a32-6c9365e763f1">
+      <statement statement-id="cm-2.7_stmt.b" uuid="ac8c381f-6376-4ef0-8717-225c63242ec9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aec2242-c3df-406b-9e5d-fb8a5d4f78cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -3050,10 +3050,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48327661-cdc4-490f-ab6c-fe60be55cd96" control-id="cm-3">
+    <implemented-requirement uuid="8b20002f-87fc-4696-ac56-f29084a0d993" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="3eceade9-519a-48ec-a55b-3e73e33dab33">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3f0e0f00-f991-4a70-b42a-985ec1b8fced">
+      <statement statement-id="cm-3_stmt.a" uuid="42365f59-42dc-47f7-8da3-2d45e8a13a76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3062,8 +3062,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="af1ae3ca-3c87-463b-8fb5-864f25181dfc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fdc3e032-18b1-4887-a27a-c7b4b99558ff">
+      <statement statement-id="cm-3_stmt.b" uuid="1b035e1c-2536-48b3-b14f-f55f3da4cae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3072,8 +3072,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="21515557-1485-4c97-961d-47b78a1a0cc2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="57f82e29-71f0-4933-a196-80923c88f659">
+      <statement statement-id="cm-3_stmt.c" uuid="8236707a-18a5-4ca4-8be3-7c39745b62a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3082,8 +3082,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="8cc29046-7afb-4407-bea8-46e4b896daed">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b3c62e15-1de3-4659-8244-4cfa4c5610eb">
+      <statement statement-id="cm-3_stmt.d" uuid="637f76df-2369-481c-bd48-6a7e18bdbecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3092,8 +3092,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="e8d945f3-b978-4c27-a5f4-7556ede5989d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b243eb23-b18e-4340-9282-4a14f700b905">
+      <statement statement-id="cm-3_stmt.e" uuid="3cd7556c-0293-4c0b-8c95-66a14873b29c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3102,8 +3102,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="fbd95044-190e-4b7b-8851-8da9a7aa94f0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="38c4c759-103b-420a-8272-151e0fc455b1">
+      <statement statement-id="cm-3_stmt.f" uuid="eba81077-99e6-499e-a7a3-f7e96ce35b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3112,8 +3112,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="1220a751-02f7-4fc3-833f-4efc15d16af4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8f2d6c00-9cfc-42fa-8794-02098126614b">
+      <statement statement-id="cm-3_stmt.g" uuid="e54c96b3-f923-4cc6-bc23-c9878c8079f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3121,50 +3121,50 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a9f8ee1-545f-4b86-96a3-bc13bdbb0fa2" control-id="cm-3.1">
+    <implemented-requirement uuid="67e3efe8-2ea3-44f7-9757-52282bcfcdbb" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt.a" uuid="071683d1-4513-466e-ad87-71220ab80b0d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5552b37a-20d0-4e69-8c53-24f322f3ea9e">
+      <statement statement-id="cm-3.1_stmt.a" uuid="01c43d9e-c071-4f02-b1f6-6e7ed3215583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.b" uuid="bcb82195-d069-4846-ae43-00fb69ce568f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="59bd11cd-97eb-4c40-9229-0ec1fd0da692">
+      <statement statement-id="cm-3.1_stmt.b" uuid="83f149d4-f8ca-4a2b-8128-c396903c9b53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.c" uuid="5784939a-f003-4e5a-907d-358343869dff">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="909ac632-60c6-49ed-9113-72f3ebc5f634">
+      <statement statement-id="cm-3.1_stmt.c" uuid="d32ae5e4-a538-4b0b-a613-0116a95512d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.d" uuid="732edb8f-b1f1-41b9-9a8a-3d5bdd7ba64f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="575132d6-8de9-4e54-8dc6-3c6e5bad2414">
+      <statement statement-id="cm-3.1_stmt.d" uuid="d7a603ea-ab56-4524-8ad9-045f9249da77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.e" uuid="fd4963f3-600e-41a4-bc3c-599a25635d3c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fcf6490f-0454-4246-ba2d-92aeba8b337e">
+      <statement statement-id="cm-3.1_stmt.e" uuid="ac1a43a3-5cd9-4fee-a8d7-0cbcbfcf008d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.f" uuid="2b0ebd60-39a7-4f05-ae65-8cbddc69960c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ba253477-8302-4f9c-a1fa-ae6a180fcd6d">
+      <statement statement-id="cm-3.1_stmt.f" uuid="0cba225b-12af-4436-819b-ee985e06e37d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3172,10 +3172,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5206b09-c24d-46e8-a036-0d60f8a7f52a" control-id="cm-3.2">
+    <implemented-requirement uuid="f2cc315e-8308-4622-9e63-d726d4a93e9a" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="3c966dab-cd78-4859-bb57-a5c23f0d554b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9170e235-2c3c-41ef-874c-1bbe60f4d57a">
+      <statement statement-id="cm-3.2_stmt" uuid="82b50faf-5a63-4f6d-a78e-fab132aadf69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3183,10 +3183,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e35a0f3c-da12-471a-8b31-6b186a09092f" control-id="cm-3.4">
+    <implemented-requirement uuid="f80e0537-5177-4750-b4c0-4f81c62849c6" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="5a656a25-a9ca-4e23-a678-276e2aadedda">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e430311-9ae1-4029-be29-dc38b05fbcbf">
+      <statement statement-id="cm-3.4_stmt" uuid="54ad9b6e-290c-420b-923f-bc0cb638d486">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="012ff6cc-f869-4e32-9507-948ec2a6b602">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The requirement for an information security representative to be
 a member of the organization-defined configuration change
@@ -3195,10 +3195,10 @@ control element is outside the scope of Red Hat Virtualization Host (RHVH) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="800d4947-b03c-4ad7-95f5-8c02ca794379" control-id="cm-3.6">
+    <implemented-requirement uuid="a9130751-2e97-434e-8c84-e6ecbd9f781f" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="ee3a84a8-c8bb-4d5d-9656-ac1e212ec08b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f19838bc-7a64-4558-b780-e7e0c3865a90">
+      <statement statement-id="cm-3.6_stmt" uuid="0a1dcdf5-6fed-45a7-a1e0-5f4dc9e33bb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3206,10 +3206,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e33c9441-440b-4bf4-ba7f-517850307282" control-id="cm-4">
+    <implemented-requirement uuid="c7d70620-3eb0-49f4-98ce-8d59965658ca" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="f517910f-1a4e-40aa-a19a-81e6ef33140e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cf3b1c00-da80-4238-8b47-7e1531850808">
+      <statement statement-id="cm-4_stmt" uuid="763bb0b2-b3c1-4af6-8436-99f29f9c6aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9df6f94b-15df-4647-a801-4aa4eef28ead">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -3218,10 +3218,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="519d2c0c-1eac-412b-a459-013694924030" control-id="cm-4.1">
+    <implemented-requirement uuid="f6f53a28-c040-41ee-b25d-f448b8a6c23e" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="3066b9b4-3e53-4f0b-b602-9c9840987f56">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9f1c70fb-8854-456e-ab61-c2fd1eb46bcc">
+      <statement statement-id="cm-4.1_stmt" uuid="4a239435-6eb9-454c-81b7-b5c3a12d38fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3229,10 +3229,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfa25a27-f939-4a2f-bb52-d4c190f018e9" control-id="cm-5">
+    <implemented-requirement uuid="7bff67d1-da84-4342-ad1f-6dc2aae9ec9b" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="0453e107-eace-4aaa-aed2-7b92f681d626">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b68362cf-cbbb-4caa-bbf2-c80141b3fd32">
+      <statement statement-id="cm-5_stmt" uuid="b00abdab-1b01-4f1e-9090-05aae69627f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3240,10 +3240,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac0505de-bae4-4f20-bd36-68b0c49319e2" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="3bd377e4-9cb8-4e4f-b441-97f67da80a36">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7c9b40d4-f1a0-40c1-b361-f577eb4c075c">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3253,10 +3253,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fd6fb73-acbe-4fee-ae8f-763d5d91f109" control-id="cm-5.2">
+    <implemented-requirement uuid="3c219dfd-525b-4b25-898b-9ef45b2cf991" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="8b6eb39b-d2a2-4ea3-ad9d-c26b68b2176c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a5236b17-736b-4c24-8fe1-45fee18f62ab">
+      <statement statement-id="cm-5.2_stmt" uuid="41babfa7-e2c3-4216-8f6a-8253d127b5f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3264,10 +3264,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8dab32f8-094a-4a01-810a-12bc139a8207" control-id="cm-5.3">
+    <implemented-requirement uuid="8bd4800b-4d23-4722-b068-f53f04d79298" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="dedbbc6a-a24f-45ee-9d5d-a644476a1a40">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9df9c47c-403d-45c6-ae62-64f760cf380a">
+      <statement statement-id="cm-5.3_stmt" uuid="1a42a7ca-52dd-4fc7-a4c6-db20e4737bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="020466c9-c44d-46eb-a233-a4b3e05d72ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3277,10 +3277,10 @@ https://projects.engineering.redhat.com/browse/RHV-20591
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41d8fc16-cb85-4c93-8c3f-d9cf8381ed67" control-id="cm-5.5">
+    <implemented-requirement uuid="8ce7dcc0-5066-47bf-8103-1431502afdc6" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="265a489e-2b84-489d-ac0e-1db997188208">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="166b2b31-1199-45df-b005-2911e380c0a0">
+      <statement statement-id="cm-5.5_stmt.a" uuid="dd60c188-efab-41b2-b837-9dd1fc6e0744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1444903b-5a53-4300-bf9a-f0c65262db2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3289,8 +3289,8 @@ https://projects.engineering.redhat.com/browse/RHV-22703
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="4c927457-7432-422c-8963-9692f4c5b069">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="14552cec-6669-4799-a522-f590e6bca72c">
+      <statement statement-id="cm-5.5_stmt.b" uuid="4c06d361-d99c-4fe2-89a2-54705b257ed4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3298,10 +3298,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27accbc7-677a-421a-9814-c0da5189d546" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="553a83cc-482b-43cc-a309-08a77de6b69e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="75a8a424-b1e7-4689-8c44-e10167b0345c">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -3315,8 +3315,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="9b3d438f-80f9-4e43-b297-9ee498b688b5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0106006e-ba1f-424d-acab-2bb8e8c59ce4">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -3330,8 +3330,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="512832de-af59-4c0b-81f9-bb0c82f46a58">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fcaffd55-e4cc-4df8-a5d2-071c8939761f">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3340,8 +3340,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="974276f6-6917-4715-8c3c-f43f6a241518">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="27b0b48b-2a5f-452f-a675-eb5d33f3d405">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -3358,10 +3358,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38478234-613f-40a0-ad07-a17c695b37f7" control-id="cm-6.1">
+    <implemented-requirement uuid="856967aa-a9a0-488d-8182-c49747d9d848" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="738f06d2-ca43-443b-b3d6-2f5eeba82456">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="16475a5c-d289-4254-aaa4-ba6620a2b5a0">
+      <statement statement-id="cm-6.1_stmt" uuid="413e2e1c-43d7-45ab-8c9b-c76ed699a071">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44ea72c2-dc7d-4422-8f76-6ff1f5ad4e68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3371,10 +3371,10 @@ https://projects.engineering.redhat.com/browse/RHV-20524
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69e44c1c-d4e1-468e-b988-52a5728d2bc4" control-id="cm-6.2">
+    <implemented-requirement uuid="eeeff042-ec63-4a37-89d4-8f9979448ca4" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="51f817b6-49a4-4711-a83f-0230d5a4204e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="92e1dd59-1a4e-4772-a344-6daf64e4db68">
+      <statement statement-id="cm-6.2_stmt" uuid="075d37fb-5aa0-4d71-97f8-c620d813a459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3382,10 +3382,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf421fc5-dcd3-4b91-a300-36585e995be0" control-id="cm-7">
+    <implemented-requirement uuid="5d481866-afa3-4223-8b3f-d048186639fe" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="2a705b25-2362-4289-85d0-6ff7a0514151">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="69a59792-5b1f-4ab5-b6c3-0c7cc95adc62">
+      <statement statement-id="cm-7_stmt.a" uuid="f1c03d8e-385d-4872-bdc7-5811d06486cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c1f7cc-f58e-4150-8003-b7f3e10862e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -3396,8 +3396,8 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="dd64350b-7f9a-4451-afe5-33781db239c1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a99e4748-87de-4d3f-9599-aa7a01b82aa9">
+      <statement statement-id="cm-7_stmt.b" uuid="75c090a7-ee60-4f64-a388-bb7ed7c9c5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0735d452-78f2-4bf5-9f4c-065b42936360">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -3408,10 +3408,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf2e7f5d-de48-4a39-a788-af34fda87b3b" control-id="cm-7.1">
+    <implemented-requirement uuid="9df378ad-07af-4f16-8970-7121beb0b4c0" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="eceb25e9-a0e5-4664-98a1-53094aa72c0d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3d4fe93d-ca93-46d8-a993-f9b83a77e483">
+      <statement statement-id="cm-7.1_stmt.a" uuid="4990b97e-55cb-437d-b94b-c67fbdd00243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3420,8 +3420,8 @@ https://projects.engineering.redhat.com/browse/RHV-20525
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="7106e4b7-4efe-4c51-853d-0c7dfab5f090">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8de5be88-7132-4d6f-b87f-9fd8b322916f">
+      <statement statement-id="cm-7.1_stmt.b" uuid="bdf67c38-65b8-4222-a28e-94cde8b3f1d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3431,10 +3431,10 @@ https://projects.engineering.redhat.com/browse/RHV-20525
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37c48048-9f32-4189-acbe-8eb43e4902af" control-id="cm-7.2">
+    <implemented-requirement uuid="d7ae7ecb-9b0e-4166-9b23-6a5583c845c4" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="e4977a67-d55a-4a80-9e17-688a8b16fdd4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8fc25c96-4a2c-456c-86dc-bf08f22fa06c">
+      <statement statement-id="cm-7.2_stmt" uuid="713b03e4-4959-4cd0-830e-ea99848a6d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce0022ee-1dff-44a4-903f-ec64de590727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3444,10 +3444,10 @@ https://projects.engineering.redhat.com/browse/RHV-20592
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4ba8ef3-e660-41d8-bc9c-2bae38a5b341" control-id="cm-7.5">
+    <implemented-requirement uuid="f1552409-31d9-4431-8cc6-a447e5c4b3ec" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="09f42764-2db2-4820-90fa-305f113379cd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6280a8e1-8746-48ee-8794-9e60ae611f12">
+      <statement statement-id="cm-7.5_stmt.a" uuid="0c69d796-a67f-4a62-a30f-59a3998fa9e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3456,8 +3456,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="c1b660f0-9291-46da-a3f2-9e85cdedfad3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="67f8e879-ccca-4b2d-b9df-84d1f8bd691b">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a04d7c8d-a185-4c75-b689-e74cf9229520">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3466,8 +3466,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="4c030919-499e-4497-abde-9384e5926e68">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="92cf1ae4-504d-464c-9c22-ecd50ae409a0">
+      <statement statement-id="cm-7.5_stmt.c" uuid="672cd179-ac40-4a51-9952-38f58927a20f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3475,10 +3475,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0191297c-e32f-4294-8e35-3373bb6317dd" control-id="cm-8">
+    <implemented-requirement uuid="07b2258b-e3d5-4ca2-960c-d9e82a056236" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="90ff2dc1-9cf5-4661-8688-02043e376f75">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="144ff950-64c8-4f29-b4c8-0fa60af0a76e">
+      <statement statement-id="cm-8_stmt.a" uuid="b53ef6f4-6571-4239-8a55-ea7a285fe47f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3490,8 +3490,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="efa2f6f6-ed22-4584-b401-e3e001e63390">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f377356f-1eff-473f-8345-e1d36fe113ca">
+      <statement statement-id="cm-8_stmt.b" uuid="6c3e7c49-c2bd-4582-bcca-eeed439afec5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3504,10 +3504,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="779662bb-10e2-4a20-9a27-fe0ec580c5be" control-id="cm-8.1">
+    <implemented-requirement uuid="d918bbaa-fa67-4981-a6cf-c1fb58598ed0" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="efb68ea7-2c0a-4411-81ec-9f2476b14ae6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="828f3a27-e7b6-41c4-a3ed-ef3dde0e87f2">
+      <statement statement-id="cm-8.1_stmt" uuid="98c82f1a-8fba-48c6-a2f3-50b707fa6cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f086a431-fb22-4d02-86b9-ec0947418fe6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3517,10 +3517,10 @@ https://projects.engineering.redhat.com/browse/RHV-20780
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40862f75-30d5-4b07-aca5-59dcd744119e" control-id="cm-8.2">
+    <implemented-requirement uuid="3de338f4-d4cc-4381-b26f-273f58d3749d" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="f37bf77d-645b-468b-8102-07607a1db3f6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3f5f9dac-e20a-4a7a-802b-404676f3c7a9">
+      <statement statement-id="cm-8.2_stmt" uuid="cbb2d979-2dc7-4b9d-a188-75044f9d6cd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3530,10 +3530,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4da1a00f-934b-4123-94d8-0adbba572c5b" control-id="cm-8.3">
+    <implemented-requirement uuid="f2b54bf3-daf5-44c2-859c-d06bf379b306" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="b97be448-c65b-4b51-b432-bd398bd1553c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d2cc34e0-0b83-45f8-a2ce-579aaa1f115e">
+      <statement statement-id="cm-8.3_stmt.a" uuid="66d965d3-4618-43ea-9ea0-c9790410ba10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3542,8 +3542,8 @@ https://projects.engineering.redhat.com/browse/RHV-20595
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="42f59342-e0c4-4bd0-b8d6-b22472a8232a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e07d0dbc-e902-4de5-b76b-ea04f1a0f39b">
+      <statement statement-id="cm-8.3_stmt.b" uuid="f4777728-b259-4f4b-aa37-d73575034a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3553,10 +3553,10 @@ https://projects.engineering.redhat.com/browse/RHV-20595
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f610e69-a3cf-4f1a-b4fa-64c2806d86de" control-id="cm-8.4">
+    <implemented-requirement uuid="d9c09840-28f8-42f6-91aa-349a22ec992f" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="7a7c3891-a619-47cd-9200-24f90b481a88">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="80849ed5-3f75-4444-923b-a0ce2903e989">
+      <statement statement-id="cm-8.4_stmt" uuid="4eb6c8f8-56c7-4c72-8ee1-4687f71bfc25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a73b7aa-8537-4c88-8ce8-6937eacc5469">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include in the information system
 component inventory information, a means for identifying
@@ -3567,10 +3567,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1da785ed-b334-4f4e-a88b-6e161be3d3df" control-id="cm-8.5">
+    <implemented-requirement uuid="c48f0033-df6c-4729-91ad-228722da8d37" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="1141876d-2f05-4e2e-959f-135ec0aa3831">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e850ec9b-3315-48db-83e4-32d899edbe88">
+      <statement statement-id="cm-8.5_stmt" uuid="861e432c-8f1a-4a7c-afe5-634c503486c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c655a8e1-6c26-4e14-8ce4-558d9f7fe49f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3580,34 +3580,34 @@ inventories is outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac68e5cb-fe69-4c40-a845-ad39a9d07296" control-id="cm-9">
+    <implemented-requirement uuid="c78702a1-e56b-4b58-b2e2-790979a0b16f" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="0970a939-dd9e-4422-900d-4ea6102c2b80">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="62b7a60d-85a7-4fff-ab34-c8ddcb07ab47">
+      <statement statement-id="cm-9_stmt.a" uuid="f03eb09d-5b14-4a85-b2d1-188122ee7adf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="a305b764-47ec-4b4f-b9cb-342df364b28c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c63d1415-ea82-4628-9c74-83e16ec74af1">
+      <statement statement-id="cm-9_stmt.b" uuid="46387aa8-bfc8-4807-b12c-1a0b73219655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="5c4b584c-f65b-45a5-ba98-43dc1980d27c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="95d3ca30-2899-4cb8-993e-e27116dbb9a1">
+      <statement statement-id="cm-9_stmt.c" uuid="465d0d39-7df3-4024-833c-84fe9e672c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="2a8c8fb5-e278-4eed-9ab5-c803e82156bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="df481c8e-6b13-41e7-9059-02d983349c13">
+      <statement statement-id="cm-9_stmt.d" uuid="0d6ed44c-fafe-486c-aa63-498afc208af3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3615,10 +3615,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7965581-7c2f-4810-a574-23a6f0ceed6d" control-id="cm-10">
+    <implemented-requirement uuid="2c661714-d065-4868-b601-26cbe5055442" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="43afaeac-61e6-4015-924f-37d38d42de16">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="06afff91-9264-4b21-8dd4-79603959af06">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3627,8 +3627,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="8f8e0aaa-5b4d-471a-978e-165c42dcd972">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="78a75016-49cd-47d4-a2b6-c2e39be428d7">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3637,8 +3637,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="69b63b34-68f8-4f59-9c14-c4559be490eb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8577c0bc-2380-458a-b177-96aa2d9c2c2c">
+      <statement statement-id="cm-10_stmt.c" uuid="d84e5f1c-a35a-41b3-894f-2b78fc2aa9a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3646,10 +3646,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fab15d4-831f-4e9e-9dbe-a3775009c4e4" control-id="cm-10.1">
+    <implemented-requirement uuid="1824b6c6-8050-4f40-b874-60a67578fcd9" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="bb8d92e9-52c3-4035-ac42-20494c103ae1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="18be2711-f059-49d8-a147-e7175e86aef9">
+      <statement statement-id="cm-10.1_stmt" uuid="0df04749-8c20-4ffb-80c7-91b36fa36f42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a64717f-e2e2-4ce2-8b96-86cb8fc25399">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3657,10 +3657,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf669836-8cfb-4831-8724-2a5014f33f0c" control-id="cm-11">
+    <implemented-requirement uuid="4e58bfa2-4492-437f-a01a-fca1e8718539" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="817fff9c-0f12-4803-91e1-6ee3896038dc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="aac610b4-4f67-42ed-8486-23ee1fe28126">
+      <statement statement-id="cm-11_stmt.a" uuid="7693dc19-dd28-4599-9e26-8b8ae1f36b38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05d2dfdc-7476-4e8b-bdab-8344fd80afce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Host (RHVH) nodes. The following are suggested
@@ -3679,8 +3679,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="c52bfdd8-261e-4787-9e5e-de07f4575cb4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e5a5a376-a360-411a-8247-e98c818fb948">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -3697,8 +3697,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="fb1ae6dd-bad6-419a-8631-b0b33e788d7f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2ade4a6-1227-46b4-b6d0-712e015dcf22">
+      <statement statement-id="cm-11_stmt.c" uuid="e323d5bb-94e6-495c-9bac-7a2755aa97d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3706,10 +3706,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26c034a4-2cf7-40d3-b9af-26797a8d292d" control-id="cm-11.1">
+    <implemented-requirement uuid="97ec37be-cdf5-43e7-9437-0b575ffd9d2f" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="66cfe5a0-563f-4c5f-ae17-355fac620b55">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="91e652e0-c81d-4ce9-afe6-8c79d7b384f1">
+      <statement statement-id="cm-11.1_stmt" uuid="dda5705e-7480-425a-ab96-d25ed45617cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29fc46a9-4423-4aee-bb79-02d19d199eb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3719,18 +3719,18 @@ https://projects.engineering.redhat.com/browse/RHV-222709
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54a2903d-065a-41b7-9987-966cbe597cea" control-id="cp-1">
+    <implemented-requirement uuid="a4d50e31-979e-413e-9d1c-bad6a286674f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="86021cc9-f010-428e-98b9-349fceb668ee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cecb085e-3d0d-480c-84ed-059c018ee7f0">
+      <statement statement-id="cp-1_stmt.a" uuid="de0eaee1-2052-4121-ab5e-d97aa37f67b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="55d25eb3-8add-448d-9254-55608b738f7e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b6ddfafa-6241-44e3-8002-f2297bcd40a6">
+      <statement statement-id="cp-1_stmt.b" uuid="450d19af-1220-4860-9c86-5224e96005b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30fb2eba-41a4-402d-89e4-3000d3b57982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3738,34 +3738,34 @@ policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fccbcd2d-dfd1-45a8-934a-58ae81882e97" control-id="cp-2">
+    <implemented-requirement uuid="1eb13bca-54c9-4920-aa02-7579e0351f67" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="ca8a535f-d0a8-46dc-b1c9-be6f21d15170">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="21b2ba30-262f-40f4-9f51-07ab69595b26">
+      <statement statement-id="cp-2_stmt.a" uuid="bde1ab58-3391-4b95-b76c-d012c47dc90a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="7bb8b132-6542-430a-b743-e2f063cfb335">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4703789c-644f-4b6a-9e91-0111252a2ccc">
+      <statement statement-id="cp-2_stmt.b" uuid="baaf50bb-ec4e-4b52-86f5-009531beea36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b192bba0-89b4-43fa-a0de-ef361af44ed3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="e7e04bd0-d4ac-48a4-a2aa-c718a7774dd4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5e716149-f3bb-46d1-9532-b6fc845df0aa">
+      <statement statement-id="cp-2_stmt.c" uuid="0618434f-fe6b-4e3d-b500-ecf4e0c6e859">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c8443da-ca03-494b-a8c4-1223add1c65c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="be4753f8-3a6f-4fca-b48f-c779bd87fbf2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="52c1704c-2092-4989-a6b2-f094cab509ea">
+      <statement statement-id="cp-2_stmt.d" uuid="766fac0d-33c0-41b5-ab5f-62d02f55b664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70fedb8a-d30e-419c-b649-c446767a490f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3773,24 +3773,24 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="7c4a2c25-538a-40bc-bdef-4a25da565769">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="da668c9c-efee-4678-a4e7-8c6f8b440d0b">
+      <statement statement-id="cp-2_stmt.e" uuid="cb696cae-5941-4b56-b94d-3be6099d04b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4394777-a16b-4df6-8066-9b76913dd72d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="fb6cedac-e213-440e-8ab5-0ff623da39fa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6c06c215-f46c-4e1b-8d1a-22e65b841106">
+      <statement statement-id="cp-2_stmt.f" uuid="77dc42be-4ddf-4c65-b4c4-f8041a1f3e49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9e64a1a-3e28-4df7-bdda-e299001953b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="eed2c12d-51fb-4024-90b4-0ef5698cc00d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5dde1348-746a-4a39-98f0-d0f00aed0df4">
+      <statement statement-id="cp-2_stmt.g" uuid="593dcee1-22e3-4dfb-96b7-b6f704a78d3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb2eed58-dded-410c-8051-d9533ce5df3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3798,10 +3798,10 @@ modification is outside the scope of Red Hat Virtualization Host (RHVH) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c82475c-ad26-4929-857e-dfe01eb97263" control-id="cp-2.1">
+    <implemented-requirement uuid="51d7924b-193e-45c9-8089-2e8e992e8864" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="1bd3d731-bef9-4db8-a1f8-030ef200395e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="15fcc159-6024-4c83-b98c-37ad06d2757c">
+      <statement statement-id="cp-2.1_stmt" uuid="a621c339-ade8-4e67-938a-c6af61ba9ca1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30cd7a39-f82d-45ac-9cdc-e2c0d0926136">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -3810,10 +3810,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a210f9f0-2daf-4d85-aafe-668d2ebd861b" control-id="cp-2.2">
+    <implemented-requirement uuid="f63bb2e5-2786-4d3f-8124-e09a15847cc4" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="754f52e5-66aa-4ea7-8475-23d7108cc962">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e1c33f4a-c27d-4728-8c51-487b36e0fa88">
+      <statement statement-id="cp-2.2_stmt" uuid="d4b2afc4-dce2-41ce-9731-4c54f6f0d25c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20eab3e7-d9a7-43c8-b847-14de3ee49657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3823,10 +3823,10 @@ https://projects.engineering.redhat.com/browse/RHV-20781
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97f773ee-cc11-4dab-8184-5d15fc82e5cb" control-id="cp-2.3">
+    <implemented-requirement uuid="d37c39ce-b3fb-4820-9cdf-fa5d2671ed69" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="87d2e665-bcb4-4818-bfd9-ede7b867783b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4bf8ec3a-e336-481f-81ec-d76cb709cbad">
+      <statement statement-id="cp-2.3_stmt" uuid="752c2dc3-6e4b-4ebf-bd8b-e04687d3c4e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d4d0332-ba47-4e28-ac91-c42a2f454afe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3835,10 +3835,10 @@ plan activation is outside the scope of Red Hat Virtualization Host (RHVH) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5042d2f1-b38b-4aa4-b071-109732ffa9d7" control-id="cp-2.4">
+    <implemented-requirement uuid="ba3e461a-7730-4a84-8312-310728f867d8" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="40bb2846-8ded-4087-9a7b-0a7857b2e287">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cbc6bf35-cbea-4fb9-a0df-0f21a1d00ffa">
+      <statement statement-id="cp-2.4_stmt" uuid="513b28d3-550c-4b4d-89e8-9f4deb692b96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e30099-b1ce-47e2-8467-cb9356c6b80b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of all missions and business
 functions within an organization-defined time period of contingency
@@ -3847,10 +3847,10 @@ plan activation is outside the scope of Red Hat Virtualization Host (RHVH) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="983e3c64-27a0-4fd4-bd16-30cc44fe4481" control-id="cp-2.5">
+    <implemented-requirement uuid="3c36e147-6bb9-406f-82e1-50d33f4d115c" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="65fe4729-64fc-4054-b400-076747bb5f6f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cf7e0c47-3fb3-4524-9593-ee5a3a5c1647">
+      <statement statement-id="cp-2.5_stmt" uuid="ba0289b2-9160-49d0-8b8f-2128815c6f45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3a703937-7afd-4700-a432-7d051eab7d64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the continuance of essential missions and business
 functions with little or no loss of operational continuity and
@@ -3861,10 +3861,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f73b0b1-a5a6-462e-96a2-ea28f212776f" control-id="cp-2.8">
+    <implemented-requirement uuid="da72d7dc-5688-459f-806a-4470085be711" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="94824ea1-7bfc-4e6e-9931-9817621e7ce6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="13211fce-1f9a-41ca-a069-77ab8fc9d7b2">
+      <statement statement-id="cp-2.8_stmt" uuid="2fc01614-f440-4fa1-8cca-c4909cc7c890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3872,10 +3872,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2ad4802-907f-458c-9247-c97fd15afaa9" control-id="cp-3">
+    <implemented-requirement uuid="c7c97cd2-5b41-4f1e-aa90-c79d83e69b59" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="a011863f-1015-4887-b3bf-9dd9af1e55cd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="87a1e366-d051-4f90-89ca-359f1c88ad29">
+      <statement statement-id="cp-3_stmt.a" uuid="43d5b766-c085-4de2-b03f-df4f30d10efc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c63dcbea-0150-48d9-88db-9802f3c0126d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3884,8 +3884,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="9dbdc217-584e-4482-b15c-29529419016c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c7bc9d2f-ccb5-43b2-a500-e9850eaf0cf8">
+      <statement statement-id="cp-3_stmt.b" uuid="4723b068-1ebf-4204-b9da-3d662e4f6500">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64b4a65e-1aeb-41c7-981f-952057f9150a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3893,8 +3893,8 @@ system changes is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="a97cd84b-fb9d-4634-baca-1156e93af96c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="047e01ad-e029-47be-a3a7-f6b50cf665ef">
+      <statement statement-id="cp-3_stmt.c" uuid="93c84b17-9755-4aed-8aa9-d9390f1b6579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d9b7f69-1c97-4afe-93a9-9c75cc4c35cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3903,10 +3903,10 @@ frequency is outside the scope of Red Hat Virtualization Host (RHVH) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e8398a3-f72b-4b9b-870a-a3eada37151a" control-id="cp-3.1">
+    <implemented-requirement uuid="6f9ae0dd-fd66-4ba7-89e5-824fabe36b80" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="8f1ef6a4-0bcb-4d5a-9512-e2527ad6b2a9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7d473d1f-dc2a-47b6-b8d4-cc98c6c79711">
+      <statement statement-id="cp-3.1_stmt" uuid="299506be-f529-41ed-a7d0-9a376564394f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c38c419-d815-424d-8ffe-67ca39765f58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into contingency training to
 facilitate effective response by personnel in crisis
@@ -3915,10 +3915,10 @@ situations is outside the scope of Red Hat Virtualization Host (RHVH) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7be4e88c-7b0e-49a7-9d22-79fcb51a9579" control-id="cp-4">
+    <implemented-requirement uuid="66fe603f-1955-488d-ab70-a072c8d9ae49" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="f1f0cf3c-c96e-45fc-a3d9-f441899914cc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9649756a-94b7-4ca4-b7d9-f7509b29c61c">
+      <statement statement-id="cp-4_stmt.a" uuid="9d9a7e50-fa92-4973-a426-da3a5cdd261f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab4951df-705a-4cf4-8ac6-c047fd2cd7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3928,16 +3928,16 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="b1871274-1814-4137-a1d0-3ddf1b5df257">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="aa868260-a4dc-44c5-8e86-8481db037739">
+      <statement statement-id="cp-4_stmt.b" uuid="ec404859-7767-4798-9634-c7f23406e4a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3513952e-7a91-4414-888c-236a38fcb64a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="0b8562ee-3e4f-4ddd-b4ca-9b13e5238f6f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="661384e3-01c1-4109-a1a9-52cc0a1b3041">
+      <statement statement-id="cp-4_stmt.c" uuid="81f1a338-f5a9-42c5-82d9-394dff735c7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1984e099-d316-4fef-8c63-1a695a4fd961">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3945,10 +3945,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c73c54dc-6741-4855-bbe6-5c2dbfb0600b" control-id="cp-4.1">
+    <implemented-requirement uuid="ae34affb-6095-41e8-a330-41b44c7724d0" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="0fe66e73-5c33-4f96-b129-fea50bb68b8d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="559144e8-e781-4f1d-ba65-cd7068af1c10">
+      <statement statement-id="cp-4.1_stmt" uuid="22c6e185-488e-4220-bf4a-73177a2b4730">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb5c3ba9-009a-4aaa-ac94-e1df130a9c88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3957,10 +3957,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afe83ef1-d608-42e2-9f4b-8ae7068a7b5e" control-id="cp-4.2">
+    <implemented-requirement uuid="7fe22178-c16c-4db4-8f4d-09e66acecfbb" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="f02f3fee-ac1f-4dc6-8a1d-fda3d0321125">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4681d307-155f-45cf-9a9c-0de5d6bd5b70">
+      <statement statement-id="cp-4.2_stmt.a" uuid="469bade0-eba9-4965-8cdf-3e6abf0440a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89644e19-e99e-4846-9223-37a3153154c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to familiarize contingency personnel with the
@@ -3969,8 +3969,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="74ee2ca0-f900-4f63-a7ff-ae67ad47986c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="041beaf5-e6cd-4ca6-b934-91fe18699ba0">
+      <statement statement-id="cp-4.2_stmt.b" uuid="194eb1e4-8614-4eef-8ee7-fe0214831284">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a233a5d8-a025-45a1-ac88-5d146190d17f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to evaluate the capabilities of the alternate
@@ -3980,10 +3980,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6a383968-be52-4784-bbd4-217d51a60558" control-id="cp-6">
+    <implemented-requirement uuid="97801796-ee86-4e2d-add3-cf7ba3b5516e" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="44078973-ccbb-4d64-8e70-3a919598434e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0317730e-aa01-4fa5-a3f9-079fd42d32c9">
+      <statement statement-id="cp-6_stmt.a" uuid="329a3f5d-8bfb-4edf-84cb-fdaafdda4cae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91375258-24f3-41d5-8221-27cee278feff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3992,8 +3992,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="c09118a8-2d97-40a5-8c97-6af97ba5606e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="66def47c-80d3-4a54-81a5-5fb8b0335f4b">
+      <statement statement-id="cp-6_stmt.b" uuid="7007f447-1f50-4410-bc6b-5e201611dcfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00b0cce8-5489-427c-bf99-a0d4a6f9d065">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -4002,10 +4002,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76edd3fb-d1e0-4db9-95e9-df035c55101a" control-id="cp-6.1">
+    <implemented-requirement uuid="3cd9d556-6b52-4644-83ef-0903fe1a0772" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="cb6d9fe4-f7c9-4491-9573-b0d402cfb4df">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3594e588-f711-4268-918d-20557ae86e7f">
+      <statement statement-id="cp-6.1_stmt" uuid="09140fc5-1ca2-4b47-8bb9-c37732c32bd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48b1faf6-df28-4a1e-a2ad-ed19158498f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -4015,10 +4015,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="343b1baf-57fd-463e-8d1a-437310b6ca37" control-id="cp-6.2">
+    <implemented-requirement uuid="34891c19-31b7-4e41-83c3-300f8d6aeac0" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="29426c32-1171-4198-825c-52bad231354d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="32e53db4-edc5-42e3-a8cb-6dd3cb5d53c0">
+      <statement statement-id="cp-6.2_stmt" uuid="1117a30a-1920-4726-83c2-f49df5685b8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4026,10 +4026,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2414d32c-bc65-4f27-85fe-44019ecfc34c" control-id="cp-6.3">
+    <implemented-requirement uuid="11a25c04-3400-4c66-8fd6-61cac89d420c" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="cefcb22c-1960-4a89-95db-471d5e9b7e79">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6fcf5d2e-eae0-401b-86f1-cc5bbc156813">
+      <statement statement-id="cp-6.3_stmt" uuid="34a5111a-7ddb-4c2b-a9ad-0ca0200c4e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e677446-1050-41ac-8b51-8e87b2bfb371">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -4039,18 +4039,18 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10181596-b50e-425d-997a-2a3cbd5ac50d" control-id="cp-7">
+    <implemented-requirement uuid="48ecdac3-c8fb-422a-a46e-f1d8d3320a8c" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="bbf3803b-f435-411c-9346-fc91bc27e33f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="85d48a8d-1d2c-4657-af70-1f9e664bc918">
+      <statement statement-id="cp-7_stmt.a" uuid="a9f36fe6-1db7-402f-af67-b5d6077a0897">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="a171ae76-f06b-4ac9-8ee8-5c116ff2a8c0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="683c6c14-1795-419e-b771-0f43431fef76">
+      <statement statement-id="cp-7_stmt.b" uuid="a0f1dfbe-434f-4a8f-8f3f-802800025991">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c9ac56e-812a-4721-baff-1bb201292bcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -4059,8 +4059,8 @@ https://projects.engineering.redhat.com/browse/RHV-20598
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="efe82c09-501e-4bc9-8c09-5d5e89d52fdd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e9a6ad9e-e3e5-4468-9ca5-62b9c03cf52d">
+      <statement statement-id="cp-7_stmt.c" uuid="00946057-d617-4702-9b86-65e79a32f4b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4068,10 +4068,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ef32e44-3313-49e0-80b1-7bb119ddffb4" control-id="cp-7.1">
+    <implemented-requirement uuid="2a87d2a7-beda-45be-8fe2-2415a9ecf8e7" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="39c39bce-c95b-437d-9a28-87eabae93ee9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dc3d32d3-6d39-4e5d-8c36-ea6903fb1ca9">
+      <statement statement-id="cp-7.1_stmt" uuid="7e02b700-2add-4331-ad2e-b88a20ed57f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c332557-b93b-440a-90e4-6f021f9aed93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -4081,10 +4081,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97088200-21d9-48bd-b582-c1eef7a7cd58" control-id="cp-7.2">
+    <implemented-requirement uuid="1f037e9b-1e91-48b2-811c-c1ed4a3a20ee" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="3e73d98a-a9df-42b9-924f-d720061b6b68">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2a18a0a-e57b-4ae1-b6d4-13d2bf7a81a1">
+      <statement statement-id="cp-7.2_stmt" uuid="2a0023fa-ebfe-4cf8-81d1-5dc24fb921f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63beac05-26ad-498c-bf98-aff07acb3b0f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -4094,10 +4094,10 @@ actions is outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="027c44f4-2b31-4bb4-a260-57d633a84057" control-id="cp-7.3">
+    <implemented-requirement uuid="61c2ba1a-7399-4564-afd4-b9b0af0b6f0d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="956c0511-6531-4d75-bb6a-f2ca6baed427">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2161305a-3813-44d5-974a-7aa65ce0e71e">
+      <statement statement-id="cp-7.3_stmt" uuid="807b92f2-cda1-4e71-aa71-7bc3855d7758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a233e6c-b211-4922-9f3b-c71b9a3f1e1b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -4107,10 +4107,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d18ff745-78a6-4f6f-8ee6-5287c366d3d3" control-id="cp-7.4">
+    <implemented-requirement uuid="c8a6dc27-62ed-498b-a12e-33ff659eb8c0" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="3f453e2b-d5b6-4415-8135-eb54d4c1d330">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="80f804cd-c312-40eb-80ff-dc4615ea0f35">
+      <statement statement-id="cp-7.4_stmt" uuid="5f9e3e97-711d-4dfa-ac66-9bf6d29c1af4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4118,10 +4118,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c24af1f8-3c7c-4680-95c8-e3ae9c61bbc4" control-id="cp-8">
+    <implemented-requirement uuid="6cfd9ee6-d116-4a36-a38b-9f05ddc5794a" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="e460ef3e-4f2e-494f-865e-71c3925835b4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dce4cdb0-9940-4581-a7bf-8c15a7aede13">
+      <statement statement-id="cp-8_stmt" uuid="1cbc18d8-4b99-4613-b579-f439718be969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="59b80dcd-b0b6-471f-b278-46c79531b438">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4129,10 +4129,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9706a73-886f-4415-8056-d6ed85ee39c9" control-id="cp-8.1">
+    <implemented-requirement uuid="3c00a373-6f83-41cc-8bba-5666aa45a4f5" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="51b90a72-8bf5-42a5-a0f7-bccecad95d10">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b0db136d-75c7-49d4-9dcd-d30b1fa0541c">
+      <statement statement-id="cp-8.1_stmt.a" uuid="ecbfdab9-cd01-4986-a089-9d1754e476aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="742ad377-0c62-440e-ba79-4e81681d68d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -4141,8 +4141,8 @@ time objectives) is outside the scope of Red Hat Virtualization Host (RHVH) conf
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="5c7cabdb-bc57-48e0-906a-b74a921eea48">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3694675c-dcd9-41b4-b350-0a53134704ad">
+      <statement statement-id="cp-8.1_stmt.b" uuid="a0708b45-3741-4314-acf7-f26fab0aac9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a84ddc3e-f425-406e-ae04-4fb553a6dea8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -4153,10 +4153,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="877a1dd2-dfcd-40f1-93cb-2357bda530bc" control-id="cp-8.2">
+    <implemented-requirement uuid="40bafb14-2fc8-4022-a192-38e74defcd67" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="1245c84e-022b-4f7b-8e6f-0a48b8f2139d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bf6b925c-fac6-4075-85ad-3947cd6f4fd3">
+      <statement statement-id="cp-8.2_stmt" uuid="67fc97b3-6ede-43c5-8b4f-90ee08b61360">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5570c704-bbfb-4f50-8145-42d6eb5a26a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -4166,10 +4166,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c3a1f6b-a970-4cfe-9851-c33d241ea53d" control-id="cp-8.3">
+    <implemented-requirement uuid="d42ecf9f-94dc-498e-9c86-2d03d1510cc0" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="79264986-f535-4c88-bc43-76af8e1d1983">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9aa89583-484f-409c-abfd-46389bdf33ca">
+      <statement statement-id="cp-8.3_stmt" uuid="1f833d9e-dfb9-48ad-b728-e8df33824829">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ec0f621-9350-4e65-b585-671377cf19a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services from providers
 that are separated from primary service providers to reduce
@@ -4179,10 +4179,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="923b4596-2838-4c85-8c53-9a71b9895be2" control-id="cp-8.4">
+    <implemented-requirement uuid="9a9603af-2f5f-4536-b88e-1459b6940cd1" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt.a" uuid="ed5d2e28-59b0-4da4-a9c7-ba01c6d6ae7f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="58e1aec3-8e9c-4b81-a618-03ab46a9b651">
+      <statement statement-id="cp-8.4_stmt.a" uuid="756c1c6e-bc8c-4425-a0f7-d8dca9954125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0494969c-dc06-41c5-a0b6-e22945ebf493">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring primary and alternate telecommunications service
 providers to have contingency plans is outside the scope
@@ -4190,8 +4190,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.b" uuid="64a274c7-289d-4a90-b0fa-acd45bfa02aa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="89e78c8e-3395-4c51-876c-d481e286b333">
+      <statement statement-id="cp-8.4_stmt.b" uuid="93ac000f-b5e8-4fd0-8f8e-5479c7f36f8d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7c8e95c-eee1-4348-96f4-92b7e17048cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing provider contingency plans to ensure that the plans
 meet organizational contingecny requirements is outside
@@ -4199,8 +4199,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.c" uuid="0e12f6ab-2c7f-47ae-a563-5de9a31b6329">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1373a040-acf9-45dc-99b2-4d6f97aaa3f7">
+      <statement statement-id="cp-8.4_stmt.c" uuid="e09cab1c-6fa8-46bc-a6d1-70a6df384109">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="075eb5fb-76c2-42ca-a8ce-f8172378e11a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining evidence of contingency testing/training by providers
 at an organization-defined frequency is outside the plannedscope
@@ -4209,10 +4209,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d471818-c688-430a-9580-ed143ab8feaf" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="22dcf932-c546-4d9a-9712-b558b6d98f50">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="db7c960f-0ae0-4eaf-b38b-a69cc9ce3fbd">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -4230,8 +4230,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="6ce375fd-2c2a-482e-9c1b-07052a88f6c6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6bb8105c-22d2-4fec-895a-87644649aec4">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -4249,8 +4249,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="a12682b7-d0fb-4027-964b-c7d936883a4c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4fb92a4c-4bbb-4c1d-89c7-61f58cb9b039">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -4268,8 +4268,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="9e9a61c7-d6f2-4a5b-a2b0-7f433ddfd6cf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b601c9fa-9079-483c-b812-86661b094840">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -4287,10 +4287,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1dd21d6-9bf2-45ca-82ca-3950eadc544c" control-id="cp-9.1">
+    <implemented-requirement uuid="3dcbc793-579e-444e-87f9-1b617354d14b" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="26bcaaf4-87b9-4b69-9ab7-578d75b57854">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b76f612d-9a36-449a-b45e-21e2cab2ff19">
+      <statement statement-id="cp-9.1_stmt" uuid="31c82c4e-b68a-4df8-ae35-6be82ffd3d18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="116d8df1-d4ee-4f9e-8094-47212bf9821b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 is an organizational control outside the scope of Red Hat Virtualization Host (RHVH)
@@ -4299,10 +4299,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="208919e0-e8ea-4372-9146-5b52f1420382" control-id="cp-9.2">
+    <implemented-requirement uuid="77b7835c-8127-43cb-853e-d46b9a399b9e" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="c060f2e2-0a64-4fa4-976b-d80fc8e80b08">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="419a55d2-4e77-47e5-b839-e6594f43b5aa">
+      <statement statement-id="cp-9.2_stmt" uuid="d69d8e0d-b1ac-48de-b43a-bd3566e4e315">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1bd0788-789d-404e-aa93-873671d9d5fa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 using sampling data is an organizational control outside the scope
@@ -4311,10 +4311,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96cdd862-21f1-46a0-ae6a-2775d648aa02" control-id="cp-9.3">
+    <implemented-requirement uuid="95e93148-2726-489d-b1ca-c150ae1a9fa1" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="438789d5-c4b1-4dc9-b431-6813786f4847">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7b39ae36-990b-40df-a151-930cc7286a0e">
+      <statement statement-id="cp-9.3_stmt" uuid="ff8d9b0b-0009-452c-b12f-ac7c59e0bd9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ad9c150-e6dc-4552-9a31-fb8576c7fef8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -4329,10 +4329,10 @@ https://projects.engineering.redhat.com/browse/RHV-20782
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7ff34ad-1357-4199-bfcc-6e415fbd3f49" control-id="cp-9.5">
+    <implemented-requirement uuid="4f26e612-d93f-48f9-82ac-fd2a8215558e" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="9098a6e6-9400-4614-97a3-63fcdceb3f84">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="055c353e-4a4e-4d75-8428-49f4a998d208">
+      <statement statement-id="cp-9.5_stmt" uuid="d3548657-329e-4eb5-a017-24e24d8e33d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4340,10 +4340,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7295878f-b7aa-4e83-b10d-b69d205921b9" control-id="cp-10">
+    <implemented-requirement uuid="79e121ea-961c-4bde-a84e-e8bad5a2ef56" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="ddb7d767-fc0b-4d83-8232-bb2cd74a045a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88008cc3-494e-457d-8243-065b33ee81e3">
+      <statement statement-id="cp-10_stmt" uuid="cb8c4cbe-276f-4d6e-a855-dd128a8b9536">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d703f450-a122-49ff-8d6e-910b4434d6d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Host (RHVH) environment. A successful control response will detail
@@ -4357,10 +4357,10 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c65f07b6-6a86-4651-8ed4-9efee1e49679" control-id="cp-10.2">
+    <implemented-requirement uuid="d3b055c6-0d0a-45a8-8019-73dea3531cf6" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="abc93a27-b731-4a29-95b1-5842b2739089">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="091dce01-d1f8-438a-b845-137157603dba">
+      <statement statement-id="cp-10.2_stmt" uuid="993a3689-6c95-413b-ae4f-21568ec75a49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4368,10 +4368,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec8f907f-b352-4aa1-a14c-769167503ca4" control-id="cp-10.4">
+    <implemented-requirement uuid="2b967ea1-53f3-4339-9140-eb941abd23f7" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="7d7922f2-22c0-48f5-a1d5-27ce451275f3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a8e533fb-cfec-46c5-bf27-7c1a97bb3f1b">
+      <statement statement-id="cp-10.4_stmt" uuid="bf5b80bc-c459-4ace-a441-3af0db1b1a1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4379,18 +4379,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="514f5f95-e324-4f84-a1e3-39f56b99ddc7" control-id="ia-1">
+    <implemented-requirement uuid="f0f620e7-99d8-4036-a575-5eca390148ea" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="5e417c3e-43bf-4414-833f-071251a3b695">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="002ce460-0c69-4d47-92fe-8a59d1c71d4d">
+      <statement statement-id="ia-1_stmt.a" uuid="7ee6f6b8-28c8-4ea9-b83a-9db2448ee465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0c85dea-3e0c-4433-967e-3f27b7bef26f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="c95e8c1c-25a1-45f6-9de6-2a431936e3e7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ebac508-5359-482d-b254-fb75614f76e1">
+      <statement statement-id="ia-1_stmt.b" uuid="53d59aec-74ea-4166-9625-bcfbb2557334">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2b30f8-c522-4d86-9026-a787c8eba01b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4398,10 +4398,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e293ab3b-d01e-4a6b-942f-81448a6ce9fc" control-id="ia-2">
+    <implemented-requirement uuid="15eca7eb-969d-4bff-a7e4-909f8a73e869" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="7f4bfcd3-ac2b-44da-96aa-e176d41e520e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="97a8d5ee-6534-417c-866e-6354d0355f63">
+      <statement statement-id="ia-2_stmt" uuid="2b7ead57-5b85-4fcf-85e8-e3a5384144df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f98c749d-d278-4b84-8f24-b334804ce20a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) uniquely identifies organizational
@@ -4432,10 +4432,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="558d7ab9-ecbe-470c-ac4b-1c2652b2ecaa" control-id="ia-2.1">
+    <implemented-requirement uuid="5095b0a4-4620-4753-b05c-b53161440672" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="31b85405-e175-473b-af60-c8decd68974a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3d7171e5-d25f-42c9-ba6f-895899e878b5">
+      <statement statement-id="ia-2.1_stmt" uuid="bfd9972e-7404-4f2b-bf4d-56dd5521e099">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9cafe30-8a5e-4406-b296-6c48352d1e6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) implements multifactor authentication
@@ -4450,10 +4450,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0e8054c-0abb-4c46-b1eb-4802ab834b54" control-id="ia-2.2">
+    <implemented-requirement uuid="4d53d68d-2c6a-4a44-ac8e-b76051289b92" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="6e6a9ac8-6cb1-4b0c-8fd5-d5e8aa527faa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="40421c1f-0ad0-4def-8025-a5ee9a4c3536">
+      <statement statement-id="ia-2.2_stmt" uuid="bed222c9-6c1f-436f-8941-21b3fc8c8a1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c48dbeee-587a-42e2-ab32-91162f251ece">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4462,10 +4462,10 @@ https://projects.engineering.redhat.com/browse/RHV-20682
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b794ddc2-f776-415e-9e8c-c5ab384bab46" control-id="ia-2.3">
+    <implemented-requirement uuid="fa8b4f31-4204-401a-9799-bc98267d9a68" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="366c40ed-3e32-4fd5-95fd-1b465c775940">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c0401247-568c-459e-81f7-a388c31d0c8e">
+      <statement statement-id="ia-2.3_stmt" uuid="90feaf4f-ad6b-4839-a0e6-f8b56c15b37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="321738ca-31a2-4b1d-b1b9-0b6c6f4197ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4474,10 +4474,10 @@ https://projects.engineering.redhat.com/browse/RHV-20683
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b143fdb6-d265-425e-89f6-ac856c529f23" control-id="ia-2.4">
+    <implemented-requirement uuid="79f713e6-7a81-434d-97e7-a5ab65db29c6" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="abdfe0f2-513a-44a2-ac1d-c52214f176fc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="99312252-9f58-40a3-bd7a-a1638b212d56">
+      <statement statement-id="ia-2.4_stmt" uuid="6dc700d8-3b4a-40dd-9cf7-af9b8be508b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1b377f7-aac9-4640-bcb5-eb683895b532">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4486,20 +4486,20 @@ https://projects.engineering.redhat.com/browse/RHV-20684
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69eb2f48-ae34-4432-8f52-2fad27557e6f" control-id="ia-2.5">
+    <implemented-requirement uuid="d2ed00b6-ffac-491c-afee-bdbc8b6f5743" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="b4a0b512-051a-4958-837a-9c7f770b9e8f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="908cc8e3-040c-48e1-be89-c9070e58ec35">
+      <statement statement-id="ia-2.5_stmt" uuid="5ba28b63-95e1-440d-aff9-73893ba3bcf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ccb6d3bc-84ad-43b7-9135-a20a1488843d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Host (RHVH) does not support or allow group authentication.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2f5e604-6838-4ec9-9a93-87a7a53bd956" control-id="ia-2.8">
+    <implemented-requirement uuid="9324c09e-ebd4-4f86-8ccd-94c47ea733e2" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="ef9295f6-7061-4a8b-8b5f-32b5d5e6e997">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="10c1a3b8-c239-4dee-96f2-9cd4b188d1de">
+      <statement statement-id="ia-2.8_stmt" uuid="19a4afe9-da23-41fc-986c-259ff51f0050">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f77256-ecf7-440f-ba84-714f7912e4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4508,10 +4508,10 @@ https://projects.engineering.redhat.com/browse/RHV-20685
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bf7bf5f-4d38-4934-bd6b-372b5323fcbe" control-id="ia-2.9">
+    <implemented-requirement uuid="79687eee-90bf-4d14-8ee8-bb24a27b7542" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="cef5ce03-5c7d-419e-94c1-0493e992d5fd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="16e3a3ee-1327-4e42-9b3a-f5d7c4fe9098">
+      <statement statement-id="ia-2.9_stmt" uuid="d22159c4-a093-4897-8943-0e9036aeb824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e8e7cdc-15fc-4d15-83c3-55455d777501">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4520,10 +4520,10 @@ https://projects.engineering.redhat.com/browse/RHV-20686
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="827e7f1e-bd2a-4c2a-9f10-a3f4ed2f275b" control-id="ia-2.11">
+    <implemented-requirement uuid="3b0bc4d2-9c8b-40b2-832b-47105fd850db" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="5e30dda9-abb3-4b84-a968-459466771902">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e6a0b13-2618-4b78-a854-7f9cb807effd">
+      <statement statement-id="ia-2.11_stmt" uuid="d5bdb471-f0d9-46bd-8b40-ba71fc204f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe551ed6-c765-4dea-98a6-4bf2b88d82c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4532,10 +4532,10 @@ https://projects.engineering.redhat.com/browse/RHV-20687
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33014248-5128-4afc-a4be-5ef2757d8c11" control-id="ia-2.12">
+    <implemented-requirement uuid="de776585-976f-4b41-aba6-fbbf4eb1ef88" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="d6b17024-eecc-4af5-8e73-ca46227d1407">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e22a99c3-68e6-46c9-af27-8e9862edf186">
+      <statement statement-id="ia-2.12_stmt" uuid="44139483-c869-4e9e-87b3-5c9497bc594f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcf74c64-a18f-4080-aa09-367eab934047">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) accepts Personal Identity
@@ -4550,10 +4550,10 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c9a68b7-1b3c-4268-9d56-54a0ddf473e2" control-id="ia-3">
+    <implemented-requirement uuid="813ba8a3-1cc8-4e5b-8c64-22a599c8634f" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="74d9e109-708f-4cf5-85df-4ba2bef06791">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e852e8f9-c8b4-4aee-b2d9-80583645ebb3">
+      <statement statement-id="ia-3_stmt" uuid="fe4a9b85-3267-485e-a6b8-1c4190d9b864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0289593-6a95-4233-8e1a-780edff8a21d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4562,34 +4562,34 @@ https://projects.engineering.redhat.com/browse/RHV-20689
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec23c8bb-c074-4a30-926e-972acf979387" control-id="ia-4">
+    <implemented-requirement uuid="68c1ed91-8b92-42d7-af40-9a35c7ca3a43" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="35d3069f-66d6-448f-87a4-697876371905">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ef50cca8-c7e6-4ad2-b5c0-4c9b0ec5d795">
+      <statement statement-id="ia-4_stmt.a" uuid="68861cd3-5042-454a-81ac-d8767ae4b479">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="b76561ec-f014-49f7-bab4-25d46f54b021">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bfd9e848-2964-4291-9c9c-67610fe52f42">
+      <statement statement-id="ia-4_stmt.b" uuid="c3be4c07-b372-4f86-a61b-c643a28a0651">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="819c2bf7-01a9-42a7-b878-8d83aab8345a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="16f391c2-4db6-4f04-adfb-53f7c3eac0b6">
+      <statement statement-id="ia-4_stmt.c" uuid="c0100a17-fc78-4b8b-ae49-0285a57226c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="f5f1fa77-49b8-4576-8b39-f4567cba822a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4c70e54f-09f5-4dcd-82f5-39ec739faadb">
+      <statement statement-id="ia-4_stmt.d" uuid="17ba4241-f897-4c6f-befc-443916ec1596">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11cd2900-3a52-429d-a991-6692867ae02e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -4599,8 +4599,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="06691bce-a5d3-4f45-a6d3-3ff1c9ff4ad7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9397a186-c139-4717-ba5d-a3c9ae586c28">
+      <statement statement-id="ia-4_stmt.e" uuid="b2cdf31e-a423-4f1c-a9ba-c2ea599dc41c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d5a3cc-1c33-45f0-b5d6-5252c0ed9a81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -4615,10 +4615,10 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="566e9ac1-ba71-41dc-a3e7-1a958f89fcff" control-id="ia-4.4">
+    <implemented-requirement uuid="cb2e83cf-6797-40ec-b91e-33d057ee5dc1" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="773ed978-68f4-45a5-a7e5-d2345ca33f7a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="857a36dd-e9af-4dcc-b537-b36769e48e03">
+      <statement statement-id="ia-4.4_stmt" uuid="9cc3eefd-0e08-4d4b-8cdc-85996a5dd30b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4626,18 +4626,18 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c388c6fc-5dbd-4639-b933-b1d1199ebacb" control-id="ia-5">
+    <implemented-requirement uuid="3f357209-59f7-4ed4-8e43-fc4a29fe0793" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="233d9422-1ec0-468d-b219-9a43d0bed5ce">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="55c87dd6-3a41-41b7-a652-2268bf00cf0d">
+      <statement statement-id="ia-5_stmt.a" uuid="4aa0fc19-bf18-4875-af10-0ca428ae7df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="ad349428-6b06-4674-a1e0-7d82b668cd38">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="74592217-f32b-44f0-8f37-a6a216f4ecd3">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4645,8 +4645,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="5b86b6cb-e803-4330-8176-8ce9868e5cc4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ae7e0665-3bf9-4b84-87da-e936e72fe1a9">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4654,16 +4654,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="1da073a7-6ebb-46c1-9d67-95f9cd1b4eda">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e9578fb6-6524-436d-8f12-dd85b0784f24">
+      <statement statement-id="ia-5_stmt.d" uuid="47f7ff51-8b3e-4bd5-9880-9099706850d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="b99f13ed-ee60-475a-a770-16918b4b2d7a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="141069ab-3f33-4574-8b37-e6c7fbb9ad46">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4671,8 +4671,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="1a3f45fc-39a8-4db0-8562-186fdd575541">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f330038c-d812-4a5c-b48e-7e0b564ddee4">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4680,8 +4680,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="87401dfc-6cff-4d8f-9cef-95fba825514e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5f659c06-7e13-44b5-9635-922e38ca3ca2">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4689,8 +4689,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="55116c6e-178a-4e04-8f2f-0e4e1b16e7ed">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="30112251-ce61-40a6-87a4-66fd51d1f826">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4698,16 +4698,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="fd4bf4ff-36a0-498e-b6ee-67fe19990511">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e674f2d2-f969-43ec-96ea-e9678d792b4a">
+      <statement statement-id="ia-5_stmt.i" uuid="95b60fd3-c552-4002-8ef9-58a17fbab84f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="d70d790d-245d-4c6b-b1c6-8974555f37ee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="91ed54df-2df6-4b81-ab1e-6046a17cc057">
+      <statement statement-id="ia-5_stmt.j" uuid="401d8d60-ea1d-4bfc-9604-db1f455a054b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4715,10 +4715,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3de51a51-ac8d-497a-881a-9cd2f6afaebd" control-id="ia-5.1">
+    <implemented-requirement uuid="8067b1a8-8e82-48e0-9c1a-f3d3410f8533" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="311a19ce-605a-405c-8ede-d87944b7bee0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c8599d3c-c8fb-4b05-85d7-5f24760c886d">
+      <statement statement-id="ia-5.1_stmt.a" uuid="dee671d1-1f26-4cde-877f-80d7699262c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36eb0d36-25e3-4ab0-bfb2-209436fb2c60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prevent logins to accounts with no password, the following
 configuration checks must be enabled:
@@ -4775,8 +4775,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="a6f95fc8-296a-40be-9594-a99197731fd9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="604b9efa-4cb4-44f2-bf06-7917a8298faf">
+      <statement statement-id="ia-5.1_stmt.b" uuid="8dd2366f-ce4e-4db9-b1fd-58a4d1d4a41f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8875c1b4-2c28-439f-9b84-0a4db53b1492">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce an organization-defined number of changed characters when
 new passwords are created, the following configuration checks must
@@ -4790,8 +4790,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="be42332e-aab0-4629-aaa8-edb028559848">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="048bbf53-2d93-4d20-ab84-af67cb929353">
+      <statement statement-id="ia-5.1_stmt.c" uuid="cc03a041-5186-4aa0-96ad-f42d584e9368">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="270f0523-2ebf-4480-8bfb-61cdbea05151">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure passwords are stored with appropriate cryptographic protections,
 the following configuration checks must be enabled:
@@ -4808,8 +4808,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="6baf7e43-e726-4632-89d8-69641b57658e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a772555d-cae8-4648-bd38-cd2ca9a1289d">
+      <statement statement-id="ia-5.1_stmt.d" uuid="4dd5667a-77f0-4270-9409-6a2fd435cc3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06726de6-106d-4dba-bafa-a0e6ce0819ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce a password minimum lifetime restriction, the following
 configuration checks must be enabled:
@@ -4827,8 +4827,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="9a6b4096-1967-420b-a72d-1a1accf84cbd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="26f82988-ac60-4b76-851d-4b0e2efe11a1">
+      <statement statement-id="ia-5.1_stmt.e" uuid="38d30139-07e8-4f6e-af76-37bb36f87e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b22178b-7ae0-4677-869c-c2ceeccaabfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit password reuse for an organization-defined number
 of generations, the following configuration check must
@@ -4842,8 +4842,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="5a317a36-b381-405c-9ef6-08d808cee3c3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e86a5488-0ad0-42fd-8daa-3853e0fc2fb4">
+      <statement statement-id="ia-5.1_stmt.f" uuid="1e18edde-395a-4ecb-ac69-c36e5ee34044">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3220d521-4fec-4fd4-9274-31a69798806e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4860,10 +4860,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03aa437e-467d-4f80-bf3e-c90c1ca94725" control-id="ia-5.2">
+    <implemented-requirement uuid="a6b20dac-858f-4432-a9f8-454c24473d75" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="26815610-bc8c-4956-8b8a-825e5ec47221">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b25620e7-873a-4850-8090-052a56955b43">
+      <statement statement-id="ia-5.2_stmt.a" uuid="260426ad-e896-4c8c-bbbf-f9954d38e3bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4871,8 +4871,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="93e6432a-585a-4ad0-be10-79b4606ddd8f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fed750c2-f585-4983-8c11-5ccf9747b202">
+      <statement statement-id="ia-5.2_stmt.b" uuid="6a899cdf-1ff3-40d7-9f3e-d85b26f43e7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4880,8 +4880,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="c9bdbfcc-b8cb-4908-86b2-b4bbaa74153e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2bb6cbd6-ec96-4923-b5f7-b6bbac178f3e">
+      <statement statement-id="ia-5.2_stmt.c" uuid="5bb16a9b-a53d-486f-b097-939d1300eb80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4889,8 +4889,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="c2b0eec9-1eec-4e5e-9fde-b7d579523351">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a4a83b6b-dbb8-43e8-a135-a8e0138ca328">
+      <statement statement-id="ia-5.2_stmt.d" uuid="5c943719-8bae-40cb-96a4-29de69026782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4899,10 +4899,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ec8dd15-1b0d-4939-9851-5b85fd7487d0" control-id="ia-5.3">
+    <implemented-requirement uuid="7d50edd1-aa23-4413-95d0-5babc405b8e1" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="663727fb-caa0-4a6b-829b-77e3b0293127">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="975775cd-0f0f-489c-8caf-7bc523a8febd">
+      <statement statement-id="ia-5.3_stmt" uuid="a557d60c-3a8a-4efa-a51d-42b99f7d8dfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43d8e628-4880-4b30-9847-3388fc2fd460">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4914,10 +4914,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e4915b9-c5a9-4ff3-9675-76d421e47c4d" control-id="ia-5.4">
+    <implemented-requirement uuid="94607c21-260c-4efe-949e-59ccb3c94b40" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="9a1ea803-a883-4028-9c68-746afee65652">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6949acb5-5a2b-4eb6-8d71-6f59bf5589b0">
+      <statement statement-id="ia-5.4_stmt" uuid="516d6712-007c-4d1d-a6b6-825b46552ab6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4926,10 +4926,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3609d11-dd4e-401f-8c5d-00d812352f1f" control-id="ia-5.6">
+    <implemented-requirement uuid="bfc81b03-6e17-4190-9105-757647815cf2" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="946e00aa-ac95-4971-868f-3e3c00aa2359">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3434a864-4d99-43ae-97ba-f752d1778f8b">
+      <statement statement-id="ia-5.6_stmt" uuid="74435d67-eea6-4fa1-8ad5-76a97261f0cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4937,10 +4937,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fda3639-3858-4a34-9d48-a50354da2df1" control-id="ia-5.7">
+    <implemented-requirement uuid="19ebd989-8420-4755-ab4c-0bcec6997600" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="a2dd2476-54df-4044-85f6-0c3d40002e40">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2cead127-b95c-41e5-9160-a6e70025e4fe">
+      <statement statement-id="ia-5.7_stmt" uuid="7f6fb122-c12a-4362-8ec5-47258add160d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4949,10 +4949,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6b1a376-6e1d-4847-9b1e-7a4bb163eb42" control-id="ia-5.8">
+    <implemented-requirement uuid="0d342943-359f-4d28-a3ec-7782cea7b5d3" control-id="ia-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.8_stmt" uuid="e71a3aeb-3507-4dda-bac2-a8ff5ebdffe1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0db29a40-b713-4e34-b6e2-464fe5e920f3">
+      <statement statement-id="ia-5.8_stmt" uuid="47ce5f0f-530e-4591-8672-9690eb756e50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce7f3e4-c099-4bc7-8e24-761469800719">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational implementation of organization-defined security
 safeguards to manage the risk of compromise due to individuals having
@@ -4962,10 +4962,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aab63dd2-4a5a-4a7b-b767-51d3d6cfcfbb" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="4b6a85e0-5590-479a-9cb7-3f2cd2c49d7c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4622f364-a97a-4710-8445-41e120f2a0e6">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4974,10 +4974,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b5e501f-b9ee-405b-81f9-7a5cbc203544" control-id="ia-5.13">
+    <implemented-requirement uuid="4f206a52-a096-4779-94d0-5d9a35f4146b" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="077e2ebc-cec8-4d28-8e2d-513488b55d9e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="235feecd-d0d9-448d-b247-c97dee20d4aa">
+      <statement statement-id="ia-5.13_stmt" uuid="08de25f5-40a6-4869-8ea2-352293f9697e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4986,10 +4986,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4ed5661-ae12-4c9e-8729-379d3cd49e6d" control-id="ia-6">
+    <implemented-requirement uuid="c18d8a87-a83c-45b2-b926-a81975d8c1d8" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="838ddf3e-2d62-4c11-bd5b-1849977cf14c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="06006a42-3cc4-4fa7-873e-def84b34bb3c">
+      <statement statement-id="ia-6_stmt" uuid="36c5fd33-c3f5-442c-aeb7-6a77f91a8e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="41406028-d256-445e-8e1b-6bbf7dec6478">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) automatically obscures
 feedback of authentication information and cannot be configured
@@ -5002,10 +5002,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0eae360e-2d01-4cf5-b65c-8248e3b6af13" control-id="ia-7">
+    <implemented-requirement uuid="ab61d155-92ab-40b5-9e81-9fd9bac6cca1" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="de35757d-0d6d-4844-8519-7849c7c3e041">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7e57ef35-627d-415d-854d-9a1c0aeac0fc">
+      <statement statement-id="ia-7_stmt" uuid="f3ac9fbd-5915-4c13-bfa2-d780c3775d03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aec0a254-77c0-4a93-b4a7-9b2b04b0f966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -5029,10 +5029,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="432087c3-d673-46b4-947f-aecd0199fd6c" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="68e9277b-9840-494a-9521-9e2ce95cd09d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="730224e2-8e22-491b-ad21-9616a7aba62e">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -5042,10 +5042,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aa8080e-a577-4d1c-944e-c901150b8421" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="fb2e437b-1e73-4b71-9e26-b69943f53e45">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="95032240-fe5c-41a6-9a6b-2f9e2610cf45">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -5054,10 +5054,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ae70b42-f728-4931-918a-4db17c914e94" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="f6ec223f-93bf-41ef-90e4-a6ab66ec5db0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="39560065-0460-4dcc-b53f-c6b0aef34fd1">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -5066,10 +5066,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="156602ab-80c3-4f90-b580-6c7455904217" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="16e3f636-8ee2-4d1e-bace-be5f33cd1684">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f7043892-569c-49ba-a353-119b2fe7a6c1">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -5078,10 +5078,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db633c4a-e8b3-4fa6-b162-796ac4172412" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="c748aee6-03d6-4693-926e-91e5b929b9c4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a8ba9f0f-38f0-4534-9725-7bd683bc59be">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -5090,50 +5090,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48b32034-c69d-4033-8a7b-31157a6a3a24" control-id="ir-1">
+    <implemented-requirement uuid="3c9e71c0-58ae-4aee-9155-47fc9e843f65" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="ad3da85d-0484-44f0-822e-2b5875c9439b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6022b60b-5f96-433b-be93-24b3d1f3da1c">
+      <statement statement-id="ir-1_stmt.a" uuid="d60d6bea-ef5d-4626-aed2-3c3f53698ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="61ba588e-e0d4-420d-aa1d-886820063907">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b924bdb9-5764-4a47-b2aa-edb6f2394fe7">
+      <statement statement-id="ir-1_stmt.a.1" uuid="5e667772-e5d9-4872-865a-48786759926a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="7cd01038-9ea8-4278-b559-187609dc89fd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="873980af-539d-4186-8db4-3f622e2ff0ff">
+      <statement statement-id="ir-1_stmt.a.2" uuid="22d201c3-6207-4103-b445-85e8701cebbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="e17112b1-2882-4380-8cb0-20bab9a2899b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0f2e6aee-542b-4b46-9d23-19f9a0ede9a9">
+      <statement statement-id="ir-1_stmt.b" uuid="eac06a1c-4b7b-44b6-82fb-ad5cdb54c5d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="6211f67d-27c0-4158-b109-d69057c93b6c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b92e7b96-935f-4c43-b5cd-5b43883aa0cd">
+      <statement statement-id="ir-1_stmt.b.1" uuid="15832489-8979-426c-8fcd-3c70285b37e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="b974c7c9-1ce1-4b11-97c3-86ad19dc0670">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c1519db0-d042-4fa1-9f29-00079b0bd67f">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d22849dd-76b4-48af-92fe-6232a9f1a716">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5141,26 +5141,26 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c110bf5e-8a75-4ad3-bd53-2e5b2b6e929d" control-id="ir-2">
+    <implemented-requirement uuid="fe524269-e4e7-4d6a-bcf5-6b9543b9ca47" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="5744e33c-de91-4263-9d4e-afcf3b9d9dd5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1f880e7f-f193-4d5b-8e29-5b25ed5145b2">
+      <statement statement-id="ir-2_stmt.a" uuid="5c175ed8-82cd-4728-bcd8-5db6e1308527">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="d7f00408-1c0e-446d-b5d5-d1a7642d30c3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="eca0451d-3834-41e8-8dc5-0bcb1b21e3c2">
+      <statement statement-id="ir-2_stmt.b" uuid="a49bf765-58bd-4b2b-b1b4-8e6a41715d1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="d238255c-3edb-4d3d-9654-f536fdc86c39">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8087ace9-1017-42c7-9678-acba05184100">
+      <statement statement-id="ir-2_stmt.c" uuid="c95c03bd-5f95-4c91-b3ef-55844a695d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5168,10 +5168,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ea788ff-c747-4841-af1e-e73ac3380ac7" control-id="ir-2.1">
+    <implemented-requirement uuid="27c2d11f-06fe-415a-bdc8-3df4c8d3ecdc" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="e6f78745-3eab-4840-8589-cf81c8a8a54d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="50bd707b-5386-4384-bd40-4ef2b59c22a2">
+      <statement statement-id="ir-2.1_stmt" uuid="38a084ed-8d03-405d-bd06-91b27958e013">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5179,10 +5179,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47722eb8-b3a2-43a4-86e1-2870d7b91fca" control-id="ir-2.2">
+    <implemented-requirement uuid="f109105d-be5e-4e8c-b0a4-475baa9d1e53" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="1dfe1d33-7669-4833-a558-db9570f77a63">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7eb8784d-c0d5-4094-8be7-e16cbe08278b">
+      <statement statement-id="ir-2.2_stmt" uuid="62c59d0b-1a6a-485e-9394-040c9ba62b07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5190,10 +5190,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c603a09f-7b01-422b-822d-795974dd9739" control-id="ir-3">
+    <implemented-requirement uuid="dfe87267-0eeb-4244-b7ca-c35683827acf" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="7ed943fa-ee50-4736-a17a-72b69b1a67cd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1e0b0f39-09f8-46d5-8fd1-a982d3e6b15d">
+      <statement statement-id="ir-3_stmt" uuid="4161cef9-2159-445e-b264-ce64443892e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5201,10 +5201,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb425684-de91-4992-92a9-c8699c38355a" control-id="ir-3.2">
+    <implemented-requirement uuid="27ddd2fb-0b38-475e-8270-9ba769148ab4" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="4a840843-b4c3-4964-a5ba-4aba275d949e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5b41239f-99d0-4614-9f16-e8d12cb93543">
+      <statement statement-id="ir-3.2_stmt" uuid="d1d5c9f9-def0-428e-bf29-6294b04a76b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5212,26 +5212,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8229c2fc-b7af-40f0-94fe-ca0b37cca446" control-id="ir-4">
+    <implemented-requirement uuid="eb33911c-d4b4-4191-aeb7-67ac9fe7707d" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="cd1f46da-77d0-4186-a153-3cb6380b58dc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="51af6c91-717c-4a57-99d3-5bf30cc1acee">
+      <statement statement-id="ir-4_stmt.a" uuid="33dcbe65-c67f-478d-8137-9eeaf2f74dc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="7086cd52-6cb3-490e-8f7f-384404ff2592">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5b0604ca-93b1-4b3b-96bf-ab3478aed128">
+      <statement statement-id="ir-4_stmt.b" uuid="294e8fab-9f0d-44a5-ba1d-03d9c54033e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="95a3df6c-cb83-4040-af31-9cdb000c7b32">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2a62d7af-13a1-4aa8-90c8-1a2cbd984eaa">
+      <statement statement-id="ir-4_stmt.c" uuid="54af38e1-84c6-4c32-a8ab-cae687194130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5239,10 +5239,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2f78e64-06c2-444a-89e6-680ae1d17fe7" control-id="ir-4.1">
+    <implemented-requirement uuid="645ff6b9-c162-4e51-920b-3a94d4f0fb61" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="d6f35f14-50b1-40b0-98a2-c9e7fdad5f8d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8936f2d6-04f4-4fd0-b34e-2104be34fb97">
+      <statement statement-id="ir-4.1_stmt" uuid="cb0f4585-715b-4ea0-8994-5c99838709c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5250,10 +5250,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57a0f089-7dc0-4b0b-94e1-fe418188ee67" control-id="ir-4.2">
+    <implemented-requirement uuid="71ab1497-e77e-4b3b-8dbf-2c6ff8dd631a" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="e99884a7-8174-48c4-b84b-75912ecc4048">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5eca59d3-f7bd-48a7-aa6f-ed7d4a233b2e">
+      <statement statement-id="ir-4.2_stmt" uuid="5650c844-a864-42d3-8da0-1e2620174cb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5261,10 +5261,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ae57cd7-ba76-4441-90b3-bab3af35201f" control-id="ir-4.3">
+    <implemented-requirement uuid="a0dfb9d4-30e9-4197-87e9-7247315efa5b" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="369db0bb-8cb0-4626-a7e4-3aada181fa39">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c4b9fe60-3ebc-4280-ab6e-c8a144fe5377">
+      <statement statement-id="ir-4.3_stmt" uuid="ef76d19e-3474-433a-b3d0-32703fb71677">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5272,10 +5272,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="763fe3ff-6c9d-4115-bd75-5d2b3b4a9493" control-id="ir-4.4">
+    <implemented-requirement uuid="9e15ae35-d837-43fb-aacd-639721d410a0" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="99086dfa-8fd6-4675-bb76-8719117feed7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3faab1d8-2ce6-40f0-b280-3750380be42e">
+      <statement statement-id="ir-4.4_stmt" uuid="a9faba20-7cbf-4950-8741-82ac612d8883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5283,10 +5283,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b7ffe70-ac46-4194-91c3-cf53d24b4937" control-id="ir-4.6">
+    <implemented-requirement uuid="488fdd4f-a6db-43f7-8ed9-53ae1ba8a1ef" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="acce4ed5-b3bf-4ca7-b7c2-d28d7bc3bf08">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d3d41411-290f-4648-8396-689fe1dab3a0">
+      <statement statement-id="ir-4.6_stmt" uuid="e7fce193-1186-4757-b236-f63a2c45c6c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5294,10 +5294,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b720f6c-6677-444a-aa65-79e7cd81d208" control-id="ir-4.8">
+    <implemented-requirement uuid="833ea696-f96f-45ad-80d9-7813cb4696cb" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="c47b2dbe-5973-445c-bea7-e11b2b166eba">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b69e004f-f4c8-46e1-ade8-fe166773df5b">
+      <statement statement-id="ir-4.8_stmt" uuid="bce78331-2737-44c7-b3de-12bbe2e1b2aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5305,10 +5305,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b0557e2-08e9-4673-a099-230a0d4b57be" control-id="ir-5">
+    <implemented-requirement uuid="fce171fa-933d-4c31-9d91-22db3460611e" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="fcab7892-1e10-4d57-a976-eaff1f315799">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="72604cda-d538-4409-98c4-0f2d54906e46">
+      <statement statement-id="ir-5_stmt" uuid="3369b8b2-59b2-4653-9523-e1543e94ea4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5316,10 +5316,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5f0b533-35de-4fa9-b15b-94d1c247ca6b" control-id="ir-5.1">
+    <implemented-requirement uuid="6b0e0983-3dc6-4bc2-99ba-56201094cd2b" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="33933c07-3831-492c-8a9a-70347f031b08">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0c8c62f9-724c-4e99-9677-4e5c0923c86d">
+      <statement statement-id="ir-5.1_stmt" uuid="a3de3098-ca49-483c-8af1-f7c1d0702846">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5327,18 +5327,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="514fde53-e72f-4035-8a12-b8c749ba817c" control-id="ir-6">
+    <implemented-requirement uuid="89d5380b-005b-4609-bda3-e796d6aa8778" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="d6fecb40-3a78-431a-91ed-491fe8fb24cb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e2dff890-e572-4663-bda1-53c97e1a2d82">
+      <statement statement-id="ir-6_stmt.a" uuid="a9f85a42-b737-4905-9ac0-ef0f969b72ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="6a5de91e-0b6e-4834-b014-331a684c0174">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="83c67a94-cd51-4b21-9f99-cdcc8ddb0454">
+      <statement statement-id="ir-6_stmt.b" uuid="bbd9ac3b-10ed-4429-8fe7-fdf26be8fa7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5346,10 +5346,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="533153f8-a4af-4998-9eef-40c92396b8a7" control-id="ir-6.1">
+    <implemented-requirement uuid="565b5616-fa8c-465d-9a56-049569731000" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="67767978-6812-40bc-b4bd-58d64e738f1c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fef7610b-b19b-4d43-a82d-296316bf6c38">
+      <statement statement-id="ir-6.1_stmt" uuid="1148f4a5-d79c-49b2-858d-a362fa69dbe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5357,10 +5357,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4433f988-de75-442a-a221-dac09686e6f3" control-id="ir-7">
+    <implemented-requirement uuid="e303e930-0cd3-4243-92e5-5192b3845d0f" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="829c1c60-9f5c-4a6b-8ccd-711b7ffa6197">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e91df68e-f9ae-4adc-9b8a-d28e8874d161">
+      <statement statement-id="ir-7_stmt" uuid="047a743e-e421-46e3-87dd-0b3424dc85e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5368,10 +5368,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd46395f-04d4-434f-9b38-db25e0a72eb2" control-id="ir-7.1">
+    <implemented-requirement uuid="33d846fb-a03e-42e1-9488-e0bc266ef476" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="742021e7-d38c-4002-8119-083278f0f444">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8341e39b-cb0f-45a7-a004-8f654a2ed92f">
+      <statement statement-id="ir-7.1_stmt" uuid="9663849e-b679-426f-bb0d-d6e84223736b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5379,18 +5379,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="330f8720-abac-4c7d-bbe2-00b231a67d8b" control-id="ir-7.2">
+    <implemented-requirement uuid="daf17bd4-f8f7-4693-98d8-2b2ac196b17e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="41283fb8-a5d5-4526-9e05-9c86f1404583">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fbc5a01d-7b6e-47aa-88e7-27f52956c0bd">
+      <statement statement-id="ir-7.2_stmt.a" uuid="13d4e2b7-6d9f-4af6-b964-fc2db1885223">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="df09cc77-d5b2-4ead-9563-8f7cacf2bab4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a798d9cb-1ea1-45e8-8cd5-caa659cb5daa">
+      <statement statement-id="ir-7.2_stmt.b" uuid="b2702284-f887-4e4e-934f-dd599b2ef766">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5398,114 +5398,114 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fcb4004e-b761-4ec8-8835-f03622f58a86" control-id="ir-8">
+    <implemented-requirement uuid="595d022b-7ad6-4c82-8934-e3c21903607b" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="d1e4d494-5caa-463b-8a96-6ffb54e484e4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a7737da7-601d-472f-877a-e81608684448">
+      <statement statement-id="ir-8_stmt.a" uuid="69e20c17-c2e6-491e-bdcb-242d01a87abc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="285f41d2-69a9-4c31-84c5-f9b800cd1c0f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8bcd7b9e-10ac-4694-ae88-143ab648bda8">
+      <statement statement-id="ir-8_stmt.a.1" uuid="72643e28-b35f-4f87-9d5e-53933f812b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="66e46433-78c6-435f-82f9-d551595c7e6f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="57d51c4e-0048-460e-b299-7e72ea84c28e">
+      <statement statement-id="ir-8_stmt.a.2" uuid="4e5c7d57-2f90-45be-9f74-bff226c173fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="1bbfe156-e4ce-4104-b101-54821d8ed4b6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="72eaccd7-84ae-4427-a8ad-3d1da06567ec">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b619e512-1860-4e36-be97-0fef26fa3fdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="1f77b336-991f-456d-8cf2-ac5857f0c248">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88766e4d-214a-4eaf-871f-badd0b2d592d">
+      <statement statement-id="ir-8_stmt.a.4" uuid="496784e7-2932-4245-9d35-6ca30e7a4996">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="258ccad2-744c-4c79-b0b0-b50a168243eb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f738b637-77c9-4d66-a8d6-ee5f10b7873b">
+      <statement statement-id="ir-8_stmt.a.5" uuid="b0be9941-f831-4d53-8707-163badaf2954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="ebd28775-0779-43d7-af50-c320f31bc61f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="099d6b30-92ec-4363-baf5-91ab6309b8e1">
+      <statement statement-id="ir-8_stmt.a.6" uuid="e7fadd37-8831-474b-aac7-04f508f585c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="80bf56d7-dbcc-40c5-92c2-aee605dd4857">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7f609728-3ad4-4469-a189-1d99ae7562be">
+      <statement statement-id="ir-8_stmt.a.7" uuid="508aefd4-b732-4beb-81b3-25d1c8af57c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="278de211-5ff9-49fc-92cb-b2595d1a7e68">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c9a508bc-016e-472d-ae8c-5ae5f53aa892">
+      <statement statement-id="ir-8_stmt.a.8" uuid="96e9806f-4ed3-4202-9c93-14662e29113a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="50eb1a19-c6f4-421d-a2c6-c8106e98c2bf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="45ef6c35-e97c-4009-a9a9-7dec4b566295">
+      <statement statement-id="ir-8_stmt.b" uuid="dd657902-cbc5-4ee1-9120-98366b9741f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="72822c4c-8c5c-4ebd-8aee-164f3694672e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e66b9eca-817c-4420-af35-8dc01621d287">
+      <statement statement-id="ir-8_stmt.c" uuid="749989bc-d4a6-4954-b414-067ab2efdd4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="c4c2fba2-5bc1-4a2c-8ea6-3d5e500c4c98">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="90f895a0-26e3-4fe6-a909-2ac42800f5a7">
+      <statement statement-id="ir-8_stmt.d" uuid="592206a3-a940-4153-af52-1643c347f726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="fbe1c195-bb7e-4b30-8b3b-95ebd8924efd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="96290bf2-76cd-41a6-8fe8-b6a8af534976">
+      <statement statement-id="ir-8_stmt.e" uuid="25670e9a-0193-4bd2-b298-40527001f551">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="54767d9a-dc06-48a2-bfea-6ebe9705feaa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="69ed1c24-0771-40de-acd7-2a90072e7575">
+      <statement statement-id="ir-8_stmt.f" uuid="ec849266-6579-4265-b734-c8cd7b749d3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5513,50 +5513,50 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d525002-baea-4f6e-a3b3-303b1390a81d" control-id="ir-9">
+    <implemented-requirement uuid="9df025b6-0f19-42c1-a0bd-320a658cbbc4" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="9a7b7b2d-d2d5-4270-b53b-998ee843d845">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2493cf0-b03c-4a24-8018-2dea072f3a46">
+      <statement statement-id="ir-9_stmt.a" uuid="049b72a0-1a71-4441-845e-dcc92d2ae0b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="77bf2dd2-70e0-4bc2-924f-d12d160eb310">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="22632349-e209-4bf6-a48d-ce32d984e9c6">
+      <statement statement-id="ir-9_stmt.b" uuid="77e3710a-d405-4a2a-bec1-8b2736953314">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="8072f681-d46b-4930-9c0f-062d23e1d6e2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="743a6765-d2d6-4897-b410-dc26fb52d447">
+      <statement statement-id="ir-9_stmt.c" uuid="aa1efb6d-4749-4a43-b7b9-ce6f963c6579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="9a60da62-c688-40f8-b0c0-c7800ad2e5e9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1d8da02c-8cbc-46b2-bbfa-63100c2c47bd">
+      <statement statement-id="ir-9_stmt.d" uuid="0ddb0f74-8291-4472-a292-50ff9cee2890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="c77063d6-3e23-4d26-8efd-991ade8b8ef1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="409ba6c7-5edc-4399-9e38-46abdd2e8dbf">
+      <statement statement-id="ir-9_stmt.e" uuid="7eb578f8-5f45-4c81-a553-943a3dbbb046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="349eeac5-7c01-4381-9558-e62bbf747692">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="43c46437-07e6-4325-824e-62bc915c322d">
+      <statement statement-id="ir-9_stmt.f" uuid="e559c3ae-2480-4efa-acad-cf8ebaddf155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5564,10 +5564,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce4c6538-bb1d-4055-8ac2-c48c1fab3fd0" control-id="ir-9.1">
+    <implemented-requirement uuid="d373d5b7-90f4-44aa-b986-aa692df48fa2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="a27590c0-3be5-4f88-b207-1088088432fa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e43a7c29-b042-463e-85e8-c41be13df87b">
+      <statement statement-id="ir-9.1_stmt" uuid="14897118-995f-4756-84fa-1a34906aa70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5575,10 +5575,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0808fa0-fcb8-4e8a-b347-93f8986570e5" control-id="ir-9.2">
+    <implemented-requirement uuid="a378b7c2-f47b-4ce0-b9de-76d7bc6c8bcf" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="4bb39be9-e6d1-40c0-b0f2-5fa7408ca07f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b5ce49c8-ff8c-4712-bccc-197141110f33">
+      <statement statement-id="ir-9.2_stmt" uuid="1f5c56ed-4d1e-4bb3-9c99-f77744271117">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5586,10 +5586,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aea000b5-3dc3-40af-80dc-c82a102cde37" control-id="ir-9.3">
+    <implemented-requirement uuid="cfbe37de-b721-4054-8a99-f5d964a0287a" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="9523373a-c73b-40d3-a724-7b504070b940">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="149b74fc-0abe-4c15-997a-c8ec1c752aab">
+      <statement statement-id="ir-9.3_stmt" uuid="a1b5ff63-849e-4cfc-a99d-5896b0b31daf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5597,10 +5597,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ceb1f79-6b6d-4d07-8099-84e1e8423f58" control-id="ir-9.4">
+    <implemented-requirement uuid="b9780021-b1bc-4f10-9de1-34469ce75fbc" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="d240257a-3ef0-4e13-b054-d9edc2a0196e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="db75b18d-a217-4f7b-98c1-38de4c51b392">
+      <statement statement-id="ir-9.4_stmt" uuid="9ae8ca7e-3f55-40e4-9b96-079b2c3fe656">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5608,18 +5608,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebafdf36-1eaf-46f3-8248-94f5d372a8e2" control-id="ma-1">
+    <implemented-requirement uuid="7c9f8c2a-701a-4f18-8625-edcdf7ca4e86" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="f73b3143-4617-4c6e-b66f-a4d8bd078e39">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="21f1c61d-fcf7-4a6f-8cfc-6fc9277d81bd">
+      <statement statement-id="ma-1_stmt.a" uuid="52b9031d-430c-4473-8a5e-e1d2b013e31e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="20046276-f88b-4787-98ba-27b196994e1f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="38806a32-620c-47e1-b2ca-ba63eca0d6e3">
+      <statement statement-id="ma-1_stmt.b" uuid="c132478d-5909-4718-9289-4415db12ef5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5627,50 +5627,50 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edd6e5ad-383a-4e83-93ef-1b732aa5cb53" control-id="ma-2">
+    <implemented-requirement uuid="e7d5b680-e4ac-43c0-a574-5cff41e6e337" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="f115e3e2-463c-4125-8705-7a85726439de">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5f06cd86-7ed2-42e2-90b6-89606d494a35">
+      <statement statement-id="ma-2_stmt.a" uuid="fc868847-1f7d-46d8-bd2b-22a040fa1ccb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="1bbe4898-8529-40b9-854a-a7ccc9184c16">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8302cfaa-6d1e-41b6-b548-7fa22be0e007">
+      <statement statement-id="ma-2_stmt.b" uuid="eb1ccb7b-8606-4e45-9dc4-79be60042561">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="980555ed-fe7b-49d4-98fe-607a5e687943">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="62008645-0839-40fc-a4e6-687745a39e86">
+      <statement statement-id="ma-2_stmt.c" uuid="8afdeac6-75a2-4306-abd2-27724886daa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="dfd2d4cc-0043-4bbc-8dad-595ce30ae864">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e5eb71aa-9ce0-474b-ba2b-cad4c76e2d62">
+      <statement statement-id="ma-2_stmt.d" uuid="a3cb1b26-cd05-4452-bd93-47b66ad9fb81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="a30995b2-a34a-4466-9176-a78386bbc901">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1766f347-66db-43d8-a172-904a44c64408">
+      <statement statement-id="ma-2_stmt.e" uuid="6b15fd53-2caf-4fa0-aa59-1bdc627c30cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="c929483c-f632-4c08-bd40-8dfa582b230d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6f73c803-3976-4cba-baed-a6ecc949cbb3">
+      <statement statement-id="ma-2_stmt.f" uuid="e745b580-12b5-4aaa-922d-8e7b5f5b2453">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5678,29 +5678,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad16dd5c-8617-4d8e-bcfc-2009fba864a6" control-id="ma-2.2">
+    <implemented-requirement uuid="98ee1625-1b95-4833-8bf9-987244c14cac" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="7e81722f-97dd-4a04-9a90-572bd5f9adbc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="26519c02-fc0c-4999-ae34-3cec1b59d539">
+      <statement statement-id="ma-2.2_stmt.a" uuid="2a5dc774-88a9-4aeb-b12a-efff407e982d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="3690622c-631a-4e2f-9c0a-63662be47acc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2fa47b8-06d0-4e25-9185-01c23dcac488">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="5001d637-aa4d-4e1a-814b-9404d491e012" control-id="ma-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="7bbc6193-9188-449b-a988-3757e35c573a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="96f0484a-ecc5-43e6-85cf-ea29325b0148">
+      <statement statement-id="ma-2.2_stmt.b" uuid="6829a82e-af57-4ea1-9b2e-d7a4babadc58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5708,10 +5697,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f2361c1-cf4a-4a76-816d-5312ba4b747e" control-id="ma-3.1">
+    <implemented-requirement uuid="be1eedba-a6f5-4129-b68b-7e2803adb001" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="ed3a93b5-55f1-439f-b3f8-265cd12ba08d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="97b4737d-46ce-4c3f-a314-90d1b87ee066">
+      <statement statement-id="ma-3_stmt" uuid="d66d7e31-a93f-4c2a-9b54-ae2c71b2e6bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5719,10 +5708,21 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6bcdf54-6025-47c9-9d11-0752be4e95a5" control-id="ma-3.2">
+    <implemented-requirement uuid="1e95f557-0d06-4b13-baa8-4658fb618e07" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="f27b9a0b-71f4-4ee4-8bdd-137133c6eb9a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9390653b-9e41-45d1-8621-2a0f1b6ae90a">
+      <statement statement-id="ma-3.1_stmt" uuid="f731abe2-3ef8-48e1-9e3c-012cf404e6d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="275c4d7e-7ce3-4fa5-9c20-748c2b9ae1bd" control-id="ma-3.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ma-3.2_stmt" uuid="e6537073-dfc0-4e16-90ff-83d9ed136e0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e14296b-490f-411b-aa3d-fa0d06e457b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -5731,10 +5731,10 @@ system is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bc32fd6-b9fa-4b59-a695-24e5ce87abb2" control-id="ma-3.3">
+    <implemented-requirement uuid="c4ed0f0f-be66-4c34-a2b7-bca101ff011c" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="4a114dc3-e1ad-4442-8268-5d646096244f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="96df666e-9696-4615-af98-df0eb4f8d6fc">
+      <statement statement-id="ma-3.3_stmt.a" uuid="604d6d51-e0e4-489f-b30b-6477ef2ef2ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="307d4a1d-cb27-4524-8134-c572ee99190e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -5743,8 +5743,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="cb1c3c1f-b990-4f1f-a7b9-79e9af96aeca">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="443be09a-c305-438b-b5cf-bc3566d531cc">
+      <statement statement-id="ma-3.3_stmt.b" uuid="d8d66447-4c72-4e7f-a795-310ed08b1687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d1ef96b1-a60c-43f3-bed9-391a0bf44ed1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -5752,8 +5752,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="435d3bbf-f6e9-4707-9993-0eeae4337acc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="11e15afb-5a1b-42d2-9ca2-e489b72e65f3">
+      <statement statement-id="ma-3.3_stmt.c" uuid="a9d2402c-bd9d-4092-9ec7-dcb37617413e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="923ca9e2-379f-4521-8720-879f71f138ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -5761,8 +5761,8 @@ facility is outside the scope of Red Hat Virtualization Host (RHVH) configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="dae75cdd-ba90-4124-88b3-49b1568fed0f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1fe0f142-a444-417d-add2-c9c1bc88969b">
+      <statement statement-id="ma-3.3_stmt.d" uuid="4c32215f-540f-4b0d-9952-2a6dd6c14fe2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd8e8a3e-e68c-4ae8-a90b-97858a558a18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -5773,10 +5773,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="abb4587e-5e24-412a-b828-efbac65f41a0" control-id="ma-4">
+    <implemented-requirement uuid="341bf661-08a4-4d3d-9efa-713d218238a9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="a19fead3-d38f-4875-b708-d58f6efb81b9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="be3ce452-ce83-402c-915d-f7bb35d9d317">
+      <statement statement-id="ma-4_stmt.a" uuid="21dc58c8-d1cc-4ce8-8ff4-3c999f643ade">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca007b9b-ec78-4a11-8803-478f5cffbb74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), all
 maintenance and diagnostic activities are monitored regardless
@@ -5785,16 +5785,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="816aa384-963c-4371-9427-a6b2aeeef0ad">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f56ab0d4-84e2-4453-9b82-a0bd54e1f437">
+      <statement statement-id="ma-4_stmt.b" uuid="3e8c5061-7e35-4d70-a900-158e219ff89d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="1374b446-98e6-45c8-9005-9c1958ae93b8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="059db6b8-4c08-4730-b3d6-aa93b2e6a479">
+      <statement statement-id="ma-4_stmt.c" uuid="07ae523e-199a-4c53-9489-200e1bdad128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70054354-f7b5-44f6-88d9-e6568d0b9f76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -5806,8 +5806,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="f61a04d1-ea78-48a4-b75d-4e5419f403ae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1a346a19-2aaa-4384-8e67-4a6433215cd9">
+      <statement statement-id="ma-4_stmt.d" uuid="b840c898-0971-4def-b4b2-70d9c16498b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd48cd2b-50b7-4966-af6b-5ea602bb5dd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -5819,8 +5819,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="f1a7546c-8b67-42d1-acfb-4ae30819d00c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6a8ed2b7-a1a8-4005-a33c-6fb79ce283b1">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5829,10 +5829,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="18c79785-e53f-41dd-96f6-c3839b4c034a" control-id="ma-4.2">
+    <implemented-requirement uuid="5da754c6-bbb9-41ed-acf2-bc9cb898d2e9" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="f8c22a4c-17cb-4c4a-bcdd-b17d1eda6142">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3ceb61a7-6efc-4f34-bbd4-d3d24c7d5d44">
+      <statement statement-id="ma-4.2_stmt" uuid="25fce7ee-55f0-440e-a747-1ef7cbedaeda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5c40590-7ad3-4049-8b16-b6bda19d56d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5841,18 +5841,18 @@ https://projects.engineering.redhat.com/browse/RHV-21014
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08b5e795-8567-48d5-9bb9-cd33a169c7bf" control-id="ma-4.3">
+    <implemented-requirement uuid="8debc3e2-4ce6-40cd-b76d-ca8fba338b45" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="e2a5e35e-2267-460d-8316-47597feaec0c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d52375ea-8d94-4ab0-b4d8-5199765476a3">
+      <statement statement-id="ma-4.3_stmt.a" uuid="4a79a78f-4a35-489b-a3ba-f81ad1a1f840">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="029dc67c-b519-4b52-90f6-a6ad8bda262e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="44210332-7de3-400b-961d-8a3edcdbbbd4">
+      <statement statement-id="ma-4.3_stmt.b" uuid="dde90afe-8e20-4a01-864d-3df122a4e7e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2512108e-038b-49c3-bdb1-2f1f934f8050">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5861,10 +5861,10 @@ https://projects.engineering.redhat.com/browse/RHV-21015
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="845182d9-e067-438c-ada7-2d2c31872839" control-id="ma-4.6">
+    <implemented-requirement uuid="50a21906-c9a3-4643-b11b-9acf04f46697" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="a3fd8925-3ebc-47a8-9c87-6f8cf52df258">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6dd7e337-e83d-4d6c-ba07-dc7227fc8a87">
+      <statement statement-id="ma-4.6_stmt" uuid="8e9739d9-df9e-447b-8e01-148e463ead92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5873,10 +5873,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42b43afc-02b2-41ad-ab5a-3bb87bca89d0" control-id="ma-5">
+    <implemented-requirement uuid="ba2b169a-d9fc-413b-9721-59b24d50673e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="46c39f3b-1570-4d4f-942e-a336a3ce325e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="12159d7b-a229-48ee-8719-e9aab330aa42">
+      <statement statement-id="ma-5_stmt.a" uuid="9110044f-ebcb-4758-b9f6-6698655348a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="868f382f-1e5f-4e6b-95a0-b3e1db5ecf1b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -5884,8 +5884,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="4c142cd9-b566-4c44-909a-caf486721d87">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c0f87eb7-d0c1-446c-9644-629133d0b6b4">
+      <statement statement-id="ma-5_stmt.b" uuid="d2680ea6-9c2d-4919-bcce-2c3bd3eb8bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d98e3fd3-fd5b-4ee7-b6f1-f96163ec9435">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -5893,8 +5893,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="15910e54-4da9-42ff-8a65-6ffcff4b1990">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cfb0866a-bf3c-4aa9-8c8c-37da2a9736a8">
+      <statement statement-id="ma-5_stmt.c" uuid="e65d432a-7ccc-401d-a0ae-68733d89f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cde3adab-8e3a-4373-b7a9-64953d4cdb4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5905,10 +5905,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59c52204-5158-490f-9f05-9be99de7366b" control-id="ma-5.1">
+    <implemented-requirement uuid="cf832377-c133-4dc5-b588-1cbc9b32c1c0" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="4b648249-bcaa-454f-9a03-eae31542f979">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="edaf06c5-dfb6-4e40-a8c9-9a532e70ffe3">
+      <statement statement-id="ma-5.1_stmt.a" uuid="545f294a-cdaf-49ca-acaa-2600ef538248">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f29e0c6a-aaef-4851-946a-3f6b12c23efc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -5916,8 +5916,8 @@ citizens is outside the scope of Red Hat Virtualization Host (RHVH) configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="eb37570c-37ad-4d2a-8b41-7005c9f50f4f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cd2ef583-41b7-4200-91b3-64ad674f17fb">
+      <statement statement-id="ma-5.1_stmt.b" uuid="598df173-f38a-498a-8abf-86fee530059b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5efdc66d-9f94-4e9c-a1d2-464447b832fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5927,10 +5927,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="065df360-0758-4ecc-8223-bac0e4cf8f29" control-id="ma-6">
+    <implemented-requirement uuid="32b69454-b03e-4bc4-ace8-f327d63813fc" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="883b977b-e060-4691-b9b5-ef9872dd0008">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0b832f0f-6631-435d-a56d-90215eeaf4ff">
+      <statement statement-id="ma-6_stmt" uuid="5a8fc70f-bcfc-4f12-b02d-011a5a8d8ec1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023e6e11-475c-46e2-86cc-7498a60ded11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5939,18 +5939,18 @@ https://projects.engineering.redhat.com/browse/RHV-21052
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9015d8f-bd4b-45fe-bf24-4297e5347e4a" control-id="mp-1">
+    <implemented-requirement uuid="b91b9414-6da6-446e-beb8-a29c64afc3d9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="143a4967-c51c-486a-9d87-a8ceb25def30">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1359c9b4-3304-4253-ae78-47f97b944534">
+      <statement statement-id="mp-1_stmt.a" uuid="649b7dba-34c3-490c-b299-1ea3b7164cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="6740ec7a-53d1-420e-8927-87526518482a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8a6dcc9b-0bf9-4044-b062-55417c9c45b1">
+      <statement statement-id="mp-1_stmt.b" uuid="14175897-bb69-4049-97db-483e77f3048c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5958,10 +5958,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9a0c494-0666-4ee1-9834-dbc992845aa0" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="f77ee165-1bcc-4fdb-861a-e832d6d35cc6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fc141ce1-2cda-4633-810d-851c271642bf">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5970,18 +5970,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9a39faa-2768-4725-b017-e616ba3f6dbe" control-id="mp-3">
+    <implemented-requirement uuid="1cd06fc1-f89f-4aa7-807c-7191d8a32a73" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="98d5cc4d-cf21-4086-ba80-6f140e23e047">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2fe6d9a5-5f8a-41b8-8bd6-e401b82df058">
+      <statement statement-id="mp-3_stmt.a" uuid="a1e28e43-0a25-49c6-96cc-cdc77d101309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="73e36f7a-d9fb-4522-ba9c-b809c9df9b2b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="10a26869-13a2-4048-9862-5544ebe3f40a">
+      <statement statement-id="mp-3_stmt.b" uuid="5dc84729-6609-4229-8017-68c1ca094753">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5989,10 +5989,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e28f7f4-d204-428a-b01c-f814047cdfe5" control-id="mp-4">
+    <implemented-requirement uuid="0ae07f16-fcd6-4ca1-af12-5484c7228ed1" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="e4cf4de3-f03e-48cc-948d-4c1ad0bff077">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="661d0838-f47e-43c3-83c9-c7c5f749eebe">
+      <statement statement-id="mp-4_stmt.a" uuid="b2c9bfab-6447-4a76-8556-1f3cf56f77b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -6001,8 +6001,8 @@ https://projects.engineering.redhat.com/browse/RHV-21054
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="4f7b576b-a88c-4609-9bfe-dc7c16fa5cfb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7c6daf94-3589-44e9-b0ef-67586ea696ee">
+      <statement statement-id="mp-4_stmt.b" uuid="152c6172-3805-4382-af5e-3493779568ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -6012,34 +6012,34 @@ https://projects.engineering.redhat.com/browse/RHV-21054
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90e66947-7bc0-4837-b971-8c10306d5169" control-id="mp-5">
+    <implemented-requirement uuid="1fac0186-1c95-4f77-984c-c2c6f2f3a4ce" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="38c5307c-272d-4f95-8a06-49dd764c13dd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4c75a5c8-d2dd-4f6b-9d24-691eb18f7635">
+      <statement statement-id="mp-5_stmt.a" uuid="31e1058f-fe34-4cb1-b3c6-0b87b7495dea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="5c4866c0-7924-4b9f-8103-1163f27b4287">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ff9a619-477b-4185-8004-a42685b971d5">
+      <statement statement-id="mp-5_stmt.b" uuid="47c22722-53c2-4fe7-8806-9db0026b1d1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="e8d7c59c-b8e1-4150-8428-02a48454f976">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8df8d390-abc6-44ca-99e4-1f103e071d5a">
+      <statement statement-id="mp-5_stmt.c" uuid="89059183-b72e-4361-9478-c1cae1cea377">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="3e1c99cc-bac9-4f4a-9e7f-1080a0eab3a8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="562b38db-f879-4789-a2e1-3ee68b1d9fcc">
+      <statement statement-id="mp-5_stmt.d" uuid="957ed3ae-501c-4088-bd50-d6c7b7f9a482">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6047,28 +6047,28 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c36097d-2dd5-4f75-820e-5b94a9f9afad" control-id="mp-5.4">
+    <implemented-requirement uuid="6361f93d-b6f2-4993-8a6c-7346274e7404" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="b30f890f-b0c2-4605-bb7e-494c7d2a6382">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ff9b662a-3791-4000-a54a-872b0910105a">
+      <statement statement-id="mp-5.4_stmt" uuid="87bd7a66-c599-493a-9d8e-4920920b8cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41f2e964-bb7f-4b86-b8cb-df44d7220103" control-id="mp-6">
+    <implemented-requirement uuid="0e80f605-dcc6-4658-9018-a4e5c1aabd8d" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="0075ab74-96f3-47ef-b61b-e1b94d5c9150">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="044469b3-f61e-4414-b3c1-a4ad6f2a0a0c">
+      <statement statement-id="mp-6_stmt.a" uuid="bf42d0d5-594b-4fc2-b39d-c6f4203d9460">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="6afceb43-088d-412b-b0ee-95f3ab1c7200">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3af2c9b0-6b7b-41ee-81b3-93e4a24882c4">
+      <statement statement-id="mp-6_stmt.b" uuid="4e9e26c0-e2b3-4333-be22-3d8c99c37ff1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6076,40 +6076,40 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fa2512b-0af8-4c56-9d3f-db26b036a8a7" control-id="mp-6.1">
+    <implemented-requirement uuid="70a820a9-0277-4e31-aab9-3ca9deaa6925" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="a6e559a1-4a3b-45ab-a686-e805bae2447f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="41c409dc-58f0-4d1c-b4e7-631827cb85d5">
+      <statement statement-id="mp-6.1_stmt" uuid="0a7d9f20-34bc-4ba7-ae1e-b1a66dc15171">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4291903e-3f6f-4b0a-8033-5081de167182" control-id="mp-6.2">
+    <implemented-requirement uuid="0fe7c2ba-1a18-4cb3-95e3-55d239194022" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="3d67ec1a-8a00-4aa8-a50b-b86f819f53bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="824314ce-cf9a-4f9d-8fbd-ead96948f2d9">
+      <statement statement-id="mp-6.2_stmt" uuid="9435f252-d50f-4660-8587-7fed1a77100f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d9e33ad-c7ab-41f3-a02d-0825cdd2d73a" control-id="mp-6.3">
+    <implemented-requirement uuid="7543bdfd-8f22-4380-be44-d30d5f0f8612" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="d55934ee-01f7-4310-bf34-de5a6d276d4c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="319c3e89-e1a6-4594-a5c8-0fb1f637d28b">
+      <statement statement-id="mp-6.3_stmt" uuid="21193a1f-bc93-4224-8823-6814db18fb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="919bfcf8-242c-4593-97b7-4634cc229767" control-id="mp-7">
+    <implemented-requirement uuid="88e879dd-d8fe-46a0-a2d5-85902d1dac8d" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="229d77ca-d07d-4389-84ed-316d1a01c1eb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fe948e3e-3f8d-47c0-b343-42c74edcfd6a">
+      <statement statement-id="mp-7_stmt" uuid="b119f2f9-a732-4f58-92ef-b726234503bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac911b73-894a-4f8b-8d0e-77429aee0a8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Host (RHVH) nodes, the following configuration check must be enabled:
@@ -6130,20 +6130,20 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6e03b69-0f7d-454d-936f-68612f599afa" control-id="mp-7.1">
+    <implemented-requirement uuid="94b7a6fc-0724-4aa8-b9a6-2ac24e2dbe46" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="89e210e2-bcc6-4b20-ae86-be1761e403f7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5690d071-32a2-4532-bff4-0cceb742ff73">
+      <statement statement-id="mp-7.1_stmt" uuid="cffb274f-4a38-4e05-8a40-8e541fb0faf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0dce6a2f-b00f-4097-a08c-9aa7cdb90ac4" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="d93f114f-8726-4702-838f-21485046b4c3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="224496e9-47dd-4749-9aa9-3161edb8ebf8">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -6152,8 +6152,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="8fc10fbd-1107-41b7-9965-7ce907cb3901">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5ddc99b2-af6c-446e-9368-34e8ff47c569">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -6163,10 +6163,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f985250-06b7-4e59-8727-4d354353a6db" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="72d45878-1519-42f0-8904-c76d5b2613ef">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="58504099-36e6-4231-a9e9-10b23e961353">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -6176,8 +6176,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="94731157-96fe-4122-9237-96730b00d60e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="22337771-fe36-4b85-a0b4-659ac4da0f44">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -6185,8 +6185,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="84a2a73c-ec1a-4799-88e2-97b985803ed4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c4b7fae9-4b86-4b0f-a9e9-4878e81b75e6">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -6195,8 +6195,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="4c17af50-f6c7-4e2c-9121-df27179802e9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="44a7657e-bd61-4443-a80b-f6058cc3c2c9">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -6205,10 +6205,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="656446ff-0480-4f9b-94ec-738b7852f236" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="2d2bb3d9-39ac-4a0d-bd2c-cf6622a9e6a0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8bc8cdcb-2a53-4e49-aa26-51e194d4b95c">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -6217,8 +6217,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="8c58fb00-103d-482f-ad59-1e607f5f294d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3a6ca61d-247c-4a25-a55a-56ad8191ca6a">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -6226,8 +6226,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="dab34049-4e48-4ab0-b388-f9e890391f4f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e7018320-a4b6-4c5f-aff5-8c100ab963bd">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -6236,8 +6236,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="1f640a5d-6341-49d2-828a-d04fe81f4017">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="92c88dc8-1be3-4e78-a4c9-2d74b04a0f1a">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -6246,8 +6246,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="f12839da-f80f-4b9e-9452-0b6831ab3b43">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f725ff6d-1348-4a5d-ad1b-f811d7026ca2">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -6255,8 +6255,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="7a025459-112e-4638-b157-d20b4ed31eba">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d67873b4-9ad9-47a0-874e-195626d3a5c4">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -6265,8 +6265,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="0fa3155d-401a-4720-a18d-f19147d3a993">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c22ea284-f909-4806-a40c-0940887ae5b0">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -6276,10 +6276,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0da2e0c8-8928-41ef-afe7-0b3de52bfc5a" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="435a0173-d190-44b4-be13-672207e4be86">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dd8416d4-db1c-41c4-8dbe-6b98d42a07c6">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -6290,10 +6290,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4db86b36-7f0e-4086-b305-6060373c77f7" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="5c26a26f-b804-42e4-9747-be158f187ea1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e32d709d-2e22-4601-befe-e367432c0003">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -6304,10 +6304,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e320cc8-5d56-4648-99d3-f7ab3fdb5ec2" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="a4bfb4b0-e155-4ad6-9c3e-f80b3fac3779">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3a6a55a7-52f4-4c31-8f5c-e4dddeb3c677">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -6317,10 +6317,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3b58fde-741e-45fc-b5bf-efcd318caaec" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="328bc921-61ba-4186-bc19-2437b8d11e10">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fa4f9b7c-8be2-4d74-9b28-c3a9bb9f030b">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -6329,8 +6329,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="cb641f40-66fd-439c-8b31-77d66d3ce251">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="25509ff8-b9ce-4696-88b9-6bed9d1b5dbf">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -6340,8 +6340,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="5773ae44-3609-4504-b23e-066d47f25a21">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bf78f01d-2ec7-448f-984d-55e00ae3e824">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -6351,10 +6351,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3b75574-be05-4556-b1dd-e1068a3f047c" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="1dbe85cd-f989-488e-a2f7-869161feaeae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d253fe72-f32d-4f54-a0c7-8c88501c974b">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -6363,293 +6363,250 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfb04292-45c6-4d4b-85e5-aa91f482b10c" control-id="pe-6.4">
+    <implemented-requirement uuid="a695b928-24ca-4043-bff3-2baa86fc0055" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="a82c3697-c08b-48ad-b86c-ba95d2e4507d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e64d53c2-eab4-4034-a289-3b97f6917680">
+      <statement statement-id="pe-6.4_stmt" uuid="63844293-b82d-4907-b685-e92d98e3573b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8001072b-e304-4c84-9905-986ce64a7dc3" control-id="pe-8">
+    <implemented-requirement uuid="8e522774-5721-4589-a4b5-6846ec925da4" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="3daaf144-7f66-47e9-9f82-6b7aa6671589">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c9495ecb-9fa9-4ce1-a77c-d33bc24b9ac2">
+      <statement statement-id="pe-8_stmt.a" uuid="16b1bbc5-1c36-4de8-9af2-fec6a50db9ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="78b0ba0a-1afd-4209-8da8-044c5d2277fb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="52e28e7f-ae8c-4542-8ad3-a070fd2d2fe8">
+      <statement statement-id="pe-8_stmt.b" uuid="ed894004-a8b5-40f3-96d0-ceaae4188dd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fb466d7-9803-44d4-92f3-901e52edeeb1" control-id="pe-8.1">
+    <implemented-requirement uuid="e14565ee-11f4-4d20-9743-1e01a25374d5" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="ce44b6eb-3326-4d28-8c91-826d6d401147">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9f1bac60-148e-4d17-b22d-2840244fb192">
+      <statement statement-id="pe-8.1_stmt" uuid="3fd5e375-92dc-4907-ad6a-ba6a54daef96">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f77229e-ae07-420e-9cfd-d0d8a45a5fec" control-id="pe-9">
+    <implemented-requirement uuid="74077cb5-6191-4723-b9c3-1d0ae41024b6" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="3219edd0-6c33-4071-8f2d-205e0cf8878e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="13814899-8788-41bc-81af-61e1ac2ec74b">
+      <statement statement-id="pe-9_stmt" uuid="911abc86-a30f-470f-a63f-270602b628c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56e8691f-8f21-4f36-884f-1d7826e89ac4" control-id="pe-10">
+    <implemented-requirement uuid="7408f5cc-1dad-433e-8460-de347abfdf5b" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="6ce6e3b9-8593-4724-a446-ffb681ecf433">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="44feade1-1302-407a-9937-111dc5e87eda">
+      <statement statement-id="pe-10_stmt.a" uuid="c30eb199-b0c6-4a78-9659-ec5a8fa8e3c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="0a9d040a-a8ba-4c10-ab68-7b0a5398a2bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ccc95a56-783e-4d71-a85e-304f8bce4259">
+      <statement statement-id="pe-10_stmt.b" uuid="249c6acb-9212-4217-aa49-7dfa676e2e7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="f80266d7-aa24-4a02-9a0e-505f30e4d823">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="43b836dd-3d6b-44c7-9d10-a8d7f951583d">
+      <statement statement-id="pe-10_stmt.c" uuid="3001ef7e-68c8-49b8-ab45-505a2b5c6168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ab8efea-05aa-41a3-90bf-2fcd28216d46" control-id="pe-11">
+    <implemented-requirement uuid="d3adaea3-24cd-4d4d-abe0-42dfc6d8f5a7" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="4e212723-76f3-4d0d-845f-d13fdd8cf882">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="82bd6763-5a0a-40ff-9907-694fa99485de">
+      <statement statement-id="pe-11_stmt" uuid="541a37ac-e31b-4d0b-879d-0ce8dfd09ae3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c886fcf-2851-43d7-8499-5d1ddc42feaf" control-id="pe-11.1">
+    <implemented-requirement uuid="d4bcc857-be05-4610-9226-33984a8d6bf4" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="79771a2e-5298-4826-9335-700f8c603e6e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="be4476bf-3c80-42f7-a6f3-5c901e6edc17">
+      <statement statement-id="pe-11.1_stmt" uuid="9902dc93-d9c1-42eb-934e-c588bf5b1ba7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dca15fe1-5bac-4545-9501-536faad96d80" control-id="pe-12">
+    <implemented-requirement uuid="73a0b14e-7660-453a-94c9-9545a21b0b64" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="8e416c6c-6134-463a-a879-799ce9964c76">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3ee81c79-f515-415c-ad0a-26d70f887b1b">
+      <statement statement-id="pe-12_stmt" uuid="d6f29b84-d877-4288-bfda-3ce09c52f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="080db2dc-9a36-456d-a07c-9d4a1c66acf0" control-id="pe-13">
+    <implemented-requirement uuid="989d3380-0745-4b3b-ba40-59fcf7bbcd79" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="ebe6263c-f0b6-4c08-8cf8-db982124deae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="885fa78b-8401-4de3-a524-5c1283892ccc">
+      <statement statement-id="pe-13_stmt" uuid="fbff0cdc-a8cd-4396-9381-591253c01ada">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89c12b48-909c-42f7-ae2f-51869f90f06a" control-id="pe-13.1">
+    <implemented-requirement uuid="dce3d343-8792-4291-9665-260203da0f1d" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="519cfbfa-f74d-4b02-846f-b0a0a81ca341">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8621d1dd-7f83-4263-801e-9f2eb4947713">
+      <statement statement-id="pe-13.1_stmt" uuid="782a7521-51f8-46f7-8613-224ceb714f9d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54695203-7ceb-45e5-9740-84308642b2b0" control-id="pe-13.2">
+    <implemented-requirement uuid="8f6475ed-63c4-4c90-9311-110a5611c94c" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="b5fa2ddc-549d-4545-9e24-753c159458b3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e90449a7-977f-4b35-be4a-d95897c6992d">
+      <statement statement-id="pe-13.2_stmt" uuid="0a884b9e-988d-47a3-b600-a6c997f527a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f3fdcd7-39fc-4e7e-8cd6-2ca8f8e5ff17" control-id="pe-13.3">
+    <implemented-requirement uuid="732c0a27-fe4b-4133-8eb9-4bef1eb5a6fa" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="9bc2408c-26b7-475e-a9bf-7f87918a24fb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bb2ea5e2-5f09-44ab-9ebb-4d0e2e2f3903">
+      <statement statement-id="pe-13.3_stmt" uuid="3140fe80-7527-4887-9a44-fae6da4a04e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bba6c45-ba9f-4114-bd05-334fd7e5a8f3" control-id="pe-14">
+    <implemented-requirement uuid="88c69622-6688-4c1a-989c-90ca905211a9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="01f91b27-0b1c-411f-8770-8ec4be7bb961">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b78762c3-86d4-469b-a138-b670549cea38">
+      <statement statement-id="pe-14_stmt.a" uuid="97025072-163b-491e-9317-a91790d40ea4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="1418f5ac-b6bc-4510-99ac-5d8a3fd43f78">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2f18cebf-1036-4311-afdd-bfe02ef0f4fe">
+      <statement statement-id="pe-14_stmt.b" uuid="c8b7b3db-7476-47c1-846f-f1bb83c24553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="12158848-5a6c-4f63-9b89-f0a1a4345083" control-id="pe-14.2">
+    <implemented-requirement uuid="70de85f0-62f3-454e-b88a-7596c01471e0" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="a482d99d-dfc7-4bac-b515-e1cb27a4de54">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d4ce6d5c-c608-4ec7-81e4-c99d88337a63">
+      <statement statement-id="pe-14.2_stmt" uuid="60f50e05-0e80-4c13-b04d-fdc7eb03f3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f694a76a-7e00-49dc-999f-86240852d45d" control-id="pe-15">
+    <implemented-requirement uuid="54c1493d-b77b-4b0f-9764-526d33b12d01" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="1f83a190-4dc3-4275-9b7d-fe0b3894542e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b07f895e-5cf0-498b-8ef2-0d5e6eeaa783">
+      <statement statement-id="pe-15_stmt" uuid="76e4fbe1-5df5-41f2-80cb-df66c1fbff2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="710a5b13-fa48-41c2-85aa-58a9e2e0f62a" control-id="pe-15.1">
+    <implemented-requirement uuid="4e6b825c-bd18-4164-afd0-24bb2ce519b6" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="3666efba-9c94-4a88-91b2-2de60c3bbf5f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="40675216-2d52-49a4-a989-a4933ab4f102">
+      <statement statement-id="pe-15.1_stmt" uuid="df77d424-1257-4609-801c-ce99851fc6b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e4bd8d4-5eb3-41cd-9e2d-05174a693d17" control-id="pe-16">
+    <implemented-requirement uuid="8273106c-975b-47bb-8ab8-c7fa37dc5bb9" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="960d0a84-d27a-426b-8135-d7f142579065">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ab25fb5-991b-4f6f-953a-0ec02329a85f">
+      <statement statement-id="pe-16_stmt" uuid="1a6e18f3-ad4b-42ed-a48a-f97d8cbd6f3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d973086f-ce59-4cf7-8be5-42b91d11b02e" control-id="pe-17">
+    <implemented-requirement uuid="d75e661a-5ac3-404e-a97e-43a208e98b0f" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="c476e84b-e2f8-4857-a74f-553c4c38209a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0ddf0f40-e186-4563-8ff5-4d43f27df607">
+      <statement statement-id="pe-17_stmt.a" uuid="c8358812-2072-455f-8809-286fca2a5070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="11505ca0-085a-4e22-b682-192676399d49">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d2506267-0703-4e51-9300-17aae89546a9">
+      <statement statement-id="pe-17_stmt.b" uuid="98a6c2d0-859a-4dce-a4e3-455e4bfb85a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="bb30424e-1bee-41fd-8ade-e7e6d0c8edf8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a338baed-7c90-4ecb-a083-70a01541bd58">
+      <statement statement-id="pe-17_stmt.c" uuid="52bf7480-7746-469a-abaf-860f5c0a23e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2f2d7c5-bdc4-4984-a51f-98b658c7dee2" control-id="pe-18">
+    <implemented-requirement uuid="a85ce5e0-364d-4f7f-be70-b7eb357acdba" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="93a357ed-5610-4119-af2c-4d7ce6fffb44">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fe2cb863-1278-4836-a04e-1f6dc1bb2d43">
+      <statement statement-id="pe-18_stmt" uuid="e40dab9a-d057-4f35-acc7-bdf4dd842c38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f97ea5e8-6c43-4407-92d5-d0a461e4936b" control-id="pl-1">
+    <implemented-requirement uuid="0e82974a-1e5e-4803-93e9-61175640b5c7" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="cbe6c5d2-19bb-40e0-a98f-76eeb98d7f35">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d8575293-1a66-4625-8311-aaffb9b32356">
+      <statement statement-id="pl-1_stmt.a" uuid="45dde084-83b2-4d2c-93b3-1409bd7dbb04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="92487473-47ba-4654-80ab-84229ba1dff5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="638c1661-f675-487b-bb0b-8ae655fe419a">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="9c392713-490d-4d41-a362-d1e4316ffc06" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="d94544b3-ca6d-4509-9590-6b37c7b3c6d0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8fba9221-dbb8-4c20-abaa-094552d9f200">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="0ff38690-c256-4669-8d7a-26a21cb5978e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="45daad5d-50dd-4ccc-8906-bdf8419b92eb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="f1544646-64f4-441c-97ef-26144f4a71e3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="24e86407-ab50-423e-887d-99877d6c85d2">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="ef8763e3-21cf-445c-bcde-3b27baea9591">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4359ccb7-00c9-4f9a-ab7b-aac1a0adc94e">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="ca31dcfe-7f7b-4330-b62c-c99a25da2fd7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="41a643c9-2ee9-4d20-bb12-ab8f94b02c51">
+      <statement statement-id="pl-1_stmt.b" uuid="584ebb6c-020f-483f-ab68-44fc7883c9a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6657,10 +6614,53 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b282e6d-9a7b-406e-a1fb-93dc1c0c65c4" control-id="pl-2.3">
+    <implemented-requirement uuid="74f5010a-cf8a-4d6d-a7d6-faf6af0a04d0" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="c20b61a3-723f-4fcc-863d-917b9ec2f170">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a5630821-9b96-4757-b770-70227d977aaf">
+      <statement statement-id="pl-2_stmt.a" uuid="ef7e6239-22d4-4606-93a4-a629e9f064f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="ec903918-36fd-4c0d-aeb5-0eb0c456e85e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="12b3e99c-6844-4dc6-9e4d-8ca775ebe9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="7e2dbc92-fa11-4993-a43c-905b59ca13bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="538fc076-02b8-43d4-9f18-ab19099afc2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="23f8bbff-45a8-41ee-b0af-bcb99f2bc95c" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="09f686c6-3e0d-44ad-ab08-3a699c0ff372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6668,34 +6668,34 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73a23e2f-361e-484e-9244-c5ab122461de" control-id="pl-4">
+    <implemented-requirement uuid="0c0db8de-aaa9-42d8-b3a6-9b3471138c3a" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="f7577073-f246-493f-8988-70ce7289f04d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="17a4c39d-be91-4f98-9de4-42ae554d90b2">
+      <statement statement-id="pl-4_stmt.a" uuid="2b08835a-92bb-4eb1-899a-3f7aa979d943">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="6636dfd2-d190-4012-a94a-b7c66a5761c4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="313e2a92-af68-4b9f-a549-ad5436316424">
+      <statement statement-id="pl-4_stmt.b" uuid="f9ecc899-861e-4122-b0dd-c19d20c60e3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="ef5fc842-8a8b-4748-bab1-e5c89bb3f101">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dc727dca-0a50-4954-8109-9a81b0b61ed2">
+      <statement statement-id="pl-4_stmt.c" uuid="f13de092-1212-4991-964c-2228d884171d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="14e5e36d-0aff-45eb-b150-6d419a8e4ced">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="231c1d64-7d36-4508-94aa-3c2d99baa8b4">
+      <statement statement-id="pl-4_stmt.d" uuid="acad6217-b1e6-47b9-9aae-36a8b4baacf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6703,10 +6703,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48815877-7430-46bd-af90-96da316e6e02" control-id="pl-4.1">
+    <implemented-requirement uuid="e0add23a-efc5-4e09-872d-93407df52408" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="6127db63-dc35-4992-b41b-5c589cd04dbe">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e88d50a1-18de-4fa1-bd8c-ddaeee5f91bb">
+      <statement statement-id="pl-4.1_stmt" uuid="3970ca01-c0fe-4e34-ba4f-c4807e7f6f89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6714,26 +6714,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e3d3343-f4a9-4e97-96cb-5b83c508897c" control-id="pl-8">
+    <implemented-requirement uuid="caea3767-a4fd-4cfc-84d1-59074a1f10a9" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="c22215ed-7339-4227-aa4a-b0adff6c5fcb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0fc5faf7-29aa-441e-ab80-6a8e73d7e9b0">
+      <statement statement-id="pl-8_stmt.a" uuid="d5908a05-a474-4d88-b542-e56555f2b5cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="93bd88ca-e1a1-4ff1-ac8c-817a6bc0e57e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="38383220-38d3-47c8-9ad5-80634d5f1038">
+      <statement statement-id="pl-8_stmt.b" uuid="4857d403-3431-493f-b89f-fc49b8900320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="8a850e4b-c4e4-4b2a-ab61-4b8fe5b3bc06">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="50579e56-ce1e-4914-ae4d-bc50b673d48d">
+      <statement statement-id="pl-8_stmt.c" uuid="502e1e80-ea60-46f6-890e-032cb77e921a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6741,10 +6741,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f48b8e2-271a-4011-b13e-482d8eb4ee88" control-id="ps-1">
+    <implemented-requirement uuid="84fa0851-5291-4f57-b0da-86a38d7f2982" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="218f68dd-e954-428a-ae6f-07e6728024ef">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="23989947-51c6-402d-b3da-69ddb8ada779">
+      <statement statement-id="ps-1_stmt.a" uuid="9213924d-1488-4be4-bd6a-cc5efa99876f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6752,8 +6752,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="337da4c2-8c40-4434-8dc6-a78463d94e77">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1166496a-86db-41de-9b66-96fce8051606">
+      <statement statement-id="ps-1_stmt.a.1" uuid="da2613d9-5c1a-47ec-adb0-ebaad4ce9c16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6761,8 +6761,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="9aaf9bf4-3e8e-492b-ba4f-aca6b784de18">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e58d0121-9296-4275-8ec4-b700ecb8b00d">
+      <statement statement-id="ps-1_stmt.a.2" uuid="1efdb8a1-467f-40af-a50e-1cdf32e1e90e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6770,8 +6770,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="b963fa55-c08d-4c46-a1bf-2a9807ff6ebf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8d645b8d-9b9a-43cc-90e0-329e4e582846">
+      <statement statement-id="ps-1_stmt.b" uuid="f30e92b7-4e27-4c5c-a3c6-8350752dbcf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="115ee815-286c-4c88-a826-6b98653cc1f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -6779,8 +6779,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="c0cb96aa-4d28-4f31-921e-3bc5ec5dfe1e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="24245e7b-cdf3-417c-b51f-f3856e5db0c6">
+      <statement statement-id="ps-1_stmt.b.1" uuid="cc3171f5-1472-46c0-b23f-2d94cb548882">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6788,8 +6788,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="aa26f81e-859a-4f96-abb1-8bc59f5d1d64">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a9698aa5-0c59-4efd-8017-a73c7e6b3365">
+      <statement statement-id="ps-1_stmt.b.2" uuid="3c05a938-986b-4b8a-ac65-8e4baaadebfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6798,18 +6798,18 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1300bca3-edcd-47d2-8192-24a8650c7221" control-id="ps-2">
+    <implemented-requirement uuid="e834884a-c809-44c5-a9f1-79134132c383" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="6fc20b59-848f-42e7-9dd3-18c4809160e4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a3162297-dbb1-4f2b-9189-4c4175dce0de">
+      <statement statement-id="ps-2_stmt.a" uuid="8d06a4af-de17-4158-8055-d34a8cace546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13b7d353-e385-42fb-9e2a-e61c6b0879ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="19ccc438-7428-4f85-ae1f-bf73a320f031">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="badf2667-29dc-44b6-880a-e58e7ab69408">
+      <statement statement-id="ps-2_stmt.b" uuid="b05c1d64-086f-4bc9-88dc-7f04768be288">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92e499d3-e65d-4b2e-a421-4af961b84fdf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -6817,8 +6817,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="79aedadd-669f-4646-9791-c97e979e225b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="67329964-c2dc-4b74-87e0-b677adabe734">
+      <statement statement-id="ps-2_stmt.c" uuid="f9e0ef0b-25ba-4a88-ba45-bf8ca190ed05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e3f2232-2b16-4ba1-bf6f-e674b556db84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -6827,10 +6827,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5823d4eb-9201-4ddc-a6a1-a011ba864a1a" control-id="ps-3">
+    <implemented-requirement uuid="89fd10ff-caf7-4598-b7ea-7d9ca1e5cd7c" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="daa64bd0-053d-4e40-8a79-485ab35010c5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="33de5fcb-884a-4e5a-bf7f-8a6fccea9508">
+      <statement statement-id="ps-3_stmt.a" uuid="a619cc9a-42cf-4af9-a620-42c536650484">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3873dc66-8e97-4c5a-a184-83b4cd93f73c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -6838,8 +6838,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="1f285270-f72a-4483-8b37-ef6af567f326">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1bc5f3fb-19f7-43cc-bbba-dc75055c45fe">
+      <statement statement-id="ps-3_stmt.b" uuid="dd01c751-379c-4a36-a81a-db402d39ce38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c7bde33-4798-4c3f-aeec-b5365aee9a50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -6850,10 +6850,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbdd17f4-2514-43df-a254-2b420c986903" control-id="ps-3.3">
+    <implemented-requirement uuid="2876c776-a18a-4c1b-89f9-90238c88cef0" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="0d2357e3-36cc-410a-977d-7fc0117f2bf4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="06fc9fdf-3452-43ba-bfd5-7b5c696e4faf">
+      <statement statement-id="ps-3.3_stmt.a" uuid="fedd2790-52eb-4858-9190-7ef23d64a7c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4edd1808-6619-4e1c-a8ed-79fa33630f96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6863,8 +6863,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="bedc05f1-4455-4018-9c16-48c341b7575c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="db3b829f-0043-4395-9452-d2005a94eb83">
+      <statement statement-id="ps-3.3_stmt.b" uuid="8cf1e308-8488-4631-b8bb-ebbdf91a3ced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="551ef7f2-9cb3-4a96-86f4-583ecb369531">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6875,10 +6875,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a333b3a-c699-4fc4-b072-5edfb5cea9a3" control-id="ps-4">
+    <implemented-requirement uuid="612a0c80-52c1-4f04-94e2-d18b940dde95" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="12151747-4793-4ca1-8e14-35dba99142b0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="40813a34-4be1-40a5-baa3-f245a17efffb">
+      <statement statement-id="ps-4_stmt.a" uuid="8f5ab02c-a8e1-4678-848e-34d79fdfaa4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8adb751c-8bf3-4e25-85a5-c0994cb40d6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -6887,8 +6887,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="6d10afc8-f969-40c3-a76d-f757fb71b7bf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="76bc0b74-e9f2-4333-b80c-d34b3ecf1cfc">
+      <statement statement-id="ps-4_stmt.b" uuid="3f61a87d-9371-4b96-82a5-6fd30a3f6f74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39706fde-a5eb-4dab-8aa6-7a01c74c3691">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -6897,8 +6897,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="b69555f5-cc8f-4b09-9e62-0b76973b34eb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2675db6d-3737-4597-a072-331185b3a3af">
+      <statement statement-id="ps-4_stmt.c" uuid="de300ea9-b5c7-4ffb-9930-6f4ac2a2bca4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75c9f933-0fd3-4d95-8865-0ccbc03cd6e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -6907,8 +6907,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="dd8e790d-cc99-4664-9159-9c542fe8b905">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2366be18-b7ac-4470-9c26-d80dcb762e1b">
+      <statement statement-id="ps-4_stmt.d" uuid="591cec48-d427-41d7-804a-efdcfd2bbd06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf7eb54d-a450-46f2-ad69-ac1984b55eda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -6917,8 +6917,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="c17af0e8-37dd-4514-87eb-79238d785853">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="409dfe8e-6c40-4473-ae6b-76356baa928b">
+      <statement statement-id="ps-4_stmt.e" uuid="7ee3cb63-1f1b-452e-93aa-a6f2a5d9f985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93634a54-407f-4527-9a28-e2d7210c0520">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -6927,8 +6927,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="72c15f5b-56af-4d43-ad05-4abf8da07c25">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0b705bc1-3c57-4f91-85d6-094d25add8f2">
+      <statement statement-id="ps-4_stmt.f" uuid="360cf1f6-2876-424c-ad24-af3a67054b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3591532e-af31-4580-85cf-551c084ed643">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -6938,10 +6938,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b493795-7fa5-4294-b856-7ac3805bb2d2" control-id="ps-4.2">
+    <implemented-requirement uuid="ecadc171-b400-42d7-be8e-dddbf94114d9" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="0b7e7799-2d62-4c3b-ac61-430bd93567e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1b57a07c-5bea-45a6-a0fc-130001cc15f4">
+      <statement statement-id="ps-4.2_stmt" uuid="a729e9db-332a-4175-a273-83b5a2578535">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="42ab37aa-4792-4731-8bb7-84f44bdddd73">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -6951,10 +6951,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce15fc61-f08a-42ad-819d-df19c8291ced" control-id="ps-5">
+    <implemented-requirement uuid="0c906102-fa0a-46f0-971b-8f1e2edc9ff1" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="23409754-6687-43d3-a3d7-c6db27682938">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5b7887d5-08cb-4d56-8f0e-850ca52073af">
+      <statement statement-id="ps-5_stmt.a" uuid="dac52aba-aacb-4a15-924e-4dcc42c6b3b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0ef460-d521-416a-b989-1d90f6d2d657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -6964,8 +6964,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="986a9744-43c6-4e61-a59c-f65f4aface3a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2069d6cd-1ded-4d78-8be8-18bf44a0098a">
+      <statement statement-id="ps-5_stmt.b" uuid="34ef076c-a762-4404-a186-b759ae59e9b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9244b67-8356-459f-99cd-ce8c2c7ba68f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -6974,8 +6974,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="c67594e4-4a16-4c14-b647-d7ec4c79613d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e9cc90c3-d3c8-41fb-8df7-4a3854710aab">
+      <statement statement-id="ps-5_stmt.c" uuid="980c4738-bc5e-4b3a-85c9-d250d4011be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d22bff25-1b86-47f2-847b-a027ea5a7854">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6983,8 +6983,8 @@ or transfer are outside the scope of Red Hat Virtualization Host (RHVH) configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="09397a90-c2e8-460a-a014-ee0536a54347">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b8e31ec0-f29c-4f46-907c-75024c4a05f3">
+      <statement statement-id="ps-5_stmt.d" uuid="9f87a8d5-3677-494b-89dc-92b8c83f2351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f15c433c-50ca-4da9-91d4-ee59dac63996">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6993,10 +6993,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7b73c08-5eda-45c4-a796-4ec3343037df" control-id="ps-6">
+    <implemented-requirement uuid="970d4ceb-dea7-423f-83b9-a7dc36452960" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="3cee26c9-c7f3-4dd0-bbbf-f8b1838ad2e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c6542224-a34c-4e45-a0d0-dcb5824fec2a">
+      <statement statement-id="ps-6_stmt.a" uuid="83ed6df6-c2b9-467c-81d3-f4e8daf86d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14d8f40d-e8d4-4b52-8d15-c567f239a9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -7004,8 +7004,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="095499eb-33c2-4033-8cb3-ff0d6db76d74">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e9598d4a-0208-458b-a568-724b2e77219a">
+      <statement statement-id="ps-6_stmt.b" uuid="d504491c-ff57-46ea-b170-d3bc4b8495ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="231b3495-646e-4034-abce-ae9880df32f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -7013,8 +7013,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="bd83ffb6-6d69-46e4-a752-5b2e54f0ddda">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5912743d-14e8-4a9e-a7f5-1533c26e57c5">
+      <statement statement-id="ps-6_stmt.c" uuid="56333d1e-033c-4ed0-a411-f6740b9d1d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -7022,8 +7022,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="b4c0ec26-a331-491f-8793-6dbfffab2c1c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="eb4ac17b-a498-4809-ae05-86b80bf904db">
+      <statement statement-id="ps-6_stmt.c.1" uuid="4fc4f46a-b906-4e46-9cfe-431d1c12c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -7031,8 +7031,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="16c4ec0d-7b0b-408c-8eef-b3759ea042c9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="24c48dc3-3962-45ce-9f94-d46f6c7d73be">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d70730a3-b03d-4fad-b388-ac103cc47677">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -7041,10 +7041,10 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f3967fe-7825-496c-b8a2-ef38ba8a20f5" control-id="ps-7">
+    <implemented-requirement uuid="fac24704-d248-492e-9bd8-a0c280f2fc1e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="c6e65e31-d5ea-4a68-be8f-393f6af24126">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3988e700-c67f-4109-ac41-096bde01beed">
+      <statement statement-id="ps-7_stmt.a" uuid="b7c98a12-b8b8-4851-88e9-e2f9ab7f5804">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96520830-f9ad-4d71-bb04-d5a410cb455f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -7052,8 +7052,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="2eeb803c-0bcd-44f5-8447-2b5866403fb3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3186c313-b757-4bef-81fc-63b319f2e5c5">
+      <statement statement-id="ps-7_stmt.b" uuid="fd580b3c-1de7-42cb-b66c-7ca16e2f962c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f901d41-b1b8-410b-8e4e-ccd4ca080dc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -7061,16 +7061,16 @@ the organization are outside the scope of Red Hat Virtualization Host (RHVH) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="ece90cbd-7dfc-4cf7-9820-c0697207d5e4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="95304fae-056f-4901-b019-5791ad30dca7">
+      <statement statement-id="ps-7_stmt.c" uuid="5dec03dc-dd4b-4505-9bd9-5ef5deb78d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4ee0740-bb4c-463e-9a82-3da7afc81ac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="0493ab76-62fe-4b74-a303-8014629cb783">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="41ad8154-ed33-49f1-a201-9d8fe2e3b03d">
+      <statement statement-id="ps-7_stmt.d" uuid="6a3a7403-eb49-4e7e-95a6-ad9013979d87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6659f23-ba9e-4232-a865-05ec205d1d46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -7081,8 +7081,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="08d0801c-f9ad-4b64-b2e8-c1e745154c17">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2adffbfd-724e-4adc-b604-6cefc14ea012">
+      <statement statement-id="ps-7_stmt.e" uuid="1ef73a4d-839a-4b55-b11b-8257bec2fd45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3eebad91-c8c0-454c-bf7e-6f0a8d0fa4c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -7090,10 +7090,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a407b3c-49fa-40b6-b40c-cb58298880df" control-id="ps-8">
+    <implemented-requirement uuid="c1618cd0-ecac-4cc8-8ec7-2f1554f45d1c" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="c3c999dd-5704-4c70-b386-5d1000a6eea9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d5a40e40-3593-42cc-8729-1a053d86d954">
+      <statement statement-id="ps-8_stmt.a" uuid="b6e8dc70-4100-4376-b47c-a732a5e6c553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c700116-2ff1-4ae4-bca8-4f1c9fbefbc7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -7101,8 +7101,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="25e2f783-87eb-4cdf-94f7-c54ffeab4e5e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9cdffd94-cbc6-411e-b01c-a230684f74b9">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -7112,10 +7112,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b29ab809-c3d9-49a5-95e1-13562e567b91" control-id="ra-1">
+    <implemented-requirement uuid="bb9c2283-c424-4c07-af4f-a28d0e31d667" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="2bfeaf4e-81b6-4f5f-b34b-5e323df1ad1d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ceddfb6a-4b30-42d8-bd5a-7d595bf5b44e">
+      <statement statement-id="ra-1_stmt.a" uuid="ffcde792-2e83-4d79-8eb8-c1fdd1914001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -7123,8 +7123,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="1297cd3f-0341-4b36-a625-053aba428c7d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3e379872-1c79-486e-ab18-5f38d3220181">
+      <statement statement-id="ra-1_stmt.a.1" uuid="ac25bf60-f6fd-47e8-aad1-3ad084f6fb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -7132,8 +7132,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="d1c662f7-37f4-4c36-8631-4c194acd41e6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4f3b8d48-9a0c-429c-bcc9-3a00b040924a">
+      <statement statement-id="ra-1_stmt.a.2" uuid="7c0b8357-7e32-4dee-a23c-7ea5790b9972">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -7141,8 +7141,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="517a8ca1-ebe8-4a7a-bc0c-0a17c1246065">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="73dba2c7-d0d7-4d68-bcb8-418559b782d6">
+      <statement statement-id="ra-1_stmt.b" uuid="3658d5a7-8cf5-41dc-83e2-25adfbaf181f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -7150,8 +7150,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="5684169b-f957-4c72-bb84-e43f2ab7e83c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a7a36f7f-de17-4c11-8d0f-2ae5632d6fe8">
+      <statement statement-id="ra-1_stmt.b.1" uuid="fe8f2864-1648-4a81-bb6d-3a4b8a304fd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -7159,8 +7159,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="c66bac80-f39a-4194-aedd-23c0a2182e05">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ffeeffeb-d2cc-422e-8829-937b67952e56">
+      <statement statement-id="ra-1_stmt.b.2" uuid="46ef312b-fe1b-44d1-a414-aa73bf7fc817">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -7169,10 +7169,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="468006a6-a785-4bb6-9618-2532e7e210a6" control-id="ra-2">
+    <implemented-requirement uuid="94569d4b-4741-408c-b03f-7171d11cd216" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="af6cc42f-7550-4637-bfce-259bb905a82c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="29bbf257-ea60-4585-946e-70d76c662d65">
+      <statement statement-id="ra-2_stmt.a" uuid="87ae68f6-0ec2-49aa-bdc7-34fb3ba4778e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a20a7b8d-5d92-4463-be70-70921bca333d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -7181,8 +7181,8 @@ guidance, are outside the scope of Red Hat Virtualization Host (RHVH) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="5b3c301e-6716-4a63-bc18-879a8a2a9591">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="431cb393-6977-49ee-b1e9-5e2770ca6841">
+      <statement statement-id="ra-2_stmt.b" uuid="7ba08607-3ece-4f07-bfa3-2b522fedfd0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1e56041-35d4-47b7-8afb-999d308c6e86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -7191,8 +7191,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="26b89d46-e185-4c0a-b9a5-e407ae206e98">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="64878c0f-442a-484b-9ffc-12cd29719aa9">
+      <statement statement-id="ra-2_stmt.c" uuid="e091d042-ce3b-4138-ba8e-1e862ebce5d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d809a202-a485-4fa1-ade4-8e6f49148653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -7202,10 +7202,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3b3b2d6-f591-4942-b344-35ddbbb61811" control-id="ra-3">
+    <implemented-requirement uuid="6acffac5-0e06-4584-893e-5c489d9c432b" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="2d903605-79d8-4242-9789-eb58efbcd05b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="17e3875d-6e93-43cd-881f-29d89adac2f7">
+      <statement statement-id="ra-3_stmt.a" uuid="e6303230-4559-4a5f-9af9-68be90981c45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="929c2e09-70c4-4be4-bf68-ae55747ef24b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -7215,8 +7215,8 @@ transmits, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="6b18c2c4-358d-44dd-a300-4052ccde57d3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ea72ac5f-05dc-4295-86f7-071788989b1a">
+      <statement statement-id="ra-3_stmt.b" uuid="7f84310e-5fbe-494d-9beb-a7a2a8b74b6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6de19af8-7c17-4e8e-a9be-72f20f05165a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -7224,8 +7224,8 @@ documents, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="439cd435-6ae5-4bb1-898d-bf8002c3b42a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="81899588-5e8f-4607-9fab-8d6375bce4e5">
+      <statement statement-id="ra-3_stmt.c" uuid="3b91cd21-746f-4b5f-8de0-da385081d364">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553933dc-e764-43d3-8f5d-c2227c679f68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -7233,8 +7233,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="e9c74b5e-df5b-4606-b49f-781031262256">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b9358f3e-fd72-41f4-903d-b3d26859dfb5">
+      <statement statement-id="ra-3_stmt.d" uuid="262e0842-f1d5-4688-a504-e22df92a3187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a55ff7e-5b8d-4d09-9c85-eacdf924c0e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -7242,8 +7242,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="c0fb8bc2-3d6e-44ef-b1d0-eaed5670b0b6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="637f82d1-bf1d-4164-a14e-7545e0459dac">
+      <statement statement-id="ra-3_stmt.e" uuid="45d54b78-4e15-4abf-ab45-1f5f7f4dff0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0be82016-6e9f-4c36-bb75-f1f91f9015ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -7255,10 +7255,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f70f938-fa60-477b-9422-1fa20ab1acb2" control-id="ra-5">
+    <implemented-requirement uuid="1e80c085-6c6c-408c-989d-d37048edd298" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="0d37f797-8f5e-4083-9075-9df42aaaa61e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c9bf08d8-48bd-40aa-9286-27e13afc9573">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7266,8 +7266,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="0c459cc1-1a5f-417f-8e1b-536602cc61ef">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f4265f9c-bac5-4294-ab75-03044fad86be">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7275,16 +7275,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="1fa3ec0b-5fb6-4ec7-b4b1-e238b8eae308">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ae5387eb-3e95-40f2-86fc-c957fccf19de">
+      <statement statement-id="ra-5_stmt.c" uuid="dfbeeee4-4a89-43d7-8cb4-b213da619959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="c9c0e941-a502-46e1-8c4e-c3c46372045b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bd56dbd8-6c6e-4657-9ca2-3478bd682c07">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7292,8 +7292,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="8463ee23-5b78-412d-836e-bb15707348fa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ad7eeb49-292d-4581-9837-6aef03032bf7">
+      <statement statement-id="ra-5_stmt.e" uuid="ec8f09ed-5645-493f-9723-79faa9c9dda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf5bf54f-10e3-4517-b21b-dccfad84b100">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -7305,10 +7305,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d257e2f-5073-484d-ad11-ecb383bdaebf" control-id="ra-5.1">
+    <implemented-requirement uuid="25e0e198-6272-4100-aacc-c751b1d866e6" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="f3df1037-2c68-4d12-baf1-9fb29e6e32e8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="50c687c3-ee73-42a3-bd96-e6e5d8ec21f4">
+      <statement statement-id="ra-5.1_stmt" uuid="d8e4be41-53d9-4ebc-bbfa-1f575d095b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7317,10 +7317,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c627089-3252-46a1-98a5-d4563a03df59" control-id="ra-5.2">
+    <implemented-requirement uuid="c03894ab-c36f-481e-84cb-f4d553d3e7b4" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="0ae26fe7-a623-43e3-804f-7611652a2a27">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b5d465ad-951b-4fd1-9edf-885669e46966">
+      <statement statement-id="ra-5.2_stmt" uuid="5adb3817-da95-46f9-851a-615b5e4e5b3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7328,10 +7328,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9421fcfb-4936-4b3f-84a8-d7087c0a0afa" control-id="ra-5.3">
+    <implemented-requirement uuid="097372a4-d124-4484-9a98-e789732a960b" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="a9f0d80a-603e-43dc-b708-c9524d3d0a81">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="142ec01e-bb80-4320-92a2-0fd90f0938a2">
+      <statement statement-id="ra-5.3_stmt" uuid="8b973f17-674b-470a-a534-d73dab830849">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7339,10 +7339,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42013c6c-fac7-4177-a561-fa24160eb119" control-id="ra-5.4">
+    <implemented-requirement uuid="9850ce77-ddbb-4279-a9f3-c805945b9b21" control-id="ra-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.4_stmt" uuid="132c5a33-ba35-4761-96fc-a6da7f06bda4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e157be3a-d7eb-4e3d-8db5-06975840c841">
+      <statement statement-id="ra-5.4_stmt" uuid="3fbd3577-f2a5-4ff2-bcde-7e929da889f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a494467-32fb-4bbd-9c57-df641a401d9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7351,10 +7351,10 @@ https://projects.engineering.redhat.com/browse/RHV-21056
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02630659-53ee-4f3d-a996-54790dd79278" control-id="ra-5.5">
+    <implemented-requirement uuid="85d3387b-07ff-4c11-9afe-62dde7b4b20b" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="4cb39d38-eb6a-464a-8750-79a4556f21d6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="eca55213-2834-4754-b426-5f00437075ff">
+      <statement statement-id="ra-5.5_stmt" uuid="56153afb-5fff-4d83-a274-c80dbe05c2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7363,10 +7363,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fd90eb9d-bce7-458e-ab70-576015b75037" control-id="ra-5.6">
+    <implemented-requirement uuid="631f32a6-79e9-4c7e-bce5-dce1e05fb448" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="b16a512d-ef99-4bb3-bba0-6410d9625030">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="aca40ea7-fec9-4a49-905a-eee8c889a190">
+      <statement statement-id="ra-5.6_stmt" uuid="ce8738be-55d6-4014-8ce0-9fa3e2e06d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -7375,10 +7375,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95407d25-d90e-460c-bafd-eeb2f3fb8c61" control-id="ra-5.8">
+    <implemented-requirement uuid="37be01e9-ed18-4570-a6a3-891fd8e2a47b" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="79d82be7-66dc-4325-bda7-37be85c3776c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6367f945-3553-4e10-ab48-6b1aaa205230">
+      <statement statement-id="ra-5.8_stmt" uuid="361cb116-1925-4019-9852-13d964fa2108">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e053e2d8-71a5-4a5b-a196-c1628465e902">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -7388,10 +7388,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21d81bc0-73b0-47a9-add6-e6e8872b2d06" control-id="ra-5.10">
+    <implemented-requirement uuid="70bf23f0-1d56-4ca1-a2db-f16e18f4c5c9" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="89e8ffde-7712-4bc7-901a-92f8a2ed3765">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="67a0fdb8-d39a-4e6c-b424-ce690be864ee">
+      <statement statement-id="ra-5.10_stmt" uuid="e435bc13-2bb3-4387-980d-aba1bdb7b843">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a942ce25-8704-4373-a1ac-5c5694bff94e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to correlate the output from vulnerability
 scanning tools to determine the presence of
@@ -7401,10 +7401,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4e16775e-3c20-4dc6-8486-626db51b7f9f" control-id="sa-1">
+    <implemented-requirement uuid="fdfa2836-e0c0-4a53-a520-1cd8fd2d0371" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="4ad62b6a-c9f9-4a1e-9db3-e90dafad05ae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="02a05f0b-1ea9-46f7-9c4e-455aebca0bf6">
+      <statement statement-id="sa-1_stmt.a" uuid="da233118-e5a1-419b-8ef9-d74cf88ec9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7413,8 +7413,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="2b00952d-4448-4239-9b24-75a5d75430b6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="75ccda57-ba5a-4f79-a01d-38641e013e8c">
+      <statement statement-id="sa-1_stmt.a.1" uuid="4d4e8f4b-2459-40fc-8a2b-cef39e7a5565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7423,8 +7423,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="cd9a2d8f-e0d6-4570-abd9-1002024ef0bd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8fb8512b-dfa3-42e5-aebf-98667e697ea6">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2a8c9751-bb38-4a01-a49b-e9a73fd0937a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -7433,8 +7433,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="5d2ee386-1aab-4bb1-a2e4-05d05e837a53">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="082228b4-3214-46dd-a2f8-468a89838f89">
+      <statement statement-id="sa-1_stmt.b" uuid="b243136b-348e-41d0-a36f-7a01b53932a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7442,8 +7442,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="4efdf238-94e5-44f5-a15e-1e31fd783625">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="366fa7e9-3fd5-4048-80f3-ff44628317fd">
+      <statement statement-id="sa-1_stmt.b.1" uuid="9339a14d-436c-4ad3-9b60-4289811e48c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7451,8 +7451,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="e1dbbcb2-ed4d-4e1a-9e45-063323d634ce">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ca4c69c1-bb41-4988-afc8-7441119ea508">
+      <statement statement-id="sa-1_stmt.b.2" uuid="e765aa23-fcba-4668-9c64-00191c316f57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -7461,10 +7461,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4a43165-1a66-4543-9491-db78fb8c9053" control-id="sa-2">
+    <implemented-requirement uuid="80720690-1e69-414e-aec3-f6303a2723dd" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="141db8a7-5ec0-4358-9fd7-3de7d12ab7e0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e85f54f9-2371-4b5c-b590-27673c38f211">
+      <statement statement-id="sa-2_stmt.a" uuid="70fbe520-9c80-4883-ad01-032d06e754a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="824db0f4-1273-41f6-8617-9b0796e3140b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -7473,8 +7473,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="f623eecb-beff-4d9f-968f-26e782f2b4a5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="accf2c92-98ae-4304-bc6e-25a5eae4d669">
+      <statement statement-id="sa-2_stmt.b" uuid="e2deed58-ac14-44ef-9fe5-4b0d10845768">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e6859d4-0559-4f4b-8d46-01d46a13d3b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -7484,8 +7484,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="96694dbd-a391-42c1-98dd-16aa7c6a3151">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="828990d4-74e0-47a6-9a1d-835f356962ce">
+      <statement statement-id="sa-2_stmt.c" uuid="1c1599e1-37ac-47cb-9a06-f84758267703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1260d5ad-f1e3-4b2e-81a0-9d05686f06de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -7494,10 +7494,10 @@ documentation are outside the scope of Red Hat Virtualization Host (RHVH) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9f5d1bc-498a-4b16-8e53-ed16d783fa34" control-id="sa-3">
+    <implemented-requirement uuid="5e984ca2-a2a0-4b61-b837-f1f2aef74c43" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="481a7347-3ccb-4d7d-b621-c6c3ce407d25">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2593a46d-2d8b-4813-997e-e4cb2f6bc9d6">
+      <statement statement-id="sa-3_stmt.a" uuid="a77b59ac-1444-4c7b-9b75-f7504c5dac4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4e3653f-212d-4d7e-b613-cc64927606d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -7506,8 +7506,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="aca89dfa-388e-4c4d-b674-46b6a45d186f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a3c2adfa-b84a-4a59-bce4-837134cbe20e">
+      <statement statement-id="sa-3_stmt.b" uuid="c2138e4b-f580-46fa-812d-9c695c306382">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f36e31ba-00fe-461a-8f8d-50956846bf60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -7515,8 +7515,8 @@ life cycle are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="036f1edc-4e78-4432-8465-4d02f81f01a5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1c9537ea-2af1-4326-adc2-595059eadad8">
+      <statement statement-id="sa-3_stmt.c" uuid="c57c5c36-96ce-4b82-ade8-71472cfdd0a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fdc08e7-548e-4102-a52e-4afcf59054a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -7524,8 +7524,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="03c298e6-76cb-4e0e-a5fe-0ae70ca901c4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1bf9ae20-777d-46e7-8a4c-945ee1a77038">
+      <statement statement-id="sa-3_stmt.d" uuid="834154bc-a9ad-4b29-9da9-689e209e5b9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314f63ca-ee21-4db6-9698-8c9537441f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -7534,10 +7534,10 @@ activities are outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd198630-1b8a-464f-9e0f-7760a2978cb1" control-id="sa-4">
+    <implemented-requirement uuid="7f7ce6f2-a54c-4be9-adb2-cef1cb1bb5cd" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="3e62aa12-94d0-4941-b552-fafe372ace05">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9506229d-32eb-422f-a76d-11016f7c7b9d">
+      <statement statement-id="sa-4_stmt.a" uuid="8477982b-4daf-40d7-a996-90a3f891ea00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aeab4dc1-ee7b-4c48-8886-cc74d87df81a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -7545,8 +7545,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="07623840-b3f4-40fb-a797-2b6fc055e644">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2621b254-12cf-4669-a510-dbee7a561b0e">
+      <statement statement-id="sa-4_stmt.b" uuid="ad50360b-72d1-40f3-8434-0ac78128fc91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d0a219-ecda-477d-a17f-db06df2f54a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -7554,8 +7554,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="28719419-3774-4e7c-a1d9-708f450be914">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="24965079-bdf3-4edd-b8c2-3af14dff6d16">
+      <statement statement-id="sa-4_stmt.c" uuid="80ad4a69-2f94-4877-968a-67583be09daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78883912-eaad-49aa-b2c1-32077d1b6715">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -7563,8 +7563,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="ac8bed5e-8dd3-4cfc-905d-d6098c6feefc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="691182ef-06e5-4bb1-ad6a-c9514aebcdb9">
+      <statement statement-id="sa-4_stmt.d" uuid="02579e51-d88b-47f5-9856-22fb80fc80cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc18f9ac-4f27-445f-ae6f-615f205fcee7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -7572,8 +7572,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="f2849fd0-7902-4f74-bbc0-98db99ed9a6d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2c131126-d432-4c99-b71f-2611f3e3e082">
+      <statement statement-id="sa-4_stmt.e" uuid="6dda20cb-aa6c-4e67-b666-aab9c5645d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea03972e-988b-4b12-ab49-176c6bd56b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -7581,8 +7581,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="ab73e3b0-849e-4c48-8a81-2ed8743fb276">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="82777945-efdd-4cfb-b6f1-94a48c779576">
+      <statement statement-id="sa-4_stmt.f" uuid="76068ac0-6f9b-4a77-8b1f-e792c6335219">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e5ac5c9-e113-44d1-bb5a-aae2c3300727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -7591,8 +7591,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="ef49cd33-bc19-47b9-a876-2d42a5472d5e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="09ec232f-f30e-4881-88cd-93a0f59570e5">
+      <statement statement-id="sa-4_stmt.g" uuid="0390dd8e-4476-4e8e-8f49-ef97ec4cd43c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14e27f1a-92ae-44a1-9a1e-8cb5c2cd6baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -7601,10 +7601,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5786184-71b7-40f2-86fd-3dd47cf1f085" control-id="sa-4.1">
+    <implemented-requirement uuid="c852b8ed-46e8-49a4-942e-02ad98e2145f" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="17436e64-d465-4878-a856-9fe558eccbce">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c9dcc115-cb2f-4188-9cd3-566e070995b0">
+      <statement statement-id="sa-4.1_stmt" uuid="5f744a19-86b6-458e-ae5b-9391fdaaf2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d0b45d5-3df5-4226-a89d-858eb0881fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -7614,10 +7614,10 @@ https://projects.engineering.redhat.com/browse/RHV-22638
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fa64dec-adf9-442f-af34-374a893941e8" control-id="sa-4.2">
+    <implemented-requirement uuid="494cce61-f250-443b-86bf-6428be908965" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="99df4aab-078e-412f-af1e-1a40fcee22b1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="92731776-c94c-4b4c-810d-f1cfd7293fea">
+      <statement statement-id="sa-4.2_stmt" uuid="fe19e678-d406-486d-a68b-a93da729dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a090f9c-dcc8-4565-95ba-9da0c5baa527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -7627,10 +7627,10 @@ https://projects.engineering.redhat.com/browse/RHV-22639
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aab668a5-751c-45b0-8cdc-b589644bfc61" control-id="sa-4.8">
+    <implemented-requirement uuid="f576d7f5-7768-4335-8d9a-6a92332f08f0" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="b9df6236-abcc-4f00-a3f8-faa9f41cee5d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ab2a7f68-e640-4d58-a656-82dbe45ba1d5">
+      <statement statement-id="sa-4.8_stmt" uuid="3d81371f-0030-4269-8918-c09b32dabcc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d4765e6-3e2e-4e4b-afbb-5fb77763e42d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -7640,10 +7640,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caabb174-967c-414c-8cc3-cbdff77adad7" control-id="sa-4.9">
+    <implemented-requirement uuid="183aecf0-bdf4-413f-8de9-fcbde8bda9b2" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="9f2b28cd-275e-47b4-b116-4975987d8119">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="733bf346-c6dc-4095-bdf9-a57bb45f4303">
+      <statement statement-id="sa-4.9_stmt" uuid="57789a83-af12-481f-8fee-d2420e3b5e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61c674b5-dda5-46f5-96ca-871e9452030f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -7653,10 +7653,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd414a33-e018-421c-a7cb-7dbd74664d5a" control-id="sa-4.10">
+    <implemented-requirement uuid="3c8a4e03-42e8-4617-ab5e-809b0a1a56ca" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="c44d2ccb-3e87-487a-a75e-12772b272136">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e8adad82-f44a-4713-902b-cbad3a0c1174">
+      <statement statement-id="sa-4.10_stmt" uuid="7f01eb5f-fddb-48cb-84bf-9663cf946e1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7664,90 +7664,90 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1a429ce-d334-476d-99ce-2b3aeef01e3a" control-id="sa-5">
+    <implemented-requirement uuid="1075b91a-26d4-45ab-af5e-7efa9804df78" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="fb08e60c-7d27-4785-9b21-f7866813bb5f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="91cbb718-696a-4c9b-97e0-7eedffa26943">
+      <statement statement-id="sa-5_stmt.a" uuid="cae1dc20-dc61-44b5-9a37-62f6f2cb410e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="4cc85dba-8469-40f4-a34a-d9d496835641">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="da97de9a-1e65-4bab-b8cc-9e5f1ff88a65">
+      <statement statement-id="sa-5_stmt.a.1" uuid="99b3a3d4-5328-43f2-a5d9-89f8184c882e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="cec79583-00f9-45cf-b2b6-95d05caad543">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ec01654e-eee1-4336-a49c-91b9f6e089c9">
+      <statement statement-id="sa-5_stmt.a.2" uuid="537f69f8-4ba4-46c9-be59-efe10637c240">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="8716767b-4ce2-441c-b2c5-8e6a1c1de893">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="204f8b2a-b95b-4adb-b3fe-fa8779dddd5b">
+      <statement statement-id="sa-5_stmt.a.3" uuid="784f11f5-4b7d-40ac-a76f-58a9fdad9064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="464d70e7-fcb7-4039-8150-f91d4dbafd59">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7290ad0c-291c-4654-83a2-12def66119b5">
+      <statement statement-id="sa-5_stmt.b" uuid="0d18c19a-6577-4de0-a417-58649b39ae33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="4e1313f4-4b44-48ec-9b0e-9e5a3c588008">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0b6ce0da-8979-4e2e-9185-49c9df8ac0eb">
+      <statement statement-id="sa-5_stmt.b.1" uuid="2935da53-589c-4942-873b-17308b1db3e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="3feff66f-c47f-4e43-85b3-a0525db82b53">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ea09e695-0f18-4228-99c9-30738670c8b5">
+      <statement statement-id="sa-5_stmt.b.2" uuid="59237e65-7285-4421-9360-23c2f5dd49de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="3b11eb01-6fb2-4566-b7d6-84fc1034837f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="504350f4-62da-497d-b5bc-8c604cdef78f">
+      <statement statement-id="sa-5_stmt.b.3" uuid="8412a76c-28a1-4c2a-a792-8fe5f8ddb978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="c1d6665d-0500-4071-9868-c0df9d5a5132">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2dc4a627-3028-4473-8abf-976cd06a179f">
+      <statement statement-id="sa-5_stmt.c" uuid="8d9619be-592c-4025-b179-cff67addee3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="6da2f32f-6dd6-40fc-baee-bf8fdc0ebfb8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2ac304b-2362-4f78-8ed6-8878dfa9127e">
+      <statement statement-id="sa-5_stmt.d" uuid="662de344-472b-41be-91e7-f36b324438fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="84f74ad4-5f41-4492-a010-4b9839e07195">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d4fcb6fb-40ca-4c7f-8caa-a8fe4ef3d3a4">
+      <statement statement-id="sa-5_stmt.e" uuid="8282b696-60a1-4f72-9c01-43c4fd6970e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7755,10 +7755,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db631cc9-e93b-46bc-a2e2-026fe72c07cd" control-id="sa-8">
+    <implemented-requirement uuid="8782f8bd-c4de-4614-b56f-4f650c950f28" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="5cf3b72c-67a4-4f68-8b16-2c58ca27fc55">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="83bcd90d-7255-41d7-b118-cb896b3bdd4d">
+      <statement statement-id="sa-8_stmt" uuid="053e8088-1e23-4e80-9cd7-17d29def757b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7766,26 +7766,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef8de38b-9053-4afe-822d-7426f3f3cfee" control-id="sa-9">
+    <implemented-requirement uuid="5fe8b02d-1c13-4fa1-8b41-93a5262cc178" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="cacb9df1-17e6-4853-a794-d7dde2a27ede">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="029026fa-0812-4907-8ff0-3a520626e87e">
+      <statement statement-id="sa-9_stmt.a" uuid="ec90d1b9-2433-47bd-95f3-db9ba1cc3b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="33c15091-6ccb-4230-8dd7-f2706263e193">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a774a987-b9a3-43c9-bb96-913688b141fd">
+      <statement statement-id="sa-9_stmt.b" uuid="af646d19-e251-4f4c-a698-0079392edb9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="a1f8e97d-0efb-4b5a-9b17-d8be6497ad4e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="358f5e9b-e356-4260-af98-af917ee84388">
+      <statement statement-id="sa-9_stmt.c" uuid="d6abc2a7-08af-4f36-8ef5-481871de8fba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7793,18 +7793,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d17baee-9dfd-4d8e-b1e1-9cfc56816a30" control-id="sa-9.1">
+    <implemented-requirement uuid="7d75ce32-d4ed-4628-90b5-3f2b2ccec246" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="b107615d-23f5-4a44-b5d6-265b0e40377f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5410c659-0385-4de3-a66c-89efb61db859">
+      <statement statement-id="sa-9.1_stmt.a" uuid="6a02e26a-fe5b-4fe7-8d36-a495ae86ef74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="127fe617-b01e-4bdd-8dda-7c03e8632723">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8cb06037-7f00-4be3-bfa9-31ffc5ad58ef">
+      <statement statement-id="sa-9.1_stmt.b" uuid="8319b719-d06f-4ebe-b40f-c684d701527f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7812,10 +7812,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c4d4a05-9c48-4a83-a684-9cf9a2fae6c6" control-id="sa-9.2">
+    <implemented-requirement uuid="75209627-7a51-49ac-95b5-5a12a3d034c9" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="40c6789d-0d06-4dfe-aabc-9e75a6b399d1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="32c1e21c-4716-43c7-bd1d-21300b7f87d0">
+      <statement statement-id="sa-9.2_stmt" uuid="62c5ecdc-7fa0-4b8d-b632-fdb896811077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7823,10 +7823,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c25255c8-16a9-430f-97f1-42ef67960c2e" control-id="sa-9.4">
+    <implemented-requirement uuid="554f2b84-c67a-43f8-8204-869620c499ea" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="2dc1df9e-e56a-4085-97a1-1d40bddcf726">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="66d4fe6f-67b0-4afd-aa05-05444f8f8004">
+      <statement statement-id="sa-9.4_stmt" uuid="eb13716e-ee14-48bb-977f-d85331e28df2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -7834,10 +7834,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24f190f5-88ec-425d-98e1-4b10e6183257" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="af85bb4e-4f4f-4949-afe9-7faebebeca54">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9166edb4-930e-4cda-8133-96b7207ea917">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -7847,10 +7847,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="740e2130-d97e-4b6a-aed1-4e218c6cfe43" control-id="sa-10">
+    <implemented-requirement uuid="293f268f-39a8-47da-85fb-b1aa98f204be" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="a2b19f11-1534-438c-abf4-8972e183ee89">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="12a72b2e-385e-497c-8230-f63414663d92">
+      <statement statement-id="sa-10_stmt.a" uuid="148daf57-78dd-44f4-9034-2a5a5bf501c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c007989f-6207-43a4-8a0e-c4bbfbcbcfc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -7859,8 +7859,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="22da3398-c7cb-42d3-9ee9-6bea231256f3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="7178a85f-ba2a-4499-b3cd-f4dbbb3304c8">
+      <statement statement-id="sa-10_stmt.b" uuid="5c2cc993-ddab-465b-9f1d-e46d3e024e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfb7401e-c900-4ced-9a20-2bee25790497">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -7869,8 +7869,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="746c58e4-f706-4fc0-92a1-43a666f42da1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e19fc63f-1207-4bab-b587-e232cac5c733">
+      <statement statement-id="sa-10_stmt.c" uuid="f1413046-1128-4cb3-8268-177393cfdaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b14ad649-026f-462d-849a-0cf4e092d2f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -7879,8 +7879,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="2e0d3394-f9c9-4d63-bd7a-bd144b010018">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="25e4d8b1-45ec-400b-96e7-64378dc9cb6f">
+      <statement statement-id="sa-10_stmt.d" uuid="9d632fcd-3f58-441e-8adb-cc1c3dfa0bca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49544cdb-c4a6-4185-80bd-2b5ecb724ab7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -7889,8 +7889,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="7da7438f-ec07-4ffa-82cf-807f418b6c46">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="612961e4-35f2-44c8-bd38-f455d3a38a01">
+      <statement statement-id="sa-10_stmt.e" uuid="2f1236ef-8afa-4b2f-899a-156aa02be068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2706133d-eb66-4fff-939a-950056d0e299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -7900,10 +7900,10 @@ https://projects.engineering.redhat.com/browse/RHV-21061
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aadcfcdd-4725-4df0-87b0-2e0896988901" control-id="sa-10.1">
+    <implemented-requirement uuid="adc8007e-d183-4e3f-aadc-c49f3d8d4132" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="88827ad8-0264-4a08-b608-45b4447190a2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="12002d42-aeec-4481-a704-9eed7a393c55">
+      <statement statement-id="sa-10.1_stmt" uuid="22ec1ae1-100e-4b20-9cc2-3402cdeaef57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec1c56ee-d6ab-4f33-9e0d-279b141d27a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -7913,10 +7913,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1520bbf8-15ce-4994-875d-071c2ccb397c" control-id="sa-11">
+    <implemented-requirement uuid="3793a082-b793-4415-a3e2-a5617d4a09c6" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="cfdf421c-4394-48c0-a3d8-f7ef1da431ee">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="03599c0f-170b-4c55-a0ca-e236e799fda5">
+      <statement statement-id="sa-11_stmt.a" uuid="cf46ba78-5a5c-475c-be80-c5b57ef96281">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36a99276-5f2d-428f-9816-f2e4786351d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -7925,8 +7925,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="47cc1d2b-f5aa-474b-88a2-edb7cb579ee2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e181802-3154-4dcd-8448-295cfbd86d69">
+      <statement statement-id="sa-11_stmt.b" uuid="061e3634-d640-4dab-be4b-e30bfe16c61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1937705b-ad55-4470-85df-afd21c29d99f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -7935,8 +7935,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="ab834b57-afb4-4424-87c9-e2d5d8525037">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="74b5508c-d075-414b-8d9b-f0f22c5fc1a0">
+      <statement statement-id="sa-11_stmt.c" uuid="b76445b3-6271-4033-bc41-0f358e6badbb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4863aa6f-1480-476e-b863-25faf09c8469">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -7945,8 +7945,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="bea95edc-3896-40f4-8d6c-f430191eb36b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9b34704b-a405-4509-bf93-153ec84c9d2d">
+      <statement statement-id="sa-11_stmt.d" uuid="0a2f3d54-2762-41d6-8713-c22e8832c84b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="681bd9b0-f378-4bfe-a3b4-14cc0fc1c799">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -7955,8 +7955,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="d4c053a3-af0d-4201-a967-acb85697460b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="242bd13e-1726-420c-94fe-e12cb8b8c9cb">
+      <statement statement-id="sa-11_stmt.e" uuid="713f2000-3e7c-40d5-a3c9-b40edd933abd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9b31e1-662d-4c73-8b23-53ee3a1234e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7966,10 +7966,10 @@ https://projects.engineering.redhat.com/browse/RHV-21062
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab8613f7-bbac-4a42-b71c-e36df9d5fd01" control-id="sa-11.1">
+    <implemented-requirement uuid="f4654e5b-5c8c-4556-acff-4a55e2d7a462" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="fbe2e225-5dd1-4587-94da-329af08b4b90">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="67298da7-95f5-40dc-ba90-b7c41b296eca">
+      <statement statement-id="sa-11.1_stmt" uuid="499fdb69-b5bd-40ba-addd-0e0c310ba5dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a5e446a-ffc4-4b73-b1ee-fd52746fdc16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(1) is planned. Progress
 can be tracked at:
@@ -7979,10 +7979,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1645bc9-4c57-4cc1-8824-14c1ec557af4" control-id="sa-11.2">
+    <implemented-requirement uuid="ddb2c3a3-ecc2-4a77-99fd-6f779f776f71" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="4beafb29-07b8-421c-9c8d-54b78362fe66">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c5fa0b94-b9cc-4dda-bb7b-b6229ec109bf">
+      <statement statement-id="sa-11.2_stmt" uuid="dbc9c3c0-0d9a-4da6-b616-af78319989cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="888ad617-e394-456e-a020-63a4f9bcf251">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(2) is planned. Progress
 can be tracked at:
@@ -7992,10 +7992,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf400db0-44f0-4a4c-9b76-6ef2259ef097" control-id="sa-11.8">
+    <implemented-requirement uuid="431a7e86-4fa6-41b0-a14e-8a7b40f965f8" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="683fe80c-7f3d-404a-8aa9-509fc060a6f1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="db6ca451-8254-44c8-af53-54c5fccae9b4">
+      <statement statement-id="sa-11.8_stmt" uuid="c329c78b-2ad2-4474-9716-37bad9f62df1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20dadd46-daee-4ac0-a03d-61a01669d400">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress
 can be tracked at:
@@ -8005,10 +8005,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f80470e-f565-43d1-bc0a-a2e7f035269a" control-id="sa-12">
+    <implemented-requirement uuid="9e64d238-89a3-4c67-ac49-598a9ca688ec" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="cffb7321-d1fe-443f-a146-d85689db0ba9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="99c71b11-2b4d-41ce-abdc-c68047a273f3">
+      <statement statement-id="sa-12_stmt" uuid="7142543c-9350-44f6-8469-69069a4a17e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -8016,10 +8016,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e0fac59-0821-42e7-914e-a1c478a15f4e" control-id="sa-15">
+    <implemented-requirement uuid="f7d0453d-ac77-4a82-808f-3318129e53dc" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="c6ad6328-a470-4031-84e0-786fddb66936">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e524d24-9c89-4bd1-8a4d-f5f904dc5e21">
+      <statement statement-id="sa-15_stmt.a" uuid="c8a358dc-d179-4398-93fa-69344a0ac7a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ddc8226-8bcb-4209-8148-d8c43589a812">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a) is planned. Progress
 can be tracked at:
@@ -8028,8 +8028,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.1" uuid="323988c3-1b02-4604-85e7-866572e6f1d8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1b515bd6-2bdf-406d-98be-f521be4a4dc8">
+      <statement statement-id="sa-15_stmt.a.1" uuid="9c67a162-0a3e-4061-8b9b-fb9542c4ce90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d31d2ae0-e0cc-44bd-a884-964e21ed522c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(1) is planned. Progress
 can be tracked at:
@@ -8038,8 +8038,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.2" uuid="14214e5d-caad-48e3-9855-d50191731072">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8348af6b-ad87-428a-b7d4-9c2f762e1681">
+      <statement statement-id="sa-15_stmt.a.2" uuid="acd44614-97ce-4e13-802f-e41adad6df00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e2bb82b-b86d-4092-be37-eb5505a8c341">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(2) is planned. Progress
 can be tracked at:
@@ -8048,8 +8048,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.3" uuid="97246bf2-c6ba-4609-b688-0d752a7f229b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="07eaa085-dc29-4b7f-847b-48a904d14666">
+      <statement statement-id="sa-15_stmt.a.3" uuid="88fd7f6c-e422-429a-beb2-2026c28728a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="330b11be-8081-4060-9903-c8bf4ed13b10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(3) is planned. Progress
 can be tracked at:
@@ -8058,8 +8058,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.4" uuid="f94da97d-27fc-4604-b94f-425b406bbe6e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e039b511-c1c4-43f8-90f0-669b5cb9629a">
+      <statement statement-id="sa-15_stmt.a.4" uuid="32bf16bc-45ee-4023-8360-c6720239e664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="468193da-e28d-4d52-8ad8-986a1af08a34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(4) is planned. Progress
 can be tracked at:
@@ -8068,8 +8068,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="456fa254-ad3a-4c9a-8a28-ff9c2b6d9888">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="18477b5f-0e72-478e-8e2f-43c7f8229dee">
+      <statement statement-id="sa-15_stmt.b" uuid="c5d7eb50-ecb5-4dd2-9ade-aea8497d5890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29568523-98f7-4286-806a-fc0f4e0e75e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(b) is planned. Progress
 can be tracked at:
@@ -8079,20 +8079,20 @@ https://projects.engineering.redhat.com/browse/RHV-21063
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aab2ed9d-cd1f-4442-9f0e-59c0c9245dfd" control-id="sa-16">
+    <implemented-requirement uuid="9bb3c0cb-a2a8-46a7-9ca4-b2a4e6f1ef91" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="108cf227-f175-43a1-b633-4498353e87b3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3d32cecc-14b4-4f4d-8b49-8d93eb2d58c9">
+      <statement statement-id="sa-16_stmt" uuid="1b44cb72-6d8a-4a8d-8437-288906e1ddc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90480eb2-7f20-4b67-b557-b325700907b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-16 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="faa6edba-91f0-4999-8979-18385df0ffc0" control-id="sa-17">
+    <implemented-requirement uuid="782101c6-45de-434c-8a73-ca3d89fd5b5d" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="89672e99-a352-4958-a806-8125bb65df5d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3a746def-d52b-4280-90d1-c748cb2740e8">
+      <statement statement-id="sa-17_stmt.a" uuid="d213e9ce-09e6-4920-abde-111481c0ab10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64639535-b475-4b1c-95f9-4872768e79b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(a) is planned. Progress
 can be tracked at:
@@ -8101,8 +8101,8 @@ https://projects.engineering.redhat.com/browse/RHV
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="f68b7832-5c65-4e02-bee7-3e44307734a0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="93e914cd-7000-4e12-aa3a-7aadad8a9d15">
+      <statement statement-id="sa-17_stmt.b" uuid="cf7ad531-f3bd-4b92-9f3d-ef1920e53dfe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12d4cfea-e2bb-48b5-93c4-6c4338bebf1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(b) is planned. Progress
 can be tracked at:
@@ -8111,8 +8111,8 @@ https://projects.engineering.redhat.com/browse/RHV
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.c" uuid="7c6c5a75-55e7-4c50-94f7-cc55a1eb586a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0d37e1bd-ceab-4804-851f-d03eadcccbb7">
+      <statement statement-id="sa-17_stmt.c" uuid="981fd123-1dc9-4b95-8cad-dcbdd7906278">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09ba63e-f021-48e0-81fd-f870b9d48d6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(c) is planned. Progress
 can be tracked at:
@@ -8122,18 +8122,18 @@ https://projects.engineering.redhat.com/browse/RHV
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3c4a1e6-a3c7-4634-b6f8-d20259bd0e2d" control-id="sc-1">
+    <implemented-requirement uuid="446eb7f1-88f0-417d-8c9f-2b714d7c16c0" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="31048b04-7291-4b08-9e92-b398f45f9631">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6f937e19-5e3a-4199-8e23-bc55dcf9c857">
+      <statement statement-id="sc-1_stmt.a" uuid="d66866d3-3daf-467e-8c02-2894866405cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="e1937fa3-2661-40fd-828e-15a9408df1ab">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="60ca334a-14fc-4a77-b940-6efc7d60ac2e">
+      <statement statement-id="sc-1_stmt.b" uuid="cb24c54e-8e75-4647-9a5e-add0f6b2cc1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8141,10 +8141,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c9082f4-44e9-4c0c-bf3e-ce43fb31d35f" control-id="sc-2">
+    <implemented-requirement uuid="70da8442-3398-457e-b7c3-f7fc3dae5909" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="ceb0fcc9-a5e3-4701-ae35-a396abbbb949">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="836b46ef-9fa8-4d24-9460-030d44117b72">
+      <statement statement-id="sc-2_stmt" uuid="44acc704-1e60-4fd5-abe2-024d5664d1aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4d9884-03fa-441f-b60e-dcc41011bfec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -8159,10 +8159,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b986741f-c678-4d19-a40a-e7e8ff609758" control-id="sc-3">
+    <implemented-requirement uuid="4a079485-8497-4991-adf5-581471c1768b" control-id="sc-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-3_stmt" uuid="6689a9b7-6649-4d20-868e-1d8d85865054">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b2139705-b15a-48ff-a6ad-8b376064a2d5">
+      <statement statement-id="sc-3_stmt" uuid="bb181bc6-3964-4ffb-8b37-a3b674dce3bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcb46851-9f9b-4fca-9402-6eb2b3b16b4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for deployment utilizing namespaces,
 host roles and other features as well as policies and procedures
@@ -8177,10 +8177,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="715fdce7-9fb8-4894-bd3a-13c753f1f07d" control-id="sc-4">
+    <implemented-requirement uuid="5682e79c-2a44-4798-a0b2-f3380e749850" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="5d04f560-bdb5-4ed2-a6e0-8d082e5f9437">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5ea64981-1b02-4469-b64c-3cb11c96004c">
+      <statement statement-id="sc-4_stmt" uuid="59fce0b6-f3c2-477f-8f72-105d101d9c08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f71cd20-c3ff-4a42-bebf-207b35e29b8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -8194,10 +8194,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06d29e73-849a-476d-af0e-7527d9d6b55c" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="5672365e-e94e-442f-908f-60728b9ae516">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a62a2d4a-60fd-4c5f-afda-43256053aca6">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8207,10 +8207,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68ea7d4c-cf93-4a55-9007-fe5c5fbec3f4" control-id="sc-6">
+    <implemented-requirement uuid="82bbbda7-2397-43ce-8a91-45ebe78b28d2" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="e0330b77-1939-4e51-8783-ca81f8da5bba">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="56f5773a-bcc1-442c-86d5-978abd275752">
+      <statement statement-id="sc-6_stmt" uuid="b13d5767-f2bd-4b7f-abb7-098b2d703125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b1aa9cb-3e60-45d5-a0cf-18dfeb9a218c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -8225,10 +8225,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19566836-bafb-498e-851a-0205e0d662f5" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="433d1dd8-dbf3-472b-a24e-0e9cba36db28">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="40ded17a-2cc3-4433-9b79-1b4e22ef903f">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8237,8 +8237,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="a5b0d8a8-b7f1-4c3b-ac06-6b4533eedeb9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e520bd20-1868-4114-bf58-48a41ccd1301">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8247,8 +8247,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="fa0ecdc0-96d2-4726-aad8-5526cf0ca328">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e87f4287-e264-42de-af1e-439bb5efb51f">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8258,10 +8258,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af21a090-e5a6-4442-b65b-1540ce745ab8" control-id="sc-7.3">
+    <implemented-requirement uuid="bd054bfa-4fc7-4624-91e4-6bf2052ee2da" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="528b3bd2-18ff-4f1f-bfda-dd03cdd923f6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0253b178-6e44-4a47-894f-ceab0b2dc8ab">
+      <statement statement-id="sc-7.3_stmt" uuid="bd50dd22-917d-43af-be8e-58c4da6d8e02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="755d6cf9-a601-470e-95e6-6a9d439390c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -8276,42 +8276,42 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ae7546c-b602-4447-b4b8-325f9f9ce686" control-id="sc-7.4">
+    <implemented-requirement uuid="4b69ec5f-f303-47e5-b420-7c78eee3fa86" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="f9cd27ee-cad3-4f90-9fb8-619835090bb2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4a68fccc-f5da-4c8f-8aa4-d01e650242a7">
+      <statement statement-id="sc-7.4_stmt.a" uuid="13f63240-7427-4acf-877d-7c0f33b770c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="674754f2-98cf-4542-8c36-8a854e42ced6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="31f35e46-3def-4019-8972-bfa0239e401c">
+      <statement statement-id="sc-7.4_stmt.b" uuid="5d366d42-087f-4a96-9e36-fb36f15e60e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="d520f4f7-64d4-4fe5-921e-bc88b43a18e5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="281c65fd-6ad3-4b03-bb74-4a191b951ae6">
+      <statement statement-id="sc-7.4_stmt.c" uuid="deb5035e-509a-48f2-9bef-f8a5ede07738">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="5a89c7e3-8dcd-4cc8-8b08-081c85ff0678">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2b9f4ebc-a717-487c-9fc8-6393a7a204cf">
+      <statement statement-id="sc-7.4_stmt.d" uuid="0275262e-03e2-4989-ac72-fbb54699b65d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="ca550de8-d7e3-4adb-8438-453f788cc29d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f4fe4443-d7d2-4642-bc28-2b2c41ae9a32">
+      <statement statement-id="sc-7.4_stmt.e" uuid="438501f8-6120-4d9c-b05e-f811caa38465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8319,10 +8319,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8012dd36-0d6e-44f5-b214-39fc772e36c6" control-id="sc-7.5">
+    <implemented-requirement uuid="6352f83a-1990-4f77-b7d4-20477ea193fc" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="36b73ef5-006b-466a-9f5e-081d37959c02">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="10fd7386-6a7a-4857-92fd-576276f1cba7">
+      <statement statement-id="sc-7.5_stmt" uuid="77c7eed5-e937-431d-9ecf-06142441cead">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017bbc7a-e859-49ef-99f5-32b45c249480">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -8336,10 +8336,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5cacfdb7-6920-4fab-a851-171d6da23144" control-id="sc-7.7">
+    <implemented-requirement uuid="f47db4c4-4330-4c63-b5c5-68aa8efa7631" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="32a415af-e0c5-4bbd-a378-28163c3ad8a9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b465ced9-eacf-4f2a-9c37-b32ddb5593da">
+      <statement statement-id="sc-7.7_stmt" uuid="d7ff8ec6-8e83-4999-97bb-989a4fd41c03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a8ab2c1-dedd-470c-97b1-30ad1ccebea5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure Red Hat Virtualization Host (RHVH) nodes do not act as proxy or relay servers between
@@ -8348,10 +8348,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ccbe002-8b56-41f1-8de8-e86a921c53ba" control-id="sc-7.8">
+    <implemented-requirement uuid="c27f649c-058c-46d1-af09-2651e9668239" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="d44755dd-a880-490d-8f8d-ba04bc66868a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5ce7b28e-275e-4fd8-9db4-d940cd864f54">
+      <statement statement-id="sc-7.8_stmt" uuid="d2cb6062-09d9-4314-9a79-1a3b3bb55fc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8361,10 +8361,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="337eb660-eb4c-42aa-bf49-acd03116921b" control-id="sc-7.10">
+    <implemented-requirement uuid="cc49fbe8-b64c-46f0-80de-948244ebae7b" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="e8d688a3-c3b0-4c79-9c62-e04965166df3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="c1f68cd7-8319-470a-93a4-2eb6b28339b6">
+      <statement statement-id="sc-7.10_stmt" uuid="0d61d3ad-5c62-4c7b-a099-298a65951f81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8374,10 +8374,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd31b3b5-87fe-41f6-a0bd-7dfbd0836c19" control-id="sc-7.12">
+    <implemented-requirement uuid="88cc2cd2-e8b8-474c-a3f7-e1da1d36e3c6" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="ceec32f5-b439-4130-9379-9c91150744e9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="5101814e-7767-4301-a1e9-8f575f88f72a">
+      <statement statement-id="sc-7.12_stmt" uuid="47ea0ad6-5d46-4f24-a661-403095ebf876">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c52e724-9ba0-4f88-bf6d-10dc91dee8d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -8391,10 +8391,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a24338fb-4b6d-4fe2-9169-faee9c66acf4" control-id="sc-7.13">
+    <implemented-requirement uuid="f209172d-ae02-488c-b1c5-90b2d42249b7" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="c9860e9d-5123-45ff-9ec2-73dd15a36db8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e88088f-2017-4964-a9b8-e431062d4958">
+      <statement statement-id="sc-7.13_stmt" uuid="409504e4-57cd-4141-9f27-f90b352d97b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dccbab9b-0adc-4777-9ebe-f76d78a8b46f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that Red Hat Virtualization Host (RHVH) is
 isolated from other internal information system components by
@@ -8411,10 +8411,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f62591e-c89e-4f88-a010-34fb7fcb097a" control-id="sc-7.18">
+    <implemented-requirement uuid="005ffd60-e29b-4bb5-a964-7ef65783f3d6" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="876a3123-f15a-4468-a6bb-53658e090105">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a35ec19d-7643-4dd1-840c-f480b98a2de2">
+      <statement statement-id="sc-7.18_stmt" uuid="00c478bf-252c-4c48-91df-18734f3c248d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8424,10 +8424,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa7ac39b-67e3-4416-8fa4-3c9dc4215481" control-id="sc-7.20">
+    <implemented-requirement uuid="ab95877c-c35d-48ec-a63b-31a1b89de7eb" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="88197d92-7893-4d9b-abc3-6b73471c1162">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dfcb9cc2-7f4f-407f-8e3d-e3ca0367294a">
+      <statement statement-id="sc-7.20_stmt" uuid="9f463691-e195-4fee-8c41-146ba28f45d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8437,10 +8437,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39682449-3797-4cc3-9065-b0fca999c4e2" control-id="sc-7.21">
+    <implemented-requirement uuid="e5a85d54-73dd-4ad9-979f-2fb93f020afd" control-id="sc-7.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.21_stmt" uuid="8e93614f-9b04-4d58-a1d0-99235d83b526">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="36023c74-a747-4af3-beac-cda330fd5303">
+      <statement statement-id="sc-7.21_stmt" uuid="bbc96d1c-a56c-4a65-8746-c50a71054aeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8450,10 +8450,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce67bde1-e3a9-4d65-ac42-724781a49a3c" control-id="sc-8">
+    <implemented-requirement uuid="6ebf81ff-2d9d-48c9-bc42-2cf9637471d8" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="5a2467d2-5a86-49d0-bc9c-5d2b08a6f9d3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f0e5621e-73f3-4b37-badd-23be16660377">
+      <statement statement-id="sc-8_stmt" uuid="49e34fad-76b9-4853-9a6a-5d5de9b11158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8463,10 +8463,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52fbbcad-2177-4f08-8e4f-41dad1fae7a6" control-id="sc-8.1">
+    <implemented-requirement uuid="1263ce60-fead-4fe3-91c1-2c246a05e045" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="b11eec45-5352-43b7-9ed8-91c990f12b68">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="77eab8d3-e556-4e43-8abe-ee76cccdd50c">
+      <statement statement-id="sc-8.1_stmt" uuid="e8d6016b-24d2-4229-94ae-3de7956621a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8476,10 +8476,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0c236f8-447f-4f40-9a52-682ea0c10900" control-id="sc-10">
+    <implemented-requirement uuid="e5a2c493-ec0e-491d-86e3-7b162bdb4ef3" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="4716cbe5-15d6-4a8b-b1ed-b3b227e85c01">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="86665471-9c0f-45ca-a132-a0f949f4951c">
+      <statement statement-id="sc-10_stmt" uuid="ee7681ec-31ee-4c11-8ab4-7777139adc68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc326e1e-9b29-46ee-8e79-35af828fc76e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -8494,10 +8494,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a24db22-9388-4384-b5fc-96fc861275fa" control-id="sc-12">
+    <implemented-requirement uuid="020c4c07-e9b7-4492-b6e8-c7dff5e18fed" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="6e7d5ab6-7312-4b2f-8c64-e17991c224e0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d10fce53-b2ff-4cc0-8279-8c13f9c65f7d">
+      <statement statement-id="sc-12_stmt" uuid="50788e68-a89d-4186-affb-16ee5c3769c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2d725b2-fb78-46d9-bb72-3cd88ac8bfe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -8516,10 +8516,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="155c1bb3-1bd4-4ec4-bed6-cf4997f93b51" control-id="sc-12.1">
+    <implemented-requirement uuid="1934a050-8156-4c6e-9bec-31f5dc1a0187" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="28ac763e-0bc2-4fb5-ab7a-0ced68d977c8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="494d98b5-a7d8-44a7-a375-1df26b92db1d">
+      <statement statement-id="sc-12.1_stmt" uuid="9aa0ac2c-47d8-4e8a-a0f1-45e7200dfa28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8529,10 +8529,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="526a7a8f-b2bf-465f-912b-86537ce56c47" control-id="sc-12.2">
+    <implemented-requirement uuid="4d4f5d27-f723-4222-939b-a20a7b8f0b43" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="20da0ec9-25df-454c-8586-c4e7f7c38179">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6d0b938e-7e12-4bc6-b154-9511599a3654">
+      <statement statement-id="sc-12.2_stmt" uuid="a5a12b62-f938-4920-bb4a-79a0fe345369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8542,10 +8542,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94506514-203e-4959-b506-2d7548a9a60c" control-id="sc-12.3">
+    <implemented-requirement uuid="08160e29-14fc-4dd7-b5b6-fba597db4b6e" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="47e058d6-039e-4436-b309-b0d4dca966b8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0acd8172-67a0-4c44-8a13-974250e36a96">
+      <statement statement-id="sc-12.3_stmt" uuid="84f2cc66-d583-4e4f-abea-1ec72a4c573b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8555,10 +8555,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53177f35-8500-4faf-b6e7-bdc4eeb79606" control-id="sc-13">
+    <implemented-requirement uuid="f298b315-5458-4a40-b974-c940e05a6d9c" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="697050a6-fb50-48d3-ad50-1446ff0d511a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="849b1450-7fe5-4c4a-bb27-445590a64fbe">
+      <statement statement-id="sc-13_stmt" uuid="6c7fbd19-4670-4988-a837-308fdc161851">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74c0f9d3-e304-4102-8b71-c897d213fc58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -8583,10 +8583,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6e4aa8d-715c-46d8-925d-5111700370ae" control-id="sc-15">
+    <implemented-requirement uuid="ff2a4f17-3134-4017-994c-ef6973cb8dd6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="bff97478-c9c3-4300-9d43-59bb9c70054e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="6a8bc389-9b07-4ea2-a544-7f4b569c27a2">
+      <statement statement-id="sc-15_stmt.a" uuid="9cbda246-5497-4d1e-9bc8-15f212d3f971">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8595,8 +8595,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="e5e8ba7e-a4e6-495f-b51b-d46ced921eeb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b5607a45-c8d2-4539-8837-565ba6c58190">
+      <statement statement-id="sc-15_stmt.b" uuid="857f6d9f-6f6f-42fa-9ff9-0c7efb5b7b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8606,10 +8606,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e7c6f81-c07b-431c-a41b-fcbeb8cd40e5" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="3538458d-127d-4e61-9c92-e18dff8652a7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="647b5d27-e4d9-4e8e-9544-f7e1c63bd198">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8619,18 +8619,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b9d1851-4fe6-4950-bee0-0096d7cca00e" control-id="sc-18">
+    <implemented-requirement uuid="5d3f05bc-c7c8-470c-914d-ec87c04ee392" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="3707cf1e-471d-4b69-aeb9-95915f151371">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="36c28ff4-1889-4610-932d-7479e9e7bad1">
+      <statement statement-id="sc-18_stmt.a" uuid="288c4934-cfa1-43b0-80b6-2c17d0c59fb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9bbcb63-8565-4eae-b386-70f3337b4970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining acceptable and
 unacceptable mobile code and mobile code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="bf62c9a4-dc10-4d14-a2ad-07e092099a8c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88db8f4d-006e-453e-b91a-e7e91eedb543">
+      <statement statement-id="sc-18_stmt.b" uuid="f2075982-e716-4d6f-b59f-fb353c22add2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="300a4a3e-4553-45b6-9fa6-64fb56470ffa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for establishing usage restrictions
 and implementation guidance for acceptable mobile code and mobile
@@ -8638,8 +8638,8 @@ code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="6d28e0ad-9d5d-4e4c-8307-5c03895db295">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b0d007c6-5196-48ce-94f9-e00c0c26e1b3">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -8648,18 +8648,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b79eccdf-ee8d-4ebd-8123-fbcc91a51a5f" control-id="sc-19">
+    <implemented-requirement uuid="6106cc7c-0a57-4740-9d9d-ff2259591c26" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="062efdf0-6fb0-44ac-94f6-8949d23064cd">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ad7e19b-1938-443e-b237-a019d2fafe8c">
+      <statement statement-id="sc-19_stmt.a" uuid="5451183d-ff3b-47fb-9b72-51655cca3074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="bc18e7e8-ffcc-446d-803b-45466364c8fc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bb62770d-9bd3-4120-8831-5314015f5e07">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -8668,10 +8668,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6300968e-bbf4-424f-a47b-9f5c807804f1" control-id="sc-20">
+    <implemented-requirement uuid="13d07e43-538e-4555-a7a4-a849d30614a6" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="d18c281e-a4c1-4153-8295-d4b6b6df3cd6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fb7dce85-74c8-45ab-a76c-9e173d6d69b7">
+      <statement statement-id="sc-20_stmt.a" uuid="9b3841e7-06b0-43de-8176-0403c350e22c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b673a29b-5ef5-4775-b02b-9f8a0ddffc6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -8686,8 +8686,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="d8f56fb4-4bd0-4d75-8598-4123268eeb30">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="39f92fc1-9590-4dbe-b79a-fee9a9927628">
+      <statement statement-id="sc-20_stmt.b" uuid="f6c89107-60df-4621-98d0-84ce19c2b83f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bed2578-f811-4697-a21f-4b423a65142f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -8703,10 +8703,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbcafb76-c181-455f-887f-c95b30152f02" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="042d4237-4046-43c2-92f9-c478443d20f2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="afc4034c-4553-4e37-a931-206a67bc44ee">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -8721,10 +8721,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77b9172d-3e11-4904-8dd7-54861210486e" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="5166d2e2-b88b-4de7-81ef-1be41c7113cc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="528c5a47-04da-405a-bf1f-320d7e87b604">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -8733,10 +8733,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dddf01ea-4687-4d34-99d5-9259b0793e57" control-id="sc-23">
+    <implemented-requirement uuid="28c49b88-5b53-4b72-a6bf-66216e571cb8" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="1cb6422f-ace2-4002-a5bc-cae072b66a7e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="48169f33-bd4c-4334-8703-e664806dbcf1">
+      <statement statement-id="sc-23_stmt" uuid="a49c993a-d648-41fd-8316-e7458d19ef89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6536c089-9c3c-4f8a-920d-67bf4b6e55e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -8756,10 +8756,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed8bde39-19b2-478c-b8a2-d26bf34b2bb9" control-id="sc-23.1">
+    <implemented-requirement uuid="d753123d-8a30-4a29-8b2c-5d85ba63d24b" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="9ddc9df5-5a98-4d28-8eec-376b5852d877">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e0c4d90f-2d0f-44a4-b50e-32143d3bee4b">
+      <statement statement-id="sc-23.1_stmt" uuid="871e60d8-2d43-4a32-883e-840e6c3e4340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8769,10 +8769,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d666ede-c11e-4f2f-b76a-314cc0e46166" control-id="sc-24">
+    <implemented-requirement uuid="a630d193-a419-452b-86b2-b8bdccbc8b42" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="918a8c6b-c48b-4a52-8a13-93d95227f113">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="56836fa1-711b-478e-802f-d5d41cba4500">
+      <statement statement-id="sc-24_stmt" uuid="8fcd865f-3154-43ca-baf3-7f1acfc40b84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8782,10 +8782,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e34ff477-749a-4324-8b6a-6c81d7d772f5" control-id="sc-28">
+    <implemented-requirement uuid="5369e7e4-4f63-47a4-a269-858e0d726ed2" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="bb29fb17-711f-4c9e-a118-223813f5315c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0b372237-40d2-49ef-8133-c7e856fc5202">
+      <statement statement-id="sc-28_stmt" uuid="3c623361-fd52-46c2-b652-86f40cfbf05c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8795,10 +8795,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98789e30-dd2f-48bb-9341-3a94f38246ad" control-id="sc-28.1">
+    <implemented-requirement uuid="61959263-ad0b-4e37-8cae-0f31856c2e0e" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="1c8dae72-5335-4443-abd3-d0cec5ab58a5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f5a8c496-0639-4d57-8367-c88f2124b99b">
+      <statement statement-id="sc-28.1_stmt" uuid="112e2e75-aa8d-4b39-b010-207a36f8297c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69ce2f8b-e0a3-4bbc-9951-4b7a33805851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -8819,10 +8819,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4ae5f0c-90c9-4e05-9db9-0e0c86b3eaff" control-id="sc-39">
+    <implemented-requirement uuid="c85bb898-b489-48a1-b71a-e74625f7b216" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="d7c4edc7-0b70-4d47-862b-e5717f729c96">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="9a8ce52b-9e48-44f0-9297-d20a7d2da6c1">
+      <statement statement-id="sc-39_stmt" uuid="33337f99-eaa4-44de-81e2-877df2ee77aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24b4672f-398c-471e-b8a0-14388d77a318">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks must be enabled to satisfy this control:
 
@@ -8844,50 +8844,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ef25057-ea05-4826-88d8-a1294769b2eb" control-id="si-1">
+    <implemented-requirement uuid="5d7e07d9-4558-4bf9-9b56-8ddea777b5d8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="a710429f-72f4-4ce0-9edf-1b915cda9a49">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1af15776-b3a6-4b30-a6a9-395efacbb689">
+      <statement statement-id="si-1_stmt.a" uuid="8787884f-585d-4aab-99df-a609926f4b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="79c2b98b-fff5-4559-bbb6-830767d35df5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b6b34f0b-c881-40de-acab-ade3cba44f1c">
+      <statement statement-id="si-1_stmt.a.1" uuid="8c07c419-6245-4a61-826e-775f5052f045">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="17d8aa79-067b-4976-b9df-c9ffde1861ae">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="620e543c-a86a-4d6b-83b2-1398d6785188">
+      <statement statement-id="si-1_stmt.a.2" uuid="3d0ab5fe-cc7d-4301-8ce7-6810ad62390e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="8703fe2c-0d51-49c4-9c42-6610d1a5c9de">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4be2b763-cd98-408c-acae-95ccdd659583">
+      <statement statement-id="si-1_stmt.b" uuid="df847d3a-bcb9-444c-9e18-c555eeff1492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="6d518786-7e09-47fc-9993-72f578d7f39b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="ad3b0617-e953-49a4-b632-85f86d04d60f">
+      <statement statement-id="si-1_stmt.b.1" uuid="23ab5b73-bdc4-4884-b80e-14c8c704508d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="90b9265a-2ea9-4512-b213-8c1ebe599a36">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88d4a87a-1ac7-4037-88cd-a164285efbb2">
+      <statement statement-id="si-1_stmt.b.2" uuid="cfc702c2-8138-43fb-ad59-b9273ce1ed9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8895,10 +8895,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f0f50c5-dee0-430b-ab3f-70925e8d3207" control-id="si-2">
+    <implemented-requirement uuid="dc0ee075-4b67-4ca1-80de-e12ad3054399" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="3e941ca4-2150-429b-96bb-a89dd5e3c940">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2e5e21b3-8b07-40f5-a886-8ca3d14d9df2">
+      <statement statement-id="si-2_stmt.a" uuid="ea7e76cb-cded-4c89-897b-67b0f6290878">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00c6f6a5-bcad-45d7-aa86-099ad8ff7902">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Host (RHVH) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -8908,8 +8908,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="8bbff9b3-0fcd-4a69-b9f5-27c64370c268">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e0e8d93b-3c2e-4380-b034-24fa809a04cb">
+      <statement statement-id="si-2_stmt.b" uuid="c93b23b0-3685-4e74-8a11-e9130f2b17b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3cc16f-0b1c-4966-ab2c-a775e94deb09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Host (RHVH) updates
 related to flaw remediation prior to installation. A successful
@@ -8919,16 +8919,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="5f32ce65-f14e-41ef-8bfe-89416009b874">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1f26d456-8563-4b99-950d-32157dedba9d">
+      <statement statement-id="si-2_stmt.c" uuid="af9092b1-daaf-492e-9691-de3ee7c94546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="37caa8ea-fe09-49ea-b63f-e16d7bf49eb7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="50b9cbfc-2d50-4fb4-8cbd-bbbf336e7483">
+      <statement statement-id="si-2_stmt.d" uuid="9da7889e-0085-4023-b7a9-6a88c6e7a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8936,10 +8936,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97abace9-3b12-45d3-b4f1-4cbca76deea7" control-id="si-2.1">
+    <implemented-requirement uuid="cb386662-eee1-4a0e-9f60-6934573e24b2" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="9fa3a3be-5ffb-4922-b85b-6c9210f8180e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dbb08cec-d880-4d1b-9223-58786622ccc0">
+      <statement statement-id="si-2.1_stmt" uuid="c845d583-2a7c-4904-ae6f-90ba2996a2c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad4dfd7d-62cf-4f50-8d54-5acff9614b55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-2(1) is planned. Engineering progress can be
 tracked via:
@@ -8949,10 +8949,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="045c7095-7283-4705-995e-28227be1ea94" control-id="si-2.2">
+    <implemented-requirement uuid="f39f62f5-798d-48f5-8703-27d537979525" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="aa0cf07f-7c81-498c-a441-0a76ae3869a1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cd73f87d-4085-43cb-8dba-e9010aa2a0d4">
+      <statement statement-id="si-2.2_stmt" uuid="2fcbc796-5a33-4953-b75d-ed3bbf6cd579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d37014f-dd7c-410f-8ccd-f0873ee726fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -8970,10 +8970,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55811f51-4267-43c6-a1ed-89c711145f9a" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="3ebe4199-e076-4dd9-9b70-bcf791e4fcf0">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="31e51947-3c1c-401e-ad0f-34bca585aad1">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -8984,8 +8984,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="e142ddc8-a9dd-4069-bdc4-f3350a20b3f5">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8a263002-40e0-4a83-b82d-4bdef396b050">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -8997,10 +8997,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e2421b-3ad9-4ea5-ab13-56cd3d0750f1" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="627d68e5-9448-4a0f-befb-2c086a518060">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="125c46f4-fbe5-4023-9250-4d3d7dffe69e">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -9016,8 +9016,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="ff33878b-9f90-4555-9af1-7101513be28a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="37999ed8-d84d-44a2-a97f-ec5b64831f6c">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -9026,8 +9026,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="2acef1da-531c-41cb-899e-619eef411a5c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4be19a1c-553c-4a20-8a2e-747d6c8aaa0b">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -9036,8 +9036,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="b53e58c1-85de-4ee5-a4a3-a48b9a9374cf">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b4dcea91-379b-4c8d-84c5-d4d56e57d216">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -9046,8 +9046,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="4f983086-5ba6-4ee6-9485-acc2f2e99360">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e0a925b1-e58d-42e3-9e21-24cf0c280d6f">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -9056,8 +9056,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="5ab231b6-52c8-4bc3-b644-65ecda63e739">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="2eb4c059-4ce7-4166-bc76-e90220064946">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -9067,10 +9067,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb47ae43-1b48-4a41-b1b7-f8f74750cc47" control-id="si-3.1">
+    <implemented-requirement uuid="3ebea031-233c-464a-998d-c0c3d922b851" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="0611857f-539b-4f46-8014-4c2d9251ee4b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d7bf5ad7-4ff4-4f7c-94a8-c07efdf80503">
+      <statement statement-id="si-3.1_stmt" uuid="9e989886-07e9-4d4a-98ed-be98fb1368ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c58ac54f-22ef-4855-adb1-33eee390792b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -9086,10 +9086,10 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31b72d0d-7263-499f-8a6a-e35666fad1b8" control-id="si-3.2">
+    <implemented-requirement uuid="67609e78-72bc-40fd-b9f8-0728765cfc5a" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="eb449173-24cf-4afe-8ee1-09c48a89bbc9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="36838480-ff2a-4ef3-9d1e-215ff9e72c2c">
+      <statement statement-id="si-3.2_stmt" uuid="b0ad1bcb-2da0-409a-bce2-8c8dce7b4539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071bdb1c-8691-40b5-b1e8-17d54c02caa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -9105,10 +9105,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1b606c6-67c8-44be-a19a-acd2660f9da4" control-id="si-3.7">
+    <implemented-requirement uuid="e0f1ca33-2212-4e02-bea8-2b2961431e00" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="8e783925-cd87-4dbf-9dee-0835bfae895a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3c6a5e28-9045-4b8e-a098-92a5bc01e7e1">
+      <statement statement-id="si-3.7_stmt" uuid="c197c739-ab67-4d4a-89bd-78bc67721465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98787694-bec5-4c19-a079-27ca4960a28c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -9123,90 +9123,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4eb943f6-2e6b-4985-89a9-ff61f1cdbf1c" control-id="si-4">
+    <implemented-requirement uuid="59b20aad-49c3-4881-9195-6a89041b5906" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="e27777ea-7cbe-40a8-b364-37427ac4de06">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="b48e5e45-41bb-4351-984c-38cc4171e5a0">
+      <statement statement-id="si-4_stmt.a" uuid="dba40fba-14cf-469c-8411-389d0906fecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="d7703b2c-1597-4863-a91d-2de086a1051a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="78431228-f200-4612-b92b-0a3de2e18c8d">
+      <statement statement-id="si-4_stmt.a.1" uuid="8f062e56-42ed-480d-be3a-a084a404a92d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="bb8b12da-70e2-42e8-9168-a6024842337b">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8228106a-5710-4468-ac76-df232670be85">
+      <statement statement-id="si-4_stmt.a.2" uuid="c99eebf6-76dd-4834-a8a8-702955f0de22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="1a95f74f-7c52-49ab-9654-b92929ca4aaa">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e3eb29f6-b371-4c3d-ac3c-94dd207abce6">
+      <statement statement-id="si-4_stmt.b" uuid="8b63244e-e370-45c1-93e9-8fa3167757c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="a8ab4b5b-7b74-4944-82b3-6f2137a81ae7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="388f95f9-ca94-46bf-8334-16e2594eaf1e">
+      <statement statement-id="si-4_stmt.c" uuid="6654702f-0944-4119-b792-9d5d62145d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="ca7ddbb4-86aa-40aa-9bd2-9a32ba485109">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1e451704-cabb-4096-af36-6f554dc5459a">
+      <statement statement-id="si-4_stmt.c.1" uuid="ec5b5673-4f98-4232-8b5f-d5a55003f609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="42845d1a-3513-49c6-a722-dbfdc2e15de2">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8e3c62c5-867a-42db-9e67-48fc45249cac">
+      <statement statement-id="si-4_stmt.c.2" uuid="779ce949-375f-49de-91eb-8cca14636ad0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="ad9e9b00-ffc8-4229-bb0f-f1c52f0d9165">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8124a62d-581b-4921-987a-952237314f08">
+      <statement statement-id="si-4_stmt.d" uuid="14feaa64-7bc3-4db9-bb76-2e714e9407e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="ecfe2d0a-51fc-400b-8f5c-c1056dea8439">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e8577291-7bfc-4aa5-8f47-f18e079c44b8">
+      <statement statement-id="si-4_stmt.e" uuid="b3cf0398-2a1d-472d-b11d-a4f66f126706">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="d8dee082-6ac3-41fd-a7cc-c74b997ca2b6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8054b3e0-9d2b-4dda-a053-97dcd668db51">
+      <statement statement-id="si-4_stmt.f" uuid="6b46395f-a140-4b9d-b9cb-97333f90e885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="6f1bf9a2-39c3-4446-8a9a-012689d6505a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="484d3cf8-70c6-450f-8b68-b8476b323204">
+      <statement statement-id="si-4_stmt.g" uuid="bc73ebf4-bf15-4a47-bad0-533a3fcb8b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9214,10 +9214,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9333796a-fc16-4d9c-b87b-e51f59813356" control-id="si-4.1">
+    <implemented-requirement uuid="4bf5835e-47ab-4a5c-ab5c-0f6be46315ed" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="7cf953a9-013a-4554-8ea3-e88fad4dfc7e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e8619d6a-2668-4486-8c27-050f34821d45">
+      <statement statement-id="si-4.1_stmt" uuid="f8cd313a-2042-44d9-b3d5-b988f1c08bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af343765-d8cf-43a1-8385-42f27bddcb7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the Red Hat Virtualization Host (RHVH) environment, and documenting how this
@@ -9234,10 +9234,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e49d61cf-333a-4966-a414-7d2047a57b92" control-id="si-4.2">
+    <implemented-requirement uuid="283ad864-6082-4571-848c-9fd3accadf1c" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="de6076ed-80b0-4bf2-a431-f1e3158f4066">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="3218d1fa-7964-41a9-8aeb-0ac720955cde">
+      <statement statement-id="si-4.2_stmt" uuid="80a356fd-653d-432a-bfa8-eaaca3b3cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bf351-1106-49a6-9dda-1dda289ea4db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -9256,10 +9256,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9930b11b-7063-441e-b892-8b1a728857f6" control-id="si-4.4">
+    <implemented-requirement uuid="16783170-544f-41c7-9a13-99abdbbd9c36" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="7f30753a-62af-410b-83cf-d5357404b507">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="88bf2687-bea5-45d8-b9ef-a2bf4e06c8cd">
+      <statement statement-id="si-4.4_stmt" uuid="c2cf100d-6819-43c6-be66-ea9fb2012e61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d2ca56b-bd9b-411b-bb38-3e205fc8d841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored.
@@ -9272,10 +9272,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4036218a-cbe0-4218-9334-bede9f7fee79" control-id="si-4.5">
+    <implemented-requirement uuid="5396bcbd-5df3-468b-a6fc-70f008a8c1b5" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="8cf2a677-1915-49e8-8b6b-b5ae45e644a4">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fc71827e-afd0-41b4-81ed-d9ecf215f9ce">
+      <statement statement-id="si-4.5_stmt" uuid="7d4e1aa3-8989-4b97-8cb1-1b607440335b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c63bf7-e4b8-499d-8db7-bf313c017b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -9292,10 +9292,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88c0f253-c69e-4c20-9f88-eaecbfdde582" control-id="si-4.11">
+    <implemented-requirement uuid="22e912d1-69b7-41ad-82b0-5c1c5f88245f" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="aa7415dc-b036-4e50-9dee-aea31754ea66">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="257f6ab7-aecc-4571-ac56-47512b1307f0">
+      <statement statement-id="si-4.11_stmt" uuid="3cd8dd8c-a7f9-48b8-9f1b-4c18238ca4a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9303,20 +9303,20 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27694b16-226b-404c-b7ec-9bac37cf7346" control-id="si-4.14">
+    <implemented-requirement uuid="bdb0ea51-ab3f-412b-88f8-ad75ffb8309f" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="ef0f6653-77ef-4b29-8d90-49f48212dd42">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0a502daa-4877-4150-b73e-c2c47b2cfc85">
+      <statement statement-id="si-4.14_stmt" uuid="7675ef46-b5a0-4251-83d9-eadd20dcaa7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c6a1fe-41d3-4ac5-bc66-6224342a3c5f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An Red Hat Virtualization Host (RHVH) infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5908320b-dfdb-4486-920f-005d6f72002c" control-id="si-4.16">
+    <implemented-requirement uuid="253bf33a-ac68-4dd3-b870-7700ee285f87" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="84da515a-a175-42b7-b87b-0f59d5504576">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="48221863-8625-4183-ac72-f301bcf27aa4">
+      <statement statement-id="si-4.16_stmt" uuid="a152da88-93f8-4db0-81c4-cb866db6b80a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7452c87a-d7b0-43c2-8a16-d7f459271774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -9331,10 +9331,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11ec5628-aefd-476a-adae-5930cc56f3e3" control-id="si-4.18">
+    <implemented-requirement uuid="9f8f854e-6037-49cc-9ab3-441435676162" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="7bce8d23-4d56-4332-b696-5d7654927a7c">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="f4f74eb4-9d25-4dc1-b6b2-66ada7a96c1b">
+      <statement statement-id="si-4.18_stmt" uuid="0df2b7f5-1a6a-42c9-b6f9-f55a2106f62f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="01c57c4c-9c00-4662-b6ab-6e175282e464">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(18) is planned. Engineering progress can be
 tracked via:
@@ -9344,10 +9344,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="308ff08c-bd42-41f7-a520-bde9a407ec43" control-id="si-4.19">
+    <implemented-requirement uuid="54cdcb28-c10b-4e06-aedc-938c430fd336" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="4824a6ca-d56a-4423-8623-5e7b6d4e070f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="0416bbec-e6cf-4726-afac-eb99651fa835">
+      <statement statement-id="si-4.19_stmt" uuid="b81e4e2e-0bd4-4763-893d-8acdabfc7fb2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9355,10 +9355,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1f1b276-37f7-4883-9769-000a68a2499a" control-id="si-4.20">
+    <implemented-requirement uuid="3d18cce4-09bb-4987-bcbf-d730f6c7031c" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="5251d605-a8a2-4ff9-a4ae-e2fb88d3f43a">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="cdda8afd-784e-466e-be4a-2e3412d33982">
+      <statement statement-id="si-4.20_stmt" uuid="c1b02903-76ab-4989-8c57-5c76212a01dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9368,10 +9368,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c70ba6ff-ec6a-4c83-9479-db4fc1b2099c" control-id="si-4.22">
+    <implemented-requirement uuid="b22622d3-10fb-4d8d-90d9-a004ed3acfb8" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="cb29c136-ace6-4f8b-a4bf-20f012332591">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8051dc7a-6cbc-408a-a933-da8f6d5983e3">
+      <statement statement-id="si-4.22_stmt" uuid="a0422862-aa8f-4e3d-b4de-a719eb7309cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9381,10 +9381,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="300f01a9-5431-4fcf-860c-3a42f5134c0a" control-id="si-4.23">
+    <implemented-requirement uuid="919cd6de-1429-4daf-95b3-19aca7ee0b8a" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="608a0380-4a70-4127-b80e-5173719d31eb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="43c22095-0d44-41e1-b87e-31cec5151501">
+      <statement statement-id="si-4.23_stmt" uuid="2bfeb2d7-99e8-4173-9fe6-308e019b794a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c3b8882-a814-401d-b47a-c6a32d2bb35d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -9398,10 +9398,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e25cc499-7e57-47b9-9e7d-0e9af2b9adb5" control-id="si-4.24">
+    <implemented-requirement uuid="0e6a813d-3704-470e-8ebc-16eea18b800a" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="44528389-9a8f-4695-81b5-bb2bd8231a94">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="1a8f1d06-1181-4538-8541-20db84be62d3">
+      <statement statement-id="si-4.24_stmt" uuid="2657beee-c87a-43a5-8de3-cadbf4589cce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -9411,10 +9411,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="488f9de1-5c67-4b3c-935f-896f1c5ff13d" control-id="si-5">
+    <implemented-requirement uuid="db26ba38-1239-4f83-9440-22b97f99486a" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="5c18a905-a764-4b14-86bd-95f96a2bf724">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="abebede8-e302-4733-9031-14f7cad1b253">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -9423,16 +9423,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="ced23099-bd38-4ea6-96f9-88105dfb5dff">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a2f0e480-815e-428f-8022-79534df742ea">
+      <statement statement-id="si-5_stmt.b" uuid="e6f52326-2876-4f3c-91b5-c584a78c6b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="92d81fc3-b100-4bd5-861b-172ad23760cc">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="61b74fd7-3b2d-4f13-9e1a-1159d369992e">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -9441,8 +9441,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="d724b94d-4f91-4878-aeae-ab0153300b6f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="bdd5023f-a610-469c-9ac4-e854db5df89c">
+      <statement statement-id="si-5_stmt.d" uuid="9cbc5870-d294-43ae-92c1-7c3ca5d92a36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9450,10 +9450,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e626161-9fe3-41da-8a08-edaddee4e536" control-id="si-5.1">
+    <implemented-requirement uuid="bce1f848-154a-4509-b7ca-a071a92a9264" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="52ef5411-09fb-4b88-9d2c-783e4bee1373">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="fc4e2075-b16a-4d17-8a38-f8b226b0e1af">
+      <statement statement-id="si-5.1_stmt" uuid="6bf761dc-668c-4bae-b1bf-9d6df778e38c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9461,10 +9461,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a6ae5c7-3799-4f7b-acb0-a5356fb12ac1" control-id="si-6">
+    <implemented-requirement uuid="38b01b39-5943-49c8-b108-044a6e4bacd8" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="e9a2bf80-d970-419b-9d48-1b3e4d1e9aa6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="da815969-f97e-4764-9ef1-8cd66181b8fb">
+      <statement statement-id="si-6_stmt.a" uuid="d64f2de2-7f02-4e63-aaff-02696686cb5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a447dc-056f-47a6-933c-b570d8213b54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -9479,8 +9479,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="25186bde-483b-44e2-8175-eff1c3761319">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="60b7c8a7-d4af-45dc-95bd-46343b78178e">
+      <statement statement-id="si-6_stmt.b" uuid="d22f4f0c-240f-4b13-bdc9-47cce702cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -9489,8 +9489,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="44d72abf-51a1-43c3-a13f-c98e8a8f4eb6">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="326da355-fcb6-4429-9449-b7cc340db47f">
+      <statement statement-id="si-6_stmt.c" uuid="4bb561ed-8a3d-4fe3-9ca6-00b7213dc2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -9499,8 +9499,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="6e4976dd-74d1-4cd8-a4d9-f86e3ed01ba7">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4ec7043b-868f-46bb-a144-bd483cc84307">
+      <statement statement-id="si-6_stmt.d" uuid="2d6bd4eb-8197-41d5-9e13-023435276675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -9510,10 +9510,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24b59d01-5038-4aba-92f4-a905028ec443" control-id="si-7">
+    <implemented-requirement uuid="fd45ca54-ac27-4043-9523-cb122d75ef7b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="6528e7b5-0be0-4a93-bd2e-a86d13e046b9">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="4e30fadd-a2ce-40c5-82b8-7f45c94d60e3">
+      <statement statement-id="si-7_stmt" uuid="2d2570a5-feaf-4efa-9783-099aa818c505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff0de457-49b4-4344-8372-7c7e6a4164cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -9528,10 +9528,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e555df3-27e9-4d54-bfdd-dd5dd5def4f9" control-id="si-7.1">
+    <implemented-requirement uuid="3c62e9a0-e77d-4915-b5bd-d8e7c7cebf56" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="244968b8-f7d4-420b-826d-77671c75605e">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="8b44f0df-47dd-42a3-a2eb-e6ce0cd242b6">
+      <statement statement-id="si-7.1_stmt" uuid="a3e8de9b-0300-45f9-a7b7-2d965e7a83ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db598211-5d2e-4a86-b372-f2d6a2f5c9de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -9547,10 +9547,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cede7796-4b39-48d6-b2c4-eb4b67327145" control-id="si-7.2">
+    <implemented-requirement uuid="65843773-a426-4fe8-902f-a514ab7330e2" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="95ed34bf-0031-45b5-a2c8-56bd8bcd1dc8">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d1d82df9-11ac-4f92-86c3-7a779cc64003">
+      <statement statement-id="si-7.2_stmt" uuid="c260d1a1-0aa0-412b-8446-c2a617a6e53f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="201b77cb-ae40-4171-a48d-0f9f2852d959">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(2) is planned. Engineering progress can be
 tracked via:
@@ -9560,10 +9560,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5f1a75b-5fc0-44e4-b4a1-fd43dbbb85fb" control-id="si-7.5">
+    <implemented-requirement uuid="cc7ba65d-f990-4d6a-b594-d9bba5dcbae1" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="f94f7612-3c13-4559-b0e5-276524057524">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="a8d8f4c3-561c-49aa-8020-58f6469f17bb">
+      <statement statement-id="si-7.5_stmt" uuid="6271f138-4a0a-4833-952b-531be65bdcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13f44617-703b-41be-b9c1-61eca6e44852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(5) is planned. Engineering progress can be
 tracked via:
@@ -9573,10 +9573,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="37f89ee1-0143-44da-b348-926950083d1c" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="ef548ed9-9cf3-43a7-9dbc-c277577b44bb">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d51353fc-9da7-4d8c-8645-0541fbe08d57">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -9588,18 +9588,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7afb5375-fa2b-4737-aff5-3f2cde9528c0" control-id="si-7.14">
+    <implemented-requirement uuid="14eb694c-e4f8-408c-b54c-81efd314588f" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="c6b16bbd-d530-476e-ac5c-4f02d76b1a79">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="245a1319-4893-4621-968f-81516e0f910d">
+      <statement statement-id="si-7.14_stmt.a" uuid="f5bff8e2-e1bb-4828-b8f3-eea56c7fce09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="ecb745ae-427c-45c3-aca2-154d7d31c791">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="332a5aa1-8733-444d-8613-dd2424559338">
+      <statement statement-id="si-7.14_stmt.b" uuid="612f6639-e5d3-456f-ba4c-a04836f0c717">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9607,18 +9607,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cedec6e7-eaba-4710-ba81-afad604921f1" control-id="si-8">
+    <implemented-requirement uuid="f4e92b38-9c3e-4adb-9bef-fd56ae03f510" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="2e5e1f0b-c576-4e81-94c7-1996f95b5c7f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="96fec12e-d0fe-441c-a8f5-4ad70bce4f41">
+      <statement statement-id="si-8_stmt.a" uuid="6d2494f7-e034-4cc8-8edf-258385e2195f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="77d80b81-685d-4f40-a314-85f826537ba1">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="e363d93f-977d-40fb-ac5b-6532b10be647">
+      <statement statement-id="si-8_stmt.b" uuid="3710b24f-249c-48c0-a9de-3fd0fdcbbc5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9626,10 +9626,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4c97c64-a5c6-4628-81b8-ba3b694dfd2f" control-id="si-8.1">
+    <implemented-requirement uuid="63342f57-2aae-48d2-801d-98704088e1a5" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="0e79ab47-73ed-4331-922f-b8be9e6480e3">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="dd03c30c-c7e0-4899-9b02-7614ab7a848f">
+      <statement statement-id="si-8.1_stmt" uuid="b7f7cf43-6ed6-41d5-834c-4b5a6691c670">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9637,10 +9637,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42d5dc74-4e37-42ee-99fa-064deeb169a7" control-id="si-8.2">
+    <implemented-requirement uuid="b1265444-eb20-45aa-bb36-90477c38fd67" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="ee8e8fb0-2cc2-48e3-9dd8-cb0febcc921d">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="74d5a383-51e2-4ea2-8bd2-78503ffa984a">
+      <statement statement-id="si-8.2_stmt" uuid="d452429c-f034-4e71-9611-5724b5968524">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -9648,10 +9648,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47d2f647-f0d0-4dfb-b649-0bc6da0526e9" control-id="si-10">
+    <implemented-requirement uuid="a692ad57-9df9-46f8-9f6b-9cfdc5eb8331" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="0d66bb9d-5e76-4094-8ba5-270683b7892f">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="09ab413b-cf7a-4933-a624-9424e37e5b59">
+      <statement statement-id="si-10_stmt" uuid="5653a342-a850-4ce4-86c7-ee90659a39b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f5633d-efbc-49d5-9e55-9124a516abe3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -9668,10 +9668,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="152a27db-16f8-43b1-826b-853be54035ec" control-id="si-11">
+    <implemented-requirement uuid="b3a5c29e-0faa-469d-b445-999334811b7d" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="5a9a9cb7-d9d7-402a-be77-5cce76500746">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="d1370b08-3c98-4003-a492-e5892b4de40d">
+      <statement statement-id="si-11_stmt.a" uuid="96e25551-2aaf-4632-aede-caced5280e5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="336b8f57-a23a-47a8-b9d6-99b085addd75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -9687,8 +9687,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="e7a8428e-6607-494f-88e1-1822ae980889">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="94169c4d-460f-43e2-90ea-c391f090bae9">
+      <statement statement-id="si-11_stmt.b" uuid="865efc56-48e7-464c-9d66-8d1fd50b47ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad9a4e66-e871-4618-ba62-7d464c99668d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -9703,10 +9703,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5bf88b6-5185-474e-877d-5ec850fcc62d" control-id="si-12">
+    <implemented-requirement uuid="09e0132d-6ccf-49ac-a537-29560849f42a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="2519c55a-4cba-4b56-907d-c7f3f1b6f963">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="07b9b843-1de1-4d9a-bd17-7f2a3e73b660">
+      <statement statement-id="si-12_stmt" uuid="5dc6c15d-d248-4165-b960-af8e7fc3acd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7efcd9c4-a080-4cc4-955d-96131fd8f0bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Host (RHVH) in
@@ -9720,10 +9720,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5599d54a-fda2-460a-8ae1-82cd87f3d19d" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="b4f3d6f4-d78d-4ad2-8323-96610f078214">
-        <by-component component-uuid="6dc6c78d-53f2-4f62-bd41-166aecdce99d" uuid="01950f69-59d9-4373-9735-75a2019bd57c">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/virtualization-host-fedramp-Low.xml
+++ b/xml/virtualization-host-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="6df52a72-1bf0-4a11-b2c5-04178d340ae7">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="4a720d81-f64c-41d8-aac9-2aeafba80981">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.71+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.79+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="c7d2fb66-aa17-47d6-a508-d253a4d4e209">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,69 +484,69 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="6935f002-ab37-423e-ba00-b55c5b4fe4ca" control-id="ac-1">
+    <implemented-requirement uuid="fa701737-9ee3-444f-a822-2d00abc0ce14" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="ddc7baf0-d0af-48cd-a65a-0bdbd84158b2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="08ee9905-f0b2-4dde-acaa-5427bc145ae7">
+      <statement statement-id="ac-1_stmt.a" uuid="e79f158e-6add-4530-8fae-a14530cd3213">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d5ec4f2-5bc7-4425-a8c6-db4371696baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="3d168510-07fd-4486-8365-68e83cbd844d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="acb2b832-385c-4a29-9a7c-78b481fc542c">
+      <statement statement-id="ac-1_stmt.b" uuid="383a924d-c22a-4209-a9e4-1d75bcaf3ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0128bd2-2067-4f52-91c3-7b52eb85b101">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0ab4993-4ac5-4934-82e5-003811c120df" control-id="ac-2">
+    <implemented-requirement uuid="4fed2379-d30b-41d3-9ffa-9f8e4eb1489f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="9b016907-c869-4537-8be9-8cd715606eca">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fa082534-1162-42d0-9b0a-209186f0fbb6">
+      <statement statement-id="ac-2_stmt.a" uuid="bcd3cce4-0c2b-408a-80ec-da208033ff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="110cfea5-2aa5-4a93-8c1b-5063e328712c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="8132f836-e239-4eca-b844-88cada4bf18c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3e9b978c-82f7-4714-a518-56521679e70c">
+      <statement statement-id="ac-2_stmt.b" uuid="faab07b6-9814-477d-9601-7aa872c416a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc79e596-54a3-4f76-9f56-f82751e10396">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="4b951182-a372-4b5e-9112-21aa78d69a44">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6306c947-6fe3-4d22-8342-9c5faaef7214">
+      <statement statement-id="ac-2_stmt.c" uuid="167f867b-56bd-40bd-9249-0f5ab7f2a8d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f2a97ea-8b2b-4bda-ac51-fec3c2116e45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="80f3f5c6-3bec-437b-b5b6-67ac917dba58">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="11163c5a-2c59-45ae-8f28-6c80097a08be">
+      <statement statement-id="ac-2_stmt.d" uuid="4056bec3-4b46-4f62-bf68-ae47db08fa6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0597b132-ef8a-409d-bad0-3ad622e4ff0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="1f9b9051-1735-48ba-b525-afc893167f8a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0d2473c7-ace1-4574-a055-bc80bb73a8f1">
+      <statement statement-id="ac-2_stmt.e" uuid="198cda94-0fd7-45a6-b02a-1cec97445351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87a9cf41-a3c6-42c0-85e5-1579f696a03c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="c1028248-21de-491f-b29c-ce149198d0c6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="776436ad-9ee1-4e2d-8f98-8870ab094584">
+      <statement statement-id="ac-2_stmt.f" uuid="b9383762-ed06-4fa6-9168-aaf501bbbea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d33bdb-a014-43f9-aa39-4635db1660b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="aa650768-f174-4a63-a562-add62ce50258">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9700adc6-82dd-4c34-9bc8-dbdfb5cd9ccd">
+      <statement statement-id="ac-2_stmt.g" uuid="2448f24a-9cbf-49b0-9f0c-e9405e348158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb26ba54-f3ed-4d29-816a-1e4132fed948">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem must be enabled to ensure audit and monitoring
 of Red Hat Virtualization Host (RHVH) information system accounts.
@@ -560,39 +560,39 @@ events that the audit subsystem will be responsible for capturing.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="5cfd8f67-e733-4494-aa51-b58cfc160235">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5cb3a7bb-6a87-4ba8-b955-28ce60ca26c8">
+      <statement statement-id="ac-2_stmt.h" uuid="28c65170-7539-4b0a-8d70-9cc9ab7add25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fafd74a5-41c4-414e-8d9d-ba79a2bf4e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="e2cffbe6-4097-464e-a776-def9ea39fc6c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0a239735-4dbb-4aa8-908e-25b4fc74b734">
+      <statement statement-id="ac-2_stmt.i" uuid="f2517473-8de0-4df7-963e-6c0072e94b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aab400c6-783e-4b90-8b47-4c6df01cf2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="5a27a617-78fa-4afa-9c60-afb6527c02b1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="68f3af63-3ab1-443f-825d-f0e070928ad7">
+      <statement statement-id="ac-2_stmt.j" uuid="d011ba12-8d77-4068-8ea2-16b092b8341c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f829215-f634-4e0a-86e4-3ed5702c4780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="b9d3acfc-730a-48ea-8edc-2becb8b14124">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9c47e5f8-bb20-4af1-a3f7-33fb929e413a">
+      <statement statement-id="ac-2_stmt.k" uuid="56388cd2-93d8-44d3-8dcd-4979ae202a2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bb7841-0542-4c4a-825d-a45e7a294b4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ad63b4c-a40c-4fbf-93f3-cca1e4236798" control-id="ac-3">
+    <implemented-requirement uuid="291df6ca-5c31-48ec-a484-799392cc4d19" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="0d883da4-a238-4bd0-baaf-28956734ebc2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e89e8087-4758-4f7a-9c31-9d2e6d12801d">
+      <statement statement-id="ac-3_stmt" uuid="f358ffb9-7aaa-415b-8eb2-48fee861d62c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c28f339c-fbcf-4674-aedb-82d4be2d5649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) is capable of enforcing
@@ -624,10 +624,10 @@ approved authorizations for logical access:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a47f460-15e2-4c4b-b2fd-11b0c22b2d74" control-id="ac-7">
+    <implemented-requirement uuid="bd4093af-1e69-4000-9685-fa2b09f1b859" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="8e662bef-2263-4283-a80f-c4262eedac96">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="15c72d69-3778-4a80-9568-ecfd81d4c5c0">
+      <statement statement-id="ac-7_stmt.a" uuid="843757dc-c3bb-41bd-aa7e-23b34c22de8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4da5858-8f53-42dc-89eb-d0d477853378">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) enforces an organization-defined
@@ -646,8 +646,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="1466b174-8f17-4008-b3b6-b249c8010e83">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="78f34425-2fd6-45a4-8305-81f3441932e6">
+      <statement statement-id="ac-7_stmt.b" uuid="1e1a552b-bb76-4aa0-a438-9a7c5faa9e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96ad9325-f04e-460e-b295-69b0b407ad00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to automatically
 lock an account for an organization-defined time period, or to lock
@@ -671,10 +671,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d70de23-8feb-462c-aac2-7e5493743364" control-id="ac-8">
+    <implemented-requirement uuid="8d430a33-8d65-4073-9a06-876dc1efd893" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="0f6d8597-f303-42d6-96b9-431629020148">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bccd0a79-7bef-4a74-a998-7e47464a8d56">
+      <statement statement-id="ac-8_stmt.a" uuid="578d1f2a-3921-47fc-a4c9-139e07f251f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -691,8 +691,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="43c7cea6-493b-4a1d-a0fe-01e471b0941e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c47c0f73-6f9c-4d6e-a622-41aad018e763">
+      <statement statement-id="ac-8_stmt.a.1" uuid="fea04920-020d-4465-99d4-6abe68dc3e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -709,8 +709,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="260f248b-dd87-47b3-b79f-0b46a6a81f8d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="23308813-29aa-4dea-b5d3-755dbc1bb75a">
+      <statement statement-id="ac-8_stmt.a.2" uuid="8c26f5fe-c79b-4706-9fc8-7146ef4c41b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -727,8 +727,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="86e3444d-5367-4f71-a536-a6d31f13934b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d634a785-8b25-40be-a0f4-99c1fdc8308b">
+      <statement statement-id="ac-8_stmt.a.3" uuid="345e0b72-dd6c-4d69-831d-051c64fa77a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -745,8 +745,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="04cb13aa-d25c-490f-85dd-541f6601fed2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8d136b15-8d3d-433f-a2df-912068677579">
+      <statement statement-id="ac-8_stmt.a.4" uuid="b225ff56-5766-44d2-ba08-7dbec06a10d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -763,8 +763,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="299d20f6-af75-46f0-b5d5-56db121496f1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2c657942-e94d-489d-833e-6f89d3adc54b">
+      <statement statement-id="ac-8_stmt.b" uuid="672f5f2f-425e-4146-bfd6-8c4b0b22ef9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="283a8a12-0912-4e76-bc7d-94300515179b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will retain the notification message
@@ -778,8 +778,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="5e11c31c-f9a8-49bb-b4e0-3c473a687862">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e85aea91-81f3-4ec0-bff5-38b3b158e695">
+      <statement statement-id="ac-8_stmt.c" uuid="6542b907-4c96-435b-9646-91e6183f9bcc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89177120-8793-4492-a6a2-cc3276d76459">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will display system use information
@@ -792,8 +792,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="b5da1b7a-82ad-4b82-af65-3d8f2cf57ef3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fca93766-96a5-4c92-8c28-f7292db46ee6">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -805,8 +805,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="b9a3f351-a9fd-4573-a67f-dba59ce4b484">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="74c16f93-adfe-486e-917e-6f925f682dae">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -819,8 +819,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="30f5a392-78c1-4384-b423-62ccea533582">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6fd25c62-ef31-442f-856b-d063d2185314">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -836,10 +836,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68c6cc4f-6f41-4fa7-816e-b1cc692b6b31" control-id="ac-14">
+    <implemented-requirement uuid="684c2758-5cfd-459b-aa4f-5236451d89c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="43bf8184-0bfa-4788-8430-faa7ea61d32a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="430188d8-0d1e-4fc4-9d7c-dcc98d4a61d7">
+      <statement statement-id="ac-14_stmt" uuid="98fbea0c-7a97-49b7-ad10-d519e17504a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ade1f14-d64b-43c6-a3bc-4a09b37d14dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Host (RHVH) without identification
@@ -849,10 +849,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f6c3516-ad79-4f95-ab5d-cc3001377069" control-id="ac-17">
+    <implemented-requirement uuid="00433395-fa1d-426b-ae24-19065a86ffd0" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="a1dd04e4-1615-4aa5-9d1f-af37df554048">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="248bab42-f4ab-432d-84f8-5f4f5da98ce3">
+      <statement statement-id="ac-17_stmt.a" uuid="98e3a56b-95ee-40c7-9990-7fbcf14104e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d37e756d-8ef0-4b4f-8357-e22cb5bcb32e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Administrative connections to Red Hat Virtualization Host (RHVH)
 are performed over SSH. The following configuration checks are highly
@@ -911,26 +911,26 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="ebd31abe-706c-452f-a9a7-0857055b7876">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c28a8e2d-d28f-46ea-bef4-ce9f15209ceb">
+      <statement statement-id="ac-17_stmt.b" uuid="2a664edf-1c55-4227-85ef-fcd0664f7e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b03f6d3d-4fc8-472b-82bd-12186b5c307d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="287ac5fa-a2b4-4c45-abcd-22066e86f5d1" control-id="ac-18">
+    <implemented-requirement uuid="cf94a9d2-9c80-4648-9d1a-8230c226c567" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="d3a73e74-8aad-4e2f-8e85-2c43a87f9f73">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="821b86b0-c01b-48e7-a9fc-5dc10d8b5e48">
+      <statement statement-id="ac-18_stmt.a" uuid="311da3f0-e4e8-4eb6-9608-0e07d6138736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0288252-f9e3-4799-b317-2eef7e56dc32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="aa3b818f-5fe2-441a-ad37-c5679926f565">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="daa3796d-90ac-4e1f-8a60-ed70e2718adc">
+      <statement statement-id="ac-18_stmt.b" uuid="e88d12f0-ed95-4bc1-aead-1a7618d5dee6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fca007b-4bd5-47fc-9d79-2e20f48e28a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -938,18 +938,18 @@ system are outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="94992119-3fdc-4a96-871e-cd8ad78557a4" control-id="ac-19">
+    <implemented-requirement uuid="78ab6b5d-0a11-4f22-9827-88750979254d" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="9a88e68e-f805-4266-a8fb-8bda4c441c18">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4a13189d-ae88-42aa-aee2-9ef1e9b8940c">
+      <statement statement-id="ac-19_stmt.a" uuid="d8e4bd09-c320-4c5c-b376-bc6385f43bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ee6b0db-3fd5-4373-bf29-c4a426eb6884">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="e2c87522-86fe-4236-88a5-6aa9e4258d3b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6c5a3d33-3c51-4743-b772-aa07e2de3051">
+      <statement statement-id="ac-19_stmt.b" uuid="f00355c7-3b2a-4d78-8ff1-e8ba6eb677e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="206f5e0e-1f5a-44c8-9dd2-cb418965dded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Host (RHVH)
 configuration.
@@ -957,10 +957,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="103c52d0-895f-45de-bfc9-0824daa355b8" control-id="ac-20">
+    <implemented-requirement uuid="3733ec6f-76d8-493f-9490-91a5c25ef3cd" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="f6e2e7f2-005c-442d-903c-4be6f91ef7d8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3c0122df-1f7d-474b-a85d-6d4ae75cd792">
+      <statement statement-id="ac-20_stmt.a" uuid="3fdb7fae-e48a-45fe-a1e9-3fa009502b06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c64b1e2-40d3-4609-becd-e33f4f85d73d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -968,8 +968,8 @@ systems is outside the scope of Red Hat Virtualization Host (RHVH) configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="bcfdb86e-43ab-4937-82a3-9be09774c8f1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="38325b79-34b3-467c-8375-c0e50782faf3">
+      <statement statement-id="ac-20_stmt.b" uuid="a4eadd7c-a583-456e-bff8-69ecdd5903bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd3e1d9-c2ce-43aa-84b0-301c83bc8bf0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -979,10 +979,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c970ebff-e196-46dd-8151-c2bc2dbd9fba" control-id="ac-22">
+    <implemented-requirement uuid="22d9b4d6-436a-4319-8f84-f356873d10df" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="f45b0229-343d-4a37-bde1-223c3617e4b6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bf15b756-f5ff-4764-bbdf-9be5a7b06e02">
+      <statement statement-id="ac-22_stmt.a" uuid="6744af3f-1fc6-4bfd-b70a-86d731c3a9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="accc6867-088f-4fa0-a311-f8ec1625cde0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -990,8 +990,8 @@ system is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="05bfa1c6-e753-48c1-89c8-0b10c4c5b348">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0cfca75f-c9e1-4f1e-a0c8-ec4b6bf910e1">
+      <statement statement-id="ac-22_stmt.b" uuid="11d537de-0e77-4a89-a424-2d313832e46e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e117711-d918-4757-9c53-cd8e925fb189">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -999,8 +999,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="d14a15ba-e5fa-4356-97d9-1321a3c8a723">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6cabaecb-2943-4168-bad8-7406c43f8c1b">
+      <statement statement-id="ac-22_stmt.c" uuid="e9fc565e-5b3c-453d-bb6a-2c6be6f0e2c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4bf50a4-e6e4-4df8-9070-d3ee9420d06e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1009,8 +1009,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="b5890547-f3f9-46fa-a575-5148c8ba5094">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="84147dc6-53f0-444b-8061-e32e58cbd272">
+      <statement statement-id="ac-22_stmt.d" uuid="76c42769-386a-4002-9b56-dcfe271343fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80727243-4558-4500-9bbf-6b8567ebd9ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1020,18 +1020,18 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4c072cb-a85f-4881-9e0e-61abb0436e54" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="16f86f73-6b9e-4e69-bd72-f333ab08fcf3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7e892f2a-64b2-4ff4-8af4-faada70a9ae4">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="3d6bd121-81c1-4d1c-945e-dfc755f9fd27">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0afdab5e-a587-4e7b-9279-c88cf69bf6d2">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1039,26 +1039,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9976f49f-5602-4361-a699-612f4ffe543d" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="322766ac-9a4c-4e53-bb7a-2699ddea1458">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8aee8feb-85ba-4ae2-8d7b-a39744c38558">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="15c79372-60ee-4b9b-b8b6-09f41fd0c2cf">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5989f1d7-c8ce-44ee-bdfd-59e11b7f08d5">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="8f0de577-fe26-4487-8cb5-1fc0ec8f3052">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1bce5805-8f05-4513-b70a-06ee61e799f1">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1066,26 +1066,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de6bd98b-a175-4ddd-9f8a-0ea9f4d1dc6f" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="8bdec9e9-90d9-4ec2-8219-7beba3a9b173">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7db60b45-1334-49b9-96bc-ebd44a80cb98">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="1128bb07-a9fe-4784-9a25-de188c0e2e86">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a859e0e6-6d82-4631-bf88-5f3c640ecdf9">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="036a39d7-b94e-4d49-8ffe-c7362ba7ba87">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4d76db6a-5dd8-4b02-8f96-498072fda6a2">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1093,18 +1093,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b2cee12-0f14-431c-a9c6-eec562c59189" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="11fc8f94-5570-4411-88b4-c725210126ce">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="063fb7bc-f59e-47bf-bb0f-8805703e5a08">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="8ba9cb97-ae82-43eb-b9eb-dad276c24f06">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6392d9e2-1ae6-4db2-b461-246137dd9eb1">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1112,18 +1112,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd9e6308-e718-402b-8741-e6404997698f" control-id="au-1">
+    <implemented-requirement uuid="9f3bbb92-4fd6-4f4f-a234-43e8b2f9d321" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="c7a3e5c5-f473-4e86-a13f-1d8ef1a927ed">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="968106e8-500f-4a64-b586-38b778ac5c90">
+      <statement statement-id="au-1_stmt.a" uuid="c2636108-0713-4727-908b-9d644f5ef47a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6d15083-8660-4473-bd76-f23f53dc412e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="e5e21f8e-33cf-4451-90ca-c4c5e98dff72">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5755d00f-323e-420e-8bf6-0f8be176dfa2">
+      <statement statement-id="au-1_stmt.b" uuid="c63af622-3579-4f08-9ba4-caaac03fe2f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b09d43c2-ff7d-4474-9cf6-41f5b9827270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -1132,10 +1132,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06205c41-1a9e-49a4-b786-b5f5b3ecaf2c" control-id="au-2">
+    <implemented-requirement uuid="b7db7dc9-b503-436a-8f61-937f91b306d6" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="85bd5857-8d2b-4eee-b60e-de65b00dc998">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7d1f9b42-f9df-4f21-8e92-0ad42bc40692">
+      <statement statement-id="au-2_stmt.a" uuid="f4c58566-e8d5-4cb4-8d80-5814a9a4d258">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5dc2ddf-e441-4bad-bafb-d41bbd5dfa89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1167,8 +1167,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="8a93958e-3944-4f7e-bdb4-7e384885a30e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e67f5c21-b44b-433e-a536-c63df1722230">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1176,8 +1176,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="c17ad0a6-af50-4fd9-b37c-d877f4b4ba13">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4d224d93-9781-462b-9877-cb4e08bda701">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1186,8 +1186,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="2dd13269-8dc2-455c-89d6-c09cc4a00fbb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="dfc35e2b-c856-4bbc-9a52-7c7021beedff">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1199,10 +1199,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3cd59ab8-1571-47f8-9aba-d7b8e8e71875" control-id="au-3">
+    <implemented-requirement uuid="8e3dae3b-dcbd-4acb-942c-254be196b09f" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="3e945274-e6d5-46cd-854c-fc0769a6d4a8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="675ff140-c784-4f3c-adda-0c70885081e3">
+      <statement statement-id="au-3_stmt" uuid="3f79bc0f-b8c6-4846-804a-0ef92deae5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="602ba1d2-55b7-4547-a71c-79ef4acc3e2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) audit records contain
 the required information and cannot be configured to be out of
@@ -1210,10 +1210,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8e72650-0051-4835-9de3-184ea8519023" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="6bd08324-e007-42af-85f5-2655ff322728">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f87e2928-e2f6-47e8-a075-c8c56f524e79">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1221,10 +1221,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4e741dd-e462-4a53-8f04-704204211207" control-id="au-5">
+    <implemented-requirement uuid="5b395705-475e-447d-aadd-b8c26afedae6" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="f3b582fa-7732-4807-9de4-becb324649c3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="007a2bda-14da-4155-99c6-3d8660f16902">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -1235,8 +1235,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="05c1db85-483a-4a5f-88b4-b64108848400">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="72490fa1-5beb-4a1e-82dc-654eb6d6713d">
+      <statement statement-id="au-5_stmt.b" uuid="17101dc5-e63f-4235-9379-079def2556d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8322a91-fee3-4987-9b27-c869af08a5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To shutdown a Red Hat Virtualization Host (RHVH) node upon
 an audit processing failure, which includes software/hardware errors,
@@ -1258,10 +1258,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af1eb2dd-7ecf-41c5-8af1-437dd67e7112" control-id="au-6">
+    <implemented-requirement uuid="3444efd3-f653-41c7-be8d-b52fe68795ef" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="fa141290-ef97-49fb-ba2c-4856dedb765c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b0268647-4466-40f8-9f71-a1199f13495d">
+      <statement statement-id="au-6_stmt.a" uuid="0a10e0d9-e8b3-4d8c-8a1d-21eb61c789e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7932186a-3291-4937-9080-1023ab875818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1270,8 +1270,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="5795de22-4184-465c-9e3a-512e1fd23c79">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7b263705-7cf6-4674-88cb-becc893d6edb">
+      <statement statement-id="au-6_stmt.b" uuid="b514c067-55cf-486c-b3a5-74348c51c675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a00e37ab-b563-40d3-93f9-2ecf04468c31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1280,18 +1280,18 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f94bd078-9639-4291-8082-b0df4eb5b54e" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="94f30051-13c4-4c51-a674-4b94d49fad1f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7eae1f28-e007-4b9f-af04-eb3a86d2333f">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="bfce98bd-a74b-4f3c-861b-7ded5938c168">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d46df9b7-96f4-4c33-b4cd-1f6aa37ab7a6">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -1305,10 +1305,10 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70ecb579-e195-45ea-a30d-1a4f3dfa486e" control-id="au-9">
+    <implemented-requirement uuid="9eec989b-e59f-4c58-bb64-15cd8b4cd415" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="289662c6-da86-4c22-813b-ce3af0bf4576">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="24a5c996-bcae-42a7-860a-09f10d420578">
+      <statement statement-id="au-9_stmt" uuid="2837780e-02a0-44ab-afb1-5c221e5f9f38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acfe3ec3-a01a-4943-b0cd-65e93a684b6f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure the audit records are
 protected by appropriate file permission, user, and group ownership settings:
@@ -1334,10 +1334,10 @@ been modified/tampered with:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="793de617-2dd6-401a-979c-c530ad184ab3" control-id="au-11">
+    <implemented-requirement uuid="6b3bbfa4-14a0-4bc9-8576-b92c461c4150" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="1410fbe3-7f64-4a00-b747-0d2d322aa78f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3991c863-5507-4025-8982-cf04061b4acc">
+      <statement statement-id="au-11_stmt" uuid="30e22ec4-cc35-4140-a186-122b751ea450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98a9df94-f1be-4c9d-adc3-a34c9358b230">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1359,10 +1359,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f75ac211-5b87-4b6c-aaf9-9efd9a96c3ef" control-id="au-12">
+    <implemented-requirement uuid="6f8494bb-c00d-47f5-bda7-0ae955eb3822" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="ca2df994-c35e-4c35-bfe0-64ce709575cc">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a7966cb3-d41e-4c42-8943-cb7419549075">
+      <statement statement-id="au-12_stmt.a" uuid="49b9b7a6-a777-4820-b4af-81b7817398a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05794480-06d3-4c97-a7ec-634d165fbc1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure Red Hat Virtualization Host (RHVH) nodes provide audit
 record generation capability, the underlying audit subsystem
@@ -1378,8 +1378,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="78510e5c-c06c-4001-8693-9723b7492279">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="39b24283-b96b-4927-a43b-483ab80e7f07">
+      <statement statement-id="au-12_stmt.b" uuid="ae3d7411-b456-4b09-b30d-7b49f8d21f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="435db5cb-b92e-43d3-a0c5-1a103bc53163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>System administrators may customize audit rules by editing the
 appropriate files under /etc/audit/audit.d/.
@@ -1390,8 +1390,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="fbc868cc-4f23-4dcf-bd48-a1bd85138f1e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0a56b83d-29f8-4b28-8a6e-25366f6b7ad7">
+      <statement statement-id="au-12_stmt.c" uuid="92631140-5b9a-497a-9a62-1fc88736cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8a1327c-6ca4-46a0-a0ac-cc2f87d19dcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks correlate to recommended
 audit events:
@@ -1526,10 +1526,10 @@ audit events:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="849adbd1-5f5a-4221-816a-77426b79f8e3" control-id="ca-1">
+    <implemented-requirement uuid="9f7998ec-517c-4f59-9cb3-183766cdc84d" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="eeeb6d28-00fa-4fb4-bf76-32b3fd65dcc7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3feeb9b2-c1e3-48b5-a49a-3d108ece7d9d">
+      <statement statement-id="ca-1_stmt.a" uuid="6e1cfd0a-61e2-45fb-beb1-ad29db0968af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1537,8 +1537,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="eac5c8e4-979e-413e-9e78-4d14f76b53f4">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5f9d52c6-9b94-4e2f-9625-e2abe643b632">
+      <statement statement-id="ca-1_stmt.b" uuid="3a2fae8e-3afa-43e4-a06e-9c493bee605f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1547,34 +1547,34 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42c669d9-c285-4f07-be5d-bfa1040ed4ea" control-id="ca-2">
+    <implemented-requirement uuid="289d60a5-96e0-4c8f-ba5c-ee51e290a842" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="1710c2a4-e9f6-4b99-b565-719d617806e1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="546c90aa-7c6c-4e07-bcbf-552df51c5456">
+      <statement statement-id="ca-2_stmt.a" uuid="a7abe116-eac2-4cdd-8d14-45471e54f6a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="3bb055be-e993-4c4e-8f20-80b8b4c96d77">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7ccb48d7-e9a2-4e1c-8af2-bff562e832c9">
+      <statement statement-id="ca-2_stmt.b" uuid="d1dfb904-939b-4f78-b8ed-47b4f1c3116e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="58ecd153-7166-4659-be5c-de5a1eebfd95">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6b4a5f45-5354-4f44-9656-2475f490e8c6">
+      <statement statement-id="ca-2_stmt.c" uuid="f247ced2-eac6-4696-b78d-b0435339a085">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="92d30a71-ab95-4b48-9b40-338613c2159b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fc82799d-d6f8-4e16-8e1c-952be59f935a">
+      <statement statement-id="ca-2_stmt.d" uuid="ce26608e-47e4-4c3e-bd43-ce258ddb8254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -1582,10 +1582,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26e0158c-abdc-4686-853f-a3a50ac5b7a4" control-id="ca-2.1">
+    <implemented-requirement uuid="6ef18e3d-dc28-49ad-8675-40ab7c85fcd9" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="f1827cf5-4e20-438b-8863-6dfe2d1345e7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0c92b75b-d3ab-4688-ba96-cd4381c37339">
+      <statement statement-id="ca-2.1_stmt" uuid="57b3b99a-2df5-4fe7-ab08-9935ae4a4474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed1c9eea-65a1-42c1-bb95-e72a6403fea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -1593,10 +1593,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="962b124e-9baa-4bfa-902a-9868e2f4f450" control-id="ca-3">
+    <implemented-requirement uuid="2cdfa14d-b733-4897-a340-b8e3f05bbec9" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="d2ef9743-96ed-4990-a104-cdd6049b25c9">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e3818b7f-3a52-4e7d-bfc5-4fb67b5a88f3">
+      <statement statement-id="ca-3_stmt.a" uuid="38b26537-a0fb-491c-a6ec-4eba6cf219ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -1604,8 +1604,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="9da4ca19-50ad-4032-906b-2ab0f6d3bac2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="27a0fc26-b23f-403d-9eaf-ed3e781aac53">
+      <statement statement-id="ca-3_stmt.b" uuid="8dbf9169-8348-4c89-847e-cbb73c852d62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0315457-27b4-46d2-b4a0-e26c51bc6331">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -1624,8 +1624,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="8f9c9fe9-b705-494c-a940-e51133318052">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="821dc803-d311-4cd9-abc2-9c50ae15939b">
+      <statement statement-id="ca-3_stmt.c" uuid="0d1c4f9e-fff8-4cdd-a9f7-f66acd150010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -1634,10 +1634,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ec512ac-5e62-4715-80e9-0623e5827677" control-id="ca-5">
+    <implemented-requirement uuid="86d74c00-0c31-4d76-b3fb-c0c9a65518da" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="7a49ffd6-f1c6-4214-ad47-066d85b0845c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9808c4b2-2414-44cc-9c02-2f1374b19317">
+      <statement statement-id="ca-5_stmt.a" uuid="47df7fd2-84ab-40da-86ad-2af43e1230f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b013587-8b21-43ec-8ef6-0917e64a1462">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -1645,8 +1645,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="5306c444-c970-4369-907d-e1b1d9b57736">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8de63131-cf53-456f-a93d-94688705c162">
+      <statement statement-id="ca-5_stmt.b" uuid="a48733c6-22f6-4c39-96c2-0b8738304727">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea64d27c-3385-4fa6-93d6-575913ac2533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -1655,26 +1655,26 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration process
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3052b924-cd15-4754-9d3b-129eaff28a6f" control-id="ca-6">
+    <implemented-requirement uuid="f614a8be-533c-4f88-8721-e6069c1932e1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="91a1bad5-0742-47d5-b069-44f1b21d41d8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d9e97511-d1ad-4ff3-b024-efcadb4d14e8">
+      <statement statement-id="ca-6_stmt.a" uuid="c0d2ca6f-e92a-46b9-9552-8403ee244e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="40aa57dc-cd39-4bd9-b859-33cfe8797605">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="51bca4e5-e179-45b1-947e-cec9967be529">
+      <statement statement-id="ca-6_stmt.b" uuid="ee5d757d-b418-40c0-952b-1956499bcb08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="529a9257-2fc7-4788-b7ea-0d35484a1550">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8e1d61d8-53c4-48e8-8093-d4f2a431c128">
+      <statement statement-id="ca-6_stmt.c" uuid="504677fe-0e57-4537-9f05-b57d3833d732">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -1682,10 +1682,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed43ed16-9196-4c0d-9045-ba1ed7d884bf" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="00baa99e-9694-45d7-bd8e-944c193d880a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6c9c444f-f616-4b0f-b90d-0bf399fb02c6">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1693,8 +1693,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="7537a299-f377-4ad4-b4e9-26886e65edc6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5ab4d584-0912-4c27-b090-d7d35fca317c">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1702,8 +1702,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="51ba68a4-5fdc-4839-999a-f3a3f656912c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0294629a-bdd1-4656-a2d5-5ff2d5b3b8f7">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1711,8 +1711,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="deb0f57e-2d00-451a-89b2-5d360ffcb81e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1db31bc8-14a8-4fe0-abc6-1f0dd9ce2d24">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1720,8 +1720,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="b0d5a1c8-331a-4f60-9d47-30c96f0d464d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1734a825-3327-4e3c-90c2-325a92acb80d">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1729,8 +1729,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="5766e779-60c0-448d-9378-47bb9fa19e9e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="acf7f1aa-da5e-417d-972c-ea9ca6e3171e">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1738,8 +1738,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="0527ff33-b55d-4b45-bc9f-71c03a19cd32">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9039f9aa-94d8-4b6d-82c1-a53e1c545719">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1748,10 +1748,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b1ce5c6-9fd5-4b81-b5ba-2495233ba2b7" control-id="ca-9">
+    <implemented-requirement uuid="81438902-6d72-48c6-bdef-512ce86f9cc8" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="505abdf0-5615-4234-b37f-bd318d7870ae">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="411686be-e0eb-496c-8953-2d25ce1da32d">
+      <statement statement-id="ca-9_stmt.a" uuid="37075470-ee1b-4d57-bd59-9e906f08185b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ba32062-5e14-4358-a282-0c161301fd23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -1769,8 +1769,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="13e5afce-2341-4b0b-baa6-9c73aafc52e7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4641503c-2ff7-4292-b41c-394e76a7bd66">
+      <statement statement-id="ca-9_stmt.b" uuid="8757eaea-2bf1-4007-9b9c-1d12b7808641">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4085cf70-9957-47a4-9b8b-97caac2a5166">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -1790,18 +1790,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bac3e1b-b609-4cb8-842a-60f109810744" control-id="cm-1">
+    <implemented-requirement uuid="cfdc0ca1-6cef-42e4-8d4d-ed3938123b40" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="38c44ba9-504a-416a-8252-62ce7144671d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9b0cca4c-9943-42f8-b640-ba22bbdbbfc7">
+      <statement statement-id="cm-1_stmt.a" uuid="8e9e428c-067e-47be-81a9-5bea33a7a446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08f31ac0-12ba-44af-a682-36187123d8c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="c182c9bd-1d9f-40ad-80bd-20baea8cacbb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ceb8ae85-306b-4308-b0d3-b8f36022bc22">
+      <statement statement-id="cm-1_stmt.b" uuid="05595bed-e10d-4ed8-b954-b8e07ca96a22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27ae912-1014-4d2a-b6c7-32a644fe6dad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1809,10 +1809,10 @@ management policy is outside the scope of Red Hat Virtualization Host (RHVH) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4c41097-1c97-4756-b7bb-60230e126d9c" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="2e804f0f-e2c9-435e-98cc-ff8a1804a680">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ff84d8da-dd35-439e-874b-b109854519d8">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1822,10 +1822,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8beef5bb-6fd9-48d8-b982-393d7cf846f7" control-id="cm-4">
+    <implemented-requirement uuid="c7d70620-3eb0-49f4-98ce-8d59965658ca" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="b13c1a87-0c3e-4041-9675-3e84e839a578">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1a149f17-6a22-41e7-aa37-d446824f8f65">
+      <statement statement-id="cm-4_stmt" uuid="763bb0b2-b3c1-4af6-8436-99f29f9c6aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9df6f94b-15df-4647-a801-4aa4eef28ead">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -1834,10 +1834,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a0720ee-4a12-4e47-8498-cdccb282e97f" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="f6c93613-c4e3-4e4b-94ed-50e26cde5858">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="731970fd-611f-4c0a-b03a-7b03b88354eb">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -1851,8 +1851,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="31ca7281-4ec6-4cee-a7a6-7f565a715d9a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="37555e73-64e1-489d-9b2f-b83a3fbaf6cb">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1866,8 +1866,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="86a570ab-1be0-4127-bffe-5b289239d0a1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7b3c2bd8-4913-4621-bfb9-e24a51abdc49">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1876,8 +1876,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="276a71e8-921f-44ab-b88f-a75bd23486c6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="50f1ae88-de2d-405e-9dc9-865c803d2b70">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1894,10 +1894,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1476a0a-28c2-4437-b589-756028aa6f0e" control-id="cm-7">
+    <implemented-requirement uuid="5d481866-afa3-4223-8b3f-d048186639fe" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="59545918-1e13-4e14-aa16-fa342dd84604">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b767ca51-9c78-43c7-ad7e-ef98e3fcd67c">
+      <statement statement-id="cm-7_stmt.a" uuid="f1c03d8e-385d-4872-bdc7-5811d06486cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c1f7cc-f58e-4150-8003-b7f3e10862e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -1908,8 +1908,8 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="5da9f449-b681-4e89-a3d8-a2e2b2ed8e2a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="814bd65d-3706-4ee1-b263-69e3e2399e86">
+      <statement statement-id="cm-7_stmt.b" uuid="75c090a7-ee60-4f64-a388-bb7ed7c9c5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0735d452-78f2-4bf5-9f4c-065b42936360">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -1920,10 +1920,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8ca300f-8b9d-402e-a9c7-61ea84a9775c" control-id="cm-8">
+    <implemented-requirement uuid="07b2258b-e3d5-4ca2-960c-d9e82a056236" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="495ade36-60c5-49f8-9e42-ca65d1c74bbb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ca4fdebe-3568-4e46-bc5d-ba6e0592c207">
+      <statement statement-id="cm-8_stmt.a" uuid="b53ef6f4-6571-4239-8a55-ea7a285fe47f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1935,8 +1935,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="00d778f1-d2ca-4ef2-a0c4-c60bc9e9393f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2e8bf9ea-1bdc-4e72-83a3-7b93d927e257">
+      <statement statement-id="cm-8_stmt.b" uuid="6c3e7c49-c2bd-4582-bcca-eeed439afec5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1949,10 +1949,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59f4f4aa-76b0-48f1-9a75-b9ca00a17c9a" control-id="cm-10">
+    <implemented-requirement uuid="2c661714-d065-4868-b601-26cbe5055442" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="4dace363-53f7-46a5-9e4d-ab9fed22fba5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8087e959-a0d6-44d0-a840-aece35bb44cd">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1961,8 +1961,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="5cd7309e-1308-4e30-915f-73cf30f4005d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="79899f50-9db3-4d6c-995e-3c8e848f36f7">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1971,8 +1971,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="73ad4c43-4dd5-4cf6-9731-d0b95c7629f2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1ae90295-3608-4f96-96db-cd4994ab7ce7">
+      <statement statement-id="cm-10_stmt.c" uuid="d84e5f1c-a35a-41b3-894f-2b78fc2aa9a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1980,10 +1980,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6ea1ec8-9fd1-4b8a-8d53-33023f1d9e1c" control-id="cm-11">
+    <implemented-requirement uuid="4e58bfa2-4492-437f-a01a-fca1e8718539" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="cb5e757b-5631-4c45-9dab-fdd69d68b261">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b052f68f-77e6-429d-8c53-9534df1902e1">
+      <statement statement-id="cm-11_stmt.a" uuid="7693dc19-dd28-4599-9e26-8b8ae1f36b38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05d2dfdc-7476-4e8b-bdab-8344fd80afce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Host (RHVH) nodes. The following are suggested
@@ -2002,8 +2002,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="c335b633-183c-40a5-ae3a-7ba036673961">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="77dd58dc-69ac-485c-bc84-4a65a7d191b8">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -2020,8 +2020,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="76479c6a-1bc9-48ad-98c1-87a179a0df26">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8e4a4f92-b7c0-42a2-9361-35e8101e6f06">
+      <statement statement-id="cm-11_stmt.c" uuid="e323d5bb-94e6-495c-9bac-7a2755aa97d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2029,18 +2029,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fdff670-7473-4d7a-af1c-569e7582404b" control-id="cp-1">
+    <implemented-requirement uuid="a4d50e31-979e-413e-9d1c-bad6a286674f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="15685cb4-3220-499a-bfaa-00a2c6979d5b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2287ee78-55ad-433f-b499-d2df1b108c89">
+      <statement statement-id="cp-1_stmt.a" uuid="de0eaee1-2052-4121-ab5e-d97aa37f67b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="306c69c0-9be4-4fd3-89c6-988ef9eda100">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7a233f70-933a-48dd-af11-6853bc96b462">
+      <statement statement-id="cp-1_stmt.b" uuid="450d19af-1220-4860-9c86-5224e96005b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30fb2eba-41a4-402d-89e4-3000d3b57982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2048,34 +2048,34 @@ policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f39b605f-854d-47c7-ad50-4922673b90ab" control-id="cp-2">
+    <implemented-requirement uuid="1eb13bca-54c9-4920-aa02-7579e0351f67" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="fe90b0d4-d652-4341-b81d-74daed52908e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2e79dfe5-b076-4fc5-920e-86c853332ba2">
+      <statement statement-id="cp-2_stmt.a" uuid="bde1ab58-3391-4b95-b76c-d012c47dc90a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="339df0e7-35e5-4388-9304-14661c1c3548">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0a6f0a11-939b-46db-b34d-0c64cf147afd">
+      <statement statement-id="cp-2_stmt.b" uuid="baaf50bb-ec4e-4b52-86f5-009531beea36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b192bba0-89b4-43fa-a0de-ef361af44ed3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="3a72ee9c-606d-4b61-89f2-f82dab144ff5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4ffd8133-a135-4dc0-8c95-81510e14ef15">
+      <statement statement-id="cp-2_stmt.c" uuid="0618434f-fe6b-4e3d-b500-ecf4e0c6e859">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c8443da-ca03-494b-a8c4-1223add1c65c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="f75ef800-1e00-4546-9d3c-0a4dd86f3ef0">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a994b7f4-c019-44a9-9417-ae581c32d4e5">
+      <statement statement-id="cp-2_stmt.d" uuid="766fac0d-33c0-41b5-ab5f-62d02f55b664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70fedb8a-d30e-419c-b649-c446767a490f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -2083,24 +2083,24 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="60f318b9-deb1-4657-849d-69a3905e0c01">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="de4a3da1-a0ba-4429-9abd-0ccdf0213250">
+      <statement statement-id="cp-2_stmt.e" uuid="cb696cae-5941-4b56-b94d-3be6099d04b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4394777-a16b-4df6-8066-9b76913dd72d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="fcbe1792-3e0b-42d5-bb6c-4890e23cf581">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7b46f004-1b40-4079-a922-e0608e20b148">
+      <statement statement-id="cp-2_stmt.f" uuid="77dc42be-4ddf-4c65-b4c4-f8041a1f3e49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9e64a1a-3e28-4df7-bdda-e299001953b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="24ee6a82-6b10-4e17-b407-542eea131fef">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6d3b850f-b8dc-4761-8584-9590ce5ab7f9">
+      <statement statement-id="cp-2_stmt.g" uuid="593dcee1-22e3-4dfb-96b7-b6f704a78d3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb2eed58-dded-410c-8051-d9533ce5df3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2108,10 +2108,10 @@ modification is outside the scope of Red Hat Virtualization Host (RHVH) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b069712-084c-4266-8ae5-d08d80656986" control-id="cp-3">
+    <implemented-requirement uuid="c7c97cd2-5b41-4f1e-aa90-c79d83e69b59" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="91424fcf-46f6-4aa9-806a-4103c484aaaf">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="afcf2c0b-02fa-4797-8cf7-1139a97e3314">
+      <statement statement-id="cp-3_stmt.a" uuid="43d5b766-c085-4de2-b03f-df4f30d10efc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c63dcbea-0150-48d9-88db-9802f3c0126d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -2120,8 +2120,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="388193a0-9299-4fdd-ac41-fbdcbfdef5b1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="cea63c3d-c80b-4d3f-9cc1-f2d0e468cac9">
+      <statement statement-id="cp-3_stmt.b" uuid="4723b068-1ebf-4204-b9da-3d662e4f6500">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64b4a65e-1aeb-41c7-981f-952057f9150a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -2129,8 +2129,8 @@ system changes is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="913109a0-1ed2-40c9-9ae8-58c3f7e06235">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="810ae6a7-218d-4697-9b08-f3929edb9531">
+      <statement statement-id="cp-3_stmt.c" uuid="93c84b17-9755-4aed-8aa9-d9390f1b6579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d9b7f69-1c97-4afe-93a9-9c75cc4c35cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -2139,10 +2139,10 @@ frequency is outside the scope of Red Hat Virtualization Host (RHVH) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a61a6d9-5132-49c9-a4a0-424c08dccb1e" control-id="cp-4">
+    <implemented-requirement uuid="66fe603f-1955-488d-ab70-a072c8d9ae49" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="118a978e-8447-4d47-a33b-c1cf83ddfe74">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8b488520-06cf-4d60-9942-b2d9722f3dd3">
+      <statement statement-id="cp-4_stmt.a" uuid="9d9a7e50-fa92-4973-a426-da3a5cdd261f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab4951df-705a-4cf4-8ac6-c047fd2cd7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -2152,16 +2152,16 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="54f33c71-a6f5-4510-b557-debc9ba8c2cb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b1d65946-1a86-4613-9ed1-cf5c2a60dcdb">
+      <statement statement-id="cp-4_stmt.b" uuid="ec404859-7767-4798-9634-c7f23406e4a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3513952e-7a91-4414-888c-236a38fcb64a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="66117744-301c-4cb0-8d9f-60563bb1eb4d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fb509bb2-36cf-46d0-9686-30d018d325b6">
+      <statement statement-id="cp-4_stmt.c" uuid="81f1a338-f5a9-42c5-82d9-394dff735c7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1984e099-d316-4fef-8c63-1a695a4fd961">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2169,10 +2169,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f26dab8a-dca2-44f2-898a-dd49fcb6c85d" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="747f9f92-3696-432f-8886-119020b43959">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d4454601-f94b-4e60-b597-75e4b90e764f">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -2190,8 +2190,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="ae1a8590-fa4a-4d57-886a-7ce85663c8ec">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="76b9fd15-90cc-401b-9b20-bff3cc9d8c55">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -2209,8 +2209,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="be41ca3b-90e7-42e5-b486-7a4aa3d9c506">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8c765530-3018-4923-90bb-f995754492a3">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -2228,8 +2228,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="42dc3498-e632-4fa7-bab2-4c268dab1f87">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5d9040f7-7858-4438-9692-456dae3d266e">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -2247,10 +2247,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc266d98-9582-4056-89c9-6b0f1d96c014" control-id="cp-10">
+    <implemented-requirement uuid="79e121ea-961c-4bde-a84e-e8bad5a2ef56" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="6c4d195f-5f09-4966-8ce9-d4a9b1cbdca8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d6c3ff58-f550-4531-9f1c-a8df1c52fddc">
+      <statement statement-id="cp-10_stmt" uuid="cb8c4cbe-276f-4d6e-a855-dd128a8b9536">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d703f450-a122-49ff-8d6e-910b4434d6d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Host (RHVH) environment. A successful control response will detail
@@ -2264,18 +2264,18 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="396c3d7a-fd3b-486c-8d7a-05162ad1be66" control-id="ia-1">
+    <implemented-requirement uuid="f0f620e7-99d8-4036-a575-5eca390148ea" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="58451b24-6c68-4627-9334-ff5784a057c4">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="75394450-fb58-4d02-93b5-11dbd2edbdc7">
+      <statement statement-id="ia-1_stmt.a" uuid="7ee6f6b8-28c8-4ea9-b83a-9db2448ee465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0c85dea-3e0c-4433-967e-3f27b7bef26f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="c08bfe2f-b067-4d4f-9c12-1c75e0a92157">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="319f38aa-7c03-45e3-b546-caa27fb3934c">
+      <statement statement-id="ia-1_stmt.b" uuid="53d59aec-74ea-4166-9625-bcfbb2557334">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2b30f8-c522-4d86-9026-a787c8eba01b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2283,10 +2283,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1ae67bb-be2d-4e0d-892a-c5e7f6fa4d03" control-id="ia-2">
+    <implemented-requirement uuid="15eca7eb-969d-4bff-a7e4-909f8a73e869" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="a42196a0-1fca-4457-8630-166381f96943">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a72a80c3-bf36-4235-b5bc-9adf03334a24">
+      <statement statement-id="ia-2_stmt" uuid="2b7ead57-5b85-4fcf-85e8-e3a5384144df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f98c749d-d278-4b84-8f24-b334804ce20a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) uniquely identifies organizational
@@ -2317,10 +2317,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fbfface2-c5bd-4032-9015-3f6d9ac5e32d" control-id="ia-2.1">
+    <implemented-requirement uuid="5095b0a4-4620-4753-b05c-b53161440672" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="ad8fb650-1b95-43ca-b456-efec0e0ed65b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="429b8a75-7d75-4151-8690-5554e0227a72">
+      <statement statement-id="ia-2.1_stmt" uuid="bfd9972e-7404-4f2b-bf4d-56dd5521e099">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9cafe30-8a5e-4406-b296-6c48352d1e6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) implements multifactor authentication
@@ -2335,10 +2335,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e03e4395-0678-4070-bbdf-8a35239d9273" control-id="ia-2.12">
+    <implemented-requirement uuid="de776585-976f-4b41-aba6-fbbf4eb1ef88" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="60cbacc5-6d6d-458a-9537-9eb413cd9870">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2465489d-25f1-46f5-98e5-5be98f64d791">
+      <statement statement-id="ia-2.12_stmt" uuid="44139483-c869-4e9e-87b3-5c9497bc594f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcf74c64-a18f-4080-aa09-367eab934047">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) accepts Personal Identity
@@ -2353,34 +2353,34 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7268227d-e93e-4a03-9d5a-a1ad1cb1589e" control-id="ia-4">
+    <implemented-requirement uuid="68c1ed91-8b92-42d7-af40-9a35c7ca3a43" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="983783b7-9dcb-4144-8dd6-d80ea2e8f617">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c502a10f-896c-435f-9d7c-245d929e0339">
+      <statement statement-id="ia-4_stmt.a" uuid="68861cd3-5042-454a-81ac-d8767ae4b479">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="8bf624ae-6500-4423-acf9-aa0d0e24059a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ffcf9554-c859-4063-9cbb-279d67f3a45b">
+      <statement statement-id="ia-4_stmt.b" uuid="c3be4c07-b372-4f86-a61b-c643a28a0651">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="f7376c4a-0f98-4112-addc-9b3240a1c5d5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b3fc5530-ee13-403e-b109-bf7c5067a8cc">
+      <statement statement-id="ia-4_stmt.c" uuid="c0100a17-fc78-4b8b-ae49-0285a57226c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="bb54bca7-956a-4a4e-aa00-65d4082519bb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="64cd8208-cba4-424b-9b27-f614b5b8da36">
+      <statement statement-id="ia-4_stmt.d" uuid="17ba4241-f897-4c6f-befc-443916ec1596">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11cd2900-3a52-429d-a991-6692867ae02e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -2390,8 +2390,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="19c7a6f4-1a01-4e80-a813-50617c820282">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="328ccaef-2efa-408b-882b-57c4d3e349ec">
+      <statement statement-id="ia-4_stmt.e" uuid="b2cdf31e-a423-4f1c-a9ba-c2ea599dc41c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d5a3cc-1c33-45f0-b5d6-5252c0ed9a81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -2406,18 +2406,18 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="754b2da9-1ed3-41b5-a47e-b500d2364a02" control-id="ia-5">
+    <implemented-requirement uuid="3f357209-59f7-4ed4-8e43-fc4a29fe0793" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="f9e2398b-2f79-43db-88aa-1a902740db62">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a2c638f5-10ba-45aa-84fb-b7dbf4f447f2">
+      <statement statement-id="ia-5_stmt.a" uuid="4aa0fc19-bf18-4875-af10-0ca428ae7df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="58118bf7-4815-468d-9a47-e64582671e34">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d48f65a9-c48f-45d8-b23d-a84a770c4550">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2425,8 +2425,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="e68bc153-3751-4d1f-953d-b0fce5152db9">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bc6a39ee-5fbc-4bbc-b564-892ca75ce6c8">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2434,16 +2434,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="73ab6b40-0e2b-42d7-b5ba-ed23a6929efe">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4577468e-affb-445a-afd4-ee4fd2edc5e2">
+      <statement statement-id="ia-5_stmt.d" uuid="47f7ff51-8b3e-4bd5-9880-9099706850d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="3a13d421-0079-4561-a32e-2580d7260886">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="167413ad-29e1-49a3-a9d2-9e7277fdbeeb">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2451,8 +2451,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="689bbb57-0c2a-4874-87a3-8fe7acdfb9db">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="cfae3e32-5028-49e7-8611-6669c3779ace">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2460,8 +2460,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="b4976f57-fd31-4424-95ce-1a5374c08697">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="87600fa5-6d54-4be4-b225-38c2d78c72f1">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2469,8 +2469,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="29f6e24a-8385-468c-bf98-1e59e73ee8ea">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b8333137-7daa-4e6c-8f34-09011cc1172e">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2478,16 +2478,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="23d3229d-e477-49f1-9e22-489cc1785b94">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ade01a60-09be-46f8-88de-5a44334cdf21">
+      <statement statement-id="ia-5_stmt.i" uuid="95b60fd3-c552-4002-8ef9-58a17fbab84f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="708d88f4-e858-44d1-a18a-b2b7138c0f5e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="99d4cd9a-3be9-48c1-8441-6a270787fd3e">
+      <statement statement-id="ia-5_stmt.j" uuid="401d8d60-ea1d-4bfc-9604-db1f455a054b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2495,10 +2495,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5ce2e2a-86b8-4d25-9f2c-589acfb6bc31" control-id="ia-5.1">
+    <implemented-requirement uuid="8067b1a8-8e82-48e0-9c1a-f3d3410f8533" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="b90e7979-4e4c-4a4e-a4bd-9221564346a1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="56b0a28b-903b-407e-9167-cc10cb456e99">
+      <statement statement-id="ia-5.1_stmt.a" uuid="dee671d1-1f26-4cde-877f-80d7699262c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36eb0d36-25e3-4ab0-bfb2-209436fb2c60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prevent logins to accounts with no password, the following
 configuration checks must be enabled:
@@ -2555,8 +2555,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="4fc71843-421f-4240-8a51-b72e636e8ef7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1149cf88-11a9-4c3e-8cbd-4086cdc8583d">
+      <statement statement-id="ia-5.1_stmt.b" uuid="8dd2366f-ce4e-4db9-b1fd-58a4d1d4a41f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8875c1b4-2c28-439f-9b84-0a4db53b1492">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce an organization-defined number of changed characters when
 new passwords are created, the following configuration checks must
@@ -2570,8 +2570,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="8f63f0d9-e3ec-421a-8ee7-5e3f0c0f6181">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ddc9d774-a4e4-45fa-ae25-6bdd86963164">
+      <statement statement-id="ia-5.1_stmt.c" uuid="cc03a041-5186-4aa0-96ad-f42d584e9368">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="270f0523-2ebf-4480-8bfb-61cdbea05151">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure passwords are stored with appropriate cryptographic protections,
 the following configuration checks must be enabled:
@@ -2588,8 +2588,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="5c183f39-8636-4070-a86f-9e5131d8e1a3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2ddd649c-4e41-4898-88c0-185b3a5e47e9">
+      <statement statement-id="ia-5.1_stmt.d" uuid="4dd5667a-77f0-4270-9409-6a2fd435cc3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06726de6-106d-4dba-bafa-a0e6ce0819ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce a password minimum lifetime restriction, the following
 configuration checks must be enabled:
@@ -2607,8 +2607,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="39d7ac1c-2721-4bb3-b98a-710779a19a66">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f815abba-9f44-43cc-827e-3688976f6253">
+      <statement statement-id="ia-5.1_stmt.e" uuid="38d30139-07e8-4f6e-af76-37bb36f87e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b22178b-7ae0-4677-869c-c2ceeccaabfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit password reuse for an organization-defined number
 of generations, the following configuration check must
@@ -2622,8 +2622,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="3c9ad7a9-71af-4f16-b5f7-907ecb08ef58">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="28ddc3e3-0061-4262-81ce-1933bdbf1e64">
+      <statement statement-id="ia-5.1_stmt.f" uuid="1e18edde-395a-4ecb-ac69-c36e5ee34044">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3220d521-4fec-4fd4-9274-31a69798806e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2640,10 +2640,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="135a6051-dd3f-41f8-8f57-8c74ceb04c59" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="62607690-0206-4a1e-9e8e-675d8bbb92da">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b3916e0a-1e50-4b82-a523-83fa4b586600">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2652,10 +2652,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5799b70a-9743-4166-98a7-41ceccfe7acc" control-id="ia-6">
+    <implemented-requirement uuid="c18d8a87-a83c-45b2-b926-a81975d8c1d8" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="711d1348-a156-4ef4-9f3e-4981a30653ad">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5c53f4c3-d7fc-4518-ac7e-0ce1483a8bd4">
+      <statement statement-id="ia-6_stmt" uuid="36c5fd33-c3f5-442c-aeb7-6a77f91a8e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="41406028-d256-445e-8e1b-6bbf7dec6478">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) automatically obscures
 feedback of authentication information and cannot be configured
@@ -2668,10 +2668,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d254e658-4ffb-4809-8e63-119063cce9df" control-id="ia-7">
+    <implemented-requirement uuid="ab61d155-92ab-40b5-9e81-9fd9bac6cca1" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="25c0db9f-70fc-41ba-98ca-86b47345318c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e103e52f-99ae-4f5d-b0bf-21626f4c84b9">
+      <statement statement-id="ia-7_stmt" uuid="f3ac9fbd-5915-4c13-bfa2-d780c3775d03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aec0a254-77c0-4a93-b4a7-9b2b04b0f966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -2695,10 +2695,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c24baa5b-ae0c-453e-87cd-7edb3cde2d3d" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="a6fc92b6-a7de-4722-a770-66a0a5815809">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f74a3733-14f5-48d8-8c7b-bd2b7533b2a4">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -2708,10 +2708,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f561b2eb-4766-41b4-bea9-b97105946c9e" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="5927c68f-f521-48a4-b4ca-9fb81ad270a6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b24893f1-bea2-48b0-b49b-91ac264b480a">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2720,10 +2720,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79d1508e-861a-4331-9bef-6364d9381ce2" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="6d1b21d4-fc84-4c91-909b-74d8bd3f7a79">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6ad7c7ed-7c3f-4a46-98b2-ad75f1f8c72a">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2732,10 +2732,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcb4fc86-1388-4ab9-800a-369fe9bddaaf" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="ed9c46a7-64fa-419a-9c86-68954422830a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4bc97a7e-a427-41ea-8484-dd59ac246da5">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2744,10 +2744,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e27c7b3f-508c-4ab0-b143-372e020b6cf3" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="4edc4e36-1cac-4d23-b893-526a26c27854">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="091a2837-4b50-4f55-9a2d-df23af80d97a">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2756,50 +2756,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb43669a-c80f-4c10-be7b-632ab29ee1da" control-id="ir-1">
+    <implemented-requirement uuid="3c9e71c0-58ae-4aee-9155-47fc9e843f65" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="663c822b-f56e-46b5-b6b8-d233e2a1a470">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a8f598eb-0fe4-42b1-9f1c-e5b4dc9a0786">
+      <statement statement-id="ir-1_stmt.a" uuid="d60d6bea-ef5d-4626-aed2-3c3f53698ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="cc19ea4d-9aba-4b13-a300-8a8d112845a6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a5b7c8ae-92b1-420a-99b7-3212586cb7e9">
+      <statement statement-id="ir-1_stmt.a.1" uuid="5e667772-e5d9-4872-865a-48786759926a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="ecc2784c-c630-4fc8-9d7f-d541ca27a6b3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="918bb65b-d698-4170-90ff-124cb17c77f7">
+      <statement statement-id="ir-1_stmt.a.2" uuid="22d201c3-6207-4103-b445-85e8701cebbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="9cf70431-68f8-4ba5-b8dd-5d0f9f402c22">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2985cb50-0735-4627-ade8-f3b265ab0cf9">
+      <statement statement-id="ir-1_stmt.b" uuid="eac06a1c-4b7b-44b6-82fb-ad5cdb54c5d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="790a4bcc-ef85-4b3d-8ac6-b874ff7e070f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="39640e7d-ccf5-4244-ad5b-2af313c0a8a5">
+      <statement statement-id="ir-1_stmt.b.1" uuid="15832489-8979-426c-8fcd-3c70285b37e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="cce9e1fe-3c8a-417b-ae8a-db35e039b648">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2d0bf3d6-de99-4d32-a59c-656ece01b520">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d22849dd-76b4-48af-92fe-6232a9f1a716">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2807,26 +2807,26 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30e41640-ddb7-4324-ac59-38dd93d9c01a" control-id="ir-2">
+    <implemented-requirement uuid="fe524269-e4e7-4d6a-bcf5-6b9543b9ca47" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="26e4d307-636c-4dea-a4b8-671864ee0d33">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bcfac3cf-dacf-46b7-9f7c-c4dcb76364a6">
+      <statement statement-id="ir-2_stmt.a" uuid="5c175ed8-82cd-4728-bcd8-5db6e1308527">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="356700f8-637e-4de5-aaa2-31a0b1bda9b9">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c7acbfe4-7f56-4c5f-99cc-dc121e2078cc">
+      <statement statement-id="ir-2_stmt.b" uuid="a49bf765-58bd-4b2b-b1b4-8e6a41715d1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="3fd20dc2-8c29-4246-842d-ffc233fbd1d1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="89660381-2811-4624-8cf7-cff2062d641b">
+      <statement statement-id="ir-2_stmt.c" uuid="c95c03bd-5f95-4c91-b3ef-55844a695d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2834,26 +2834,26 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="817e66b7-dfd0-4324-b757-88781d8228a4" control-id="ir-4">
+    <implemented-requirement uuid="eb33911c-d4b4-4191-aeb7-67ac9fe7707d" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="a4232023-5094-46d2-a882-18fa67c5a360">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="cad79360-9b84-417d-bdb6-e3b1256fab92">
+      <statement statement-id="ir-4_stmt.a" uuid="33dcbe65-c67f-478d-8137-9eeaf2f74dc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="33b839b4-26e3-4607-b14c-52e4147da972">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="238c6858-689b-473b-a2bb-7dbd961655e3">
+      <statement statement-id="ir-4_stmt.b" uuid="294e8fab-9f0d-44a5-ba1d-03d9c54033e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="e50d2a38-421b-4060-91e3-b48d3e49702c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1b779e95-6c6e-40a9-ba38-77115f64acc2">
+      <statement statement-id="ir-4_stmt.c" uuid="54af38e1-84c6-4c32-a8ab-cae687194130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2861,10 +2861,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aefcf82c-4f3f-4661-b4ae-7bc714955db3" control-id="ir-5">
+    <implemented-requirement uuid="fce171fa-933d-4c31-9d91-22db3460611e" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="8a7b4c63-1682-41f3-8de9-d77a297ada0e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b55904c9-7be2-4302-97cc-f0dde2549948">
+      <statement statement-id="ir-5_stmt" uuid="3369b8b2-59b2-4653-9523-e1543e94ea4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2872,18 +2872,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21f3bfd6-32f9-4096-a6b1-84b53bb797d6" control-id="ir-6">
+    <implemented-requirement uuid="89d5380b-005b-4609-bda3-e796d6aa8778" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="bd12f7b3-0905-4a5f-ac79-b617e4a5b43e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6de2d618-fb39-4574-8457-f75267d6d9d5">
+      <statement statement-id="ir-6_stmt.a" uuid="a9f85a42-b737-4905-9ac0-ef0f969b72ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="6bd4daa1-267d-4c8a-9d5f-e83811940e0f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2bedbc26-fdbd-4822-8b58-5aae2e803ca9">
+      <statement statement-id="ir-6_stmt.b" uuid="bbd9ac3b-10ed-4429-8fe7-fdf26be8fa7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2891,10 +2891,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ccf4c54-e805-4333-ba87-5da2258935dd" control-id="ir-7">
+    <implemented-requirement uuid="e303e930-0cd3-4243-92e5-5192b3845d0f" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="d9474364-9c34-4954-a2b7-a5ec50c22bde">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="576c0e39-315a-465e-b55f-0eedc48ed011">
+      <statement statement-id="ir-7_stmt" uuid="047a743e-e421-46e3-87dd-0b3424dc85e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2902,114 +2902,114 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1de0426e-68d7-4156-908d-86583ac5ee5d" control-id="ir-8">
+    <implemented-requirement uuid="595d022b-7ad6-4c82-8934-e3c21903607b" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="53eddb68-bfc0-4fce-87a6-40d52aa8f65a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="662f965f-9bc0-4c18-b782-d73fdf57aa8b">
+      <statement statement-id="ir-8_stmt.a" uuid="69e20c17-c2e6-491e-bdcb-242d01a87abc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="7f1b4043-8f81-47c8-8e4a-a071bc02fe23">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="21eb1bcb-36bb-46c1-8bdf-9a09ae9c7f3d">
+      <statement statement-id="ir-8_stmt.a.1" uuid="72643e28-b35f-4f87-9d5e-53933f812b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="32b4b5ac-a01a-4366-a28b-88cfc48d616d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a031e30b-adb3-48ce-9914-65117ed0145e">
+      <statement statement-id="ir-8_stmt.a.2" uuid="4e5c7d57-2f90-45be-9f74-bff226c173fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="6d6abd7c-871c-42b5-96b2-87022336b3b7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="28a9955a-9787-4df8-80be-3bcf56f37017">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b619e512-1860-4e36-be97-0fef26fa3fdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="20ccd59f-227c-4a25-b415-3174217a30b9">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6ef917f5-3fed-4016-a742-a80f387478b8">
+      <statement statement-id="ir-8_stmt.a.4" uuid="496784e7-2932-4245-9d35-6ca30e7a4996">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="f4cd4971-e5ef-466b-9b2d-1fb56739f975">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c2e7dece-637e-44cd-8140-c1909c02bbc3">
+      <statement statement-id="ir-8_stmt.a.5" uuid="b0be9941-f831-4d53-8707-163badaf2954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="187edad2-a54c-44a1-8ea4-a2f6052ae3dd">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="acc9c621-a1df-46de-b226-532dd93e3ad2">
+      <statement statement-id="ir-8_stmt.a.6" uuid="e7fadd37-8831-474b-aac7-04f508f585c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="17973947-3621-4cff-ac07-8c7be85082bc">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4804ef2f-f1ce-46e8-a59c-3f03830162dc">
+      <statement statement-id="ir-8_stmt.a.7" uuid="508aefd4-b732-4beb-81b3-25d1c8af57c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="9073acf2-76bc-4cb5-9372-873ad1cac6d2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4fe3b102-d12e-455c-a75b-be7102f3756a">
+      <statement statement-id="ir-8_stmt.a.8" uuid="96e9806f-4ed3-4202-9c93-14662e29113a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="755525a9-2f70-43a0-bbdb-0980ae6d2241">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2df07b39-9364-4f6c-b159-d9319a2351d4">
+      <statement statement-id="ir-8_stmt.b" uuid="dd657902-cbc5-4ee1-9120-98366b9741f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="a2017609-7c13-403f-9941-3a400d18f05a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="603743d0-02e8-4b97-b135-08b6c321c057">
+      <statement statement-id="ir-8_stmt.c" uuid="749989bc-d4a6-4954-b414-067ab2efdd4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="36c54907-7f5b-482c-9ec5-2d28fe18b220">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3250a84d-184e-4ecc-9614-535d1002f4b4">
+      <statement statement-id="ir-8_stmt.d" uuid="592206a3-a940-4153-af52-1643c347f726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="81a2db37-1974-48a2-b0b0-12673cfbb038">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="935dcc0a-3013-4673-9a05-a1fdcadec2d2">
+      <statement statement-id="ir-8_stmt.e" uuid="25670e9a-0193-4bd2-b298-40527001f551">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="8b3a6c39-2350-4e15-a92a-ed6cd095d2a6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="24e5941c-189a-4cfe-aa4f-3bd2294e900c">
+      <statement statement-id="ir-8_stmt.f" uuid="ec849266-6579-4265-b734-c8cd7b749d3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3017,18 +3017,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e72047b3-2fd8-4428-937d-29a705a3f941" control-id="ma-1">
+    <implemented-requirement uuid="7c9f8c2a-701a-4f18-8625-edcdf7ca4e86" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="daf36b78-6675-4ba5-9e22-089064219c34">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="37a6610d-8667-46c9-a674-cb3e8f2e1d57">
+      <statement statement-id="ma-1_stmt.a" uuid="52b9031d-430c-4473-8a5e-e1d2b013e31e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="f859f4de-e54b-415b-b054-0d7222ca732d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="72935d46-782b-45fb-b2fe-4a29ddc483ac">
+      <statement statement-id="ma-1_stmt.b" uuid="c132478d-5909-4718-9289-4415db12ef5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3036,50 +3036,50 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2522faf3-2d49-455d-b156-727292c00c23" control-id="ma-2">
+    <implemented-requirement uuid="e7d5b680-e4ac-43c0-a574-5cff41e6e337" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="3f22e392-aab7-4d45-8271-a38fa57af5c3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="debd8a1f-2bdc-4d5b-83d2-1426b1a4378e">
+      <statement statement-id="ma-2_stmt.a" uuid="fc868847-1f7d-46d8-bd2b-22a040fa1ccb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="bc0c5e26-c44a-40db-9946-59db2975c19e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="cfb5163f-48d0-4756-b778-f753ce878dee">
+      <statement statement-id="ma-2_stmt.b" uuid="eb1ccb7b-8606-4e45-9dc4-79be60042561">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="ce2e8b8e-3af1-4231-95f8-2baf8fb05e6e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4050f62e-8f9d-4b4a-a531-27440a878d84">
+      <statement statement-id="ma-2_stmt.c" uuid="8afdeac6-75a2-4306-abd2-27724886daa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="49322a81-cab3-4d20-8bad-5cc79efc5918">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5eca70a7-8da9-4e5a-bc36-01989d86e79d">
+      <statement statement-id="ma-2_stmt.d" uuid="a3cb1b26-cd05-4452-bd93-47b66ad9fb81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="5b610b91-bb12-4186-b349-b8161163a1e1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="defef0b6-05d8-473f-b592-03ab25917afc">
+      <statement statement-id="ma-2_stmt.e" uuid="6b15fd53-2caf-4fa0-aa59-1bdc627c30cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="13590a99-cfe8-447f-90ff-c7dd62c05543">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6e93bff9-d5a0-4558-99ec-62b8a75f5c65">
+      <statement statement-id="ma-2_stmt.f" uuid="e745b580-12b5-4aaa-922d-8e7b5f5b2453">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3087,10 +3087,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6da6875e-07ff-4ba8-adf3-5b8473f2158f" control-id="ma-4">
+    <implemented-requirement uuid="341bf661-08a4-4d3d-9efa-713d218238a9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="46cf0dcc-42c8-4f9c-a02c-2bce7260f81a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4f5ad84d-e0e3-4385-a80c-90db44b065de">
+      <statement statement-id="ma-4_stmt.a" uuid="21dc58c8-d1cc-4ce8-8ff4-3c999f643ade">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca007b9b-ec78-4a11-8803-478f5cffbb74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), all
 maintenance and diagnostic activities are monitored regardless
@@ -3099,16 +3099,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="ccf15ec3-8b76-4ab2-9c7b-883d5a1b0955">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9ed38647-d844-4514-b930-3b12f19b01e5">
+      <statement statement-id="ma-4_stmt.b" uuid="3e8c5061-7e35-4d70-a900-158e219ff89d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="f296e9d3-5d26-4ff6-b144-0b78bbe5c27c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4070b52b-99f4-4b09-80b7-1b47fc939ba9">
+      <statement statement-id="ma-4_stmt.c" uuid="07ae523e-199a-4c53-9489-200e1bdad128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70054354-f7b5-44f6-88d9-e6568d0b9f76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -3120,8 +3120,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="44985a6f-8d8a-4809-b062-73842ccc8e89">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="deae41cc-50f8-475c-aa6f-5d071847f012">
+      <statement statement-id="ma-4_stmt.d" uuid="b840c898-0971-4def-b4b2-70d9c16498b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd48cd2b-50b7-4966-af6b-5ea602bb5dd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -3133,8 +3133,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="ede256e2-3d92-4602-aec4-596e555e8781">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fe6984b3-7180-4e8c-97a0-c1231b97b9c2">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -3143,10 +3143,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="84a252f4-0a4f-49ef-9cd2-5630d8ee1d34" control-id="ma-5">
+    <implemented-requirement uuid="ba2b169a-d9fc-413b-9721-59b24d50673e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="393b6403-86b6-47c9-8afc-b7068a26e21c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d2143e77-888f-4fec-9a92-74700fc7b432">
+      <statement statement-id="ma-5_stmt.a" uuid="9110044f-ebcb-4758-b9f6-6698655348a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="868f382f-1e5f-4e6b-95a0-b3e1db5ecf1b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -3154,8 +3154,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="60e71497-27df-4c7f-8261-44a9d0d8db64">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ec1f4765-74d5-47f1-8aea-27421eb1a068">
+      <statement statement-id="ma-5_stmt.b" uuid="d2680ea6-9c2d-4919-bcce-2c3bd3eb8bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d98e3fd3-fd5b-4ee7-b6f1-f96163ec9435">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -3163,8 +3163,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="035c870c-a9d6-4a35-96fe-e783d888e81b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="28e0cda6-c384-4f92-91af-bbbdd0f8dead">
+      <statement statement-id="ma-5_stmt.c" uuid="e65d432a-7ccc-401d-a0ae-68733d89f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cde3adab-8e3a-4373-b7a9-64953d4cdb4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -3175,18 +3175,18 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a06b2fe4-1e07-4073-9988-ee0ecdc1bc13" control-id="mp-1">
+    <implemented-requirement uuid="b91b9414-6da6-446e-beb8-a29c64afc3d9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="5be4afd9-d8ed-492e-8b3f-7052580d7582">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="84ebc071-b096-463f-af16-97667de5e410">
+      <statement statement-id="mp-1_stmt.a" uuid="649b7dba-34c3-490c-b299-1ea3b7164cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="d9f9fa97-58c6-4396-9266-7ec5c96cb6a6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="faf7ba66-a2e7-4979-b453-6269c530cad8">
+      <statement statement-id="mp-1_stmt.b" uuid="14175897-bb69-4049-97db-483e77f3048c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3194,10 +3194,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93b51fe1-8396-49b1-ae60-f0344f9e0679" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="66131a31-7e43-4617-8904-b89ff0388a3d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fca70fe5-96f5-40cb-a02e-d41380c76001">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -3206,18 +3206,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0184021f-5010-47a2-96c2-ef6901cc4dbf" control-id="mp-6">
+    <implemented-requirement uuid="0e80f605-dcc6-4658-9018-a4e5c1aabd8d" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="248f64c0-59cf-4b8d-bf3f-f679717b366d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e53f1de4-419a-4674-b629-c518af1d67e0">
+      <statement statement-id="mp-6_stmt.a" uuid="bf42d0d5-594b-4fc2-b39d-c6f4203d9460">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="96bd7581-ec98-421f-8123-c24dbb56c12b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="92234ca6-a186-418f-b570-6b5da69293fd">
+      <statement statement-id="mp-6_stmt.b" uuid="4e9e26c0-e2b3-4333-be22-3d8c99c37ff1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3225,10 +3225,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b57c65c-6689-4bde-80db-17eaee11a3e9" control-id="mp-7">
+    <implemented-requirement uuid="88e879dd-d8fe-46a0-a2d5-85902d1dac8d" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="332f3a46-6f48-476f-99c2-67696402ca91">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="191ba700-0b52-4b7f-9357-e5828c33540f">
+      <statement statement-id="mp-7_stmt" uuid="b119f2f9-a732-4f58-92ef-b726234503bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac911b73-894a-4f8b-8d0e-77429aee0a8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Host (RHVH) nodes, the following configuration check must be enabled:
@@ -3249,10 +3249,10 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98c4f5ed-7080-4c1c-a4e7-344c93a9f8c6" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="0c88e7ca-7802-4ae0-8106-b88ca6d706b1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="88e10dcd-5598-40ac-9e4e-c841bd1f62b4">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -3261,8 +3261,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="33a4b6b0-1d8b-4944-8d29-8c3029955ad7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c2703afc-44a4-4d7e-80a1-637f52c17481">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -3272,10 +3272,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf420b30-36bf-4453-ab0d-35b8b06edc49" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="48ed4765-39dd-4404-ab44-cdea58011712">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9b5decee-96c6-4342-bee9-eed25c71f16e">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -3285,8 +3285,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="c9324ba5-bb73-4c2f-bc3a-e789fe093e43">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c6d59d89-28f5-41ef-b6c6-4d23f8fcfde6">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -3294,8 +3294,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="88025ec6-d8a0-45ab-868a-80a47c31b708">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e2052281-e554-480e-b7ec-a71d0248cc2d">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -3304,8 +3304,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="db4b779d-4350-4148-bc74-b6932a5ba7d4">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9d1d3db7-c369-41b1-bf93-e8a0eb94c2ef">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -3314,10 +3314,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a690f624-0e09-46be-9e4f-5a76110a24e9" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="c71c992e-70d2-457a-991b-2e6186dd4e54">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3e2d0782-d478-43bb-a9df-049fd6ece4c1">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -3326,8 +3326,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="97833263-1bb1-466d-b728-fe5ab209947b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3d4a4df1-7934-4371-8bda-26ada856202f">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -3335,8 +3335,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="1bdf6e2a-5c33-4f64-8e36-5a02261e583d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="361f96ba-e232-4a56-99a9-9d9325250c26">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -3345,8 +3345,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="1951d17d-5dd4-435c-8bc5-31745ec9ea3a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="793b6b4c-74b0-41dd-8c3e-b38c91a089f3">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -3355,8 +3355,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="5e7f8f50-1969-4d20-a5b6-d5ecc3e72ee6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4ae3cd00-a604-4fc5-a07a-21913bf9e09b">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -3364,8 +3364,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="e6966d4b-bd22-445e-b76d-e896051c4e64">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8e47ab68-edf8-4805-9445-d748554fe150">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -3374,8 +3374,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="675f4a21-3f15-48a4-bbe4-71e2b3c58a8c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="11f64fd5-6e7a-4b2c-b0a1-6fcfcab200e5">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -3385,10 +3385,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09257a9a-c19e-4a53-b603-6460ab00e686" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="cfaf303d-f6fb-4fb8-8e95-c9c94661c378">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="898d0f71-c692-469c-855a-f821c6f76c4b">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -3397,8 +3397,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="c672b0c9-c61e-4402-a9a8-83eb999d6dac">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8ff37121-2511-4b19-844d-15810c3cae47">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -3408,8 +3408,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="4c8c9af8-63d3-4bf6-a541-15f4bca2bc33">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4468d333-ac22-405d-8c61-3ded51e65c06">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -3419,92 +3419,92 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8195768d-d8da-4d88-bdfa-4f11aee85fbd" control-id="pe-8">
+    <implemented-requirement uuid="8e522774-5721-4589-a4b5-6846ec925da4" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="c8632ea1-8b21-44b3-8c72-bd33804732a2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4dcefe4c-918e-48bf-aa1a-649488a8570d">
+      <statement statement-id="pe-8_stmt.a" uuid="16b1bbc5-1c36-4de8-9af2-fec6a50db9ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="d164736a-bd7a-456c-a6c4-58097a7d9afb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="de01cf95-ffe9-40af-ae75-44f28fd57a49">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="1afc3395-dd4b-4b36-beb8-4f6c98f05f1c" control-id="pe-12">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="24b73ff8-ac8c-470e-be93-a2e86e484e19">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c9b829fd-e5fd-4143-8eba-92eaaed8f60a">
+      <statement statement-id="pe-8_stmt.b" uuid="ed894004-a8b5-40f3-96d0-ceaae4188dd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2967016-3c4b-42da-8a3a-944ccbd2d4ac" control-id="pe-13">
+    <implemented-requirement uuid="73a0b14e-7660-453a-94c9-9545a21b0b64" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="4b9c0313-8aa1-436e-8fe6-2f7ad641b768">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3e9f1afd-b0bc-454d-acbb-5da24b153adb">
+      <statement statement-id="pe-12_stmt" uuid="d6f29b84-d877-4288-bfda-3ce09c52f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f49447a6-8442-4359-9dbf-1fc39b708503" control-id="pe-14">
+    <implemented-requirement uuid="989d3380-0745-4b3b-ba40-59fcf7bbcd79" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="aa6fd4ed-0472-4591-8d67-0a9326adce30">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="05889e3a-af26-4cec-a0c8-3c3211e82c79">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="661e5395-82ac-4846-88c1-bd75be1ef91f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2826edb8-cbd0-4062-a739-9591723b05e1">
+      <statement statement-id="pe-13_stmt" uuid="fbff0cdc-a8cd-4396-9381-591253c01ada">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="261e9587-05cc-48d0-a3a7-6a7ef02ffff7" control-id="pe-15">
+    <implemented-requirement uuid="88c69622-6688-4c1a-989c-90ca905211a9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="398a7524-cb8e-44b5-9e05-b6d032750eeb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3a9138c8-90d6-4cb6-8075-f4629a6199f3">
+      <statement statement-id="pe-14_stmt.a" uuid="97025072-163b-491e-9317-a91790d40ea4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pe-14_stmt.b" uuid="c8b7b3db-7476-47c1-846f-f1bb83c24553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e2bdd5f-dd61-4797-9d60-396433d7238c" control-id="pe-16">
+    <implemented-requirement uuid="54c1493d-b77b-4b0f-9764-526d33b12d01" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="d0ec18dc-15a5-4264-8e3d-9385ab393202">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="912fa795-e1bb-4689-8fde-f669643a5965">
+      <statement statement-id="pe-15_stmt" uuid="76e4fbe1-5df5-41f2-80cb-df66c1fbff2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="620a269a-75e4-40d6-b265-6776398ea00d" control-id="pl-1">
+    <implemented-requirement uuid="8273106c-975b-47bb-8ab8-c7fa37dc5bb9" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="6e466828-e819-4dd9-8f81-b96ba4ec7b98">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="287cf311-f613-4f75-99d0-47b5e1c952ae">
+      <statement statement-id="pe-16_stmt" uuid="1a6e18f3-ad4b-42ed-a48a-f97d8cbd6f3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="0e82974a-1e5e-4803-93e9-61175640b5c7" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt.a" uuid="45dde084-83b2-4d2c-93b3-1409bd7dbb04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="3ae000bb-d110-4da3-87c8-c22b5092d2cd">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="44102209-4065-4cd0-ae12-7c162d8e3a93">
+      <statement statement-id="pl-1_stmt.b" uuid="584ebb6c-020f-483f-ab68-44fc7883c9a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3512,42 +3512,42 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87235750-38b8-45d6-992d-ab5b974e077c" control-id="pl-2">
+    <implemented-requirement uuid="74f5010a-cf8a-4d6d-a7d6-faf6af0a04d0" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="d92722cb-3e92-492a-bb0b-246abe7aab0a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b1b05e8c-d0f1-4f43-9372-7f49fdf80a9a">
+      <statement statement-id="pl-2_stmt.a" uuid="ef7e6239-22d4-4606-93a4-a629e9f064f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="c9756547-6ae9-4ebf-8800-5ed96e29241c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9f6f6291-ab38-449c-89a5-7e9d7684c838">
+      <statement statement-id="pl-2_stmt.b" uuid="ec903918-36fd-4c0d-aeb5-0eb0c456e85e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="5f486da9-5566-4f84-99a5-0512f0cc2206">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="71074ba2-f886-4ca6-903d-562bc11fa3ec">
+      <statement statement-id="pl-2_stmt.c" uuid="12b3e99c-6844-4dc6-9e4d-8ca775ebe9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="4b57c1fd-aaa8-4b7a-8bcd-8a9fce0b36f0">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2583ef93-c13a-4a00-9bf5-e03321641acb">
+      <statement statement-id="pl-2_stmt.d" uuid="7e2dbc92-fa11-4993-a43c-905b59ca13bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="9ee166a2-6976-47ff-819b-9700ebe21e22">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="99612ab6-3ed3-4d72-a895-24e2fbcf23e0">
+      <statement statement-id="pl-2_stmt.e" uuid="538fc076-02b8-43d4-9f18-ab19099afc2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3555,34 +3555,34 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51011c47-524a-4abd-8836-4b1e3f600f37" control-id="pl-4">
+    <implemented-requirement uuid="0c0db8de-aaa9-42d8-b3a6-9b3471138c3a" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="d1de668e-6038-45e0-b404-5aef428265df">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ad215c0b-97cf-4f6f-aa02-ec08c62bcba2">
+      <statement statement-id="pl-4_stmt.a" uuid="2b08835a-92bb-4eb1-899a-3f7aa979d943">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="e2b0663a-2ee5-492a-b1a8-313747fda773">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7d7d5ce7-dabd-4cdb-b26b-8b5a4ad83973">
+      <statement statement-id="pl-4_stmt.b" uuid="f9ecc899-861e-4122-b0dd-c19d20c60e3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="2134a2bc-58a6-443a-beaf-9229593e48f3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b0f188a6-0716-47a8-971e-33ec044f05e9">
+      <statement statement-id="pl-4_stmt.c" uuid="f13de092-1212-4991-964c-2228d884171d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="00d72c44-b08c-43e8-9ab8-703532f3f2d6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="599d0348-a98e-4781-ad13-e9f2530d00aa">
+      <statement statement-id="pl-4_stmt.d" uuid="acad6217-b1e6-47b9-9aae-36a8b4baacf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3590,10 +3590,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2fc0d08-79b1-40d0-ac47-986cfeec5f23" control-id="ps-1">
+    <implemented-requirement uuid="84fa0851-5291-4f57-b0da-86a38d7f2982" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="84c25617-2d1e-4b84-ba0e-606189c8fc30">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="51396eb2-64bd-4820-856e-f73711e85d1f">
+      <statement statement-id="ps-1_stmt.a" uuid="9213924d-1488-4be4-bd6a-cc5efa99876f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3601,8 +3601,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="23f0b9e4-bbf8-46a9-bb04-d8c400663671">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0057df87-f4bf-44f1-b56e-1bfa63ce9983">
+      <statement statement-id="ps-1_stmt.a.1" uuid="da2613d9-5c1a-47ec-adb0-ebaad4ce9c16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3610,8 +3610,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="fe3b70d8-19c3-420f-97a8-9558aa17c605">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="41f34625-0592-428f-87f7-fea497a1917d">
+      <statement statement-id="ps-1_stmt.a.2" uuid="1efdb8a1-467f-40af-a50e-1cdf32e1e90e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3619,8 +3619,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="21d6c112-5b17-4181-8f7f-6baa2280c131">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="68d4aeaa-fd5f-4161-94de-8689c1fe2d2c">
+      <statement statement-id="ps-1_stmt.b" uuid="f30e92b7-4e27-4c5c-a3c6-8350752dbcf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="115ee815-286c-4c88-a826-6b98653cc1f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -3628,8 +3628,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="8819ebe2-254c-423d-b45d-4c8b9feb8509">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="79b2744f-3401-48af-92cc-0ed99e7f6ffb">
+      <statement statement-id="ps-1_stmt.b.1" uuid="cc3171f5-1472-46c0-b23f-2d94cb548882">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3637,8 +3637,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="fb4e7e6c-b6b7-47d9-8acd-f88ce93d281d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b90c455c-cc14-4d5e-b561-a31da8053ac9">
+      <statement statement-id="ps-1_stmt.b.2" uuid="3c05a938-986b-4b8a-ac65-8e4baaadebfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3647,18 +3647,18 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a06aac6a-a011-43e4-b279-f29143a4bfc3" control-id="ps-2">
+    <implemented-requirement uuid="e834884a-c809-44c5-a9f1-79134132c383" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="3b1c3335-fb87-4cf7-a347-d7da81b2eec1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b6d12489-ceeb-4f5a-942c-f9565cd3bd32">
+      <statement statement-id="ps-2_stmt.a" uuid="8d06a4af-de17-4158-8055-d34a8cace546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13b7d353-e385-42fb-9e2a-e61c6b0879ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="4e42b419-d391-4841-a25e-ebaf3a10c705">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="758f3ba2-36be-4b74-a16e-686f468b80da">
+      <statement statement-id="ps-2_stmt.b" uuid="b05c1d64-086f-4bc9-88dc-7f04768be288">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92e499d3-e65d-4b2e-a421-4af961b84fdf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -3666,8 +3666,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="9f71ada5-85b5-4a1a-b1d6-54e1398472a8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="570452f9-d06e-4377-ba81-6b440bcfce31">
+      <statement statement-id="ps-2_stmt.c" uuid="f9e0ef0b-25ba-4a88-ba45-bf8ca190ed05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e3f2232-2b16-4ba1-bf6f-e674b556db84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -3676,10 +3676,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf41bef7-39a9-44ac-bfb3-bbf4aa4ceba2" control-id="ps-3">
+    <implemented-requirement uuid="89fd10ff-caf7-4598-b7ea-7d9ca1e5cd7c" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="8dc09d5b-d9bb-4ef0-b47a-b391e9c00ad8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c6a18cee-6d8b-44fc-be51-e5748df2811e">
+      <statement statement-id="ps-3_stmt.a" uuid="a619cc9a-42cf-4af9-a620-42c536650484">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3873dc66-8e97-4c5a-a184-83b4cd93f73c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -3687,8 +3687,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="0038a00f-1772-4c8d-89b8-9fd65b505749">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e28510e8-4b32-4bf3-81a6-b83f81d5df37">
+      <statement statement-id="ps-3_stmt.b" uuid="dd01c751-379c-4a36-a81a-db402d39ce38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c7bde33-4798-4c3f-aeec-b5365aee9a50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -3699,10 +3699,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c7167ac-44bd-4d7c-a935-3caf50a6da83" control-id="ps-4">
+    <implemented-requirement uuid="612a0c80-52c1-4f04-94e2-d18b940dde95" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="1ca121c6-4c40-4bdb-be26-61a9a4edf2e4">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f6f84f62-9c5c-4779-963b-73c6c6f5eaf0">
+      <statement statement-id="ps-4_stmt.a" uuid="8f5ab02c-a8e1-4678-848e-34d79fdfaa4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8adb751c-8bf3-4e25-85a5-c0994cb40d6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -3711,8 +3711,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="b1c81012-efdc-4cbb-88d0-5eec9e2b7213">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7763b689-18dc-405c-a619-7eaeb3c281c1">
+      <statement statement-id="ps-4_stmt.b" uuid="3f61a87d-9371-4b96-82a5-6fd30a3f6f74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39706fde-a5eb-4dab-8aa6-7a01c74c3691">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -3721,8 +3721,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="2cbc44da-310a-4559-aaed-a08a8bf447d8">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7d0d99e7-78f2-454c-875d-ff54e848b86c">
+      <statement statement-id="ps-4_stmt.c" uuid="de300ea9-b5c7-4ffb-9930-6f4ac2a2bca4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75c9f933-0fd3-4d95-8865-0ccbc03cd6e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -3731,8 +3731,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="c088ecee-1480-42b9-a38e-55cdd1e1e7e6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5e660428-45a5-496a-8008-f407e7ae59e2">
+      <statement statement-id="ps-4_stmt.d" uuid="591cec48-d427-41d7-804a-efdcfd2bbd06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf7eb54d-a450-46f2-ad69-ac1984b55eda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -3741,8 +3741,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="4118251e-24a4-4521-b762-2650652b5960">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b018deb6-9f24-4903-9026-e206be0ce53f">
+      <statement statement-id="ps-4_stmt.e" uuid="7ee3cb63-1f1b-452e-93aa-a6f2a5d9f985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93634a54-407f-4527-9a28-e2d7210c0520">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -3751,8 +3751,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="152bde55-e341-4b34-8fd6-3e55815f2e18">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c77e9a2b-1cb6-440f-9d85-6c8c80fad4f4">
+      <statement statement-id="ps-4_stmt.f" uuid="360cf1f6-2876-424c-ad24-af3a67054b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3591532e-af31-4580-85cf-551c084ed643">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -3762,10 +3762,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1553626-bd4c-42bb-828c-61490890c3c6" control-id="ps-5">
+    <implemented-requirement uuid="0c906102-fa0a-46f0-971b-8f1e2edc9ff1" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="9cf63b65-7722-41b5-a3d2-82b42874a1ba">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="26dc419b-c830-47b1-a38c-65fbe08aa60c">
+      <statement statement-id="ps-5_stmt.a" uuid="dac52aba-aacb-4a15-924e-4dcc42c6b3b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0ef460-d521-416a-b989-1d90f6d2d657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -3775,8 +3775,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="6fdca8ce-4513-40fa-a39e-f257c8b72162">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="287ef687-21ad-4fd2-863f-6ef76e010887">
+      <statement statement-id="ps-5_stmt.b" uuid="34ef076c-a762-4404-a186-b759ae59e9b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9244b67-8356-459f-99cd-ce8c2c7ba68f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -3785,8 +3785,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="dbf15cc6-e184-4613-8510-11e182688d71">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7166512d-e742-40f2-9345-016bd4b4c94d">
+      <statement statement-id="ps-5_stmt.c" uuid="980c4738-bc5e-4b3a-85c9-d250d4011be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d22bff25-1b86-47f2-847b-a027ea5a7854">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -3794,8 +3794,8 @@ or transfer are outside the scope of Red Hat Virtualization Host (RHVH) configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="eddf6c23-1742-4cd1-89d0-ea1189229264">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c8f01812-6ab4-40d7-aeec-c96fbb13d57e">
+      <statement statement-id="ps-5_stmt.d" uuid="9f87a8d5-3677-494b-89dc-92b8c83f2351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f15c433c-50ca-4da9-91d4-ee59dac63996">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -3804,10 +3804,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a96ae8b4-4aeb-4e5b-915b-9fe4e2776e85" control-id="ps-6">
+    <implemented-requirement uuid="970d4ceb-dea7-423f-83b9-a7dc36452960" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="2f2a7854-dd07-4ce1-8efa-06e588952b67">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4119f391-b297-4f68-83e8-52642ac0ec7d">
+      <statement statement-id="ps-6_stmt.a" uuid="83ed6df6-c2b9-467c-81d3-f4e8daf86d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14d8f40d-e8d4-4b52-8d15-c567f239a9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -3815,8 +3815,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="a6d5a48b-b3b3-4cdd-97be-7312c28ddc3a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="dbd67032-27a9-48e5-b4b9-3fc8610d9e0b">
+      <statement statement-id="ps-6_stmt.b" uuid="d504491c-ff57-46ea-b170-d3bc4b8495ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="231b3495-646e-4034-abce-ae9880df32f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -3824,8 +3824,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="1f034704-b3db-43c4-9e2d-155bdfbc0dfb">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="eedb1db0-64bd-4167-9c49-e26032775336">
+      <statement statement-id="ps-6_stmt.c" uuid="56333d1e-033c-4ed0-a411-f6740b9d1d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3833,8 +3833,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="fb05f2a3-650f-483f-b753-127894a6f9fc">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2f2cbf16-9d67-413a-aa3c-1c6387b944c6">
+      <statement statement-id="ps-6_stmt.c.1" uuid="4fc4f46a-b906-4e46-9cfe-431d1c12c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3842,8 +3842,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="19fcdbf1-7b10-4895-94ce-1f6d86f2b92e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="95facd08-e66e-48b3-927b-03f1e25e69ae">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d70730a3-b03d-4fad-b388-ac103cc47677">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3852,10 +3852,10 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="259491e3-0089-4451-8729-f2377f7e96c3" control-id="ps-7">
+    <implemented-requirement uuid="fac24704-d248-492e-9bd8-a0c280f2fc1e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="67a93329-6d33-43ae-84ba-7ed9b7396527">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4b307b67-0630-47c9-a1af-2fb65a63661b">
+      <statement statement-id="ps-7_stmt.a" uuid="b7c98a12-b8b8-4851-88e9-e2f9ab7f5804">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96520830-f9ad-4d71-bb04-d5a410cb455f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -3863,8 +3863,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="31a92083-327b-4268-b39a-b942eadd5c81">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="baf32d53-df4f-4322-9314-78607c54e396">
+      <statement statement-id="ps-7_stmt.b" uuid="fd580b3c-1de7-42cb-b66c-7ca16e2f962c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f901d41-b1b8-410b-8e4e-ccd4ca080dc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -3872,16 +3872,16 @@ the organization are outside the scope of Red Hat Virtualization Host (RHVH) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="a4ed0a02-4c9b-494f-9911-43cd3ffb651e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="45b514f8-6374-4bd9-bc52-5da7fb02611e">
+      <statement statement-id="ps-7_stmt.c" uuid="5dec03dc-dd4b-4505-9bd9-5ef5deb78d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4ee0740-bb4c-463e-9a82-3da7afc81ac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="47c15991-695a-4d50-b03e-c7c29baec8b3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a2eae8d8-5de9-46ca-81db-827e3b0913c4">
+      <statement statement-id="ps-7_stmt.d" uuid="6a3a7403-eb49-4e7e-95a6-ad9013979d87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6659f23-ba9e-4232-a865-05ec205d1d46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -3892,8 +3892,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="2732b1ca-9579-4979-80f7-e9d2c1dc39f2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="af59f959-31fc-44f8-955f-cc64a975d195">
+      <statement statement-id="ps-7_stmt.e" uuid="1ef73a4d-839a-4b55-b11b-8257bec2fd45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3eebad91-c8c0-454c-bf7e-6f0a8d0fa4c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3901,10 +3901,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a3d4799-f5b8-4511-9714-c1c355ff8a90" control-id="ps-8">
+    <implemented-requirement uuid="c1618cd0-ecac-4cc8-8ec7-2f1554f45d1c" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="4f9cf974-c2cd-4287-9e71-1c74ac8cc472">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ea0adc51-0571-418b-84a4-aa88ac716dc7">
+      <statement statement-id="ps-8_stmt.a" uuid="b6e8dc70-4100-4376-b47c-a732a5e6c553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c700116-2ff1-4ae4-bca8-4f1c9fbefbc7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -3912,8 +3912,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="92c25964-2e7b-4bb4-a3c6-1e146811fe0b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="efb0989f-5e3c-412d-b2c4-3715f378f7cb">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -3923,10 +3923,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="494d728c-1e8e-4281-af29-b15e364e154a" control-id="ra-1">
+    <implemented-requirement uuid="bb9c2283-c424-4c07-af4f-a28d0e31d667" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="c7240664-3925-44e4-bd89-4ef64b86a56a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7465b7e5-9b18-4a1b-9070-2feb44611670">
+      <statement statement-id="ra-1_stmt.a" uuid="ffcde792-2e83-4d79-8eb8-c1fdd1914001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3934,8 +3934,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="287d70e2-b100-4929-9095-1e5d05970a17">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="02f2a2bb-e0a6-4043-a50a-33e78a35109c">
+      <statement statement-id="ra-1_stmt.a.1" uuid="ac25bf60-f6fd-47e8-aad1-3ad084f6fb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3943,8 +3943,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="d76f1723-edfa-4a72-a7de-9c4fd4dde857">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="339ccee1-bb70-4f4b-9ff6-05e3b3d26296">
+      <statement statement-id="ra-1_stmt.a.2" uuid="7c0b8357-7e32-4dee-a23c-7ea5790b9972">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3952,8 +3952,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="f903b3b2-f5b9-4673-90bb-f80e003d9aba">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="421d31da-01d7-4ff1-b85a-e6ca6eb3da9b">
+      <statement statement-id="ra-1_stmt.b" uuid="3658d5a7-8cf5-41dc-83e2-25adfbaf181f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3961,8 +3961,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="0bc64833-e45f-4937-bbae-c9d2d4457a42">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9111a82a-9007-4508-866b-b0ad66194f6f">
+      <statement statement-id="ra-1_stmt.b.1" uuid="fe8f2864-1648-4a81-bb6d-3a4b8a304fd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3970,8 +3970,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="088f7e4b-cba2-4f57-b97d-19109b85fa7a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9e635d13-5b5a-4dd7-b347-eb6f6b9f8a15">
+      <statement statement-id="ra-1_stmt.b.2" uuid="46ef312b-fe1b-44d1-a414-aa73bf7fc817">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3980,10 +3980,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af0a338b-6c4f-46b8-b177-ae4606473c6e" control-id="ra-2">
+    <implemented-requirement uuid="94569d4b-4741-408c-b03f-7171d11cd216" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="cc13b5bb-1832-4680-888c-da77ede2e122">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="86ca40c4-88bc-4229-b153-f19139fae27b">
+      <statement statement-id="ra-2_stmt.a" uuid="87ae68f6-0ec2-49aa-bdc7-34fb3ba4778e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a20a7b8d-5d92-4463-be70-70921bca333d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -3992,8 +3992,8 @@ guidance, are outside the scope of Red Hat Virtualization Host (RHVH) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="d8b2a106-3aa1-4d23-83f7-8c9679a5f450">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e40edbb6-0e98-4ee8-80c9-0e4be717dea2">
+      <statement statement-id="ra-2_stmt.b" uuid="7ba08607-3ece-4f07-bfa3-2b522fedfd0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1e56041-35d4-47b7-8afb-999d308c6e86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -4002,8 +4002,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="a722710f-44a1-4429-8ab9-e20552c14d6c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4f96321b-f236-40be-8a80-2e2c6caf8d0d">
+      <statement statement-id="ra-2_stmt.c" uuid="e091d042-ce3b-4138-ba8e-1e862ebce5d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d809a202-a485-4fa1-ade4-8e6f49148653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -4013,10 +4013,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47fa591d-5c85-44d9-a3e5-dba4b434c9c5" control-id="ra-3">
+    <implemented-requirement uuid="6acffac5-0e06-4584-893e-5c489d9c432b" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="93af25b1-a90e-42ae-b16b-5a460e1a1b74">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3bbb2619-c9a5-462d-b219-60ec6c83ff99">
+      <statement statement-id="ra-3_stmt.a" uuid="e6303230-4559-4a5f-9af9-68be90981c45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="929c2e09-70c4-4be4-bf68-ae55747ef24b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -4026,8 +4026,8 @@ transmits, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="5f381733-3b73-4f9d-970c-29cbb42f6ab2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="960f0854-f1c8-4c00-be82-445edac3c267">
+      <statement statement-id="ra-3_stmt.b" uuid="7f84310e-5fbe-494d-9beb-a7a2a8b74b6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6de19af8-7c17-4e8e-a9be-72f20f05165a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -4035,8 +4035,8 @@ documents, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="8eda454f-da91-45ef-bdd2-dfe83d985d53">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e77792a3-8559-497c-8ab5-3cfe040ac512">
+      <statement statement-id="ra-3_stmt.c" uuid="3b91cd21-746f-4b5f-8de0-da385081d364">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553933dc-e764-43d3-8f5d-c2227c679f68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -4044,8 +4044,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="5777eb68-63bd-448b-86fa-77bfaeab8477">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2627d9e9-5e80-4510-b4ee-430086d725c5">
+      <statement statement-id="ra-3_stmt.d" uuid="262e0842-f1d5-4688-a504-e22df92a3187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a55ff7e-5b8d-4d09-9c85-eacdf924c0e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -4053,8 +4053,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="bbe75edf-f837-4c65-b8d5-2387a2c87d13">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0e840ea4-81ee-429c-bb26-38ac54513b51">
+      <statement statement-id="ra-3_stmt.e" uuid="45d54b78-4e15-4abf-ab45-1f5f7f4dff0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0be82016-6e9f-4c36-bb75-f1f91f9015ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -4066,10 +4066,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="66050dae-16b9-4c8c-be17-aeef622a124e" control-id="ra-5">
+    <implemented-requirement uuid="1e80c085-6c6c-408c-989d-d37048edd298" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="509bbd2e-b430-4c12-a9ce-f803d50f8715">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f8b97bdd-c401-4390-9646-dfc56cc688bb">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -4077,8 +4077,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="2e898b8c-98bb-4b27-820b-78e3326751f2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e329e913-047d-4b92-8ecf-136de5379aa7">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -4086,16 +4086,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="5fa27db4-e175-4575-9c5b-9184e2cceeab">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="576a2e37-df41-49aa-b6c1-6842e67965f2">
+      <statement statement-id="ra-5_stmt.c" uuid="dfbeeee4-4a89-43d7-8cb4-b213da619959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="81770d25-3b21-46db-bc24-d5bc302eba8f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d013c785-7302-4be2-855a-67e4920ebfcc">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -4103,8 +4103,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="f4a16f5c-e994-42f4-8ca6-49d18c50d1ec">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0cc63ecf-84da-4b9f-8d1b-6d983bf9eee5">
+      <statement statement-id="ra-5_stmt.e" uuid="ec8f09ed-5645-493f-9723-79faa9c9dda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf5bf54f-10e3-4517-b21b-dccfad84b100">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -4116,10 +4116,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10fd68ed-7fda-4bf6-b51b-13f6964ac943" control-id="sa-1">
+    <implemented-requirement uuid="fdfa2836-e0c0-4a53-a520-1cd8fd2d0371" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="404ae80c-6e33-46af-8a81-c282d69bebf4">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1a070959-c772-4269-94cb-ea19b2c358ea">
+      <statement statement-id="sa-1_stmt.a" uuid="da233118-e5a1-419b-8ef9-d74cf88ec9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -4128,8 +4128,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="d2ab0a21-c013-4b6c-83a8-c3a6da167f11">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c59e625e-51b3-4796-9233-7e72fe734b73">
+      <statement statement-id="sa-1_stmt.a.1" uuid="4d4e8f4b-2459-40fc-8a2b-cef39e7a5565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -4138,8 +4138,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="bd03d991-fa35-45fc-93d2-b7292126135f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4222ad74-d79e-45e6-953c-9d4f1d4e2816">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2a8c9751-bb38-4a01-a49b-e9a73fd0937a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -4148,8 +4148,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="a323b4ff-56d4-4a07-9d86-946d1b4e28b5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c6c80615-68b6-47c9-a017-f3d38588fe53">
+      <statement statement-id="sa-1_stmt.b" uuid="b243136b-348e-41d0-a36f-7a01b53932a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -4157,8 +4157,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="040372d0-2ba2-444d-b4ac-3a7b672e4746">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="83ea8eef-2e7b-4882-ab1a-2c5136f75d31">
+      <statement statement-id="sa-1_stmt.b.1" uuid="9339a14d-436c-4ad3-9b60-4289811e48c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -4166,8 +4166,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="ff1ba99c-e407-4649-afdd-f97e8786e6d7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="98fd28d8-8d9c-4b8d-a302-0c0f1b973afb">
+      <statement statement-id="sa-1_stmt.b.2" uuid="e765aa23-fcba-4668-9c64-00191c316f57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -4176,10 +4176,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a536173-cdf2-4842-a7be-80e7490eb918" control-id="sa-2">
+    <implemented-requirement uuid="80720690-1e69-414e-aec3-f6303a2723dd" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="4171453a-6e08-465b-8dbc-52ba49b0f886">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bcaa2843-ff7b-43d1-8c6c-0768c228049f">
+      <statement statement-id="sa-2_stmt.a" uuid="70fbe520-9c80-4883-ad01-032d06e754a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="824db0f4-1273-41f6-8617-9b0796e3140b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -4188,8 +4188,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="1e30313b-c2c1-4f2a-979e-f0c016c840ee">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f7ff7b14-724e-481b-be78-aad7860a934c">
+      <statement statement-id="sa-2_stmt.b" uuid="e2deed58-ac14-44ef-9fe5-4b0d10845768">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e6859d4-0559-4f4b-8d46-01d46a13d3b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -4199,8 +4199,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="dbcd4c27-2b1a-4ac2-a413-0b985c0ce896">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9be6d017-284f-4230-8d25-5b2f19bf5d97">
+      <statement statement-id="sa-2_stmt.c" uuid="1c1599e1-37ac-47cb-9a06-f84758267703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1260d5ad-f1e3-4b2e-81a0-9d05686f06de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -4209,10 +4209,10 @@ documentation are outside the scope of Red Hat Virtualization Host (RHVH) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3ba32dd-8872-4ae3-b6e7-8f19568362ad" control-id="sa-3">
+    <implemented-requirement uuid="5e984ca2-a2a0-4b61-b837-f1f2aef74c43" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="05eba48f-d04f-453c-8b2c-a3fe2fa38e93">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="33efa778-1d8d-49df-ade2-dd26be4f9249">
+      <statement statement-id="sa-3_stmt.a" uuid="a77b59ac-1444-4c7b-9b75-f7504c5dac4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4e3653f-212d-4d7e-b613-cc64927606d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -4221,8 +4221,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="b1fb3b44-502b-48ff-a7bd-710a61c50b6a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c0e76acb-a039-4943-bb61-5f832def618b">
+      <statement statement-id="sa-3_stmt.b" uuid="c2138e4b-f580-46fa-812d-9c695c306382">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f36e31ba-00fe-461a-8f8d-50956846bf60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -4230,8 +4230,8 @@ life cycle are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="5a5c28aa-caf4-41d9-a0b6-300945ad1b74">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="03b95760-6ed0-4c0c-8138-cb2b7bf54a51">
+      <statement statement-id="sa-3_stmt.c" uuid="c57c5c36-96ce-4b82-ade8-71472cfdd0a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fdc08e7-548e-4102-a52e-4afcf59054a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -4239,8 +4239,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="544f8ad8-355f-4c10-becb-fceb9239a8a6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ecdd5290-d170-4f09-a107-3bb24c7623c4">
+      <statement statement-id="sa-3_stmt.d" uuid="834154bc-a9ad-4b29-9da9-689e209e5b9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314f63ca-ee21-4db6-9698-8c9537441f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -4249,10 +4249,10 @@ activities are outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2162c82f-07c9-463d-98e4-489c954d3a9d" control-id="sa-4">
+    <implemented-requirement uuid="7f7ce6f2-a54c-4be9-adb2-cef1cb1bb5cd" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="15b656ae-1936-471f-ab13-0160df4270db">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="fc366484-431e-4448-9e72-7a6992f70c24">
+      <statement statement-id="sa-4_stmt.a" uuid="8477982b-4daf-40d7-a996-90a3f891ea00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aeab4dc1-ee7b-4c48-8886-cc74d87df81a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -4260,8 +4260,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="6dbd836e-1029-40a5-9d5b-ce1e35ae4cc2">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="bae67cd6-650f-4b77-8ae2-70bab5eac959">
+      <statement statement-id="sa-4_stmt.b" uuid="ad50360b-72d1-40f3-8434-0ac78128fc91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d0a219-ecda-477d-a17f-db06df2f54a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -4269,8 +4269,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="ecb25b1a-5f94-4a2a-9fb9-b293ddbcdc10">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b9aae5a5-4e94-41e9-88f8-d69555d3a01b">
+      <statement statement-id="sa-4_stmt.c" uuid="80ad4a69-2f94-4877-968a-67583be09daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78883912-eaad-49aa-b2c1-32077d1b6715">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -4278,8 +4278,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="ad81e4dd-4f5f-438f-92e7-05140f848e16">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4ea43edd-d4a4-4cae-95b9-5f1b07721f73">
+      <statement statement-id="sa-4_stmt.d" uuid="02579e51-d88b-47f5-9856-22fb80fc80cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc18f9ac-4f27-445f-ae6f-615f205fcee7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -4287,8 +4287,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="d1397456-968b-4857-8a49-d62325483407">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3a592a8c-2b43-4086-815e-3e846c73ef2f">
+      <statement statement-id="sa-4_stmt.e" uuid="6dda20cb-aa6c-4e67-b666-aab9c5645d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea03972e-988b-4b12-ab49-176c6bd56b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -4296,8 +4296,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="66ffc3af-5dd5-4597-8956-8e4baa513f26">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6e2a827e-b8fa-48ac-bd37-9f76a7a3cdfd">
+      <statement statement-id="sa-4_stmt.f" uuid="76068ac0-6f9b-4a77-8b1f-e792c6335219">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e5ac5c9-e113-44d1-bb5a-aae2c3300727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -4306,8 +4306,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="3ca322a5-4c28-42d9-a4bb-12123ee1a836">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="ca43307d-1b69-4191-8d02-c428aacbbcb4">
+      <statement statement-id="sa-4_stmt.g" uuid="0390dd8e-4476-4e8e-8f49-ef97ec4cd43c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14e27f1a-92ae-44a1-9a1e-8cb5c2cd6baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -4316,117 +4316,90 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62cd5725-4f96-4a30-aa2b-c717f2367e7a" control-id="sa-5">
+    <implemented-requirement uuid="1075b91a-26d4-45ab-af5e-7efa9804df78" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="09399504-1b40-47c0-84d1-f0fbbfd6ea9a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3bd530fa-a5ba-404f-bf2c-c17c7c9e51a0">
+      <statement statement-id="sa-5_stmt.a" uuid="cae1dc20-dc61-44b5-9a37-62f6f2cb410e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="5a00c887-d67b-411c-ad8f-e35d36c49d83">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d87fac9d-5508-485c-a5d1-ef65d333b950">
+      <statement statement-id="sa-5_stmt.a.1" uuid="99b3a3d4-5328-43f2-a5d9-89f8184c882e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="8cecbef8-4365-4779-aa64-a90e3a9919e7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2fad9860-2510-45d3-9703-fe0667cdc8bf">
+      <statement statement-id="sa-5_stmt.a.2" uuid="537f69f8-4ba4-46c9-be59-efe10637c240">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="54ee603a-c509-4eaa-b98c-d5313ebf0649">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d44069f4-96e0-4bb7-82f1-21b24977eed7">
+      <statement statement-id="sa-5_stmt.a.3" uuid="784f11f5-4b7d-40ac-a76f-58a9fdad9064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="dc24c244-4cf5-48ee-8807-168cb000aa45">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="71a5e55d-8bcc-4f3a-9bc9-7f46b2915275">
+      <statement statement-id="sa-5_stmt.b" uuid="0d18c19a-6577-4de0-a417-58649b39ae33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="ab532706-f4fb-4099-8939-205b8f30d857">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="acc0302b-f5d5-4e2e-856a-e3d2b0d03627">
+      <statement statement-id="sa-5_stmt.b.1" uuid="2935da53-589c-4942-873b-17308b1db3e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="f6e83234-6703-45b0-b09d-0c6861271416">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="73d91cf2-3df3-4c92-8b7e-b4fcdf7a2d49">
+      <statement statement-id="sa-5_stmt.b.2" uuid="59237e65-7285-4421-9360-23c2f5dd49de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="a52745df-befc-45d6-a96d-1d5669393e9f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b427fc79-0c1c-4ad7-814a-18a49a70deea">
+      <statement statement-id="sa-5_stmt.b.3" uuid="8412a76c-28a1-4c2a-a792-8fe5f8ddb978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="5526a772-5468-497e-897f-9ce73486cd73">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="63d82349-3a69-4967-b514-c625011366c4">
+      <statement statement-id="sa-5_stmt.c" uuid="8d9619be-592c-4025-b179-cff67addee3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="1f66701f-0a53-453c-bfef-7149c0b20d59">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6ab2a357-6e3c-4d70-b2a4-f6944804cc80">
+      <statement statement-id="sa-5_stmt.d" uuid="662de344-472b-41be-91e7-f36b324438fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="84588caf-ee1e-448c-b3f4-b2b2572f19dd">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="493eadb2-1aa1-4a97-89da-8e82f8c64c14">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Host (RHVH) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="3e755ce2-3bc0-46fa-8d36-e0e8cb4435f6" control-id="sa-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="405188b2-0250-47ce-9d82-e86c43df5978">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2502b419-4938-4700-96d5-6a9e5119a242">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Host (RHVH) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="da7823a1-8fb5-41dc-98eb-2c1f4b60265c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="8fe9ed5b-6629-4ce9-8df9-e906c915ce68">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Host (RHVH) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="89f23fff-6ac3-45d7-be45-dc8c3707aa6c">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7dcb7d15-5299-4ef6-972a-855c398ad046">
+      <statement statement-id="sa-5_stmt.e" uuid="8282b696-60a1-4f72-9c01-43c4fd6970e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4434,18 +4407,45 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d3c7483-affc-4da1-b574-6aef7d3e598f" control-id="sc-1">
+    <implemented-requirement uuid="5fe8b02d-1c13-4fa1-8b41-93a5262cc178" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="9f1d528c-cd60-4857-9830-eac930f43081">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="30f52ce3-92fb-4d75-8fcc-1546d78707d7">
+      <statement statement-id="sa-9_stmt.a" uuid="ec90d1b9-2433-47bd-95f3-db9ba1cc3b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Host (RHVH) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.b" uuid="af646d19-e251-4f4c-a698-0079392edb9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Host (RHVH) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.c" uuid="d6abc2a7-08af-4f36-8ef5-481871de8fba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Host (RHVH) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="446eb7f1-88f0-417d-8c9f-2b714d7c16c0" control-id="sc-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="sc-1_stmt.a" uuid="d66866d3-3daf-467e-8c02-2894866405cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="bcbae954-242d-4f14-9a4b-08cac2cb6c9a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="102c8725-63eb-4722-a242-6e28ae474327">
+      <statement statement-id="sc-1_stmt.b" uuid="cb24c54e-8e75-4647-9a5e-add0f6b2cc1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4453,10 +4453,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1cdd6a26-cacc-47c5-89d6-b8746903c436" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="98a07167-f096-43e5-93c1-74108252a479">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="14750218-bd3e-430c-ad47-8fe73a9571d9">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4466,10 +4466,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="249c59a5-cb2c-4fd5-8656-80982a9704d7" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="a04fa8a2-9905-4bb2-875f-ce4072845dca">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d0a1e318-88b1-4520-812f-fdc5588d060a">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4478,8 +4478,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="06c00995-2b97-4d51-a58c-bf84124d61f6">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="64e1e689-e9be-4742-89a4-11fb53468cd4">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4488,8 +4488,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="b4a5931c-381d-4170-b536-edcbd762907f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="dbd92907-457d-4f24-ba72-ac85b0af6f64">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4499,10 +4499,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e33e416-7d43-4279-b198-1659a1f9d7c7" control-id="sc-12">
+    <implemented-requirement uuid="020c4c07-e9b7-4492-b6e8-c7dff5e18fed" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="6d283a3c-14ab-4da1-9ff5-e4f76b7d4d8a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="00dca554-2375-4dfb-ba99-46e5e06d0f2d">
+      <statement statement-id="sc-12_stmt" uuid="50788e68-a89d-4186-affb-16ee5c3769c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2d725b2-fb78-46d9-bb72-3cd88ac8bfe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -4521,10 +4521,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf9731fa-848c-4f3b-ad0b-bc552ad61a74" control-id="sc-13">
+    <implemented-requirement uuid="f298b315-5458-4a40-b974-c940e05a6d9c" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="eed959d1-da75-473d-91fd-bdf6c00a27b7">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="87616421-507e-4650-a937-d7c947b31452">
+      <statement statement-id="sc-13_stmt" uuid="6c7fbd19-4670-4988-a837-308fdc161851">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74c0f9d3-e304-4102-8b71-c897d213fc58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -4549,10 +4549,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bc949ce-3b65-4324-8e9a-53d7b883234e" control-id="sc-15">
+    <implemented-requirement uuid="ff2a4f17-3134-4017-994c-ef6973cb8dd6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="bff96f1c-3a5d-4bf0-8018-8c5f407f927b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="28a3cb83-9c75-442c-9865-8ad1bd7dc91f">
+      <statement statement-id="sc-15_stmt.a" uuid="9cbda246-5497-4d1e-9bc8-15f212d3f971">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4561,8 +4561,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="7d8eb4d7-d5cc-4235-bf91-499c5eee3b8b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="557e2b1a-35fc-4ed2-9647-758487cccf69">
+      <statement statement-id="sc-15_stmt.b" uuid="857f6d9f-6f6f-42fa-9ff9-0c7efb5b7b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4572,10 +4572,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a11644ad-d374-482e-9d0b-a6e513618a92" control-id="sc-20">
+    <implemented-requirement uuid="13d07e43-538e-4555-a7a4-a849d30614a6" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="0aaae62d-6faf-45b3-ab24-e6c354941a42">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="89498016-87de-4ecc-a90a-0c81b2155c46">
+      <statement statement-id="sc-20_stmt.a" uuid="9b3841e7-06b0-43de-8176-0403c350e22c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b673a29b-5ef5-4775-b02b-9f8a0ddffc6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -4590,8 +4590,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="bba45b13-0658-4dfb-953c-57fa22fabb5a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2c70ee2f-5d35-4b85-b980-377f506cd80f">
+      <statement statement-id="sc-20_stmt.b" uuid="f6c89107-60df-4621-98d0-84ce19c2b83f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bed2578-f811-4697-a21f-4b423a65142f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -4607,10 +4607,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="225d9096-2a35-4502-a67e-ae35f87238ad" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="fb139543-8e7e-45e9-8fef-a9c4a76c631b">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="41e1d936-6fd6-44dc-b482-0092ccfde2a8">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -4625,10 +4625,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c10c3bc8-1962-47f3-aff0-850ad7eefa49" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="fa528e7f-9195-47c3-80c3-82cbf96a4207">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="82f09bb7-8cdd-4f7b-a610-6a55a674b524">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -4637,10 +4637,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60e0c9f9-cd18-45ca-9322-61e18871363f" control-id="sc-39">
+    <implemented-requirement uuid="c85bb898-b489-48a1-b71a-e74625f7b216" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="df9ebb98-6258-4891-b5e6-3338d53f00fe">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="3a273de7-b462-4960-b227-15682f48d92b">
+      <statement statement-id="sc-39_stmt" uuid="33337f99-eaa4-44de-81e2-877df2ee77aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24b4672f-398c-471e-b8a0-14388d77a318">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks must be enabled to satisfy this control:
 
@@ -4662,50 +4662,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9314aa4-579a-4058-8506-e5afc687c796" control-id="si-1">
+    <implemented-requirement uuid="5d7e07d9-4558-4bf9-9b56-8ddea777b5d8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="771e379d-920c-4c41-85cf-a49c3069b548">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="638cfb6a-6cbb-4eb4-b3d5-1eeb28b827ec">
+      <statement statement-id="si-1_stmt.a" uuid="8787884f-585d-4aab-99df-a609926f4b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="dca2f738-cf81-4672-aa67-984c93f561ee">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="7aedc90f-ef7e-4cc5-8706-e1a420c81647">
+      <statement statement-id="si-1_stmt.a.1" uuid="8c07c419-6245-4a61-826e-775f5052f045">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="8f906877-2745-41ba-b643-fe3e4b456893">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d66b4784-7e19-4fae-a8c3-1853c39637ae">
+      <statement statement-id="si-1_stmt.a.2" uuid="3d0ab5fe-cc7d-4301-8ce7-6810ad62390e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="e0467e76-2e32-475c-8c6c-02683ff3750e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a8cca292-5d03-4fb5-a3f3-7a0970440bc3">
+      <statement statement-id="si-1_stmt.b" uuid="df847d3a-bcb9-444c-9e18-c555eeff1492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="13796142-afe4-421e-9503-60da320d49a5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="0963a3b1-fb44-4522-bffb-94531d0beef6">
+      <statement statement-id="si-1_stmt.b.1" uuid="23ab5b73-bdc4-4884-b80e-14c8c704508d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="b8a47266-41a4-400d-af8e-a66a1b87df7d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="5e93e208-20a7-4e5d-a4ed-0eb9eb702947">
+      <statement statement-id="si-1_stmt.b.2" uuid="cfc702c2-8138-43fb-ad59-b9273ce1ed9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4713,10 +4713,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1373c13-1270-4de1-baa3-3b8b82571e9d" control-id="si-2">
+    <implemented-requirement uuid="dc0ee075-4b67-4ca1-80de-e12ad3054399" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="1d8ee2ef-b63a-4b89-bfb7-8a107e2fbf35">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="01f43e0a-d0ca-4983-b474-d1467ad0b7fc">
+      <statement statement-id="si-2_stmt.a" uuid="ea7e76cb-cded-4c89-897b-67b0f6290878">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00c6f6a5-bcad-45d7-aa86-099ad8ff7902">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Host (RHVH) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4726,8 +4726,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="693a6934-f17c-4ab5-be82-03060bd22896">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="653d975e-69b9-4950-9887-82cdfd3fadd6">
+      <statement statement-id="si-2_stmt.b" uuid="c93b23b0-3685-4e74-8a11-e9130f2b17b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3cc16f-0b1c-4966-ab2c-a775e94deb09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Host (RHVH) updates
 related to flaw remediation prior to installation. A successful
@@ -4737,16 +4737,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="19077d2c-a056-443e-9fc9-84c14abfd0c1">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6d4890a0-b80e-42ac-93a4-81eaf0d982f3">
+      <statement statement-id="si-2_stmt.c" uuid="af9092b1-daaf-492e-9691-de3ee7c94546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="8fd93e95-d9cb-4cd1-9741-8f8a71f33856">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="859a4222-d9f8-4993-972d-d7190f380f4d">
+      <statement statement-id="si-2_stmt.d" uuid="9da7889e-0085-4023-b7a9-6a88c6e7a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4754,10 +4754,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="441bf17b-d892-4c2f-bf3b-af1ea55374ed" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="a26f3209-1961-416a-b864-eef27515b73a">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="b855f6fd-326e-4e6e-a692-66c16c74861c">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4773,8 +4773,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="a8138f86-21be-4320-9ff2-3a392c253e3d">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="f33fc553-4111-4615-8a11-8ad07b44a8f9">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4783,8 +4783,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="af943555-18d5-41c3-8fb6-e0b7aad49dde">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="48b0e01a-10b6-451b-ba57-42b5efbfbfd5">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4793,8 +4793,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="43ae17b0-65ce-4954-ab78-077d5a932f56">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4e4e3e62-f524-48fc-80f5-0018c0ab47fd">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4803,8 +4803,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="691df525-5982-4a7e-9445-b57b17a63516">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6d243a60-c666-48e4-bec6-4057610b3326">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4813,8 +4813,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="771e1ffb-15a8-410a-b237-ec51d4ea9629">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="6cd3a521-08e5-4ff6-a0d5-edba7d7ec326">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4824,90 +4824,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2c7fa00-48ae-4a6e-bdeb-f6173c6a1704" control-id="si-4">
+    <implemented-requirement uuid="59b20aad-49c3-4881-9195-6a89041b5906" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="bcfcf8c7-6fcd-4b15-aa68-f18ff30b3521">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="875b6e64-618b-48c8-8265-0f14310315de">
+      <statement statement-id="si-4_stmt.a" uuid="dba40fba-14cf-469c-8411-389d0906fecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="0dc9aa36-4b9b-422c-9187-02226359eb27">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="e8785483-1e93-4f8d-a925-d2e68b6d29da">
+      <statement statement-id="si-4_stmt.a.1" uuid="8f062e56-42ed-480d-be3a-a084a404a92d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="cd71bb84-2270-4798-a88a-d68d6d366946">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="4a950ae6-cfeb-42ad-8bc1-49da8a2ae0c8">
+      <statement statement-id="si-4_stmt.a.2" uuid="c99eebf6-76dd-4834-a8a8-702955f0de22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="9f454f87-bd09-4f4e-ae86-9919bfe43069">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="be9de2e8-4ee5-46d7-b1b0-dd8d7dced05f">
+      <statement statement-id="si-4_stmt.b" uuid="8b63244e-e370-45c1-93e9-8fa3167757c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="a3d311cf-96d9-48eb-b2b3-ad4f86d0273f">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1845f741-780a-4d0c-b685-6432a8291ab3">
+      <statement statement-id="si-4_stmt.c" uuid="6654702f-0944-4119-b792-9d5d62145d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="179711b6-69f1-4ed7-ad90-1e44e209ceab">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="a567aeb8-5100-45a9-9921-c610f89572da">
+      <statement statement-id="si-4_stmt.c.1" uuid="ec5b5673-4f98-4232-8b5f-d5a55003f609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="e26c572a-d814-476f-8980-9bbcd6770a99">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1641b299-3b56-4c58-b79d-8ad3656b6cce">
+      <statement statement-id="si-4_stmt.c.2" uuid="779ce949-375f-49de-91eb-8cca14636ad0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="4b2d350a-3795-4aaf-b1cb-900bf3e8c607">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="1daf68d8-7f9c-44c7-92dc-c4f63689cf32">
+      <statement statement-id="si-4_stmt.d" uuid="14feaa64-7bc3-4db9-bb76-2e714e9407e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="caa42902-ebc7-4e3d-976e-501aefb0f319">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="83d1d324-cd76-4cda-9fa2-b0a7bbdfce4b">
+      <statement statement-id="si-4_stmt.e" uuid="b3cf0398-2a1d-472d-b11d-a4f66f126706">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="be288e19-bf85-4247-9f9f-235ac87a5ebd">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="c8fbf9eb-aa38-44e4-8e31-f232cdfec12a">
+      <statement statement-id="si-4_stmt.f" uuid="6b46395f-a140-4b9d-b9cb-97333f90e885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="a389f071-1c1b-4f06-8822-8529ea3e557e">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="d0126206-54c9-4e2a-b0ad-c8fedfb231a4">
+      <statement statement-id="si-4_stmt.g" uuid="bc73ebf4-bf15-4a47-bad0-533a3fcb8b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4915,10 +4915,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0315104c-2042-40de-9587-4dd933140766" control-id="si-5">
+    <implemented-requirement uuid="db26ba38-1239-4f83-9440-22b97f99486a" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="8668333f-22e2-4a00-9b3f-d70c38162df5">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="17fa7c65-2f7c-44a7-b67a-32f62e0983a1">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -4927,16 +4927,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="583938de-d752-4a24-bb79-c01b54aa6f11">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="70690d23-a4d4-4703-8237-2ef9abb98a02">
+      <statement statement-id="si-5_stmt.b" uuid="e6f52326-2876-4f3c-91b5-c584a78c6b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="fbbc06a2-fadf-451a-ad9d-2654303eeaba">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="9e13663d-efc7-4f4e-b74c-8053fd0eb182">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -4945,8 +4945,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="5bcaa608-e127-45c8-a2f9-7b77e3448615">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="2e79f1c5-10c9-474a-9b03-53a25f10f8de">
+      <statement statement-id="si-5_stmt.d" uuid="9cbc5870-d294-43ae-92c1-7c3ca5d92a36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4954,10 +4954,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="200cb71d-c147-4cd1-bff9-cabcc519f49d" control-id="si-12">
+    <implemented-requirement uuid="09e0132d-6ccf-49ac-a537-29560849f42a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="18d4b9cc-72c8-42af-a477-835331e5acf3">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="cc36900c-7240-4704-99a5-1a2036b28fef">
+      <statement statement-id="si-12_stmt" uuid="5dc6c15d-d248-4165-b960-af8e7fc3acd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7efcd9c4-a080-4cc4-955d-96131fd8f0bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Host (RHVH) in
@@ -4971,10 +4971,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="727e2fef-318c-4e90-a9f8-84b26f074814" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="b437641a-9e03-4bcc-a5b9-eab0704f2028">
-        <by-component component-uuid="6b34330b-0413-4c82-b6e1-4061c3947d90" uuid="925f7fef-9ead-49c6-8b3e-d548d04c792a">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/virtualization-host-fedramp-Moderate.xml
+++ b/xml/virtualization-host-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="75596949-c022-4435-acf7-fbaef7295c1c">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="b35edd02-e5ca-4a03-9c47-84a3ad91be74">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.76+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:20.88+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="deb46f41-2493-494f-b2fc-1166def0e9c0">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,69 +484,69 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="3bb01d45-579d-424d-8223-4b90bd6ff826" control-id="ac-1">
+    <implemented-requirement uuid="fa701737-9ee3-444f-a822-2d00abc0ce14" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="49aea43b-34e9-4396-9e33-4f6cdf5deb8e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="02c6ffd3-44eb-4869-8c81-888cb7eda99c">
+      <statement statement-id="ac-1_stmt.a" uuid="e79f158e-6add-4530-8fae-a14530cd3213">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d5ec4f2-5bc7-4425-a8c6-db4371696baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="494e9342-6c60-42a8-aca3-6402a4c4606c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="789089df-6c0c-4fad-8f2b-bfa7376be987">
+      <statement statement-id="ac-1_stmt.b" uuid="383a924d-c22a-4209-a9e4-1d75bcaf3ab0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0128bd2-2067-4f52-91c3-7b52eb85b101">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4f488c5-0514-4346-848e-30c843ab1f8f" control-id="ac-2">
+    <implemented-requirement uuid="4fed2379-d30b-41d3-9ffa-9f8e4eb1489f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="ada8b0e1-8de4-4628-9770-38322cd1b442">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a7e9d414-8ddc-4f95-a19b-98b159ae0d53">
+      <statement statement-id="ac-2_stmt.a" uuid="bcd3cce4-0c2b-408a-80ec-da208033ff76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="110cfea5-2aa5-4a93-8c1b-5063e328712c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="628517cd-1a7d-46c7-a6af-d6dab7069fdf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="433fdc8e-01aa-452e-a1c3-969b70ebdcf2">
+      <statement statement-id="ac-2_stmt.b" uuid="faab07b6-9814-477d-9601-7aa872c416a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fc79e596-54a3-4f76-9f56-f82751e10396">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="816bcfd4-8cda-491c-bc90-c1e41c102908">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9fcd6b55-4730-4a27-bae2-0baa11295eb0">
+      <statement statement-id="ac-2_stmt.c" uuid="167f867b-56bd-40bd-9249-0f5ab7f2a8d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f2a97ea-8b2b-4bda-ac51-fec3c2116e45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="86d1aa28-6d10-42a1-9135-305a5b7fd045">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1367118a-cad6-41d3-9bfd-93b93fd3a2a1">
+      <statement statement-id="ac-2_stmt.d" uuid="4056bec3-4b46-4f62-bf68-ae47db08fa6d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0597b132-ef8a-409d-bad0-3ad622e4ff0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="cba5602e-1d38-4114-9737-7296c172bd6f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a7563bb6-d408-491d-b91d-46c42002fdf2">
+      <statement statement-id="ac-2_stmt.e" uuid="198cda94-0fd7-45a6-b02a-1cec97445351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87a9cf41-a3c6-42c0-85e5-1579f696a03c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="19f32de3-dd51-473d-adc8-02d06c5eb129">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="901082b5-0c10-4403-9290-df948ad54d98">
+      <statement statement-id="ac-2_stmt.f" uuid="b9383762-ed06-4fa6-9168-aaf501bbbea5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4d33bdb-a014-43f9-aa39-4635db1660b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="483a71f3-1b57-4d97-9fb2-5356495427c3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8c2038a7-53aa-4ba1-83e4-e6e024c4961e">
+      <statement statement-id="ac-2_stmt.g" uuid="2448f24a-9cbf-49b0-9f0c-e9405e348158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb26ba54-f3ed-4d29-816a-1e4132fed948">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem must be enabled to ensure audit and monitoring
 of Red Hat Virtualization Host (RHVH) information system accounts.
@@ -560,39 +560,39 @@ events that the audit subsystem will be responsible for capturing.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="11afbd40-1334-40ec-83a9-632a2f016b73">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7d4c9acb-1182-4987-9762-3a926e92f1d0">
+      <statement statement-id="ac-2_stmt.h" uuid="28c65170-7539-4b0a-8d70-9cc9ab7add25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fafd74a5-41c4-414e-8d9d-ba79a2bf4e4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="20b76dd1-fb35-4dbb-810e-0ebc763d02ab">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7497fa9e-5d80-46e9-89cb-3506aaff9639">
+      <statement statement-id="ac-2_stmt.i" uuid="f2517473-8de0-4df7-963e-6c0072e94b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aab400c6-783e-4b90-8b47-4c6df01cf2da">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="e3187cb3-a76d-45b7-ae41-03b643286e4b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ccab648a-1694-458a-b3c1-0301f6605f4f">
+      <statement statement-id="ac-2_stmt.j" uuid="d011ba12-8d77-4068-8ea2-16b092b8341c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f829215-f634-4e0a-86e4-3ed5702c4780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="18c02d67-b381-442c-a32e-bc9515b4b5f2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2c866963-46a3-4875-bfa2-8941a3c67277">
+      <statement statement-id="ac-2_stmt.k" uuid="56388cd2-93d8-44d3-8dcd-4979ae202a2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84bb7841-0542-4c4a-825d-a45e7a294b4b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab83c126-b3fd-4c9d-bdf5-bcf4b8b39dd5" control-id="ac-2.1">
+    <implemented-requirement uuid="8bab6c99-f7f1-4eec-8186-0b368e17e893" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="e390d055-2283-42ed-9cb3-b5df30098370">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f8087cdd-2953-4aaf-85c4-8dda3b4da861">
+      <statement statement-id="ac-2.1_stmt" uuid="db4c5cea-a43c-4c9f-b35a-52ec0e9d75b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2835a50-2963-42d1-a2d1-be71091d9b4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) components of the system support automated
 management through monitoring of accounts and system
@@ -612,10 +612,10 @@ https://projects.engineering.redhat.com/browse/RHV-19937</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5a6bfca-f362-46d3-bdf1-b7e66156076b" control-id="ac-2.2">
+    <implemented-requirement uuid="e11fe50b-0289-44ce-b413-bbe5e6630e53" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="26f83ad0-cc33-4b5c-90bb-9238f27710c8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d0457d7e-9f25-44fc-8bf7-21a5a8abf7ed">
+      <statement statement-id="ac-2.2_stmt" uuid="4e6c903c-a518-4cb1-96fb-bf7f0be7fc33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aaf3fc9b-bcd2-4038-9483-f843224a1aa0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) does not have the capability to automatically
 delete guest/anonymous accounts or temporary accounts. Any
@@ -625,10 +625,10 @@ identity service (e.g. Active Directory, LDAP, etc.)</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56eb31b5-89a9-4686-b33e-3224fd7349e7" control-id="ac-2.3">
+    <implemented-requirement uuid="704d6fd5-d8b8-4452-9429-bcdc9d2d31e5" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="10109acd-0866-4fb5-bf6a-168a88be1b3b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1d90c2f9-f781-4674-8543-c7c24169f671">
+      <statement statement-id="ac-2.3_stmt" uuid="2793ab65-312d-41bd-9540-f3525fc62391">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="381e0da0-8465-4ad2-ad7c-29ec45d6079f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -637,10 +637,10 @@ https://projects.engineering.redhat.com/browse/RHV-19938</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c8318a6-e136-4a4b-81d0-f6599d5e11e9" control-id="ac-2.4">
+    <implemented-requirement uuid="27d8f87a-5fc4-47af-8466-b3411e509250" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="5570338e-559c-4697-ace3-3f3aedd549bb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="735942ae-fbcb-43b5-879d-d4ffc5259e79">
+      <statement statement-id="ac-2.4_stmt" uuid="eaebd66e-070e-4cd7-a27f-a1f698b92a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="beb2350c-a692-4a5a-8336-d126cb5462a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -649,10 +649,10 @@ https://projects.engineering.redhat.com/browse/RHV-19939</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41e4f158-2e5f-4fe9-9763-cf2a2c0ce9a6" control-id="ac-2.5">
+    <implemented-requirement uuid="dd5e5105-d2cd-4733-9fd5-fd3020397f4e" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="0de4efad-6781-44fc-9226-40a48ba7fbe6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a9ca1c2f-4cc3-4a85-8c37-ff1cde0257a1">
+      <statement statement-id="ac-2.5_stmt" uuid="3c6eb3c7-fc42-4181-a8ec-da4f7e3b6b9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2645dafa-cbbb-4d6a-84f0-4d1ce85741c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -661,10 +661,10 @@ https://projects.engineering.redhat.com/browse/RHV-19941</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff02de9f-3d44-4faa-84fb-06af3ca3683d" control-id="ac-2.7">
+    <implemented-requirement uuid="59e36a09-44ce-40b8-9dca-b3fe96440226" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="8ad80311-6da3-459e-9e34-ac5edd8f917e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="213347cc-9743-41ba-b56b-4e7d290a0bef">
+      <statement statement-id="ac-2.7_stmt.a" uuid="f19cdaaf-9b1e-48e4-9b3d-2b356087abe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e056b0fb-5e60-4904-90b7-a7a6f3936b64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -672,25 +672,25 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-19943</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="a8437574-523e-469d-9027-baa12318f9b9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="caf945c8-aee9-4ca4-b1bc-ba4c40187de4">
+      <statement statement-id="ac-2.7_stmt.b" uuid="517d0a5f-ad8a-4807-bbc4-eba579cde3b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1a7c635-b639-43fc-86bd-302623c80dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Host (RHVH).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="89fa7539-7ee7-4e87-ae82-b730abbf638b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9ecb3ae6-e80f-453d-b340-f093b283a7df">
+      <statement statement-id="ac-2.7_stmt.c" uuid="55917923-c220-4396-97c9-f3b6cc8873c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1a7c635-b639-43fc-86bd-302623c80dba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Host (RHVH).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c36bb580-de52-4596-8d82-fa2bffda98b5" control-id="ac-2.9">
+    <implemented-requirement uuid="1d86c2e4-5c81-4ea1-804a-9448299e4adc" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="6b799c31-8f0d-492f-b880-fa0b13c59cf4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cb2e4c5a-4b6d-4176-8a80-8d55e7faeb24">
+      <statement statement-id="ac-2.9_stmt" uuid="f8e4cf40-b558-4e82-8706-750ab1823701">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b54761c-9e15-4895-ac45-02ed31e96ffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -699,10 +699,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00f0e4bb-ce44-4e12-a025-a4ea669565f3" control-id="ac-2.10">
+    <implemented-requirement uuid="c9c3bf55-612c-4339-9e25-aaf3b2dfcf53" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="46c1d5e6-eeee-4b6e-84eb-7841c43447ad">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8bc2bbd4-15ff-4d1e-ac21-8ed21b53747f">
+      <statement statement-id="ac-2.10_stmt" uuid="852836c7-18b4-4191-a4a1-525e217c407f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b54761c-9e15-4895-ac45-02ed31e96ffe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -711,10 +711,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6108873f-f441-4383-979b-da45b672752f" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="11d17d09-5648-4990-956a-6d5f9172e5ad">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5feac109-7fba-4afa-8048-24a4ebc7b01c">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -722,8 +722,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="6d3c5ff8-2e59-4e89-abdc-20afdede3e80">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="118234d7-c604-4c8b-bfbe-fc9497a9f829">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -732,10 +732,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="daf99d16-6419-45e2-b435-af2d991bd876" control-id="ac-3">
+    <implemented-requirement uuid="291df6ca-5c31-48ec-a484-799392cc4d19" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="c249568d-2d02-42f5-af3e-feddd5a552fb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="15497ee0-a7f7-4a10-ba27-686b6e26a0fd">
+      <statement statement-id="ac-3_stmt" uuid="f358ffb9-7aaa-415b-8eb2-48fee861d62c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c28f339c-fbcf-4674-aedb-82d4be2d5649">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) is capable of enforcing
@@ -767,10 +767,10 @@ approved authorizations for logical access:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1ec7231-a829-4cae-8a9b-f71c17966045" control-id="ac-4">
+    <implemented-requirement uuid="fb206e6b-1e3e-463a-9813-1054cf5eb413" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="3ad16bda-04dc-4bc5-bfe5-15d04d43466d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="10530999-1ff8-4a6d-a153-d11546027b8a">
+      <statement statement-id="ac-4_stmt" uuid="431a8b3f-25c1-44d5-b6bf-f6e13d08bf46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d03a35b-2b3c-46a6-934b-24d7d32561c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -779,10 +779,10 @@ https://projects.engineering.redhat.com/browse/RHV-19975</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfa4c029-2dfe-47ac-9e69-3aea86fdc27b" control-id="ac-4.21">
+    <implemented-requirement uuid="552e2d31-d520-4e5f-bdf2-fa21f7df835e" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="11986be3-6937-4dd2-9ddb-6ecd6a496393">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3b6ff03f-125c-492c-828b-2a48079107d0">
+      <statement statement-id="ac-4.21_stmt" uuid="a45d1455-852a-47aa-a2d0-c063b9663faf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314eeab2-b5af-48d9-a8d6-b30a00f379e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -797,10 +797,10 @@ https://projects.engineering.redhat.com/browse/RHV-20102</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40e0677d-c5c8-48ae-854d-9bfd0e86d762" control-id="ac-5">
+    <implemented-requirement uuid="58a6ee2c-595f-4f45-941f-9e0c16f6a5e2" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="fb80b0c4-05ee-4e1b-a7d2-0e0fe167e743">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="03d99fcb-75c7-4ec4-ac1f-eaf97629e461">
+      <statement statement-id="ac-5_stmt.a" uuid="da9cca65-af73-44f4-9bf6-1da00da0d3aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31feef7d-c449-48ac-ba1f-06b38f1488bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -811,8 +811,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="737b18e9-879a-419e-a5d4-8ebc6c93c031">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3b392937-b186-4b44-b45f-186a06303e59">
+      <statement statement-id="ac-5_stmt.b" uuid="fc671f60-3b5a-4937-9e6c-b5c5c936463d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30617341-8f13-48f3-9e3c-a123e8b5a4bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of Red Hat Virtualization Host (RHVH)
@@ -824,8 +824,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="40a8e56b-ea31-4540-8eb3-ab0eb98a3e6c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ef2d6c07-7999-4c3a-bd20-c9ba057a5206">
+      <statement statement-id="ac-5_stmt.c" uuid="4928af4e-8ef5-4de7-8ca6-954f97575323">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393e6d1d-c15d-40ec-970d-c90308821e4a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -838,10 +838,10 @@ user is allowed to perform a given action.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="407046ca-d133-4af9-b4c7-49349a6e6061" control-id="ac-6">
+    <implemented-requirement uuid="cd068943-85d8-4507-bfc6-c1b5ac06fed1" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="d36e53b0-54da-4ba4-b109-8f1ba4320373">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8536c147-f4d9-4624-bf48-d2c194d38146">
+      <statement statement-id="ac-6_stmt" uuid="395124ff-7909-468c-8c26-9c019a94a445">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12714d47-155a-4a25-8adf-0c9fa759d3d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -851,10 +851,10 @@ https://projects.engineering.redhat.com/browse/RHV-20104
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f20496a-2ef3-453d-b835-b01fbf87be21" control-id="ac-6.1">
+    <implemented-requirement uuid="79009ec5-feda-41fd-9466-3d1170902932" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="2f80b2d1-1cee-40ff-9e86-47a8437f7c02">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2048261d-ce88-4a12-a48d-73a643dfff3c">
+      <statement statement-id="ac-6.1_stmt" uuid="bbedf025-0a76-4145-a3a8-e0772c011e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e72751f-1477-4bd5-9b86-4079f8d1c129">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -864,10 +864,10 @@ https://projects.engineering.redhat.com/browse/RHV-20105
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e72f2dd-bb9f-4b59-b395-262a884d4b0f" control-id="ac-6.2">
+    <implemented-requirement uuid="438d7426-4873-4b73-bafa-335b630ea2dc" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="7551d6d4-cf18-4486-83bb-3dd6337fe1e2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e2f96f79-7b25-4557-9e1e-fb7951318a12">
+      <statement statement-id="ac-6.2_stmt" uuid="b74056ce-c15c-4104-bebc-7b5b288dcc66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="184f857d-53d1-4eda-bee3-b631152658d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -887,10 +887,10 @@ https://projects.engineering.redhat.com/browse/RHV-20126
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae82e16a-9479-46bf-abb9-6346585212f7" control-id="ac-6.5">
+    <implemented-requirement uuid="2a1661e8-ae24-48b7-9cb5-8a9c7749ac0d" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="cbcb6edf-f348-4370-856f-c6c794d60c97">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c508b817-09b5-40d2-95eb-9d37dc2d3c50">
+      <statement statement-id="ac-6.5_stmt" uuid="29749905-8d71-49a1-8698-80d5f8c63afa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb127ed5-b226-47ac-9b29-fb68288063a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -905,10 +905,10 @@ and login with an account that has received appropriate RBAC rights.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="092ee47b-984d-4ff1-b047-d59751116566" control-id="ac-6.9">
+    <implemented-requirement uuid="435c04e1-8c27-49fa-8e5a-112bf8ed04af" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="86a02664-e59b-488e-8c6c-61659241d37c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0b581918-08c5-4ea3-a161-b59f2b67e45b">
+      <statement statement-id="ac-6.9_stmt" uuid="4dec473d-de52-4b32-b0d1-cad9f73f8cfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023ccb0e-4287-4b46-baf4-be96cd66a27f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -923,10 +923,10 @@ https://projects.engineering.redhat.com/browse/RHV-20149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1980f1c6-4890-4d28-975c-530e9a4f1424" control-id="ac-6.10">
+    <implemented-requirement uuid="7949fd53-0e80-4c80-bb4b-9a7c96bf9e66" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="5def86d8-a6e1-450b-b8c1-2f1ffeb74429">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c7bb121f-cc5b-4ab1-aa22-1a78d5a58b20">
+      <statement statement-id="ac-6.10_stmt" uuid="f4f90226-de6b-4803-b91e-66e2e0913185">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d898ce-e363-48cc-87b7-0b6b804c10c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -942,10 +942,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f5aeed7-849f-4b93-aa7e-833cb8157fa1" control-id="ac-7">
+    <implemented-requirement uuid="bd4093af-1e69-4000-9685-fa2b09f1b859" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="e775d6fd-2706-49e7-a6f4-e768017853b8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="eca40ae0-ff5b-486b-8a71-7855ab27f95b">
+      <statement statement-id="ac-7_stmt.a" uuid="843757dc-c3bb-41bd-aa7e-23b34c22de8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4da5858-8f53-42dc-89eb-d0d477853378">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) enforces an organization-defined
@@ -964,8 +964,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="c82a9ac8-c2d4-45ee-97e9-4af5637df6a8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="81b00d2d-ab20-4dcc-bf22-85cc48ca6984">
+      <statement statement-id="ac-7_stmt.b" uuid="1e1a552b-bb76-4aa0-a438-9a7c5faa9e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96ad9325-f04e-460e-b295-69b0b407ad00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to automatically
 lock an account for an organization-defined time period, or to lock
@@ -989,10 +989,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9131ae6-1dcc-4671-933b-758b232e270b" control-id="ac-8">
+    <implemented-requirement uuid="8d430a33-8d65-4073-9a06-876dc1efd893" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="7db7fcbb-0cb9-428b-ab2e-eae77f5e2f08">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f1f5af77-21fc-4ca7-b06f-1b69995cc772">
+      <statement statement-id="ac-8_stmt.a" uuid="578d1f2a-3921-47fc-a4c9-139e07f251f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1009,8 +1009,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="0d077504-558a-4c80-8a99-b208deae503f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ba761748-6819-420b-bf33-38a19c75363d">
+      <statement statement-id="ac-8_stmt.a.1" uuid="fea04920-020d-4465-99d4-6abe68dc3e24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1027,8 +1027,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="d69ff53c-b986-45ae-af3e-b590ca3b9090">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2848602f-7bcb-46b6-9ffe-642ce7bcfec4">
+      <statement statement-id="ac-8_stmt.a.2" uuid="8c26f5fe-c79b-4706-9fc8-7146ef4c41b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1045,8 +1045,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="058f9b94-f721-49c1-99db-fb82efd2bce9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="30f9145f-b394-49f1-8d16-4512605b4dce">
+      <statement statement-id="ac-8_stmt.a.3" uuid="345e0b72-dd6c-4d69-831d-051c64fa77a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1063,8 +1063,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="1b952355-8c78-4751-9b7d-014ed3b2b8b2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="dec928d9-71c2-47e8-aeaa-67391fc250d9">
+      <statement statement-id="ac-8_stmt.a.4" uuid="b225ff56-5766-44d2-ba08-7dbec06a10d6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a1df2cf-a4fc-4337-bce8-7851667e2949">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to display an
 organization-defined system use notification message or banner before
@@ -1081,8 +1081,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="d9002fd0-c183-4b0c-9827-ae48847156cc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="226655ad-8ac0-4ff6-9d2d-f0fea7cd4422">
+      <statement statement-id="ac-8_stmt.b" uuid="672f5f2f-425e-4146-bfd6-8c4b0b22ef9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="283a8a12-0912-4e76-bc7d-94300515179b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will retain the notification message
@@ -1096,8 +1096,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="187e199b-21c9-413e-b1b7-d1e9a7227d40">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="85240ca6-612a-4a55-b7b4-50686c28ef35">
+      <statement statement-id="ac-8_stmt.c" uuid="6542b907-4c96-435b-9646-91e6183f9bcc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89177120-8793-4492-a6a2-cc3276d76459">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>When CCE-27303-7 and CCE-27314-4 are implemented, Red Hat
 Virtualization Host (RHVH) will display system use information
@@ -1110,8 +1110,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="e80ff81f-d4e5-40d4-a009-ded9e9401d4f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d15a86fb-4a16-47a5-a4ad-a9f80330c42b">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -1123,8 +1123,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="48291273-63d3-4489-9702-34fb5f0a3cc3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e27a559e-871b-4803-9c11-75c88d031472">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1137,8 +1137,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="cdcbc7a5-d4b9-443f-88aa-047f3e7fcf51">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8fb80958-b7d8-4973-a0c9-a9f011122911">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1154,10 +1154,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="da34fa0f-56b0-4f4a-b701-0be6f8be1c37" control-id="ac-10">
+    <implemented-requirement uuid="658dfd46-01b0-44b2-9e87-8b8c43b810fb" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="1f6eb0d7-29bf-4292-b0db-b8826991b946">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0ded1e58-0790-4ded-b826-9342a7ed0111">
+      <statement statement-id="ac-10_stmt" uuid="77d6b558-3a40-4f35-b6ed-4d29c010404a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24c2c079-5b6d-4e1e-a549-72a4a6046ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1172,10 +1172,10 @@ https://projects.engineering.redhat.com/browse/RHV-20220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77aea5e0-28e7-44c1-a939-f3473ee2d759" control-id="ac-11">
+    <implemented-requirement uuid="de47af6d-3ab2-4ccf-be56-0e9d1b328c6c" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="7c67789a-30f5-444f-b99a-357b2aaac977">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b833998d-0375-4748-b068-2500223ab53e">
+      <statement statement-id="ac-11_stmt.a" uuid="4322b9cb-3cc1-4b1c-aa75-ee0f7d42d6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1184,8 +1184,8 @@ https://projects.engineering.redhat.com/browse/RHV-20311
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="aca45242-1c33-4d10-96f8-2c25fd84e585">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4c9d91f9-9802-4e41-80ec-1bfd2876d4d8">
+      <statement statement-id="ac-11_stmt.b" uuid="afe463cd-920f-447c-8ef4-0c01bc1d59db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1195,10 +1195,10 @@ https://projects.engineering.redhat.com/browse/RHV-20311
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e64d1be6-d487-4f01-9339-0878846c45e8" control-id="ac-11.1">
+    <implemented-requirement uuid="9186ba2c-900a-4af7-b19f-bb180f5b2a76" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="5300e6ba-7253-4478-99a5-ab66cec3eb5b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b61fa269-687a-4ec5-bf26-596208986c30">
+      <statement statement-id="ac-11.1_stmt" uuid="9f71193c-566a-40c0-b07e-a386d1989365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33f20195-3d93-43ed-9b21-63e4c9107fd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1208,10 +1208,10 @@ https://projects.engineering.redhat.com/browse/RHV-20312
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83521715-0ef6-473e-a914-2c58dc7fc1a3" control-id="ac-12">
+    <implemented-requirement uuid="e31814b1-e9f1-4f64-803c-4d8a3773aeed" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="04adb04d-ca15-4d60-8302-d78cf86bb667">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1e0ab8ff-281b-4136-8f29-3d019c923107">
+      <statement statement-id="ac-12_stmt" uuid="90b59e85-2cd3-45ff-b096-a35056dd4d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b753ca6-6101-42a2-98ce-14b9560c501b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1227,10 +1227,10 @@ https://projects.engineering.redhat.com/browse/RHV-20313
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8899a9fb-3714-476d-b0f1-8cad8b410919" control-id="ac-14">
+    <implemented-requirement uuid="684c2758-5cfd-459b-aa4f-5236451d89c6" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="cb6fd8f7-b068-4448-9f3a-eb6669b0bfea">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3c3bb68d-79fc-4d75-8fd2-3f01911ac9be">
+      <statement statement-id="ac-14_stmt" uuid="98fbea0c-7a97-49b7-ad10-d519e17504a7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7ade1f14-d64b-43c6-a3bc-4a09b37d14dd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Host (RHVH) without identification
@@ -1240,10 +1240,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85054982-5cc3-4be9-add1-9480d1a8d626" control-id="ac-17">
+    <implemented-requirement uuid="00433395-fa1d-426b-ae24-19065a86ffd0" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="b77e638f-b24a-4c6c-885b-d2db2bba99e3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="684e8660-34ce-465c-b3ed-d2e15e7749ff">
+      <statement statement-id="ac-17_stmt.a" uuid="98e3a56b-95ee-40c7-9990-7fbcf14104e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d37e756d-8ef0-4b4f-8357-e22cb5bcb32e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Administrative connections to Red Hat Virtualization Host (RHVH)
 are performed over SSH. The following configuration checks are highly
@@ -1302,18 +1302,18 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="f6fc24e9-8159-411c-a8a1-9a8f6056ccbb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6e53de02-682b-41c6-a77f-05765614979d">
+      <statement statement-id="ac-17_stmt.b" uuid="2a664edf-1c55-4227-85ef-fcd0664f7e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b03f6d3d-4fc8-472b-82bd-12186b5c307d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c126b69-31e6-43a1-9a53-6f268649a7a5" control-id="ac-17.1">
+    <implemented-requirement uuid="2c168041-4ca0-48cd-9b1d-43827a6bfb6b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="63c1af1f-232e-48aa-b2e8-2e87be844aff">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1c55b727-da5c-4cd9-a79e-ce1a01c343b2">
+      <statement statement-id="ac-17.1_stmt" uuid="779cdd50-e242-4ef3-8fca-6512a0d0b012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70e205b6-1bc3-463b-bc62-fe2f320ba8ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1323,10 +1323,10 @@ https://projects.engineering.redhat.com/browse/RHV-20373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b5de2eb-48f6-4640-84bc-2a6b143407a5" control-id="ac-17.2">
+    <implemented-requirement uuid="4ca77273-9117-40b2-983a-4dd5040356ce" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="b2aaf3bf-5722-46be-aba9-7d80556c706e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="26f44b56-bc57-4440-9714-32bce1afd708">
+      <statement statement-id="ac-17.2_stmt" uuid="1ce07c9f-0df5-4991-b8fb-98fbac3b4bf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dce36b4a-1920-441f-80d1-3e68abe7fff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1336,10 +1336,10 @@ https://projects.engineering.redhat.com/browse/RHV-20374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86974c87-b6ed-4c0a-8d90-bcae00437ca9" control-id="ac-17.3">
+    <implemented-requirement uuid="bc44a17a-d305-40bd-aa49-f123590cef90" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="71b04db1-1418-4110-8a93-4c3a0767f7fc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d6ab18e6-0a00-4e3b-bfbd-fa135c75884f">
+      <statement statement-id="ac-17.3_stmt" uuid="42eb896e-2e27-499e-a0f0-578bb7b8ce33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d263384-2276-4a13-9725-cc474255f41e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1356,10 +1356,10 @@ https://projects.engineering.redhat.com/browse/RHV-20375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9ea01c6-8a43-48d7-98cd-cd91812d1e6a" control-id="ac-17.4">
+    <implemented-requirement uuid="601d7507-7916-4d74-9366-bce72369763c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="d1e26acc-0d4f-4ee8-8519-39bc2b45d97d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cfa7a5a3-80e5-4428-ba6a-68bc0b9089cd">
+      <statement statement-id="ac-17.4_stmt.a" uuid="e376c343-772b-42ff-9c33-17681b5bc45e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1368,8 +1368,8 @@ https://projects.engineering.redhat.com/browse/RHV-20376
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="c7793947-dcf9-4ae4-82a5-ee1d765f265b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="289bd47d-5b11-47d7-82e3-0a4d7e8f2072">
+      <statement statement-id="ac-17.4_stmt.b" uuid="4b4c9a85-6a8b-44e1-adca-dd63c6562b7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1379,10 +1379,10 @@ https://projects.engineering.redhat.com/browse/RHV-20376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85b203df-33ca-4410-83b5-bd908c0d5dc3" control-id="ac-17.9">
+    <implemented-requirement uuid="746dfdff-fe0a-4296-9d0a-755ef877cbea" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="491a7d67-1f10-412c-a909-b2bbd0a5fefc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="06baa163-278a-4827-846a-f95abd9f6b08">
+      <statement statement-id="ac-17.9_stmt" uuid="faf10f62-e49b-4ebc-a79d-896ae192f735">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e69aba8-9109-4efe-add3-4b09adcf574f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) utilizes the firewall technology named firewalld
 that allows a system administrator to configure host-based rules which take effect
@@ -1397,18 +1397,18 @@ https://projects.engineering.redhat.com/browse/RHV-20377
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fbcbdee-f3af-4578-a1d0-a71f511f020d" control-id="ac-18">
+    <implemented-requirement uuid="cf94a9d2-9c80-4648-9d1a-8230c226c567" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="044b120a-13bb-4680-a55f-2504044fc067">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="479304f6-eeff-436a-be30-12e9daffbec4">
+      <statement statement-id="ac-18_stmt.a" uuid="311da3f0-e4e8-4eb6-9608-0e07d6138736">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0288252-f9e3-4799-b317-2eef7e56dc32">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="55fcec84-8cf8-49b7-a1b6-19e774d2c420">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6988fa94-1c2c-45ba-b73c-11fe6424c05b">
+      <statement statement-id="ac-18_stmt.b" uuid="e88d12f0-ed95-4bc1-aead-1a7618d5dee6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3fca007b-4bd5-47fc-9d79-2e20f48e28a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1416,10 +1416,10 @@ system are outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4789e66-9a29-4bb6-9ad1-875900c56e13" control-id="ac-18.1">
+    <implemented-requirement uuid="1ac7f974-c33e-4090-931e-326fc42c39ba" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="78bc6616-4ed0-4f8c-a580-1daa0baf37ec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8cb61e6e-e3f4-4ccc-ac9f-9707a44854cd">
+      <statement statement-id="ac-18.1_stmt" uuid="9c519ada-8b42-4a38-9112-f4a58ab56500">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="626d3238-bb0a-4b52-b0bb-40ef55c29972">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Host (RHVH) configuration.
@@ -1427,18 +1427,18 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db658e11-62ec-4663-8aa4-dbda726e6fb9" control-id="ac-19">
+    <implemented-requirement uuid="78ab6b5d-0a11-4f22-9827-88750979254d" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="9c608cb1-af60-4c59-8d0a-4e96a14df2dc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c40046a1-1ca4-4d62-96fb-1821613d6d1c">
+      <statement statement-id="ac-19_stmt.a" uuid="d8e4bd09-c320-4c5c-b376-bc6385f43bb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ee6b0db-3fd5-4373-bf29-c4a426eb6884">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="7ce7777b-91b2-44a0-8029-f7df481141a3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7a7262f5-18a1-4c38-ad9d-a197f83be17e">
+      <statement statement-id="ac-19_stmt.b" uuid="f00355c7-3b2a-4d78-8ff1-e8ba6eb677e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="206f5e0e-1f5a-44c8-9dd2-cb418965dded">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Host (RHVH)
 configuration.
@@ -1446,10 +1446,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99b390cd-d4fd-4097-b1c4-953d824beb61" control-id="ac-19.5">
+    <implemented-requirement uuid="6fcadec5-b100-4551-bc3b-7b2457202d73" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="92afba2d-e9c2-49ac-a96a-1e806da9fa6a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1bb23a60-3c24-4d1c-a735-a4c6a638c1a6">
+      <statement statement-id="ac-19.5_stmt" uuid="b62a8896-728f-48d3-8cda-6b6dfa3d2744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c083d4-929d-484e-9cf6-a288197475b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1457,10 +1457,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c209f8b-6130-4be1-917b-1d675f364178" control-id="ac-20">
+    <implemented-requirement uuid="3733ec6f-76d8-493f-9490-91a5c25ef3cd" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="a926cc3d-f78b-4c34-a667-961c0792b6c0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5f4bd69d-42d6-4fff-8c7d-f5464fb93302">
+      <statement statement-id="ac-20_stmt.a" uuid="3fdb7fae-e48a-45fe-a1e9-3fa009502b06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6c64b1e2-40d3-4609-becd-e33f4f85d73d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1468,8 +1468,8 @@ systems is outside the scope of Red Hat Virtualization Host (RHVH) configuration
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="e2ca8001-a57d-4455-824a-f0ca585d4344">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e8056484-7c73-4eef-9d43-7c48ddf5d688">
+      <statement statement-id="ac-20_stmt.b" uuid="a4eadd7c-a583-456e-bff8-69ecdd5903bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfd3e1d9-c2ce-43aa-84b0-301c83bc8bf0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1479,18 +1479,18 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6ac3cc1-50b1-462b-9833-ae212257025b" control-id="ac-20.1">
+    <implemented-requirement uuid="129d19dd-de95-44cc-908f-a9683baf6b8d" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="dd339d8f-cf2e-42f3-ae95-1c14e067a829">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ca16f77c-ea63-475e-96e8-1e73a44c070e">
+      <statement statement-id="ac-20.1_stmt.a" uuid="75ebfe9e-4e86-48f1-a243-0dec6785c09e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="579fc5d7-e56f-488f-bca1-7c0efa91ba4d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="ff1e9c4d-140d-404a-8f3f-bc9e5ff97e09">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a6ae6888-03fb-4d6f-92ed-c319ff7b6064">
+      <statement statement-id="ac-20.1_stmt.b" uuid="4113f8aa-d44f-4639-8408-2fd8e1bd8e90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a3c899c-0be9-4500-8444-cd175fbb7b05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1499,10 +1499,10 @@ information system is outside the scope of Red Hat Virtualization Host (RHVH) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1c89653-6996-4af7-88af-61356ff36c4e" control-id="ac-20.2">
+    <implemented-requirement uuid="2faaba5f-004a-431a-b95f-a5eb3798d4af" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="70fae2a2-84bd-4b33-9f17-306c3a0e8d1b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cf09c82e-a1a5-458d-813b-1bb9fdbdd592">
+      <statement statement-id="ac-20.2_stmt" uuid="f0957d50-acda-433f-9ca4-26e0159dd3b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2522cf64-2809-4a88-ae49-9de9191f7e71">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1512,18 +1512,18 @@ systems is outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1127bc1a-9a5a-44ec-95f3-e6af96e21b01" control-id="ac-21">
+    <implemented-requirement uuid="0fb4e964-b620-433b-b065-e08292c9213b" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="4516cdcc-af55-4eac-9b00-f49e01b507ed">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ceef4af4-ac4b-47b6-bb8f-5f0208ba13e5">
+      <statement statement-id="ac-21_stmt.a" uuid="51109e1d-c7a3-4f4e-9343-ba4e88c3c42b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15c5f770-1ce7-441c-acc6-93b539c8ae58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="80347788-cd22-4c41-9966-d69301938f6a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a0a2927b-d712-4578-a899-6c909810d545">
+      <statement statement-id="ac-21_stmt.b" uuid="5183e867-8c2a-47a1-a08e-d4bd1c6c0e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd252304-5f89-435e-a48f-3251c8f16a63">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1532,10 +1532,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2564aabb-2773-448a-9e50-7a5e91b1d5bc" control-id="ac-22">
+    <implemented-requirement uuid="22d9b4d6-436a-4319-8f84-f356873d10df" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="935e779a-3250-46fe-a2d5-584bdefb146c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1a3aaed1-2960-4333-9d09-fdcdc2c3726b">
+      <statement statement-id="ac-22_stmt.a" uuid="6744af3f-1fc6-4bfd-b70a-86d731c3a9e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="accc6867-088f-4fa0-a311-f8ec1625cde0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1543,8 +1543,8 @@ system is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="7eb118af-a481-4ca1-9683-f83ba0c90be6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="56122f45-fec1-44fe-b16d-e78f287f35ee">
+      <statement statement-id="ac-22_stmt.b" uuid="11d537de-0e77-4a89-a424-2d313832e46e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e117711-d918-4757-9c53-cd8e925fb189">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1552,8 +1552,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="008c378d-4ab0-4ac4-b08e-a5f4272a95de">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1f20baf6-1767-423d-9157-ef9ede6dae53">
+      <statement statement-id="ac-22_stmt.c" uuid="e9fc565e-5b3c-453d-bb6a-2c6be6f0e2c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b4bf50a4-e6e4-4df8-9070-d3ee9420d06e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1562,8 +1562,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="0bdc6cd8-4c9f-4540-bbbc-d36f8f5ae744">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c0072f4e-dbd7-451e-b5c0-e2f81166867e">
+      <statement statement-id="ac-22_stmt.d" uuid="76c42769-386a-4002-9b56-dcfe271343fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80727243-4558-4500-9bbf-6b8567ebd9ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1573,18 +1573,18 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6dedae1-2596-4cd6-a7ba-6f062eccdf56" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="d1769986-0048-40e7-82f0-dda450452710">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="607274ab-de6f-4210-bd4e-6f8809bcf2f8">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="70b5a9c3-ab60-4525-8420-155a9322014c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f60d8392-cf5d-4769-970c-160813662020">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1592,26 +1592,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="973f716a-f109-45e9-8d9b-4614491ed9ce" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="8fcafd08-3783-42d2-a8db-74bc3b39eacb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ec04e102-fccf-4de1-8c38-374d1e51fc14">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="e882dfb6-21ae-4b14-a95e-47e0461c47ec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="394e1725-98c1-409a-a485-4b7f83844608">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="8dc8be90-2cd6-4940-bcdf-8f9a6e7fd71f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="48bc15ea-92dc-4710-854f-8c9705d0d30c">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1619,10 +1619,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06f86740-fa76-4139-996e-3d89aa16a952" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="65f7eda1-b65a-491e-a2a7-c4447d6668e9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="372e98eb-dfaf-4c35-ae1c-f151eeebf601">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1630,26 +1630,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87329e4b-7bc4-4c6f-85ab-6c33ddaebae7" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="865a5a8c-53d1-499c-a7cf-2746f10d2a8e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="53e2a631-c2d4-49d2-926c-030378bb9d1c">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="6bb54532-fd81-40f8-8464-ab7cd62add31">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="74457ad4-537a-4022-9630-10ec6d6dcba6">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="3ef89b3b-88bf-4ee0-92d0-69bfcc9adab8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c1a79451-ad44-4546-a7b7-c077a07c446f">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1657,18 +1657,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52cd505d-fa83-45ae-a53e-759123058122" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="22872e15-1abd-433f-9aea-31a930851858">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="133657b6-c9bf-4064-b761-3fc28600bc63">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="a623b847-936d-48c4-8571-9f5ed801d34e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0edaf1ee-9242-4a0f-af07-d03f25fe9e36">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1676,18 +1676,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d88e9716-3022-4168-8a3a-ced74738126f" control-id="au-1">
+    <implemented-requirement uuid="9f3bbb92-4fd6-4f4f-a234-43e8b2f9d321" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="a671fccb-bed9-49b2-8cad-15cd9e1f69a1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="13c69bc6-49e2-4d45-869f-da546ca81859">
+      <statement statement-id="au-1_stmt.a" uuid="c2636108-0713-4727-908b-9d644f5ef47a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a6d15083-8660-4473-bd76-f23f53dc412e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="a421bebd-f7ff-4dc3-801f-8085d25ecf89">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2443847d-8e94-41bd-8a5e-3e3aa55b4c32">
+      <statement statement-id="au-1_stmt.b" uuid="c63af622-3579-4f08-9ba4-caaac03fe2f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b09d43c2-ff7d-4474-9cf6-41f5b9827270">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -1696,10 +1696,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d29b6391-1f4b-4f28-96b9-a45d1878f6c8" control-id="au-2">
+    <implemented-requirement uuid="b7db7dc9-b503-436a-8f61-937f91b306d6" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="8fab11cc-edf8-411a-bd53-79d44ef9d778">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cd351446-4a01-4f47-9212-220d0a86ec18">
+      <statement statement-id="au-2_stmt.a" uuid="f4c58566-e8d5-4cb4-8d80-5814a9a4d258">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5dc2ddf-e441-4bad-bafb-d41bbd5dfa89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Host (RHVH).
@@ -1731,8 +1731,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="e535564e-1c34-4196-952b-f58695504e3e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f1f924ef-9676-4f2b-b8d3-a4d9e2653291">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1740,8 +1740,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="85d2fcb7-0cad-4b36-b6b5-f7f2a1b0ec20">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c036f7d0-16f6-465d-867d-fa90d5d5e896">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1750,8 +1750,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="06c9996a-6258-4b8f-81d6-f5a9d6253882">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b89e85f2-ae9e-438c-8309-7c03fedd8aed">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1763,10 +1763,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ca3899e-3213-48a0-951e-c807a42bc0fa" control-id="au-2.3">
+    <implemented-requirement uuid="78e86d30-c64c-4d7b-9ca7-a86134553a4a" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="a3d12aac-06e1-4df7-8323-ee1359d8aa3e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d042792d-33fe-4610-8211-214300b868c4">
+      <statement statement-id="au-2.3_stmt" uuid="3527cadf-7964-4181-ad84-4cda1f62949a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f0ba69-723c-4ee0-9f21-84503d026812">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -1774,10 +1774,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6da03206-3495-41e7-99fb-ac18ac44c206" control-id="au-3">
+    <implemented-requirement uuid="8e3dae3b-dcbd-4acb-942c-254be196b09f" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="b24abf18-a0ef-4b16-8880-e5736317acf0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a92aedcc-18db-4d19-a6cc-28d8936c910b">
+      <statement statement-id="au-3_stmt" uuid="3f79bc0f-b8c6-4846-804a-0ef92deae5f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="602ba1d2-55b7-4547-a71c-79ef4acc3e2a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) audit records contain
 the required information and cannot be configured to be out of
@@ -1785,10 +1785,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2575d17d-b8bd-41fb-a0f0-80d807bcaae5" control-id="au-3.1">
+    <implemented-requirement uuid="be77b6c8-342f-4bc5-b488-a40884a0f1eb" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="5e551029-1f45-4147-8043-aa6d7d7e9834">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e1a62527-b6f2-481f-8f21-dc672902e9b9">
+      <statement statement-id="au-3.1_stmt" uuid="f04ec7dd-9f1c-45e1-a32a-eb05a6a66d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1797,10 +1797,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc592a2b-4957-4a48-aae1-ffe466536e15" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="5460e629-78ad-43e0-a903-1b58a254709b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="465e9f5a-037f-4f01-8b96-4d8a67e9b83a">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1808,10 +1808,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52c991c8-c0a2-431d-9c93-f95e7cb1bf29" control-id="au-5">
+    <implemented-requirement uuid="5b395705-475e-447d-aadd-b8c26afedae6" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="9acea7d8-475d-42bf-98ff-1c1519f1d71c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7a89a11d-f4ec-42e6-a48f-f5975d542476">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -1822,8 +1822,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="550213a4-bc46-46da-81ab-6a5eeb134221">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c8bf477d-619b-4c84-bf44-f4ec46db7977">
+      <statement statement-id="au-5_stmt.b" uuid="17101dc5-e63f-4235-9379-079def2556d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8322a91-fee3-4987-9b27-c869af08a5cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To shutdown a Red Hat Virtualization Host (RHVH) node upon
 an audit processing failure, which includes software/hardware errors,
@@ -1845,10 +1845,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23f71945-70e0-4506-ac9a-3f5a5288b888" control-id="au-6">
+    <implemented-requirement uuid="3444efd3-f653-41c7-be8d-b52fe68795ef" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="8dded146-c544-4032-8039-8c1770d46ba5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8dfc3232-103c-4f0c-86eb-97c3e6ae781c">
+      <statement statement-id="au-6_stmt.a" uuid="0a10e0d9-e8b3-4d8c-8a1d-21eb61c789e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7932186a-3291-4937-9080-1023ab875818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1857,8 +1857,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="14834fc4-586d-491f-8091-3fd57884f4d1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2dfba740-53ee-47b8-a76c-8e91b7a4052a">
+      <statement statement-id="au-6_stmt.b" uuid="b514c067-55cf-486c-b3a5-74348c51c675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a00e37ab-b563-40d3-93f9-2ecf04468c31">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1867,10 +1867,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6a2182d-fbd1-4374-9d54-fb950e95d909" control-id="au-6.1">
+    <implemented-requirement uuid="37775031-a4ba-4fdb-bfe7-9ec860d0e643" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="b8e58114-3359-46fb-8cb6-4c101f213fb7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0a145b57-d389-419a-90d7-0d5edb04a11a">
+      <statement statement-id="au-6.1_stmt" uuid="78fb7f25-7b92-4b0c-a04b-091352b690f8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f159707a-684a-4f17-abcb-f8f7712921f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational use of automated mechanisms to integrate audit review,
 analysis, and reporting processes to support organizational processes for
@@ -1880,10 +1880,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a126ae65-08f0-40c6-814e-c720b9059a66" control-id="au-6.3">
+    <implemented-requirement uuid="3b4c311b-089c-4fe1-a4c8-34497050d552" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="7efc7918-4289-4357-91ac-93d62783ab6f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="369b1898-a46b-4a88-a151-38390cbae6db">
+      <statement statement-id="au-6.3_stmt" uuid="d90133a4-0ba1-4493-8283-8a40ebb3f97b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c4da8b4-7a73-47ef-932c-d06f4353a56a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1900,10 +1900,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6780b804-4b9b-471d-b179-2e913be1699b" control-id="au-7">
+    <implemented-requirement uuid="9d404010-fdda-4aaf-883b-c36e2876d5c8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="b09385bf-6d3e-4a5f-ada9-27d997d4cb5a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e93692ed-6a63-46d8-afe8-0aaa9ed263d6">
+      <statement statement-id="au-7_stmt.a" uuid="32c2238f-fc50-4cf0-8789-85635ac69e09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1911,8 +1911,8 @@ https://projects.engineering.redhat.com/browse/RHV-20424
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="c7630864-62e8-4138-a489-bf44cfc6449f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1c91619a-0770-48f9-acb8-86e256e14065">
+      <statement statement-id="au-7_stmt.b" uuid="460204fa-d554-49cc-8aee-1e7b603104a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1921,10 +1921,10 @@ https://projects.engineering.redhat.com/browse/RHV-20424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9f42e03-dd62-44e1-ba55-8d8c983c924c" control-id="au-7.1">
+    <implemented-requirement uuid="b714e1ac-5385-47db-b004-f4538318cbd4" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="8c6ad4e8-24d1-47d8-ac89-fe990aaaf7b9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="05c70aec-cace-4b77-a0fd-b5cade59f640">
+      <statement statement-id="au-7.1_stmt" uuid="6b9632dd-07c3-406b-a28f-0dfdaf45a47b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34dc1b8b-6c3a-404f-aa23-7106d0a34670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1933,18 +1933,18 @@ https://projects.engineering.redhat.com/browse/RHV-20425
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3759d09-4972-4dee-b522-94b8d303e77c" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="02a2fdfb-5b7b-4db3-b28c-378b0e68b843">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="200ec735-fdcd-49bc-970a-c80647d47c77">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="520a9482-c79b-4d44-9a39-30b473d2813a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0e4de001-f364-4893-a333-f194d3afdb55">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -1958,10 +1958,10 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33e99d6a-5a09-40fa-8038-d9c92ea97ea8" control-id="au-8.1">
+    <implemented-requirement uuid="fe187a61-ea34-418a-b501-ca3011363641" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="678c5b24-f013-4f58-80d2-abf4c0b29490">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a84883d5-62ab-4d96-b6be-ea98b2ecdc1f">
+      <statement statement-id="au-8.1_stmt.a" uuid="2f91fcc4-cb3a-4c91-bb53-499978eaf621">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d3051045-d17b-40c2-9797-1f75cd5a1b96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure that the Red Hat Virtualization Host (RHVH) syncs time
 with an authoritative time source:
@@ -1969,8 +1969,8 @@ with an authoritative time source:
 - CCE-82873-1: A remote time server for Chrony is configured</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="933504cc-b559-467a-babd-3b327f3f1a6a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="81ed3d1d-261e-465d-9cf5-34726e148f24">
+      <statement statement-id="au-8.1_stmt.b" uuid="a4189d5e-78f5-4777-b6e4-72ad1ba68cbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6695c4ef-ccb7-4d44-8ef5-3f793411ff2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure that the Red Hat Virtualization Host (RHVH) syncs time
 with an authoritative time source at regular polling intervals:
@@ -1979,10 +1979,10 @@ with an authoritative time source at regular polling intervals:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07ff0637-0281-4463-9a1b-0ba18e3b8f9e" control-id="au-9">
+    <implemented-requirement uuid="9eec989b-e59f-4c58-bb64-15cd8b4cd415" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="b83348a4-7c0b-4d2e-b980-ab96f150e6fe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="042ae121-0d20-469b-8289-778ed77f168c">
+      <statement statement-id="au-9_stmt" uuid="2837780e-02a0-44ab-afb1-5c221e5f9f38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="acfe3ec3-a01a-4943-b0cd-65e93a684b6f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks ensure the audit records are
 protected by appropriate file permission, user, and group ownership settings:
@@ -2008,10 +2008,10 @@ been modified/tampered with:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81013652-6432-44ad-8a88-6344d45dbd2c" control-id="au-9.2">
+    <implemented-requirement uuid="b27e50b8-48b3-427c-b6f5-207314c09526" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="e86adcaa-f606-40b4-bb70-8154f6157c57">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="907d0e09-b3e7-4ca3-adfa-eaab8749e2c1">
+      <statement statement-id="au-9.2_stmt" uuid="7ee18b7e-7ba1-48b1-9be0-e050275901dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89a9eb49-f787-4bdb-bbca-dff99867830e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2022,10 +2022,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4d4ad23-99ac-4a84-8c29-5244da9f3c44" control-id="au-9.4">
+    <implemented-requirement uuid="a265c8f6-0497-4ffd-baa0-bd923d1b9308" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="a3e0f565-7dfa-48d8-bd9e-b9596ca29285">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cc50386b-a9c8-4104-9ab3-e4b9d7f7c7df">
+      <statement statement-id="au-9.4_stmt" uuid="9be4ed66-62d1-4775-aa28-bb2096f5649d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20adb15-f43b-4008-bf7e-2fc6ac84b3f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2035,10 +2035,10 @@ https://projects.engineering.redhat.com/browse/RHV-20506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="661e5c2b-9073-48db-9671-74612bf19216" control-id="au-11">
+    <implemented-requirement uuid="6b3bbfa4-14a0-4bc9-8576-b92c461c4150" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="ec6003bb-3ec9-457b-ae95-acff0a08eb98">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ad75432b-a23c-4270-88e1-83db4d77e4d8">
+      <statement statement-id="au-11_stmt" uuid="30e22ec4-cc35-4140-a186-122b751ea450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98a9df94-f1be-4c9d-adc3-a34c9358b230">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -2060,10 +2060,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a5dd753b-60c4-401c-a7f3-a60b742ba2b8" control-id="au-12">
+    <implemented-requirement uuid="6f8494bb-c00d-47f5-bda7-0ae955eb3822" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="393a5ac3-69a1-40f0-9d3a-79f337265d85">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9354f76c-809c-48d9-969e-9a2c1e49c427">
+      <statement statement-id="au-12_stmt.a" uuid="49b9b7a6-a777-4820-b4af-81b7817398a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05794480-06d3-4c97-a7ec-634d165fbc1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure Red Hat Virtualization Host (RHVH) nodes provide audit
 record generation capability, the underlying audit subsystem
@@ -2079,8 +2079,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="6cfdb0bc-b68b-4679-a6ab-8af6779b1322">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1d2f4d3c-bf0b-4eba-b7dc-d19b65efba6d">
+      <statement statement-id="au-12_stmt.b" uuid="ae3d7411-b456-4b09-b30d-7b49f8d21f12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="435db5cb-b92e-43d3-a0c5-1a103bc53163">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>System administrators may customize audit rules by editing the
 appropriate files under /etc/audit/audit.d/.
@@ -2091,8 +2091,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="eed4f3fb-7d0a-4aa8-9c74-cee3762bff45">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="aade7c2b-eaeb-434e-b2b1-dc44bb1b6a1b">
+      <statement statement-id="au-12_stmt.c" uuid="92631140-5b9a-497a-9a62-1fc88736cf76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a8a1327c-6ca4-46a0-a0ac-cc2f87d19dcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks correlate to recommended
 audit events:
@@ -2227,10 +2227,10 @@ audit events:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1a9c0dae-f974-4212-8461-49bdf5533cb8" control-id="ca-1">
+    <implemented-requirement uuid="9f7998ec-517c-4f59-9cb3-183766cdc84d" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="62d6f46f-544e-41c1-9654-40a71de5bc55">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a2b048ef-5f5b-4c9a-acfc-77d92d39127c">
+      <statement statement-id="ca-1_stmt.a" uuid="6e1cfd0a-61e2-45fb-beb1-ad29db0968af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2238,8 +2238,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="3bc9c55f-4fa7-4ede-ae3c-0a601ed03bda">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="593b022e-4d74-463d-9ff5-84cbbf962256">
+      <statement statement-id="ca-1_stmt.b" uuid="3a2fae8e-3afa-43e4-a06e-9c493bee605f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="23b40915-b6c2-4365-b9e0-062705818775">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2248,34 +2248,34 @@ the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="342a87ef-f5c2-4d05-9ea6-c55f9511a696" control-id="ca-2">
+    <implemented-requirement uuid="289d60a5-96e0-4c8f-ba5c-ee51e290a842" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="544173bd-82a4-4239-bafe-2d71a10db28f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c11654cb-f360-421e-bfde-fc4d673fedd0">
+      <statement statement-id="ca-2_stmt.a" uuid="a7abe116-eac2-4cdd-8d14-45471e54f6a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="ce1aaeca-aca4-43e0-a7c7-911957d04e89">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="58f234a9-2527-40c2-aaff-9ad3ec2f2d9f">
+      <statement statement-id="ca-2_stmt.b" uuid="d1dfb904-939b-4f78-b8ed-47b4f1c3116e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="f4a394fd-0ff6-45b0-a52f-456aeeb84987">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="743867c7-74d8-45ae-95f4-a70f53b68837">
+      <statement statement-id="ca-2_stmt.c" uuid="f247ced2-eac6-4696-b78d-b0435339a085">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="1a11bcfb-5b6f-477e-b4f7-8968bade1c00">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="42015a3b-d5bc-41f3-bdfe-bcc45eb78a81">
+      <statement statement-id="ca-2_stmt.d" uuid="ce26608e-47e4-4c3e-bd43-ce258ddb8254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="befa4f35-41b4-4288-a643-1906d8c22e13">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2283,10 +2283,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="590834e1-01ee-4528-9f61-25dded465e74" control-id="ca-2.1">
+    <implemented-requirement uuid="6ef18e3d-dc28-49ad-8675-40ab7c85fcd9" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="062def77-81c2-4d89-94ac-67af427e747b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="790ff475-157e-4211-a34f-177fd47a4b44">
+      <statement statement-id="ca-2.1_stmt" uuid="57b3b99a-2df5-4fe7-ab08-9935ae4a4474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ed1c9eea-65a1-42c1-bb95-e72a6403fea0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2294,10 +2294,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="810cabff-e184-4d37-8dbb-acc56dec6bbe" control-id="ca-2.2">
+    <implemented-requirement uuid="b0f11a8c-fc09-485b-81f2-ec7431effba4" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="6e94a7c4-234e-44c8-9566-f601df667780">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6f81c141-51fd-46cc-9adf-f7f54af2156c">
+      <statement statement-id="ca-2.2_stmt" uuid="b5ec0373-2514-4ea6-a4d5-4358dd92c93b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7975cb57-e329-44d7-bbfc-fb4924829ae3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2305,10 +2305,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4219b866-90c8-4067-b3ab-2cdc43f9b05a" control-id="ca-2.3">
+    <implemented-requirement uuid="39142afe-1558-43e7-9c95-76cecd414cc3" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="b7edd485-d0d6-4b7c-a652-10b89a8e4f89">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3ad7250f-8756-4046-bfd1-06c9d3d3c60b">
+      <statement statement-id="ca-2.3_stmt" uuid="fb1d133b-3ada-4dcc-9195-1d9adbee0c84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e3f038e3-b26b-4790-a56c-3a1946d960ba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2316,10 +2316,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d657e664-6790-44af-9b1e-19ed864c3a87" control-id="ca-3">
+    <implemented-requirement uuid="2cdfa14d-b733-4897-a340-b8e3f05bbec9" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="8d47e119-7359-480a-ab5f-9c2c80447833">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="67c5edf1-94a3-4af4-9fc4-06547acef936">
+      <statement statement-id="ca-3_stmt.a" uuid="38b26537-a0fb-491c-a6ec-4eba6cf219ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2327,8 +2327,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="ed142a44-9920-4cbc-845b-3fa65891b25a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a5ce40c2-ab33-4762-aadd-5a9491ce023d">
+      <statement statement-id="ca-3_stmt.b" uuid="8dbf9169-8348-4c89-847e-cbb73c852d62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0315457-27b4-46d2-b4a0-e26c51bc6331">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2347,8 +2347,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="ef266e67-3891-4882-a950-9ff2925dbbf6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="276b8bfa-cdaa-46ae-aeac-dfacbf2072c3">
+      <statement statement-id="ca-3_stmt.c" uuid="0d1c4f9e-fff8-4cdd-a9f7-f66acd150010">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87e83aa5-ab34-4d86-9520-24779b131b85">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Host (RHVH) configuration
@@ -2357,10 +2357,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="611b9409-2115-492e-9c51-fd10a5b198c3" control-id="ca-3.3">
+    <implemented-requirement uuid="850a4ba4-82cf-4aad-9cf8-b8ebc65a9d3a" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="cee6705b-3c25-4cc8-aaf3-ee4f2d74b85a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9c920543-a8a1-4d2e-a359-00591ce884f0">
+      <statement statement-id="ca-3.3_stmt" uuid="b5c7d2a9-d912-4bdd-b25b-bc3b37149184">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b698b788-aff4-4227-9a0e-ecc3f1a85b1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2368,10 +2368,10 @@ Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4535b047-34ed-47ea-9ea8-00e0f08bdd49" control-id="ca-3.5">
+    <implemented-requirement uuid="fedbf269-0f66-44c8-9e7f-25605d243263" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="57097ea8-d6e5-4573-8deb-2d9ff5f7100e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a8fd4b30-8d8a-4045-b3d9-d12736f7240f">
+      <statement statement-id="ca-3.5_stmt" uuid="f6abe9b9-631d-48f6-bb3e-625110996d75">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="deb71040-a9e4-4609-b2b5-b473fc4ec3e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to Red Hat Virtualization Host (RHVH) and applicable
 through host-level firewall rules.
@@ -2383,10 +2383,10 @@ https://projects.engineering.redhat.com/browse/RHV-20516
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6e975ae-8e3b-4153-801d-6333d3a6f3b7" control-id="ca-5">
+    <implemented-requirement uuid="86d74c00-0c31-4d76-b3fb-c0c9a65518da" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="ac4f612c-c6ba-414b-9f63-72b70d957a3f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5c575c4d-87b1-486d-b8fe-6fda004790f4">
+      <statement statement-id="ca-5_stmt.a" uuid="47df7fd2-84ab-40da-86ad-2af43e1230f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b013587-8b21-43ec-8ef6-0917e64a1462">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -2394,8 +2394,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="63a6bdcd-03c7-418c-a1a5-0e2d64777fa1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4226c00f-04fa-4b9a-8f0f-d6578dc77713">
+      <statement statement-id="ca-5_stmt.b" uuid="a48733c6-22f6-4c39-96c2-0b8738304727">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea64d27c-3385-4fa6-93d6-575913ac2533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2404,26 +2404,26 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration process
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43b42e85-6575-4361-a8e7-b747d906eefc" control-id="ca-6">
+    <implemented-requirement uuid="f614a8be-533c-4f88-8721-e6069c1932e1" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="0a4a251a-5f67-4a05-9e08-25753c502fa9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="59f2936b-1c86-481f-8912-53d92f3ff5ba">
+      <statement statement-id="ca-6_stmt.a" uuid="c0d2ca6f-e92a-46b9-9552-8403ee244e06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="07cefa0a-4c34-4468-84b0-253698af7fcf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b9cefd2b-5b95-424c-80b4-3e34ca2005e5">
+      <statement statement-id="ca-6_stmt.b" uuid="ee5d757d-b418-40c0-952b-1956499bcb08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="5647a645-7928-46af-b024-ecb9090c5797">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c362388b-7b43-4de9-8e62-b8dc6a495e32">
+      <statement statement-id="ca-6_stmt.c" uuid="504677fe-0e57-4537-9f05-b57d3833d732">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2431,10 +2431,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b241215c-9c14-4cbc-aa98-6c9e94dce021" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="be03d068-feff-4f41-9f55-4370df6888b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="99f566f4-b39d-4007-b60a-7d657fda5579">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2442,8 +2442,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="7619a3f6-682f-4619-a032-011476054661">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="30ebb82c-d687-4f35-94be-5849746418a6">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2451,8 +2451,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="9e706fe1-8d37-43c2-b6a7-afb9c1b0f414">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7ca906c4-4522-402b-afde-288f42183d65">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2460,8 +2460,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="7be24c34-1050-4ac4-8781-0c1b7821cbf5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="99dcf1d7-d08e-43af-a30a-b58a3c7d619b">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2469,8 +2469,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="4c272f23-7129-443f-a43e-18726e8ba10e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="999e7c33-0bc4-4c3d-9c71-c8d9aabe8253">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2478,8 +2478,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="d308cf3a-7c5d-4675-b69d-51f8c851598e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1b9c7782-f3f4-4e7d-a515-f25c588416b6">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2487,8 +2487,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="1d844483-9de3-4fd4-88ef-b57bd46bcb99">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="30921aab-cb89-488f-bb4d-5ea76501db61">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2497,10 +2497,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f31f2188-b285-4c43-b471-d4c6411df7e9" control-id="ca-7.1">
+    <implemented-requirement uuid="9598c03f-f904-4244-9e36-c3c25ab93014" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="396f84f4-dc3b-407c-aae3-9007bd664475">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0e1d4d4f-4d0f-4abd-a8cf-90cc42c33a93">
+      <statement statement-id="ca-7.1_stmt" uuid="502f4163-776b-40ca-9c81-0f094f7ba39d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a3d82404-c62d-4668-b25b-da4dc2a9baa7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2508,10 +2508,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0ef5b6e-1730-4989-8e99-5e2f47935fc4" control-id="ca-8">
+    <implemented-requirement uuid="1dc4a76c-ce52-4b9c-860b-644bcd2d46b6" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="19f7a141-8f5e-43c6-8dfe-faf49eb8a6f3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d57e0559-05b1-4f9d-be6d-503b78e45a56">
+      <statement statement-id="ca-8_stmt" uuid="a940f98b-95e7-4673-b382-23ca28241bd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d2d7b791-7b57-4b06-843f-8d36c82228dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2519,10 +2519,10 @@ Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="824cc437-9ed2-4252-8efa-440d56968da1" control-id="ca-8.1">
+    <implemented-requirement uuid="c24de900-2274-4748-ad30-9f7faaaeab8b" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="a4e7aff2-7085-4bfd-84ed-6f08124de9da">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ea3bb895-691e-4c6c-b089-b4612ce29d3f">
+      <statement statement-id="ca-8.1_stmt" uuid="e8122375-3c7b-4569-8076-3bbd87ba8309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbc2a29b-74d2-41de-95b5-76e6afa4615a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Virtualization Host (RHVH) configuration
@@ -2531,10 +2531,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c29531cd-2964-4465-adc0-01b0f1062534" control-id="ca-9">
+    <implemented-requirement uuid="81438902-6d72-48c6-bdef-512ce86f9cc8" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="7b074022-9023-44d2-86c4-c21a0857fd3b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="990c59b0-fe8f-4592-88e0-62c10db0f753">
+      <statement statement-id="ca-9_stmt.a" uuid="37075470-ee1b-4d57-bd59-9e906f08185b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ba32062-5e14-4358-a282-0c161301fd23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -2552,8 +2552,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="e18fb312-7ec6-47e0-90ea-c8d1baef9f92">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b39cf8e2-6bd6-4251-9ca6-c21c2063b9f3">
+      <statement statement-id="ca-9_stmt.b" uuid="8757eaea-2bf1-4007-9b9c-1d12b7808641">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4085cf70-9957-47a4-9b8b-97caac2a5166">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Enterprise Linux hosts and Red Hat Virtualization Hosts (RHVH)
 require a number of ports to be opened to allow network traffic through
@@ -2573,18 +2573,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b7dc856-d27d-4ae9-a6df-e3b24fc8e07e" control-id="cm-1">
+    <implemented-requirement uuid="cfdc0ca1-6cef-42e4-8d4d-ed3938123b40" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="7b6d0e5e-9b9e-492b-a810-cca59890d494">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2ddceea6-04ee-4a0e-b3a6-23868bfe0d7a">
+      <statement statement-id="cm-1_stmt.a" uuid="8e9e428c-067e-47be-81a9-5bea33a7a446">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="08f31ac0-12ba-44af-a682-36187123d8c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="38bfcaa2-2510-4b36-977c-563ea45eb7d7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a579cf01-d2bf-4655-82e9-bda0994e5815">
+      <statement statement-id="cm-1_stmt.b" uuid="05595bed-e10d-4ed8-b954-b8e07ca96a22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a27ae912-1014-4d2a-b6c7-32a644fe6dad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -2592,10 +2592,10 @@ management policy is outside the scope of Red Hat Virtualization Host (RHVH) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebce4631-6610-47fe-9ad9-b55a5bec4c32" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="2097ed98-9b3c-4c24-8403-f321d0861b25">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b412fd5f-6dbd-461f-9c33-6eb63bef9c80">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2605,10 +2605,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e68dd60b-f1e2-4edf-8649-2066db025da1" control-id="cm-2.1">
+    <implemented-requirement uuid="1175aab2-b8fe-4b48-a82a-54c02ce8b030" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="a2052dba-2c53-45f6-a7f7-457a883a44b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fdc1880c-061c-413a-ae49-3ca56733b19a">
+      <statement statement-id="cm-2.1_stmt.a" uuid="c70cb871-7647-4a19-9e18-25d13e0c8134">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2617,8 +2617,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="b35bb738-896d-4339-bf88-6678a32e195d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b0182fef-3cec-46fb-b862-77e23fabbc96">
+      <statement statement-id="cm-2.1_stmt.b" uuid="02f6ac89-58fc-4803-9ca7-d8ba052bdb7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2627,8 +2627,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="84e2cdba-15a6-4571-9115-e712685bc4f4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="aad02778-2f8a-4565-8a70-7d510da38d2b">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5c60f968-1ec3-4d42-a3d5-6506b6229de3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2638,10 +2638,10 @@ https://projects.engineering.redhat.com/browse/RHV-20520
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8663a0b6-c4fc-40c8-87ba-8fc890c5bfbe" control-id="cm-2.2">
+    <implemented-requirement uuid="70c0fb30-fa81-406d-9884-90eda4617fae" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="df27bdb5-0b8d-4194-b83e-b3abcd9a1b49">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="51485976-0441-4747-be8d-8cb2eedff2a7">
+      <statement statement-id="cm-2.2_stmt" uuid="ad22cfd3-c298-49b0-abc1-f14139cb228d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c82280c-9d27-4e3c-bfcd-2cf177e34ba4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2651,10 +2651,10 @@ https://projects.engineering.redhat.com/browse/RHV-20521
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5644c48a-c1c6-44d4-b8b9-df869d738015" control-id="cm-2.3">
+    <implemented-requirement uuid="25e98aef-d677-4c77-9d54-2973e72f1750" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="e9fe530c-c809-4690-b80c-49c890376f05">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f9c14d7c-07d6-415c-ab65-011fe4456b87">
+      <statement statement-id="cm-2.3_stmt" uuid="9120376e-fb5f-4f88-84f4-5bd32d647c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d33969d0-128b-432f-b439-dc4f470e4466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2664,10 +2664,10 @@ https://projects.engineering.redhat.com/browse/RHV-20522
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e74b1da-080d-4308-9db3-f6494b7e72c1" control-id="cm-2.7">
+    <implemented-requirement uuid="9ded0ea3-4568-4ab3-901b-eb03cffea7a0" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="08f4995c-dfdf-492d-a787-8e0e5be90e88">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bc31ba44-8ffc-44c4-b1d0-a3f175c1e4d1">
+      <statement statement-id="cm-2.7_stmt.a" uuid="971b43bf-62cb-4fad-9519-4aa739eb1469">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="543efe33-8d56-411f-8838-6712a0af2fc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2677,8 +2677,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="076357b9-bf86-4046-a88c-a44f7c3a3246">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9e64c9fc-73ab-4822-8103-ff52a84f4ab3">
+      <statement statement-id="cm-2.7_stmt.b" uuid="ac8c381f-6376-4ef0-8717-225c63242ec9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3aec2242-c3df-406b-9e5d-fb8a5d4f78cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2687,10 +2687,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f68ba68d-fd69-4154-822b-bf3ef5ce27c0" control-id="cm-3">
+    <implemented-requirement uuid="8b20002f-87fc-4696-ac56-f29084a0d993" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="d521e562-160e-456c-87c8-8ce2d5f1353c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bed414c1-c0aa-4938-a6e1-ae0366bc1a36">
+      <statement statement-id="cm-3_stmt.a" uuid="42365f59-42dc-47f7-8da3-2d45e8a13a76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2699,8 +2699,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="150ef1cf-1bd0-4aae-b01c-889968dd6673">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="78279a95-3dd4-45de-9f29-6f08f54363db">
+      <statement statement-id="cm-3_stmt.b" uuid="1b035e1c-2536-48b3-b14f-f55f3da4cae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2709,8 +2709,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="7dc28b73-6db9-4b4b-83cf-231bf69d45c1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e66d2e60-c540-42d2-9cc2-f59b58e1fb6f">
+      <statement statement-id="cm-3_stmt.c" uuid="8236707a-18a5-4ca4-8be3-7c39745b62a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2719,8 +2719,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="4de775d2-fa5a-4624-8ffc-ecd78e71d17b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9fdd8236-44e5-4643-87f0-a6912bcab2c2">
+      <statement statement-id="cm-3_stmt.d" uuid="637f76df-2369-481c-bd48-6a7e18bdbecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2729,8 +2729,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="079d50ab-78ac-42a8-a16f-7dc22f513e07">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fbd49f33-3fea-4658-bb0d-fd7bdf427884">
+      <statement statement-id="cm-3_stmt.e" uuid="3cd7556c-0293-4c0b-8c95-66a14873b29c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2739,8 +2739,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="a2f0a9b5-45b1-4e7b-bfc8-c555002aae2b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3e2e7e94-01c1-4b9d-a34a-8b96048c8a6d">
+      <statement statement-id="cm-3_stmt.f" uuid="eba81077-99e6-499e-a7a3-f7e96ce35b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2749,8 +2749,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="a9f1bcbf-920b-466e-af13-43467a9e496e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e310a514-f985-4c1c-b8f5-5bc814dfbaef">
+      <statement statement-id="cm-3_stmt.g" uuid="e54c96b3-f923-4cc6-bc23-c9878c8079f5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2758,10 +2758,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8e229aa7-31e0-4a1f-9f79-be3607b08c3b" control-id="cm-4">
+    <implemented-requirement uuid="c7d70620-3eb0-49f4-98ce-8d59965658ca" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="53dee24d-6a96-4aeb-9b46-41385b8930a1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c2289ae5-4d25-4c82-a7a9-25f9b930c1ee">
+      <statement statement-id="cm-4_stmt" uuid="763bb0b2-b3c1-4af6-8436-99f29f9c6aa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9df6f94b-15df-4647-a801-4aa4eef28ead">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2770,10 +2770,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="69bee9b1-2cdc-4cbd-9714-05a0748d0dcf" control-id="cm-5">
+    <implemented-requirement uuid="7bff67d1-da84-4342-ad1f-6dc2aae9ec9b" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="861c7414-1dff-418a-b849-e1b8920f1cbf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ea7460e4-20ad-4a08-a2ae-f59ec33b2cd4">
+      <statement statement-id="cm-5_stmt" uuid="b00abdab-1b01-4f1e-9090-05aae69627f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2781,10 +2781,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a78c74a5-de77-4acd-857a-3f4192fba93e" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="3dcee2e0-9dc0-4e0e-8d65-35a5845a7668">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9d67fa35-8ed2-4a44-8433-99544dcd64f9">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2794,10 +2794,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdc7d121-ff27-4bfb-bc5f-a2f7b659a594" control-id="cm-5.3">
+    <implemented-requirement uuid="8bd4800b-4d23-4722-b068-f53f04d79298" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="0690c9fb-e84e-4a3c-9fc4-d221d4e0dca7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c5e6e7e1-0705-475d-803f-31df6937e968">
+      <statement statement-id="cm-5.3_stmt" uuid="1a42a7ca-52dd-4fc7-a4c6-db20e4737bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="020466c9-c44d-46eb-a233-a4b3e05d72ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2807,10 +2807,10 @@ https://projects.engineering.redhat.com/browse/RHV-20591
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c9d73af-8175-41f9-9c2d-e2a67c8b2bf5" control-id="cm-5.5">
+    <implemented-requirement uuid="8ce7dcc0-5066-47bf-8103-1431502afdc6" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="16c5c784-a6b0-4f38-b66d-b7a69a8e9c3a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b12bb5fe-cb23-4d1c-8a9b-2f3f6fbaf17c">
+      <statement statement-id="cm-5.5_stmt.a" uuid="dd60c188-efab-41b2-b837-9dd1fc6e0744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1444903b-5a53-4300-bf9a-f0c65262db2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2819,8 +2819,8 @@ https://projects.engineering.redhat.com/browse/RHV-22703
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="a283d9e2-6ff8-46fe-a598-7bb809f0f278">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a3667cba-29af-4220-93cb-899ae73dcbcf">
+      <statement statement-id="cm-5.5_stmt.b" uuid="4c06d361-d99c-4fe2-89a2-54705b257ed4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2828,10 +2828,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="796538b6-eecd-4613-848b-3f88134e3d40" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="7b5c57eb-6195-4dc0-878d-0ea4ae342e43">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0493d80f-18a7-49df-b274-1ed29bd7415a">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -2845,8 +2845,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="401d91c8-a391-4a22-b93f-758690439506">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ce43859a-a82b-431f-85cc-d835d848b4d3">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -2860,8 +2860,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="395c6587-dabd-4e69-bd4f-2f793421e392">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a41ac420-95f7-4a2f-89cd-c1e298382771">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2870,8 +2870,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="6a84a658-a485-41cd-95aa-b1819cd95291">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="925a980e-a9e3-491b-ae32-8a0d45bccb1b">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -2888,10 +2888,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db37f75f-1166-42ae-b4cb-5c7c1d7efffd" control-id="cm-6.1">
+    <implemented-requirement uuid="856967aa-a9a0-488d-8182-c49747d9d848" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="e1d7d634-4af9-4569-aed8-ec673ea2b68c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1209aaec-bbb4-40a6-88f8-6ec47bdd4cf6">
+      <statement statement-id="cm-6.1_stmt" uuid="413e2e1c-43d7-45ab-8c9b-c76ed699a071">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44ea72c2-dc7d-4422-8f76-6ff1f5ad4e68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2901,10 +2901,10 @@ https://projects.engineering.redhat.com/browse/RHV-20524
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d52870c-5d02-4cb0-a91d-5bf2c3c557d7" control-id="cm-7">
+    <implemented-requirement uuid="5d481866-afa3-4223-8b3f-d048186639fe" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="4851f402-2f0e-4ae8-8fed-068381e8b1b7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="98cbb7a5-e49b-4fe3-911a-6c147ba7a938">
+      <statement statement-id="cm-7_stmt.a" uuid="f1c03d8e-385d-4872-bdc7-5811d06486cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c1f7cc-f58e-4150-8003-b7f3e10862e0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -2915,8 +2915,8 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="9b7da5b9-62e5-48d2-9eb0-136ef7b9c28c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cfeb2526-018b-4a51-bb08-053a730b32a9">
+      <statement statement-id="cm-7_stmt.b" uuid="75c090a7-ee60-4f64-a388-bb7ed7c9c5db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0735d452-78f2-4bf5-9f4c-065b42936360">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -2927,10 +2927,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1b647526-c633-4e5c-92fd-9d7575916ca6" control-id="cm-7.1">
+    <implemented-requirement uuid="9df378ad-07af-4f16-8970-7121beb0b4c0" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="1c6264ad-b85a-4575-a4f5-96335b007cd1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="245fed7c-6f10-41dd-944b-ca948a2e9b88">
+      <statement statement-id="cm-7.1_stmt.a" uuid="4990b97e-55cb-437d-b94b-c67fbdd00243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2939,8 +2939,8 @@ https://projects.engineering.redhat.com/browse/RHV-20525
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="c707aec8-87fd-42dd-864f-357c3a8d6155">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3e7a5d7d-d7b4-4942-88a8-f92fc9799223">
+      <statement statement-id="cm-7.1_stmt.b" uuid="bdf67c38-65b8-4222-a28e-94cde8b3f1d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2950,10 +2950,10 @@ https://projects.engineering.redhat.com/browse/RHV-20525
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e110eba-4479-4f35-b6aa-8e9eacfa3e74" control-id="cm-7.2">
+    <implemented-requirement uuid="d7ae7ecb-9b0e-4166-9b23-6a5583c845c4" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="a92786d1-d24d-435b-8057-f8e28a0643de">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="27fdb5c2-6c3f-42fc-a638-2942eca7e7e7">
+      <statement statement-id="cm-7.2_stmt" uuid="713b03e4-4959-4cd0-830e-ea99848a6d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce0022ee-1dff-44a4-903f-ec64de590727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2963,10 +2963,10 @@ https://projects.engineering.redhat.com/browse/RHV-20592
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed9ae112-0c28-412b-b86f-b693917d5506" control-id="cm-7.5">
+    <implemented-requirement uuid="f1552409-31d9-4431-8cc6-a447e5c4b3ec" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="f791ec50-44d7-4dc0-9287-c94eb850ed32">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1b3f886f-73c1-41ee-939b-3d76f635ea2b">
+      <statement statement-id="cm-7.5_stmt.a" uuid="0c69d796-a67f-4a62-a30f-59a3998fa9e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2975,8 +2975,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="324111f5-d62a-4aa0-9aaf-a5f4612b9b38">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b5f159b1-72ed-43b8-b44c-29c0e7d2b67b">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a04d7c8d-a185-4c75-b689-e74cf9229520">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2985,8 +2985,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="9759d520-2563-468e-aabd-0da5b88e6072">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b6dd48ae-f451-4a3c-b55f-779c82619042">
+      <statement statement-id="cm-7.5_stmt.c" uuid="672cd179-ac40-4a51-9952-38f58927a20f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -2994,10 +2994,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86c1d520-c25b-4114-83cb-051897f4c59e" control-id="cm-8">
+    <implemented-requirement uuid="07b2258b-e3d5-4ca2-960c-d9e82a056236" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="ee542604-bfa5-46f9-9c36-999afd97e8e7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="965a6d55-6e6c-4fe7-ba1c-667bf9107025">
+      <statement statement-id="cm-8_stmt.a" uuid="b53ef6f4-6571-4239-8a55-ea7a285fe47f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3009,8 +3009,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="e467dee9-1de7-48a9-aed0-c9fff1e12236">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3eab8417-ac15-4c35-9241-22eee5fe5377">
+      <statement statement-id="cm-8_stmt.b" uuid="6c3e7c49-c2bd-4582-bcca-eeed439afec5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a4ffec-f8c2-4c19-8d0e-4191c72cb5b3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3023,10 +3023,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f45fb78-9fb1-4276-be53-3c812c443463" control-id="cm-8.1">
+    <implemented-requirement uuid="d918bbaa-fa67-4981-a6cf-c1fb58598ed0" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="f6246072-6047-4a7d-a0c2-154013ef3b59">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="adaece41-7576-4baf-86c7-f4e1131c642f">
+      <statement statement-id="cm-8.1_stmt" uuid="98c82f1a-8fba-48c6-a2f3-50b707fa6cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f086a431-fb22-4d02-86b9-ec0947418fe6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3036,10 +3036,10 @@ https://projects.engineering.redhat.com/browse/RHV-20780
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f28c1ab-70dd-4559-9d39-a7296bc6ebca" control-id="cm-8.3">
+    <implemented-requirement uuid="f2b54bf3-daf5-44c2-859c-d06bf379b306" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="7105873d-89e7-4e45-869b-18615a466382">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c66c5b7a-b278-4d2f-bdb5-0dc4ca78a389">
+      <statement statement-id="cm-8.3_stmt.a" uuid="66d965d3-4618-43ea-9ea0-c9790410ba10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3048,8 +3048,8 @@ https://projects.engineering.redhat.com/browse/RHV-20595
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="42733170-1566-447f-a93c-b08ddcbcdb4c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4f9f431f-ecd5-4b74-80ed-b89b719a13a6">
+      <statement statement-id="cm-8.3_stmt.b" uuid="f4777728-b259-4f4b-aa37-d73575034a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3059,10 +3059,10 @@ https://projects.engineering.redhat.com/browse/RHV-20595
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d44a133-36c1-41ce-91a3-705bdff5d062" control-id="cm-8.5">
+    <implemented-requirement uuid="c48f0033-df6c-4729-91ad-228722da8d37" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="c693599b-ec7a-4e00-b410-326f9d85287f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a85edcd0-2676-4bd2-9e31-c6c248e4d747">
+      <statement statement-id="cm-8.5_stmt" uuid="861e432c-8f1a-4a7c-afe5-634c503486c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c655a8e1-6c26-4e14-8ce4-558d9f7fe49f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3072,34 +3072,34 @@ inventories is outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="172c5ea3-21d0-4aab-a9bf-30cb9a6538cf" control-id="cm-9">
+    <implemented-requirement uuid="c78702a1-e56b-4b58-b2e2-790979a0b16f" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="2bf16766-d78c-4234-bd6e-817584345fb8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="dbb507f1-ae15-4f7e-80c6-e1e9c8a1a9b0">
+      <statement statement-id="cm-9_stmt.a" uuid="f03eb09d-5b14-4a85-b2d1-188122ee7adf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="42f16617-56fd-4a25-98c9-257923c18df1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="29ac9dc5-31c8-413c-99dc-4bdccc93825e">
+      <statement statement-id="cm-9_stmt.b" uuid="46387aa8-bfc8-4807-b12c-1a0b73219655">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="db097b10-05ec-47fc-9c8a-0434338c0e7a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a5081edb-236c-40ec-8fd7-b13a62c12832">
+      <statement statement-id="cm-9_stmt.c" uuid="465d0d39-7df3-4024-833c-84fe9e672c61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="71771ae1-0dd5-4395-a2a6-c2e43a70659c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="75ced943-175a-4ec5-adc5-7d7f16cd48c1">
+      <statement statement-id="cm-9_stmt.d" uuid="0d6ed44c-fafe-486c-aa63-498afc208af3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="932c0527-7361-4950-a61f-651da4e8921e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Host (RHVH) configuration guidance.
@@ -3107,10 +3107,10 @@ of Red Hat Virtualization Host (RHVH) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f3a3f33-4754-4105-b668-eeb6cb1abaaf" control-id="cm-10">
+    <implemented-requirement uuid="2c661714-d065-4868-b601-26cbe5055442" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="b0d9dd46-834d-4e78-9ae2-b4be73495927">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="000af3bc-df5d-40ba-9202-7c412fdb4cb5">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3119,8 +3119,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="07f656a0-4c45-4b91-b0c7-6e29782ad821">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="62439951-3b47-47f4-aacf-197ae20bdb35">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3129,8 +3129,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="26a61f65-c749-4156-b33d-54d4e3f43dfd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7ebe4423-f7ff-49a7-8ea1-ecd31c8257f3">
+      <statement statement-id="cm-10_stmt.c" uuid="d84e5f1c-a35a-41b3-894f-2b78fc2aa9a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3138,10 +3138,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c389c36a-b0db-4ffa-b0a4-ba6e5b57c6db" control-id="cm-10.1">
+    <implemented-requirement uuid="1824b6c6-8050-4f40-b874-60a67578fcd9" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="0e23bbb3-f6a2-41d2-80e4-648db5bddab8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9648a1b3-b1bf-4c7a-a179-b3bde9db34fc">
+      <statement statement-id="cm-10.1_stmt" uuid="0df04749-8c20-4ffb-80c7-91b36fa36f42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a64717f-e2e2-4ce2-8b96-86cb8fc25399">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3149,10 +3149,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aca3d550-dd0b-4339-8c89-e0120e63e37f" control-id="cm-11">
+    <implemented-requirement uuid="4e58bfa2-4492-437f-a01a-fca1e8718539" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="a0340274-0e6e-48fe-a051-dfee38c89376">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9accdc74-2bc3-4cc2-a4ed-93a54f3b0bd9">
+      <statement statement-id="cm-11_stmt.a" uuid="7693dc19-dd28-4599-9e26-8b8ae1f36b38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="05d2dfdc-7476-4e8b-bdab-8344fd80afce">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Host (RHVH) nodes. The following are suggested
@@ -3171,8 +3171,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="75264df7-306c-4e43-baa4-ecd655b7594e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="16e761ec-b4f1-4415-bda2-8e48e909e032">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -3189,8 +3189,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="09b412b3-2539-4c61-843a-cf7fc5da88ec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9f3e3ddc-885c-427c-86c0-484e26fdab69">
+      <statement statement-id="cm-11_stmt.c" uuid="e323d5bb-94e6-495c-9bac-7a2755aa97d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3198,18 +3198,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f83c00d-6505-4c2a-b8c4-39e8221f7e44" control-id="cp-1">
+    <implemented-requirement uuid="a4d50e31-979e-413e-9d1c-bad6a286674f" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="e39bb916-5c00-456a-9b4a-5f2ce0612c36">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="df6b4bb1-3a03-4232-8222-6883dcd74ee3">
+      <statement statement-id="cp-1_stmt.a" uuid="de0eaee1-2052-4121-ab5e-d97aa37f67b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="e565cd69-dd08-413c-8212-03547fe2fc1c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cc4e80ff-460a-4e5f-ad68-d7ff05fd0fcc">
+      <statement statement-id="cp-1_stmt.b" uuid="450d19af-1220-4860-9c86-5224e96005b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30fb2eba-41a4-402d-89e4-3000d3b57982">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3217,34 +3217,34 @@ policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e328dd6d-aad4-4d39-ad91-bd06cafef525" control-id="cp-2">
+    <implemented-requirement uuid="1eb13bca-54c9-4920-aa02-7579e0351f67" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="8795febb-e5ca-4bd5-b7a2-a34737ed1836">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="82493693-230a-4906-8442-acb28efab840">
+      <statement statement-id="cp-2_stmt.a" uuid="bde1ab58-3391-4b95-b76c-d012c47dc90a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="041920a7-d53e-42f0-9fcb-cf4f2360c61b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="43c21ecf-37a7-4287-bfd0-9045671989ae">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4f187d20-79cb-4de8-a3fd-47dedb79beb1">
+      <statement statement-id="cp-2_stmt.b" uuid="baaf50bb-ec4e-4b52-86f5-009531beea36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b192bba0-89b4-43fa-a0de-ef361af44ed3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="76443b48-2ed8-4d1e-ba35-16ffb4534a9f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6f3bd5ad-0804-49b6-9972-93e2aa189b75">
+      <statement statement-id="cp-2_stmt.c" uuid="0618434f-fe6b-4e3d-b500-ecf4e0c6e859">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c8443da-ca03-494b-a8c4-1223add1c65c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="909b0351-0546-4d0a-ad20-5f321cbdd2ae">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="579c4b76-c031-46e6-aadd-dd20329da651">
+      <statement statement-id="cp-2_stmt.d" uuid="766fac0d-33c0-41b5-ab5f-62d02f55b664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70fedb8a-d30e-419c-b649-c446767a490f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3252,24 +3252,24 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="d53ca0d9-2688-4a14-b484-24efde75cd05">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d847b419-e952-4be5-af44-c0970abc89ed">
+      <statement statement-id="cp-2_stmt.e" uuid="cb696cae-5941-4b56-b94d-3be6099d04b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4394777-a16b-4df6-8066-9b76913dd72d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="f9ebb9c4-ba1c-4dd5-ab3d-edd9b30f18ef">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3d0aabae-de10-4fb3-a461-70cc03446e50">
+      <statement statement-id="cp-2_stmt.f" uuid="77dc42be-4ddf-4c65-b4c4-f8041a1f3e49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9e64a1a-3e28-4df7-bdda-e299001953b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="e8c1425e-2e91-48fc-8125-f5a19ee72842">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a0da6ebc-b0a5-4504-b952-d4eef239b14c">
+      <statement statement-id="cp-2_stmt.g" uuid="593dcee1-22e3-4dfb-96b7-b6f704a78d3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb2eed58-dded-410c-8051-d9533ce5df3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3277,10 +3277,10 @@ modification is outside the scope of Red Hat Virtualization Host (RHVH) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8e70dc0-5036-486a-96e8-b1f736407494" control-id="cp-2.1">
+    <implemented-requirement uuid="51d7924b-193e-45c9-8089-2e8e992e8864" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="998b55b5-2ec4-4e72-b5ea-13f34747cb56">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d36d9712-7141-4e02-946e-8e253ffdbaca">
+      <statement statement-id="cp-2.1_stmt" uuid="a621c339-ade8-4e67-938a-c6af61ba9ca1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30cd7a39-f82d-45ac-9cdc-e2c0d0926136">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -3289,10 +3289,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed200b21-e519-40ba-8b0e-9f1686f247a0" control-id="cp-2.2">
+    <implemented-requirement uuid="f63bb2e5-2786-4d3f-8124-e09a15847cc4" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="401255a3-7ade-43ad-b26d-7b34b294143c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ae5a7981-ccdb-4155-9b1e-62eb1d8c7efb">
+      <statement statement-id="cp-2.2_stmt" uuid="d4b2afc4-dce2-41ce-9731-4c54f6f0d25c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20eab3e7-d9a7-43c8-b847-14de3ee49657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3302,10 +3302,10 @@ https://projects.engineering.redhat.com/browse/RHV-20781
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95bd53f8-71d7-48c9-af2d-1d2eb90497e8" control-id="cp-2.3">
+    <implemented-requirement uuid="d37c39ce-b3fb-4820-9cdf-fa5d2671ed69" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="3171bf01-8981-46a2-b030-2a9b195e0b00">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5acc9474-5815-4c1f-886a-12018bd93d86">
+      <statement statement-id="cp-2.3_stmt" uuid="752c2dc3-6e4b-4ebf-bd8b-e04687d3c4e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3d4d0332-ba47-4e28-ac91-c42a2f454afe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3314,10 +3314,10 @@ plan activation is outside the scope of Red Hat Virtualization Host (RHVH) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfc3fa95-03da-4386-a4b2-efebab14e403" control-id="cp-2.8">
+    <implemented-requirement uuid="da72d7dc-5688-459f-806a-4470085be711" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="cb4d7696-5d17-40ac-888f-a244a0c85882">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5c27405f-aa67-400f-addb-d1d53cb88b3e">
+      <statement statement-id="cp-2.8_stmt" uuid="2fc01614-f440-4fa1-8cca-c4909cc7c890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3325,10 +3325,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eeb6cae9-9bd1-40e7-93ac-374563688cad" control-id="cp-3">
+    <implemented-requirement uuid="c7c97cd2-5b41-4f1e-aa90-c79d83e69b59" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="e21f57a6-ef40-45c5-b90b-8064821a1aec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ec3cd8b3-2562-4028-bcc7-e6d777543ecf">
+      <statement statement-id="cp-3_stmt.a" uuid="43d5b766-c085-4de2-b03f-df4f30d10efc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c63dcbea-0150-48d9-88db-9802f3c0126d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3337,8 +3337,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="4cbbd7bb-d243-4885-9d56-cbf19c2f0a0e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5b8d59a0-fa9c-4329-8862-20ea0a381d12">
+      <statement statement-id="cp-3_stmt.b" uuid="4723b068-1ebf-4204-b9da-3d662e4f6500">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64b4a65e-1aeb-41c7-981f-952057f9150a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3346,8 +3346,8 @@ system changes is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="6585d303-22ac-4efd-a1d4-e8642963cd13">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cf102671-88c9-44cc-adfb-83c08b29c1f9">
+      <statement statement-id="cp-3_stmt.c" uuid="93c84b17-9755-4aed-8aa9-d9390f1b6579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d9b7f69-1c97-4afe-93a9-9c75cc4c35cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3356,10 +3356,10 @@ frequency is outside the scope of Red Hat Virtualization Host (RHVH) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8f7c884f-f2cc-44a3-902b-3970cea94366" control-id="cp-4">
+    <implemented-requirement uuid="66fe603f-1955-488d-ab70-a072c8d9ae49" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="a7310918-6363-4b1d-954e-09feba2262b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17061e3a-81bc-4031-973c-8e17c376d887">
+      <statement statement-id="cp-4_stmt.a" uuid="9d9a7e50-fa92-4973-a426-da3a5cdd261f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab4951df-705a-4cf4-8ac6-c047fd2cd7aa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3369,16 +3369,16 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="41028dc8-b587-43a8-9d77-73a887d5d7fc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f074abe9-637b-4f0f-9b07-50a8ae6b44aa">
+      <statement statement-id="cp-4_stmt.b" uuid="ec404859-7767-4798-9634-c7f23406e4a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3513952e-7a91-4414-888c-236a38fcb64a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="48e014e4-560e-4cb8-a9eb-2d1ccff50881">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="016de723-9cef-4e5f-b1f0-cdd743d2ddb1">
+      <statement statement-id="cp-4_stmt.c" uuid="81f1a338-f5a9-42c5-82d9-394dff735c7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1984e099-d316-4fef-8c63-1a695a4fd961">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3386,10 +3386,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dceca18d-852e-4a6a-938e-a52008d55ce1" control-id="cp-4.1">
+    <implemented-requirement uuid="ae34affb-6095-41e8-a330-41b44c7724d0" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="9cde97d6-43e8-41dd-a3e3-0db6059c163d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="521ff0dd-b0dd-4729-8b2f-96f4b828fa22">
+      <statement statement-id="cp-4.1_stmt" uuid="22c6e185-488e-4220-bf4a-73177a2b4730">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bb5c3ba9-009a-4aaa-ac94-e1df130a9c88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3398,10 +3398,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1523afb-8961-4ffb-bd07-3c098837a0c6" control-id="cp-6">
+    <implemented-requirement uuid="97801796-ee86-4e2d-add3-cf7ba3b5516e" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="bcfd695c-08a6-4c66-9230-8b954a918a83">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9ed5826b-8345-40bb-b995-251aac0c132d">
+      <statement statement-id="cp-6_stmt.a" uuid="329a3f5d-8bfb-4edf-84cb-fdaafdda4cae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91375258-24f3-41d5-8221-27cee278feff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3410,8 +3410,8 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="b6df4a69-be90-4d2f-99e0-e179b2dee19c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="79048b3b-e445-4f32-8dbd-a92e46cdf96d">
+      <statement statement-id="cp-6_stmt.b" uuid="7007f447-1f50-4410-bc6b-5e201611dcfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00b0cce8-5489-427c-bf99-a0d4a6f9d065">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3420,10 +3420,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b63ed781-516c-411c-874d-2f746a4a1682" control-id="cp-6.1">
+    <implemented-requirement uuid="3cd9d556-6b52-4644-83ef-0903fe1a0772" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="eb0860c3-f7b6-4620-a390-79130c14f001">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a1a585ad-eb4a-4bc2-9811-045c42a2f50c">
+      <statement statement-id="cp-6.1_stmt" uuid="09140fc5-1ca2-4b47-8bb9-c37732c32bd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="48b1faf6-df28-4a1e-a2ad-ed19158498f1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3433,10 +3433,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1f6f5bc-ecc1-4651-8d25-5e3342471814" control-id="cp-6.3">
+    <implemented-requirement uuid="11a25c04-3400-4c66-8fd6-61cac89d420c" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="981bd813-4851-40d6-bcd6-48a0eb2e56ac">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="22988557-e773-4969-9222-ca62460fa3c7">
+      <statement statement-id="cp-6.3_stmt" uuid="34a5111a-7ddb-4c2b-a9ad-0ca0200c4e03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e677446-1050-41ac-8b51-8e87b2bfb371">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3446,18 +3446,18 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bd5b8408-7911-4745-aefd-148a9cd5ea4c" control-id="cp-7">
+    <implemented-requirement uuid="48ecdac3-c8fb-422a-a46e-f1d8d3320a8c" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="abb1bc64-4e55-4841-95a4-7e4504e7e5ea">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="361d0141-2e37-487a-8a23-4b0062592481">
+      <statement statement-id="cp-7_stmt.a" uuid="a9f36fe6-1db7-402f-af67-b5d6077a0897">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="8320ccb4-121f-46db-af2f-03891cabafe5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="79a59f54-5728-4dd0-b5e8-3dcc14537c4b">
+      <statement statement-id="cp-7_stmt.b" uuid="a0f1dfbe-434f-4a8f-8f3f-802800025991">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c9ac56e-812a-4721-baff-1bb201292bcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3466,8 +3466,8 @@ https://projects.engineering.redhat.com/browse/RHV-20598
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="537537c7-5e06-46a8-81e2-13ff8d108e1f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="213e877b-8b12-4405-b62a-15f5b2ecdfc5">
+      <statement statement-id="cp-7_stmt.c" uuid="00946057-d617-4702-9b86-65e79a32f4b0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3475,10 +3475,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cff0f93d-3793-4858-9f07-7ea4a418265f" control-id="cp-7.1">
+    <implemented-requirement uuid="2a87d2a7-beda-45be-8fe2-2415a9ecf8e7" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="b0aab558-26fd-4999-a4a9-5a97da42b9b9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4150b9cd-418d-4948-b49c-6a4ed57c7e19">
+      <statement statement-id="cp-7.1_stmt" uuid="7e02b700-2add-4331-ad2e-b88a20ed57f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c332557-b93b-440a-90e4-6f021f9aed93">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3488,10 +3488,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1263eacc-fa06-48ea-b0eb-bbfd19e723f2" control-id="cp-7.2">
+    <implemented-requirement uuid="1f037e9b-1e91-48b2-811c-c1ed4a3a20ee" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="61fa2735-7d62-4f58-a89f-c1121597cf31">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b72d20ac-f215-41d4-a336-f4ef43a9ab34">
+      <statement statement-id="cp-7.2_stmt" uuid="2a0023fa-ebfe-4cf8-81d1-5dc24fb921f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63beac05-26ad-498c-bf98-aff07acb3b0f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3501,10 +3501,10 @@ actions is outside the scope of Red Hat Virtualization Host (RHVH) configuration
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="862c5d35-4169-4313-9345-2a008acd93eb" control-id="cp-7.3">
+    <implemented-requirement uuid="61c2ba1a-7399-4564-afd4-b9b0af0b6f0d" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="77651787-7f59-435a-b9b6-1e748420d701">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="16f969a5-5f4f-484d-be81-7cf65fc6dc76">
+      <statement statement-id="cp-7.3_stmt" uuid="807b92f2-cda1-4e71-aa71-7bc3855d7758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8a233e6c-b211-4922-9f3b-c71b9a3f1e1b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3514,10 +3514,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca5d7a9d-5459-47a8-a71a-b0b5208f129e" control-id="cp-8">
+    <implemented-requirement uuid="6cfd9ee6-d116-4a36-a38b-9f05ddc5794a" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="f6df10b7-d44c-46bf-801e-846b88fdf04a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="19a93973-0983-4c83-a667-abfea805c995">
+      <statement statement-id="cp-8_stmt" uuid="1cbc18d8-4b99-4613-b579-f439718be969">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="59b80dcd-b0b6-471f-b278-46c79531b438">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3525,10 +3525,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ffab93aa-2b48-47fb-8995-3ef4afc45479" control-id="cp-8.1">
+    <implemented-requirement uuid="3c00a373-6f83-41cc-8bba-5666aa45a4f5" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="ee271e76-76da-4a58-ba8e-510fdd867fd5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8a7ce16b-9728-4e68-a82c-d960a0eeac99">
+      <statement statement-id="cp-8.1_stmt.a" uuid="ecbfdab9-cd01-4986-a089-9d1754e476aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="742ad377-0c62-440e-ba79-4e81681d68d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3537,8 +3537,8 @@ time objectives) is outside the scope of Red Hat Virtualization Host (RHVH) conf
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="0d332c3f-824d-4f8a-b4ef-dd1aa51c443e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="01bc9507-4876-423a-aea9-53cc8be3400a">
+      <statement statement-id="cp-8.1_stmt.b" uuid="a0708b45-3741-4314-acf7-f26fab0aac9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a84ddc3e-f425-406e-ae04-4fb553a6dea8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3549,10 +3549,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b1b99c8-dc54-40fb-828c-7b45f5a3ff8d" control-id="cp-8.2">
+    <implemented-requirement uuid="40bafb14-2fc8-4022-a192-38e74defcd67" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="13e41448-bf46-4469-92dc-1a7cb1d42b5a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e2bce2c6-1c1c-4aee-a476-7e5c8a0e5dd6">
+      <statement statement-id="cp-8.2_stmt" uuid="67fc97b3-6ede-43c5-8b4f-90ee08b61360">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5570c704-bbfb-4f50-8145-42d6eb5a26a4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3562,10 +3562,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c06f88a-e1dd-4fa3-8068-5679d2a142c0" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="301ab2d2-656d-4d6e-bec0-ae83b7b8e7a6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="81ff8fd1-ba4c-48b2-9d98-5109f9192a3f">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3583,8 +3583,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="f37e6afa-325f-4681-b659-fd6c1dea4baa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="50522eb4-a89a-424e-8be9-60a4a42a0484">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3602,8 +3602,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="285a1e3f-93bc-4693-a69b-e2fd0649d3c4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5a104493-68bf-46f4-b3b6-fa153862d548">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3621,8 +3621,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="bdddffcc-2cff-4b40-b7a5-0eda9e916c1f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="41f481fc-ff35-4937-8a1d-d26d645789de">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3640,10 +3640,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8bbb7a5-692a-44c9-8f2f-07926f59566b" control-id="cp-9.1">
+    <implemented-requirement uuid="3dcbc793-579e-444e-87f9-1b617354d14b" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="6b1b67d6-b129-41c8-bf4b-de771fc1ac46">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1c793cdb-fe09-4fab-9e4b-f6261294291a">
+      <statement statement-id="cp-9.1_stmt" uuid="31c82c4e-b68a-4df8-ae35-6be82ffd3d18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="116d8df1-d4ee-4f9e-8094-47212bf9821b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 is an organizational control outside the scope of Red Hat Virtualization Host (RHVH)
@@ -3652,10 +3652,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08c6324b-2318-4bf9-9c27-b169202a872a" control-id="cp-9.3">
+    <implemented-requirement uuid="95e93148-2726-489d-b1ca-c150ae1a9fa1" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="4d5266ae-42b8-4753-ab38-59891c1b0a04">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="870e2f03-a93a-4067-93ed-4848d54a4ca8">
+      <statement statement-id="cp-9.3_stmt" uuid="ff8d9b0b-0009-452c-b12f-ac7c59e0bd9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6ad9c150-e6dc-4552-9a31-fb8576c7fef8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3670,10 +3670,10 @@ https://projects.engineering.redhat.com/browse/RHV-20782
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10f57a91-6af2-4f4d-98cb-e3abf90426ff" control-id="cp-10">
+    <implemented-requirement uuid="79e121ea-961c-4bde-a84e-e8bad5a2ef56" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="e6b37c6a-1e26-4ea9-9553-12cd3ed1e2f5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0f902a88-d019-4018-946d-1fa6523b0d4d">
+      <statement statement-id="cp-10_stmt" uuid="cb8c4cbe-276f-4d6e-a855-dd128a8b9536">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d703f450-a122-49ff-8d6e-910b4434d6d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Host (RHVH) environment. A successful control response will detail
@@ -3687,10 +3687,10 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="190b84ae-b70d-4de3-b5aa-7a5e4d94be8e" control-id="cp-10.2">
+    <implemented-requirement uuid="d3b055c6-0d0a-45a8-8019-73dea3531cf6" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="91ae24d6-d23a-44aa-b009-eb044e3bc3ab">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bce1312f-e66c-4c23-a997-71463c608180">
+      <statement statement-id="cp-10.2_stmt" uuid="993a3689-6c95-413b-ae4f-21568ec75a49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -3698,18 +3698,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c869ae0-9814-453b-815b-7de724e9056c" control-id="ia-1">
+    <implemented-requirement uuid="f0f620e7-99d8-4036-a575-5eca390148ea" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="4074bb58-b078-488c-9a11-84c8bcb20a45">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2871b672-d0d1-4c4a-b158-aa8530120926">
+      <statement statement-id="ia-1_stmt.a" uuid="7ee6f6b8-28c8-4ea9-b83a-9db2448ee465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b0c85dea-3e0c-4433-967e-3f27b7bef26f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="a9188a82-816c-4c01-b531-c825725628ba">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="04f6fb20-d285-4db3-9841-6d4e77f114e9">
+      <statement statement-id="ia-1_stmt.b" uuid="53d59aec-74ea-4166-9625-bcfbb2557334">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c2b30f8-c522-4d86-9026-a787c8eba01b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3717,10 +3717,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Host (RHVH
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e549a139-1f70-4d0b-9fb1-853652559751" control-id="ia-2">
+    <implemented-requirement uuid="15eca7eb-969d-4bff-a7e4-909f8a73e869" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="c7096053-120f-4226-b03e-bc8821915bb9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a512cb03-96bc-4cb2-9030-3aad20c3be23">
+      <statement statement-id="ia-2_stmt" uuid="2b7ead57-5b85-4fcf-85e8-e3a5384144df">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f98c749d-d278-4b84-8f24-b334804ce20a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) uniquely identifies organizational
@@ -3751,10 +3751,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d0a15b72-17a5-4b15-a7f0-2e1e28d74db4" control-id="ia-2.1">
+    <implemented-requirement uuid="5095b0a4-4620-4753-b05c-b53161440672" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="0ae070e8-81d7-4533-82d1-010e87aeb93f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b79bf697-ab71-493e-9ae7-7de4ae811e9a">
+      <statement statement-id="ia-2.1_stmt" uuid="bfd9972e-7404-4f2b-bf4d-56dd5521e099">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c9cafe30-8a5e-4406-b296-6c48352d1e6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) implements multifactor authentication
@@ -3769,10 +3769,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0345dc0c-dc98-46d0-a64e-ccce2f7d12ea" control-id="ia-2.2">
+    <implemented-requirement uuid="4d53d68d-2c6a-4a44-ac8e-b76051289b92" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="c1d9a968-76fd-41ba-a6d9-ee5f5c073160">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4dfdb4e9-f121-453f-9834-9862f4a0f05e">
+      <statement statement-id="ia-2.2_stmt" uuid="bed222c9-6c1f-436f-8941-21b3fc8c8a1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c48dbeee-587a-42e2-ab32-91162f251ece">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3781,10 +3781,10 @@ https://projects.engineering.redhat.com/browse/RHV-20682
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="76d00fe1-f59a-44a6-b0e0-a02c3e94e0c2" control-id="ia-2.3">
+    <implemented-requirement uuid="fa8b4f31-4204-401a-9799-bc98267d9a68" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="e9465dd9-bfac-4640-b089-a7afd4f9c13d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="970d707c-70b8-4194-85a7-a78ead53d37c">
+      <statement statement-id="ia-2.3_stmt" uuid="90feaf4f-ad6b-4839-a0e6-f8b56c15b37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="321738ca-31a2-4b1d-b1b9-0b6c6f4197ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3793,20 +3793,20 @@ https://projects.engineering.redhat.com/browse/RHV-20683
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31a5f675-aeb0-4d1a-a7c0-000e29693ec1" control-id="ia-2.5">
+    <implemented-requirement uuid="d2ed00b6-ffac-491c-afee-bdbc8b6f5743" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="b019bf29-41a0-4279-82f6-8de1fde963f1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e0f81dc3-1f12-46d6-8deb-6b3ad2d28e75">
+      <statement statement-id="ia-2.5_stmt" uuid="5ba28b63-95e1-440d-aff9-73893ba3bcf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ccb6d3bc-84ad-43b7-9135-a20a1488843d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Host (RHVH) does not support or allow group authentication.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b60c13d1-0d4b-4094-9bc0-a7171b989c05" control-id="ia-2.8">
+    <implemented-requirement uuid="9324c09e-ebd4-4f86-8ccd-94c47ea733e2" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="81193bf5-e030-4466-91ce-c6f6c587d21f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="859a4471-69bd-47fe-8e22-967fbd6f50a7">
+      <statement statement-id="ia-2.8_stmt" uuid="19a4afe9-da23-41fc-986c-259ff51f0050">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f77256-ecf7-440f-ba84-714f7912e4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3815,10 +3815,10 @@ https://projects.engineering.redhat.com/browse/RHV-20685
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="49bb2c47-f6d1-402a-a409-6f576c7b1180" control-id="ia-2.11">
+    <implemented-requirement uuid="3b0bc4d2-9c8b-40b2-832b-47105fd850db" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="78e11fe8-32a5-4396-a915-92472fe64c02">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f3dd6557-e60b-4cea-adb0-216618adec85">
+      <statement statement-id="ia-2.11_stmt" uuid="d5bdb471-f0d9-46bd-8b40-ba71fc204f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe551ed6-c765-4dea-98a6-4bf2b88d82c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3827,10 +3827,10 @@ https://projects.engineering.redhat.com/browse/RHV-20687
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b62bb335-616e-43f6-829c-c8ba06571cfa" control-id="ia-2.12">
+    <implemented-requirement uuid="de776585-976f-4b41-aba6-fbbf4eb1ef88" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="5a46a6b1-57a2-40c7-bd66-6cd388a31a5f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7cd4c655-5219-4800-b2b7-5904dbfd47a2">
+      <statement statement-id="ia-2.12_stmt" uuid="44139483-c869-4e9e-87b3-5c9497bc594f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcf74c64-a18f-4080-aa09-367eab934047">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks are required to ensure
 Red Hat Virtualization Host (RHVH) accepts Personal Identity
@@ -3845,10 +3845,10 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3583e2de-2363-4117-bd2b-b13b6f7b4ab9" control-id="ia-3">
+    <implemented-requirement uuid="813ba8a3-1cc8-4e5b-8c64-22a599c8634f" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="bf967ebe-e677-4039-be2f-19f55cfad967">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="48403a4e-4a85-41de-bd15-1edfdb012eaa">
+      <statement statement-id="ia-3_stmt" uuid="fe4a9b85-3267-485e-a6b8-1c4190d9b864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0289593-6a95-4233-8e1a-780edff8a21d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3857,34 +3857,34 @@ https://projects.engineering.redhat.com/browse/RHV-20689
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="491c4776-5dfd-4901-a0d4-fef45d77e942" control-id="ia-4">
+    <implemented-requirement uuid="68c1ed91-8b92-42d7-af40-9a35c7ca3a43" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="4410289b-d222-4c33-a456-abba9bc81331">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7c79f76c-699a-4b30-b0e4-8d6a8bb2bd66">
+      <statement statement-id="ia-4_stmt.a" uuid="68861cd3-5042-454a-81ac-d8767ae4b479">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="90d03263-a790-4fdb-b14b-ed37c58f4391">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e1d069af-42ef-472a-9776-a3e281ad85a2">
+      <statement statement-id="ia-4_stmt.b" uuid="c3be4c07-b372-4f86-a61b-c643a28a0651">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="5d3212d4-63be-479c-ba6a-379b913927c3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9bd4c3b2-929d-4319-8093-55f21ae6ec61">
+      <statement statement-id="ia-4_stmt.c" uuid="c0100a17-fc78-4b8b-ae49-0285a57226c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="1c6057e6-c62b-4c57-9618-24ff26a3075f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e3250299-8212-40a8-8fad-f0e5e3c97591">
+      <statement statement-id="ia-4_stmt.d" uuid="17ba4241-f897-4c6f-befc-443916ec1596">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11cd2900-3a52-429d-a991-6692867ae02e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -3894,8 +3894,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="49224418-9a25-4677-9ee7-f92c9148a1f2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ee847ca8-7bdf-4720-ad8e-2896fba84f92">
+      <statement statement-id="ia-4_stmt.e" uuid="b2cdf31e-a423-4f1c-a9ba-c2ea599dc41c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d0d5a3cc-1c33-45f0-b5d6-5252c0ed9a81">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -3910,10 +3910,10 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c75efec-9d10-4c2a-aa88-88f9da5b16d6" control-id="ia-4.4">
+    <implemented-requirement uuid="cb2e83cf-6797-40ec-b91e-33d057ee5dc1" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="8dcf592c-21da-448e-aae7-eae288f59b6e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e8553326-34be-4c84-8c3d-b315d8011265">
+      <statement statement-id="ia-4.4_stmt" uuid="9cc3eefd-0e08-4d4b-8cdc-85996a5dd30b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -3921,18 +3921,18 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="546c03a5-67b0-4210-a096-25a379281a71" control-id="ia-5">
+    <implemented-requirement uuid="3f357209-59f7-4ed4-8e43-fc4a29fe0793" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="41393b82-79d7-4efb-af62-5f107e57876e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a9c153c1-b77c-4ab5-9f58-2fe4e108eebf">
+      <statement statement-id="ia-5_stmt.a" uuid="4aa0fc19-bf18-4875-af10-0ca428ae7df3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="d5cd2cc4-06a8-465c-b9a0-bb3d6a6395aa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="97da3105-f69b-4065-a801-16dd5f9a7562">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3940,8 +3940,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="c9a67ffc-f852-4d64-9cc1-d9a50cb72143">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c5cd3dc9-4534-44ae-b8f3-69b2a913680d">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3949,16 +3949,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="709e8380-d79b-410b-b0a2-7152acac5644">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="658a0247-9ed0-4725-8ee6-051341148ba6">
+      <statement statement-id="ia-5_stmt.d" uuid="47f7ff51-8b3e-4bd5-9880-9099706850d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="5a2a8792-6e55-4e36-a6d0-38594c3ee6e4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cc25075c-7878-4327-b2f5-8ac390ad9b01">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3966,8 +3966,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="89fee211-16b4-4352-9e3a-7cbdfc1e4593">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ef073590-be83-4444-9ba9-f3d5372995f2">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3975,8 +3975,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="54feedf7-b620-468a-9a2c-cfbbb7e6fe81">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="12793e1d-cfad-47c5-9eac-fb29d69ccc54">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3984,8 +3984,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="d0c5c45f-c9ce-48d0-9d8e-04d55ebed756">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a4c637dc-dc12-43ee-852e-6265fdbb8565">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3993,16 +3993,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="a8ddc038-5708-48b6-ab92-fbd51ace9eb3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d26fe4fc-a60c-4aee-91be-9d4da47aaf1a">
+      <statement statement-id="ia-5_stmt.i" uuid="95b60fd3-c552-4002-8ef9-58a17fbab84f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="d5111e9e-3e85-4d72-94ef-5281a20a3893">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="92eed379-0498-40b4-92dd-d40e64672298">
+      <statement statement-id="ia-5_stmt.j" uuid="401d8d60-ea1d-4bfc-9604-db1f455a054b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4010,10 +4010,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4175b960-9552-4d30-b057-bb7ab22df94e" control-id="ia-5.1">
+    <implemented-requirement uuid="8067b1a8-8e82-48e0-9c1a-f3d3410f8533" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="026a3508-5ff5-4772-8fce-ddaf53bfc89e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="26156d57-b136-409a-9078-a0edd168d3f8">
+      <statement statement-id="ia-5.1_stmt.a" uuid="dee671d1-1f26-4cde-877f-80d7699262c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36eb0d36-25e3-4ab0-bfb2-209436fb2c60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prevent logins to accounts with no password, the following
 configuration checks must be enabled:
@@ -4070,8 +4070,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="db0135d4-2be2-478b-8669-9ba0fe64a22f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cbcbcb77-4d1f-4e02-95f4-79a9a14a14fb">
+      <statement statement-id="ia-5.1_stmt.b" uuid="8dd2366f-ce4e-4db9-b1fd-58a4d1d4a41f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8875c1b4-2c28-439f-9b84-0a4db53b1492">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce an organization-defined number of changed characters when
 new passwords are created, the following configuration checks must
@@ -4085,8 +4085,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="71834d8d-f2e0-442d-a1e7-88c7b59bb5d1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0684667f-96e5-4d9d-8f10-c85bfe601f1d">
+      <statement statement-id="ia-5.1_stmt.c" uuid="cc03a041-5186-4aa0-96ad-f42d584e9368">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="270f0523-2ebf-4480-8bfb-61cdbea05151">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To ensure passwords are stored with appropriate cryptographic protections,
 the following configuration checks must be enabled:
@@ -4103,8 +4103,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="93e1aa90-fd4f-4cf1-a576-a744dd2b7856">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="10da6c74-03a5-47af-8974-f8ad8ce72e53">
+      <statement statement-id="ia-5.1_stmt.d" uuid="4dd5667a-77f0-4270-9409-6a2fd435cc3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="06726de6-106d-4dba-bafa-a0e6ce0819ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To enforce a password minimum lifetime restriction, the following
 configuration checks must be enabled:
@@ -4122,8 +4122,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="3fdaa7d4-e0e5-4fd4-825e-8bcd144acf45">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="213233d6-654f-4283-8162-6343d0e2c059">
+      <statement statement-id="ia-5.1_stmt.e" uuid="38d30139-07e8-4f6e-af76-37bb36f87e23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b22178b-7ae0-4677-869c-c2ceeccaabfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit password reuse for an organization-defined number
 of generations, the following configuration check must
@@ -4137,8 +4137,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="a8f417ba-0dec-49b1-bc50-4df9738b8dbe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="06697991-b4e7-4c0f-ab57-67ee5094b60a">
+      <statement statement-id="ia-5.1_stmt.f" uuid="1e18edde-395a-4ecb-ac69-c36e5ee34044">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3220d521-4fec-4fd4-9274-31a69798806e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4155,10 +4155,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40364d83-e463-4163-ae67-dc462d180c2f" control-id="ia-5.2">
+    <implemented-requirement uuid="a6b20dac-858f-4432-a9f8-454c24473d75" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="f21726ba-ef77-442a-8952-03e93798508e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="327610b2-6dbd-494c-ac37-45e3f966147c">
+      <statement statement-id="ia-5.2_stmt.a" uuid="260426ad-e896-4c8c-bbbf-f9954d38e3bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4166,8 +4166,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="ef7c024d-6c5c-433b-ba61-fbb48d8adfb9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c2c1ef94-ad70-4163-a0de-636949479200">
+      <statement statement-id="ia-5.2_stmt.b" uuid="6a899cdf-1ff3-40d7-9f3e-d85b26f43e7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4175,8 +4175,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="20840864-a02d-4863-94cc-2ad955b8eb3e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ed32e062-b8b4-4705-85a8-b1d29b82e533">
+      <statement statement-id="ia-5.2_stmt.c" uuid="5bb16a9b-a53d-486f-b097-939d1300eb80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4184,8 +4184,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="c95fdff7-4d9a-4fe3-8202-0afd57ecb843">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="db16f836-3a36-41ec-a5f3-eda620acd171">
+      <statement statement-id="ia-5.2_stmt.d" uuid="5c943719-8bae-40cb-96a4-29de69026782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4194,10 +4194,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8018ce30-4e8f-40ad-ab1d-8035c3f45e28" control-id="ia-5.3">
+    <implemented-requirement uuid="7d50edd1-aa23-4413-95d0-5babc405b8e1" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="b6203e2e-2619-4be9-9558-dbc1484b9140">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="31458dab-3844-471d-a0d1-2e7a252f93ff">
+      <statement statement-id="ia-5.3_stmt" uuid="a557d60c-3a8a-4efa-a51d-42b99f7d8dfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43d8e628-4880-4b30-9847-3388fc2fd460">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4209,10 +4209,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d0e087e-299d-488d-afb0-ca8f4a2f45d3" control-id="ia-5.4">
+    <implemented-requirement uuid="94607c21-260c-4efe-949e-59ccb3c94b40" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="02c5fe14-ea70-483c-b9b7-b21781fa6ec1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4c6b8464-53cc-4b94-9846-3271b92c74c0">
+      <statement statement-id="ia-5.4_stmt" uuid="516d6712-007c-4d1d-a6b6-825b46552ab6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4221,10 +4221,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e24cb285-cda1-41d0-bc18-c19998aa2a86" control-id="ia-5.6">
+    <implemented-requirement uuid="bfc81b03-6e17-4190-9105-757647815cf2" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="84f87f8d-7676-4340-a8fa-cd0beaa4e86e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="40d8ae99-0074-4698-8978-6e0d50645a44">
+      <statement statement-id="ia-5.6_stmt" uuid="74435d67-eea6-4fa1-8ad5-76a97261f0cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70b9bd69-2b98-4358-8196-ced250b6b476">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -4232,10 +4232,10 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9593b873-fac6-4907-bd95-b37fb078935c" control-id="ia-5.7">
+    <implemented-requirement uuid="19ebd989-8420-4755-ab4c-0bcec6997600" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="5218b7e1-9dcf-4dcf-b0e2-9b337457a108">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="75c28eea-5a9a-4604-841d-9d54c3fdc176">
+      <statement statement-id="ia-5.7_stmt" uuid="7f6fb122-c12a-4362-8ec5-47258add160d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4244,10 +4244,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="937c8308-fc8a-40ef-a123-e80fcebb9c40" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="093eec21-64b5-4104-904b-f60dc0bcfdaa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3d78be74-1ced-436e-abce-8d062f7897ba">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4256,10 +4256,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfe7dbbc-8d3b-4ac8-b2ef-9ace53d0ef50" control-id="ia-6">
+    <implemented-requirement uuid="c18d8a87-a83c-45b2-b926-a81975d8c1d8" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="4df70c15-ab72-43d6-ad0a-67dc198b7520">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e76dfdcb-df6a-44ec-9caf-8049c1c16571">
+      <statement statement-id="ia-6_stmt" uuid="36c5fd33-c3f5-442c-aeb7-6a77f91a8e65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="41406028-d256-445e-8e1b-6bbf7dec6478">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) automatically obscures
 feedback of authentication information and cannot be configured
@@ -4272,10 +4272,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="903700dc-b4c2-4a3c-8c3b-e9c8f18dba61" control-id="ia-7">
+    <implemented-requirement uuid="ab61d155-92ab-40b5-9e81-9fd9bac6cca1" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="da8ba321-c891-46bb-9328-ee797edb1b0a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="543b431d-983d-4ee2-b492-89f730ae8321">
+      <statement statement-id="ia-7_stmt" uuid="f3ac9fbd-5915-4c13-bfa2-d780c3775d03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aec0a254-77c0-4a93-b4a7-9b2b04b0f966">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -4299,10 +4299,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec05f3e6-8f41-481a-9ffa-a6d3f397e27c" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="966b5faf-51c5-4250-991d-0cccd6a79841">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="62b15b15-d2b8-49c7-b536-f1e6b72a602e">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -4312,10 +4312,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b24b3af5-06b1-4fd3-a766-44986a0f180c" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="990fe98e-42b4-4243-b568-745149aa364e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="45910c2d-2f9f-4d2a-829b-1ac87aabeb71">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4324,10 +4324,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9352bebb-39a2-4325-aa69-20ed734b7474" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="787037cf-2124-4fd3-a6fc-176d6fa2b518">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="677f6528-7f1b-47ae-b890-b4bfe8d889d5">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4336,10 +4336,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="074f9c45-07b6-4678-91b0-028dd05b153e" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="e3e63a12-3747-4379-a8aa-43094e1d324e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="eb72aa0d-fc7b-4e4d-ac9f-080c3d858e8c">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4348,10 +4348,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aaf2778-9f80-4bda-bd11-8e50747f26de" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="581a993a-6247-4137-852d-3adf05bcb6eb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="08a695c7-60cd-4765-9dce-644dfde29885">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4360,50 +4360,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba3bd1c7-56bb-4ce1-8157-4467a9d30e33" control-id="ir-1">
+    <implemented-requirement uuid="3c9e71c0-58ae-4aee-9155-47fc9e843f65" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="8dd57a4d-ee13-4e03-a0d7-0b5690b39ee9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="136f191d-541c-4074-bd2b-f22a39686074">
+      <statement statement-id="ir-1_stmt.a" uuid="d60d6bea-ef5d-4626-aed2-3c3f53698ac8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="2e650750-9b0a-4c54-a18d-c2f089e75766">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17eb5502-ba7f-495a-8673-7a6b1c21aca7">
+      <statement statement-id="ir-1_stmt.a.1" uuid="5e667772-e5d9-4872-865a-48786759926a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="eb9df04f-0335-4f2a-b513-3a1e45bf8f06">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="530d4562-b4b6-4c99-be4a-f3178358eb80">
+      <statement statement-id="ir-1_stmt.a.2" uuid="22d201c3-6207-4103-b445-85e8701cebbf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="250069a7-52fd-4c97-9c91-5ace25b3ddc3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ba6ec950-00e5-49d3-be4e-892ef4c3029c">
+      <statement statement-id="ir-1_stmt.b" uuid="eac06a1c-4b7b-44b6-82fb-ad5cdb54c5d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="78d1ed6b-2e9b-4776-b91e-e144b0369337">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1452d81d-81b3-4060-b45b-972407879ddb">
+      <statement statement-id="ir-1_stmt.b.1" uuid="15832489-8979-426c-8fcd-3c70285b37e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="1a64e130-444d-4e3a-b27d-91d196105e38">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a84197aa-106a-4e75-b4b3-ce6323f925ca">
+      <statement statement-id="ir-1_stmt.b.2" uuid="d22849dd-76b4-48af-92fe-6232a9f1a716">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4411,26 +4411,26 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="daa14805-f453-4d3b-bd57-f337fcd8d6fc" control-id="ir-2">
+    <implemented-requirement uuid="fe524269-e4e7-4d6a-bcf5-6b9543b9ca47" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="21f43613-8375-4b55-94c6-67ab357bf477">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0b4d79ef-b595-4846-90db-27fa986664e7">
+      <statement statement-id="ir-2_stmt.a" uuid="5c175ed8-82cd-4728-bcd8-5db6e1308527">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="d580acd9-e117-451a-ab20-e660e0a54a35">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="65097370-03da-45fc-8a47-43d30fc0062b">
+      <statement statement-id="ir-2_stmt.b" uuid="a49bf765-58bd-4b2b-b1b4-8e6a41715d1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="e78cc357-ffa6-414f-aa74-f54128c6df6c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8238aa98-037d-48e1-81f0-f73746edd498">
+      <statement statement-id="ir-2_stmt.c" uuid="c95c03bd-5f95-4c91-b3ef-55844a695d45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4438,10 +4438,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b37d8e28-a56d-4728-814f-4797a2f29730" control-id="ir-3">
+    <implemented-requirement uuid="dfe87267-0eeb-4244-b7ca-c35683827acf" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="8c07e299-ed26-4c62-a7b2-e6935850dc81">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8bb3f5b2-ba22-4ed8-b337-8f70b10155f9">
+      <statement statement-id="ir-3_stmt" uuid="4161cef9-2159-445e-b264-ce64443892e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4449,10 +4449,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92f52ec1-8a37-4235-bf2a-73146ec32070" control-id="ir-3.2">
+    <implemented-requirement uuid="27ddd2fb-0b38-475e-8270-9ba769148ab4" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="1a2c3e9b-430c-4450-b758-f6411a2eff2a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a3ef9316-5a34-4410-9c1e-1defe51e0bdb">
+      <statement statement-id="ir-3.2_stmt" uuid="d1d5c9f9-def0-428e-bf29-6294b04a76b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4460,26 +4460,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cfc8d87e-41d3-4c60-825b-be82c1b4c7a3" control-id="ir-4">
+    <implemented-requirement uuid="eb33911c-d4b4-4191-aeb7-67ac9fe7707d" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="fbd4548b-b703-45a1-80df-95fcfdd9094a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b848f722-987a-4c67-a45c-03ec5363df74">
+      <statement statement-id="ir-4_stmt.a" uuid="33dcbe65-c67f-478d-8137-9eeaf2f74dc7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="4a9de417-8836-4e18-840b-f502a47cb3c2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d8232f37-f2c0-4c78-889c-245d5318ab96">
+      <statement statement-id="ir-4_stmt.b" uuid="294e8fab-9f0d-44a5-ba1d-03d9c54033e6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="e6318389-ca37-42c6-9f3f-d88d70479c42">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="87cdfd3f-dbc7-4aa6-a64b-cf3b4e6e4ff2">
+      <statement statement-id="ir-4_stmt.c" uuid="54af38e1-84c6-4c32-a8ab-cae687194130">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4487,10 +4487,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10597c8b-0e45-479d-ab82-8dfab171603a" control-id="ir-4.1">
+    <implemented-requirement uuid="645ff6b9-c162-4e51-920b-3a94d4f0fb61" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="5373b816-8f6e-4320-aaf6-38e8eb178cc2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6d2db44b-38f1-4f77-9258-511e47b5b3af">
+      <statement statement-id="ir-4.1_stmt" uuid="cb0f4585-715b-4ea0-8994-5c99838709c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4498,10 +4498,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b4cfc065-10f9-43c6-9977-3b13e486ee3b" control-id="ir-5">
+    <implemented-requirement uuid="fce171fa-933d-4c31-9d91-22db3460611e" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="bede0255-8fea-439b-b404-aec6f32fea47">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="572232b3-661f-47bf-a3ec-84c7998845f0">
+      <statement statement-id="ir-5_stmt" uuid="3369b8b2-59b2-4653-9523-e1543e94ea4f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4509,18 +4509,18 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9a62bda-b4d9-4655-a87d-0f32dfc53937" control-id="ir-6">
+    <implemented-requirement uuid="89d5380b-005b-4609-bda3-e796d6aa8778" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="cb86d156-a7dd-4593-95a7-81245f9a90e4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="53075b2f-2e7b-48a1-b04e-e345d6f40621">
+      <statement statement-id="ir-6_stmt.a" uuid="a9f85a42-b737-4905-9ac0-ef0f969b72ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="0a88521f-e86d-4752-a150-1ac3420f9465">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fcb6b826-c00e-4e83-b0a4-255deeb49dc5">
+      <statement statement-id="ir-6_stmt.b" uuid="bbd9ac3b-10ed-4429-8fe7-fdf26be8fa7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4528,10 +4528,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c21e767-6f53-417c-aa11-59ba252c38fb" control-id="ir-6.1">
+    <implemented-requirement uuid="565b5616-fa8c-465d-9a56-049569731000" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="9f85b887-bbe0-4682-944b-1239f5243a1a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="888ee52c-0bc5-493c-9ad9-5ab7116e9d64">
+      <statement statement-id="ir-6.1_stmt" uuid="1148f4a5-d79c-49b2-858d-a362fa69dbe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4539,10 +4539,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1eecf00-20ad-41ac-abfc-33d83c4ad40a" control-id="ir-7">
+    <implemented-requirement uuid="e303e930-0cd3-4243-92e5-5192b3845d0f" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="39ed200a-dca8-45e4-ab38-87c1dfb9fefc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="21e6a047-787c-4373-8fcd-d0e7390652b6">
+      <statement statement-id="ir-7_stmt" uuid="047a743e-e421-46e3-87dd-0b3424dc85e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4550,10 +4550,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c9b6cf5-615b-40d7-9a38-d3420ff12fee" control-id="ir-7.1">
+    <implemented-requirement uuid="33d846fb-a03e-42e1-9488-e0bc266ef476" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="476c0f9c-1065-4068-b870-c6b73e447fff">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ab5d66a4-eeca-4c3c-a223-0456f895e273">
+      <statement statement-id="ir-7.1_stmt" uuid="9663849e-b679-426f-bb0d-d6e84223736b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4561,18 +4561,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d00add97-a806-475d-9de6-7fea90cb1ed4" control-id="ir-7.2">
+    <implemented-requirement uuid="daf17bd4-f8f7-4693-98d8-2b2ac196b17e" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="cc9d5380-79a0-4678-80b4-145a4c295cb4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1e11b364-acd7-4709-a04d-9c515b622917">
+      <statement statement-id="ir-7.2_stmt.a" uuid="13d4e2b7-6d9f-4af6-b964-fc2db1885223">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="89bf182e-fc2c-406d-9689-2e4a1bc81c54">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="65b0a6fc-e66a-4f56-b3f0-559e683af24a">
+      <statement statement-id="ir-7.2_stmt.b" uuid="b2702284-f887-4e4e-934f-dd599b2ef766">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4580,114 +4580,114 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a6bfa1b-db9c-4316-a5a8-be7d282b4c37" control-id="ir-8">
+    <implemented-requirement uuid="595d022b-7ad6-4c82-8934-e3c21903607b" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="dff1e766-e3ec-4e69-ab2a-6c4227226127">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bd77dd31-b2e3-4c89-a1ab-091d872c9e64">
+      <statement statement-id="ir-8_stmt.a" uuid="69e20c17-c2e6-491e-bdcb-242d01a87abc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="5d221025-8646-4d9b-91b2-bc8888999e47">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f6455029-3c9a-470a-8487-bec862a13be4">
+      <statement statement-id="ir-8_stmt.a.1" uuid="72643e28-b35f-4f87-9d5e-53933f812b15">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="d3057893-d622-4fa6-9ed7-cd05ad339bfc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6451ad2b-4303-4180-8ee0-243be8502ef3">
+      <statement statement-id="ir-8_stmt.a.2" uuid="4e5c7d57-2f90-45be-9f74-bff226c173fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="c2077824-cee8-4075-adf5-669fb556e5de">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b7850154-1755-4214-961a-9f9e52ae3d46">
+      <statement statement-id="ir-8_stmt.a.3" uuid="b619e512-1860-4e36-be97-0fef26fa3fdc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="c1c0673d-2c91-4fec-8568-1eea4b84ae3f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fcfa059f-6f59-4059-81d7-776631801624">
+      <statement statement-id="ir-8_stmt.a.4" uuid="496784e7-2932-4245-9d35-6ca30e7a4996">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="7dbd78be-2f7a-4f1a-acc1-db4bb8c87541">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="be2adea5-d71c-447f-932b-681cedf5d4ea">
+      <statement statement-id="ir-8_stmt.a.5" uuid="b0be9941-f831-4d53-8707-163badaf2954">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="9017d45a-304a-45bb-9738-21c398d4fb4d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fe13150c-981d-43ba-a5d5-e734d6e24d3f">
+      <statement statement-id="ir-8_stmt.a.6" uuid="e7fadd37-8831-474b-aac7-04f508f585c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="c5ce5151-28a4-457a-b959-396dc79174a6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e649ba7b-ec6f-4940-acab-c1545bb5ca4b">
+      <statement statement-id="ir-8_stmt.a.7" uuid="508aefd4-b732-4beb-81b3-25d1c8af57c2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="52e961d3-b230-47f7-981a-a80790c98738">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2826b214-f348-4c67-8282-c01c53039288">
+      <statement statement-id="ir-8_stmt.a.8" uuid="96e9806f-4ed3-4202-9c93-14662e29113a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="dd3e2417-1bb1-4c78-b196-8d19114915a3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="58c83c37-f446-470e-a73a-27b1ac031501">
+      <statement statement-id="ir-8_stmt.b" uuid="dd657902-cbc5-4ee1-9120-98366b9741f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="4c3155c9-1f53-4d6f-8ab6-d28d6dc32742">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ebe0af7f-f766-4254-b5cb-41f008bfebaa">
+      <statement statement-id="ir-8_stmt.c" uuid="749989bc-d4a6-4954-b414-067ab2efdd4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="5291eb8f-a1a1-4538-9c82-f559b3a0ddaa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e577cd25-9ec5-408c-bfc6-7a65920b2ff4">
+      <statement statement-id="ir-8_stmt.d" uuid="592206a3-a940-4153-af52-1643c347f726">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="e14b9230-85e1-4fe1-b843-748e401f89fe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="220531aa-da2c-4709-a3ca-2a22455ae313">
+      <statement statement-id="ir-8_stmt.e" uuid="25670e9a-0193-4bd2-b298-40527001f551">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="9c3f70bc-70e3-4aab-8058-8971fa6572dd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="430d1b7c-5850-44a1-afaf-fdbd93f9537c">
+      <statement statement-id="ir-8_stmt.f" uuid="ec849266-6579-4265-b734-c8cd7b749d3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4695,50 +4695,50 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4fdb176-c9f5-42e1-b9f5-e8ce943403aa" control-id="ir-9">
+    <implemented-requirement uuid="9df025b6-0f19-42c1-a0bd-320a658cbbc4" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="71a7557c-6e81-41fb-9f32-f93aa6dcb691">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2c23fe95-b96c-44a4-b1c9-65d1bc64a3d2">
+      <statement statement-id="ir-9_stmt.a" uuid="049b72a0-1a71-4441-845e-dcc92d2ae0b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="82a257ba-4b6c-4606-ac1b-5694dbed8c46">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d296b9fb-9c24-4bd7-acd2-6fbae6be163c">
+      <statement statement-id="ir-9_stmt.b" uuid="77e3710a-d405-4a2a-bec1-8b2736953314">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="03b24091-03ae-4da3-ab4c-71b9fea04eff">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bdaa53dc-722d-42cc-8082-96bd2e6e6744">
+      <statement statement-id="ir-9_stmt.c" uuid="aa1efb6d-4749-4a43-b7b9-ce6f963c6579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="d773209f-60db-4687-a062-201adb3c3d03">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7bf0fc66-f5cc-4a01-864d-770e495521db">
+      <statement statement-id="ir-9_stmt.d" uuid="0ddb0f74-8291-4472-a292-50ff9cee2890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="eb5cb2a7-659c-4d2f-bcd0-54c31a3892a6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8d8426f0-6068-443d-87c0-f5d309cdf0b2">
+      <statement statement-id="ir-9_stmt.e" uuid="7eb578f8-5f45-4c81-a553-943a3dbbb046">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="87263b4d-9b26-4e09-9334-969e8c884e2f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e4bd2ed8-a545-4d5e-9842-d6a7430716ad">
+      <statement statement-id="ir-9_stmt.f" uuid="e559c3ae-2480-4efa-acad-cf8ebaddf155">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4746,10 +4746,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca0e7211-a1b8-41ee-97cf-811a5e13118d" control-id="ir-9.1">
+    <implemented-requirement uuid="d373d5b7-90f4-44aa-b986-aa692df48fa2" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="ffe36904-0f60-4575-b06f-fb210c660a57">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b0b25ff8-ddac-4ecd-a924-12ecb801709c">
+      <statement statement-id="ir-9.1_stmt" uuid="14897118-995f-4756-84fa-1a34906aa70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4757,10 +4757,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d0430f8-a971-4eb0-8175-7eda879eef55" control-id="ir-9.2">
+    <implemented-requirement uuid="a378b7c2-f47b-4ce0-b9de-76d7bc6c8bcf" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="b3ec941e-000f-4f2e-b9cf-161ed603ebec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4f1231c1-5595-488a-a8c8-8b241403fb9c">
+      <statement statement-id="ir-9.2_stmt" uuid="1f5c56ed-4d1e-4bb3-9c99-f77744271117">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4768,10 +4768,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="588c695d-176f-4ad4-9c33-c407ca9f3c9e" control-id="ir-9.3">
+    <implemented-requirement uuid="cfbe37de-b721-4054-8a99-f5d964a0287a" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="59c36c19-07a9-4705-905b-99e3f68e7815">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="85e6e074-b8f5-43bc-bd68-488bf92ab5e4">
+      <statement statement-id="ir-9.3_stmt" uuid="a1b5ff63-849e-4cfc-a99d-5896b0b31daf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4779,10 +4779,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dacbd27f-48ae-4a95-9be4-a81795d6abc2" control-id="ir-9.4">
+    <implemented-requirement uuid="b9780021-b1bc-4f10-9de1-34469ce75fbc" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="2bdc113d-0598-4129-a42d-94af8cc81fdb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4361b043-8c86-4709-a056-4e569ac6f569">
+      <statement statement-id="ir-9.4_stmt" uuid="9ae8ca7e-3f55-40e4-9b96-079b2c3fe656">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c78d2786-d38e-46b8-abcb-aee01c7e6597">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -4790,18 +4790,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="952b4692-819a-4d9a-b591-3103126d3a6f" control-id="ma-1">
+    <implemented-requirement uuid="7c9f8c2a-701a-4f18-8625-edcdf7ca4e86" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="7787c0b7-75c9-4a64-996b-cfe4f3f31b83">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="be9912f6-7ecf-4581-8465-76fce6d9dbd2">
+      <statement statement-id="ma-1_stmt.a" uuid="52b9031d-430c-4473-8a5e-e1d2b013e31e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="96cd107b-bbac-4c9f-9b43-81c8bfbfa702">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="96842f28-2b11-4d3c-a34b-68bae13a232f">
+      <statement statement-id="ma-1_stmt.b" uuid="c132478d-5909-4718-9289-4415db12ef5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4809,50 +4809,50 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae85f981-abb1-47b4-860a-8fb20b8f9fcd" control-id="ma-2">
+    <implemented-requirement uuid="e7d5b680-e4ac-43c0-a574-5cff41e6e337" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="5bccae70-dd28-489a-ab6a-411fffab0898">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="77fedc06-f48b-4b83-98a3-cca8ca6b02b2">
+      <statement statement-id="ma-2_stmt.a" uuid="fc868847-1f7d-46d8-bd2b-22a040fa1ccb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="21eb754d-7c86-49f2-b55f-1fb8fdd3546d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c6949bad-bc5a-4d08-bcb7-14491957de13">
+      <statement statement-id="ma-2_stmt.b" uuid="eb1ccb7b-8606-4e45-9dc4-79be60042561">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="7b36f70c-c888-4bb8-884e-ba7db44e40cf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="809fc55a-5ac0-4be0-9d88-4efc1c2ca116">
+      <statement statement-id="ma-2_stmt.c" uuid="8afdeac6-75a2-4306-abd2-27724886daa7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="a95a6d43-b152-4d55-9ae4-a1f9987acfba">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="96f8cdcd-82a9-43eb-825b-ad07ac4cda34">
+      <statement statement-id="ma-2_stmt.d" uuid="a3cb1b26-cd05-4452-bd93-47b66ad9fb81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="817b57cc-88df-4b71-918e-a69fdaf42c1f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1162eeb9-2c9d-456d-9890-c2e2fb13e19b">
+      <statement statement-id="ma-2_stmt.e" uuid="6b15fd53-2caf-4fa0-aa59-1bdc627c30cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="1672a7f5-e1bc-45a7-b98b-78532c22dc19">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6665a088-7121-4f54-85ff-63eac1eed890">
+      <statement statement-id="ma-2_stmt.f" uuid="e745b580-12b5-4aaa-922d-8e7b5f5b2453">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4860,10 +4860,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed4d65e9-3d30-462b-9633-799c6428de48" control-id="ma-3">
+    <implemented-requirement uuid="be1eedba-a6f5-4129-b68b-7e2803adb001" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="44db3b19-a860-4fd2-834b-dae389c96715">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8cb2b6e1-0944-418b-a626-57b71da1e85a">
+      <statement statement-id="ma-3_stmt" uuid="d66d7e31-a93f-4c2a-9b54-ae2c71b2e6bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4871,10 +4871,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40bf38a4-9143-41f1-b674-dd072cd085fc" control-id="ma-3.1">
+    <implemented-requirement uuid="1e95f557-0d06-4b13-baa8-4658fb618e07" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="1f7a2d8d-678d-4929-a508-65fb2e676631">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="54bf2fd5-00d2-4a07-860d-9568ae018262">
+      <statement statement-id="ma-3.1_stmt" uuid="f731abe2-3ef8-48e1-9e3c-012cf404e6d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -4882,10 +4882,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d73d9bb-cd67-4dd9-843a-24e9433d4037" control-id="ma-3.2">
+    <implemented-requirement uuid="275c4d7e-7ce3-4fa5-9c20-748c2b9ae1bd" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="e730d646-8eb7-4789-9e54-281deecc8e74">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="db3d1136-0990-40c5-9606-01ddaeefc7c8">
+      <statement statement-id="ma-3.2_stmt" uuid="e6537073-dfc0-4e16-90ff-83d9ed136e0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e14296b-490f-411b-aa3d-fa0d06e457b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -4894,10 +4894,10 @@ system is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e696ecfc-966f-4f37-9ffa-4ee0c996a91d" control-id="ma-3.3">
+    <implemented-requirement uuid="c4ed0f0f-be66-4c34-a2b7-bca101ff011c" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="91eb359b-ece8-48e0-924f-bc069d14d505">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1aaa1ae3-6d4e-4c14-a53a-72572fcd3013">
+      <statement statement-id="ma-3.3_stmt.a" uuid="604d6d51-e0e4-489f-b30b-6477ef2ef2ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="307d4a1d-cb27-4524-8134-c572ee99190e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -4906,8 +4906,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="2d1bfbf0-06db-4834-a1cc-5cb97755b5f9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f5c2b703-1d56-4695-b3e4-35bf55bfa8bf">
+      <statement statement-id="ma-3.3_stmt.b" uuid="d8d66447-4c72-4e7f-a795-310ed08b1687">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d1ef96b1-a60c-43f3-bed9-391a0bf44ed1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -4915,8 +4915,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="d4f70483-9b72-473f-931a-11f5b641b881">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17a39f0c-c3c3-4194-9110-46b49701f7b5">
+      <statement statement-id="ma-3.3_stmt.c" uuid="a9d2402c-bd9d-4092-9ec7-dcb37617413e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="923ca9e2-379f-4521-8720-879f71f138ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -4924,8 +4924,8 @@ facility is outside the scope of Red Hat Virtualization Host (RHVH) configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="4499aa07-3957-4a48-a724-079d110275d8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0791502c-51be-4e16-89c6-5e7791cad91b">
+      <statement statement-id="ma-3.3_stmt.d" uuid="4c32215f-540f-4b0d-9952-2a6dd6c14fe2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cd8e8a3e-e68c-4ae8-a90b-97858a558a18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -4936,10 +4936,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9b00e147-e4a6-495b-be68-cfde2c1fa00f" control-id="ma-4">
+    <implemented-requirement uuid="341bf661-08a4-4d3d-9efa-713d218238a9" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="8e2ad628-61d6-4273-82bb-377be9b77bdc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f32f3de3-a712-416d-9524-0cf682d39054">
+      <statement statement-id="ma-4_stmt.a" uuid="21dc58c8-d1cc-4ce8-8ff4-3c999f643ade">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca007b9b-ec78-4a11-8803-478f5cffbb74">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), all
 maintenance and diagnostic activities are monitored regardless
@@ -4948,16 +4948,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="cbcad137-1a3e-462d-a18c-98aaddebd48a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cdc945a5-5fc1-4c6c-8000-b12775adb7f5">
+      <statement statement-id="ma-4_stmt.b" uuid="3e8c5061-7e35-4d70-a900-158e219ff89d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="826c8fee-7731-41e8-8618-7b3616f910ad">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cbe48202-0fb4-4fee-9d5c-11507a3cb1ac">
+      <statement statement-id="ma-4_stmt.c" uuid="07ae523e-199a-4c53-9489-200e1bdad128">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70054354-f7b5-44f6-88d9-e6568d0b9f76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -4969,8 +4969,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="4c1bf200-4cf5-4417-b322-79ccdd6eeefe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c7934597-4e5b-4c12-8ee8-7a1001ae894f">
+      <statement statement-id="ma-4_stmt.d" uuid="b840c898-0971-4def-b4b2-70d9c16498b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd48cd2b-50b7-4966-af6b-5ea602bb5dd8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Host (RHVH), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -4982,8 +4982,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="19bf651c-9375-4a5d-909a-76b4dc42603e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="61809d58-131e-4751-ac1f-a026cdf988d0">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4992,10 +4992,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f7c8871-cfb4-406d-b711-a25712f8e819" control-id="ma-4.2">
+    <implemented-requirement uuid="5da754c6-bbb9-41ed-acf2-bc9cb898d2e9" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="cc0f543d-582f-4ee6-a1fe-a9a3cb84580b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cd50b173-8a54-4400-8015-0d13d391c59a">
+      <statement statement-id="ma-4.2_stmt" uuid="25fce7ee-55f0-440e-a747-1ef7cbedaeda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5c40590-7ad3-4049-8b16-b6bda19d56d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5004,10 +5004,10 @@ https://projects.engineering.redhat.com/browse/RHV-21014
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25c65eb4-1c9d-4e76-a1e1-67c600f4be24" control-id="ma-5">
+    <implemented-requirement uuid="ba2b169a-d9fc-413b-9721-59b24d50673e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="c23f9960-0db3-445b-97af-fb0d44132dd8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6b7463c0-f4d6-4b98-a13b-827a6820d107">
+      <statement statement-id="ma-5_stmt.a" uuid="9110044f-ebcb-4758-b9f6-6698655348a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="868f382f-1e5f-4e6b-95a0-b3e1db5ecf1b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -5015,8 +5015,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="e90a01b9-7fdf-4432-9b3f-61196295bf17">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="26881586-a9d4-4cf6-b5b4-c1df1b3d68d0">
+      <statement statement-id="ma-5_stmt.b" uuid="d2680ea6-9c2d-4919-bcce-2c3bd3eb8bf6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d98e3fd3-fd5b-4ee7-b6f1-f96163ec9435">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -5024,8 +5024,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="e602fc25-79eb-401b-a256-91b7494e748b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f2e85d59-85fd-45ff-a001-77b77dba5654">
+      <statement statement-id="ma-5_stmt.c" uuid="e65d432a-7ccc-401d-a0ae-68733d89f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cde3adab-8e3a-4373-b7a9-64953d4cdb4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5036,10 +5036,10 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccee8f51-f7fa-4694-b340-48b15e4c6c08" control-id="ma-5.1">
+    <implemented-requirement uuid="cf832377-c133-4dc5-b588-1cbc9b32c1c0" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="2eee543f-37c7-499b-93a1-3f8a3fb6ddd5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="aaf66b6e-9c99-4562-8edd-e22b34a4ac9c">
+      <statement statement-id="ma-5.1_stmt.a" uuid="545f294a-cdaf-49ca-acaa-2600ef538248">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f29e0c6a-aaef-4851-946a-3f6b12c23efc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -5047,8 +5047,8 @@ citizens is outside the scope of Red Hat Virtualization Host (RHVH) configuratio
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="9dd149a1-4c01-4fa5-8091-fd4f945bfe98">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b8174773-43ae-42a8-bb86-e617a06961ea">
+      <statement statement-id="ma-5.1_stmt.b" uuid="598df173-f38a-498a-8abf-86fee530059b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5efdc66d-9f94-4e9c-a1d2-464447b832fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5058,10 +5058,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc47c4ab-3399-4843-b8c4-1aefab6dee25" control-id="ma-6">
+    <implemented-requirement uuid="32b69454-b03e-4bc4-ace8-f327d63813fc" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="67b86906-cb88-4706-9150-36a1b8b7e2bf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1d5c4e03-0838-41ec-a8b3-4e87583e5c28">
+      <statement statement-id="ma-6_stmt" uuid="5a8fc70f-bcfc-4f12-b02d-011a5a8d8ec1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023e6e11-475c-46e2-86cc-7498a60ded11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5070,18 +5070,18 @@ https://projects.engineering.redhat.com/browse/RHV-21052
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39d9b662-1692-4282-b0cb-766520529ee1" control-id="mp-1">
+    <implemented-requirement uuid="b91b9414-6da6-446e-beb8-a29c64afc3d9" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="463f5f5e-121b-4d07-bf5c-fdbabe42d73e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b2a10e8c-2d18-4512-80fc-6d9a1efdf42f">
+      <statement statement-id="mp-1_stmt.a" uuid="649b7dba-34c3-490c-b299-1ea3b7164cd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="39857840-a6f9-430a-bb7d-db254b2eadb0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="45560c87-147e-473e-9f6f-e6f1737d83fe">
+      <statement statement-id="mp-1_stmt.b" uuid="14175897-bb69-4049-97db-483e77f3048c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5089,10 +5089,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="89609f8a-a2b6-4b05-97bc-eb01d61b208c" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="faf2138e-89d5-418a-87fc-f3d8e2f2e9db">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8ce8c011-1173-4b2b-8737-e11cd18bcdf3">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5101,18 +5101,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41fadbc4-1143-4257-927f-081b69d89d97" control-id="mp-3">
+    <implemented-requirement uuid="1cd06fc1-f89f-4aa7-807c-7191d8a32a73" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="006c1148-ae61-4c17-a5c1-63853ba6721a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bdd85b65-a440-429b-8c27-e18899224217">
+      <statement statement-id="mp-3_stmt.a" uuid="a1e28e43-0a25-49c6-96cc-cdc77d101309">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="731538f7-0f88-4785-8b30-1995a6c0883f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9b8a69d5-db23-4f0a-a4e6-a195bf24885c">
+      <statement statement-id="mp-3_stmt.b" uuid="5dc84729-6609-4229-8017-68c1ca094753">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5120,10 +5120,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b04ba9a6-f960-4ec1-b693-61f48bd3649b" control-id="mp-4">
+    <implemented-requirement uuid="0ae07f16-fcd6-4ca1-af12-5484c7228ed1" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="d07c00fe-d60c-4480-b366-6745878a4afa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f8e9fd39-d5bd-4911-9803-94f200b6bec5">
+      <statement statement-id="mp-4_stmt.a" uuid="b2c9bfab-6447-4a76-8556-1f3cf56f77b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5132,8 +5132,8 @@ https://projects.engineering.redhat.com/browse/RHV-21054
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="86f0f960-0298-4299-8d5a-a9516e2f7b28">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2255f880-a911-4fa6-9c5f-2eaea4a52a18">
+      <statement statement-id="mp-4_stmt.b" uuid="152c6172-3805-4382-af5e-3493779568ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5143,34 +5143,34 @@ https://projects.engineering.redhat.com/browse/RHV-21054
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92bd39f6-f16d-4227-bbed-146224b56581" control-id="mp-5">
+    <implemented-requirement uuid="1fac0186-1c95-4f77-984c-c2c6f2f3a4ce" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="f895a5c0-8cb8-4c3a-b458-fa0b1b0577ae">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="94ed1358-2e90-4f2a-bac8-c4b447d5b14b">
+      <statement statement-id="mp-5_stmt.a" uuid="31e1058f-fe34-4cb1-b3c6-0b87b7495dea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="f98d5cb8-2c2d-477f-b0a4-355842d15b02">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a1061da8-3a15-45fa-ab8c-0320f4f03509">
+      <statement statement-id="mp-5_stmt.b" uuid="47c22722-53c2-4fe7-8806-9db0026b1d1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="8d6d6335-c33b-4516-bea8-acb1686b961c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b6498e76-0ce9-4a56-9e85-9d70f80c74f7">
+      <statement statement-id="mp-5_stmt.c" uuid="89059183-b72e-4361-9478-c1cae1cea377">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="fd546848-115c-41a8-80e7-b834ae8b63ea">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7ee68af1-b02f-4d82-8698-262dc4522515">
+      <statement statement-id="mp-5_stmt.d" uuid="957ed3ae-501c-4088-bd50-d6c7b7f9a482">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5178,28 +5178,28 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63b2436c-4ed8-4b97-9f76-ee70eb088828" control-id="mp-5.4">
+    <implemented-requirement uuid="6361f93d-b6f2-4993-8a6c-7346274e7404" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="18005c9f-aeb1-4872-90bd-8ecdfe7fd5c0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ef4148c3-bf56-406a-9900-b98233d0fd3d">
+      <statement statement-id="mp-5.4_stmt" uuid="87bd7a66-c599-493a-9d8e-4920920b8cf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1c3b842-8fff-4679-b0d3-6f566903f9dd" control-id="mp-6">
+    <implemented-requirement uuid="0e80f605-dcc6-4658-9018-a4e5c1aabd8d" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="1b784422-cd04-498d-b474-26d23abfe1e0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b81b69ef-8908-4bb4-9eaa-e0d0b52142c0">
+      <statement statement-id="mp-6_stmt.a" uuid="bf42d0d5-594b-4fc2-b39d-c6f4203d9460">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="e875d36c-d5cb-4ea5-b960-fc2ab1799301">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="83e517a8-7dc1-45bd-baf9-1de31d04dcb5">
+      <statement statement-id="mp-6_stmt.b" uuid="4e9e26c0-e2b3-4333-be22-3d8c99c37ff1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5207,20 +5207,20 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a8bb128-eb28-4bcc-bac7-95d48df55433" control-id="mp-6.2">
+    <implemented-requirement uuid="0fe7c2ba-1a18-4cb3-95e3-55d239194022" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="c14ba8eb-e769-4570-b5c5-486ac413b026">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8959dc43-7b84-44d3-9893-604a211627ec">
+      <statement statement-id="mp-6.2_stmt" uuid="9435f252-d50f-4660-8587-7fed1a77100f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36d6f716-f9c5-4524-80c7-accc475040bd" control-id="mp-7">
+    <implemented-requirement uuid="88e879dd-d8fe-46a0-a2d5-85902d1dac8d" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="310b9b94-8861-4e29-aa1b-63b3c8901078">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e34e45c1-d652-4e66-98ca-f9fe1d78b2e6">
+      <statement statement-id="mp-7_stmt" uuid="b119f2f9-a732-4f58-92ef-b726234503bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ac911b73-894a-4f8b-8d0e-77429aee0a8c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Host (RHVH) nodes, the following configuration check must be enabled:
@@ -5241,20 +5241,20 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dd9b5787-3d2f-4a2d-b444-1d6dbbd5450a" control-id="mp-7.1">
+    <implemented-requirement uuid="94b7a6fc-0724-4aa8-b9a6-2ac24e2dbe46" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="1176d92a-1baf-4636-9923-57acf5bbe209">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="329cb652-df5c-4405-aeca-303267ba42fa">
+      <statement statement-id="mp-7.1_stmt" uuid="cffb274f-4a38-4e05-8a40-8e541fb0faf8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4acd22e-2543-4067-9426-3a82382c69bb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b4ab561-2a7e-4d22-baf0-42815c28da66" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="d05b7aff-c53f-46d5-9a99-318197e81866">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8a329b5b-cf97-4b6e-8a78-4c877661828a">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5263,8 +5263,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="09208fcc-aedb-4efa-894e-da025552454a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7d35e04a-a041-4eef-ac77-8bcf05548971">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5274,10 +5274,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df2dbf0c-64e3-4b1a-b94d-4ac58bafec0f" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="129f2295-2658-4a4f-9e1a-7a50d904c943">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ae946dcd-be99-4e04-b238-e1020a364a67">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -5287,8 +5287,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="fdd71bc1-4444-492e-abb8-274fd807795f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="547e8735-9b3e-457d-a518-59146cc27382">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -5296,8 +5296,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="c1604b48-8826-4518-9bf0-f10b810aa441">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="483d0105-bcc5-41ee-8bb8-ae9f44cdbb25">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5306,8 +5306,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="b2f79cda-e380-4ac3-9f81-89f80e4d4758">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7dc0fec1-482a-4a1a-a9a8-600f070cc73e">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5316,10 +5316,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efe761f8-0fd2-4358-b241-6e02286ef237" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="b9fa7762-da0a-4c5f-8b85-180e4f9036da">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a141847c-5b99-4c0d-913d-f55cc1e101ae">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5328,8 +5328,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="2442a1b4-76c9-4219-a759-d35d9c17929b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7027f08f-136d-470c-b4ba-aab6fd5f6b32">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5337,8 +5337,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="ac70a097-82e9-492e-9ce3-0a8f5b1fcd99">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d8e6e0e2-db41-4ae9-835a-1cfec95c7853">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5347,8 +5347,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="5ee0c6cc-cc8c-4435-a384-d7e55e59e651">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5dc08ba2-efa4-4142-96f5-8d2991a394eb">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5357,8 +5357,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="9d6b8d3f-3581-4896-9faf-ac804171dd5a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="132147ef-e98c-4c8c-a172-de7af1efb22f">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5366,8 +5366,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="92acab60-2596-4d84-9b05-6483ff1f219d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b8d68d02-1d30-4b5d-b94c-290744c03e54">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5376,8 +5376,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="d030a7f2-4ea5-44fe-820e-0bd2766dbbed">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f9467659-2255-44c3-8089-51ce54554fee">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5387,10 +5387,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae6d1ec6-3070-47e9-b28c-b215c6ab27ac" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="77b0bc19-b56f-4d0e-aec1-dfecd047e78d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9eb8d30c-7eff-4f3f-89a6-83e7dcf07d63">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -5401,10 +5401,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a2d36a6-b04c-4ff8-9ab5-6dca3764bd03" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="a17d7c44-1cd7-4c15-aca3-2e119757141a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f575bbe8-42b0-4100-bd56-a5cd428175c3">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -5414,10 +5414,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b0c66d9-0c8e-402c-ad4f-a63c76a220e5" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="a2827081-3d4b-441e-9524-3ab1d628fa7f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fced8886-0729-4ffa-938a-7d35273fdd04">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -5426,8 +5426,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="5d5afdd7-f7b6-478f-b61f-27ad46c13ba1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="865797f2-1cfa-439b-a62d-d1f241d80716">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -5437,8 +5437,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="f981b8c7-670f-415f-9168-c8ce495d91dc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="14a53f13-eca0-46c2-9183-22cc53607a96">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -5448,10 +5448,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcae2a3e-6294-420e-8d70-8f42325a0bef" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="762bd8ff-7918-4002-bc84-15c5faaab75b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2529e1df-e821-4d41-81d2-a3d81cad4b34">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -5460,233 +5460,190 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3db19706-deeb-4d01-b9eb-08e19d93db61" control-id="pe-8">
+    <implemented-requirement uuid="8e522774-5721-4589-a4b5-6846ec925da4" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="67ce2dae-3aae-4e3e-9865-78655d9687d1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="eed7abf5-3b5b-4e0b-906c-58553517e5ca">
+      <statement statement-id="pe-8_stmt.a" uuid="16b1bbc5-1c36-4de8-9af2-fec6a50db9ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="71f269f2-5087-4371-abf2-02d149c1132e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cf074e57-1229-436e-b53c-a58dd42632d2">
+      <statement statement-id="pe-8_stmt.b" uuid="ed894004-a8b5-40f3-96d0-ceaae4188dd1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e4613c36-e71b-4458-833f-4b36a9dd1f5b" control-id="pe-9">
+    <implemented-requirement uuid="74077cb5-6191-4723-b9c3-1d0ae41024b6" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="5b461081-b0cc-4777-85b0-60f245ead593">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3be7673e-0bd6-4dec-b665-ed6390ce85f2">
+      <statement statement-id="pe-9_stmt" uuid="911abc86-a30f-470f-a63f-270602b628c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9f57b07-0cea-4610-b80f-d7c15c52e0e5" control-id="pe-10">
+    <implemented-requirement uuid="7408f5cc-1dad-433e-8460-de347abfdf5b" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="c4ced2d4-bd98-4b58-b5e5-f0ee531a9e49">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c3064472-5a13-40e7-af33-c37c4feb6759">
+      <statement statement-id="pe-10_stmt.a" uuid="c30eb199-b0c6-4a78-9659-ec5a8fa8e3c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="06298477-30e6-45df-b79a-61b5466581d6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e3b0b9d6-a924-4037-b76b-bedf7ae9a696">
+      <statement statement-id="pe-10_stmt.b" uuid="249c6acb-9212-4217-aa49-7dfa676e2e7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="d146a48f-f70f-4dc5-a27d-1a24e9ebeb4b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="570ba42e-9f77-4440-9574-582326ed8a60">
+      <statement statement-id="pe-10_stmt.c" uuid="3001ef7e-68c8-49b8-ab45-505a2b5c6168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36e4a0cd-a22f-4f20-bb31-ba3ade1df7f2" control-id="pe-11">
+    <implemented-requirement uuid="d3adaea3-24cd-4d4d-abe0-42dfc6d8f5a7" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="a0c0cba7-d931-435f-b0d6-e79ae9858c52">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c854c06f-a39d-4880-a1e2-97d77a9fdedb">
+      <statement statement-id="pe-11_stmt" uuid="541a37ac-e31b-4d0b-879d-0ce8dfd09ae3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="857203b3-4cba-44d5-afc3-639933ba5280" control-id="pe-12">
+    <implemented-requirement uuid="73a0b14e-7660-453a-94c9-9545a21b0b64" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="ba312aea-0021-424d-86c7-c3a3050ff4b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="601e6e3c-0cec-400d-9d16-9c0118ac7d42">
+      <statement statement-id="pe-12_stmt" uuid="d6f29b84-d877-4288-bfda-3ce09c52f331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a977244-bc59-438b-9881-8f44e0809bee" control-id="pe-13">
+    <implemented-requirement uuid="989d3380-0745-4b3b-ba40-59fcf7bbcd79" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="84c922c9-116a-40d1-ac7f-b6d86c081193">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="46d59c73-2e39-49cb-950d-ddafa51b4e8c">
+      <statement statement-id="pe-13_stmt" uuid="fbff0cdc-a8cd-4396-9381-591253c01ada">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f56ddec-4ffc-4c97-b034-666c24c73719" control-id="pe-13.2">
+    <implemented-requirement uuid="8f6475ed-63c4-4c90-9311-110a5611c94c" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="efd45373-8fbe-49c9-b217-0f9e27bb7f1c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8b21bd2d-1b2e-4b0a-8e88-ab6f6eebc882">
+      <statement statement-id="pe-13.2_stmt" uuid="0a884b9e-988d-47a3-b600-a6c997f527a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad3b4296-357b-4019-a48e-309b0267108e" control-id="pe-13.3">
+    <implemented-requirement uuid="732c0a27-fe4b-4133-8eb9-4bef1eb5a6fa" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="42db41d9-caec-44c7-93a5-74805ed5ae04">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ef16d693-e08b-4847-9ec1-81cb7e2b09c4">
+      <statement statement-id="pe-13.3_stmt" uuid="3140fe80-7527-4887-9a44-fae6da4a04e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae0e1059-9d9b-440f-b776-1b60e7776380" control-id="pe-14">
+    <implemented-requirement uuid="88c69622-6688-4c1a-989c-90ca905211a9" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="41b48c88-e359-45db-9d1c-db5e7ed0a72e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="197fa105-9614-4b1a-9d0a-8f5d9dbf69d7">
+      <statement statement-id="pe-14_stmt.a" uuid="97025072-163b-491e-9317-a91790d40ea4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="b280872b-5312-4674-8241-9e830682cda9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="96533c40-0920-4f6f-97df-c745b4ede032">
+      <statement statement-id="pe-14_stmt.b" uuid="c8b7b3db-7476-47c1-846f-f1bb83c24553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ee74cdd-1bff-40d0-a1b3-c4406932d04c" control-id="pe-14.2">
+    <implemented-requirement uuid="70de85f0-62f3-454e-b88a-7596c01471e0" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="b8d65f67-b40c-4f41-90ce-90d534d4bbb5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c1e5bd5d-deb5-4488-8c15-1805c81499b2">
+      <statement statement-id="pe-14.2_stmt" uuid="60f50e05-0e80-4c13-b04d-fdc7eb03f3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="155a525d-f785-4830-bdc0-6edf78778510" control-id="pe-15">
+    <implemented-requirement uuid="54c1493d-b77b-4b0f-9764-526d33b12d01" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="e81c51f4-a040-4dee-b9f1-9aafae28d298">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ca13033a-6d9d-4c17-ac10-6b2dfc8af915">
+      <statement statement-id="pe-15_stmt" uuid="76e4fbe1-5df5-41f2-80cb-df66c1fbff2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a77a0d0-7a00-422d-9093-5e7882c91fc3" control-id="pe-16">
+    <implemented-requirement uuid="8273106c-975b-47bb-8ab8-c7fa37dc5bb9" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="696e5fee-15fa-4c28-8b2c-a60d71f31b33">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="dc3787a6-9863-4ec6-95bf-6564a6a1d995">
+      <statement statement-id="pe-16_stmt" uuid="1a6e18f3-ad4b-42ed-a48a-f97d8cbd6f3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ba029ed-8d4a-4dde-88a9-600b6f467649" control-id="pe-17">
+    <implemented-requirement uuid="d75e661a-5ac3-404e-a97e-43a208e98b0f" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="ca16a610-a4a8-4511-b78a-ca28ceba4bd9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1a1b4b15-7fd6-4338-a575-ab7c9ca7cd0a">
+      <statement statement-id="pe-17_stmt.a" uuid="c8358812-2072-455f-8809-286fca2a5070">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="f6118934-b7c8-4661-8af2-b2a8e16ede6f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e2e9b121-bcc1-4ac8-a68e-a5047fb2d46f">
+      <statement statement-id="pe-17_stmt.b" uuid="98a6c2d0-859a-4dce-a4e3-455e4bfb85a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="a539050f-edcd-480d-8ab9-037caaab33b6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="674b6cfb-7176-4ae0-846e-8db6f04bfaad">
+      <statement statement-id="pe-17_stmt.c" uuid="52bf7480-7746-469a-abaf-860f5c0a23e2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f01838c-9434-4dca-882d-bbdde0c72267">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7e4c99f-9721-4983-a29d-b93bb04cda50" control-id="pl-1">
+    <implemented-requirement uuid="0e82974a-1e5e-4803-93e9-61175640b5c7" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt.a" uuid="969aea09-959d-4471-9d04-efd14a5b8c8f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="636d68a2-2c37-43a6-a24a-1603928a2202">
+      <statement statement-id="pl-1_stmt.a" uuid="45dde084-83b2-4d2c-93b3-1409bd7dbb04">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-1_stmt.b" uuid="8de983b9-fc00-472c-95cb-3ba07969ffab">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8ef2a404-4024-421d-9dcd-6f4b6ac78404">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="b1155b28-c78d-4e42-9b24-d15818ecb511" control-id="pl-2">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt.a" uuid="893e4f7d-57c6-43e9-b113-787dfc92126f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="83e16817-ff2a-4bab-aa65-06a02e715779">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.b" uuid="a90192de-67d7-4feb-a7e1-991725f26825">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1e6eb1dd-321a-4ebe-95c1-b7ffde888eb0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.c" uuid="1aff6815-35c3-4cfb-8cb5-efe81147b47a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="120a4ef0-42d9-4ca2-96d7-888a4b3a87a3">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.d" uuid="5549b0b9-db5a-45c4-9da5-4bb34065d957">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c295f4f7-3d8b-4e9f-977c-06b4b835b496">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Host (RHVH).
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="pl-2_stmt.e" uuid="96296720-2c22-43d2-9d1c-0155b94d1f37">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="29063666-a760-4631-a24f-d232ef78bc4e">
+      <statement statement-id="pl-1_stmt.b" uuid="584ebb6c-020f-483f-ab68-44fc7883c9a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5694,10 +5651,53 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4dd5a1c-2d15-4516-ab27-ac87003ee072" control-id="pl-2.3">
+    <implemented-requirement uuid="74f5010a-cf8a-4d6d-a7d6-faf6af0a04d0" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="8dac60bc-253a-40ed-b2d8-b84196900fa2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="057abfb0-2838-44eb-88f3-07489138c145">
+      <statement statement-id="pl-2_stmt.a" uuid="ef7e6239-22d4-4606-93a4-a629e9f064f0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.b" uuid="ec903918-36fd-4c0d-aeb5-0eb0c456e85e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.c" uuid="12b3e99c-6844-4dc6-9e4d-8ca775ebe9a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.d" uuid="7e2dbc92-fa11-4993-a43c-905b59ca13bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="pl-2_stmt.e" uuid="538fc076-02b8-43d4-9f18-ab19099afc2e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Host (RHVH).
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="23f8bbff-45a8-41ee-b0af-bcb99f2bc95c" control-id="pl-2.3">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-2.3_stmt" uuid="09f686c6-3e0d-44ad-ab08-3a699c0ff372">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5705,34 +5705,34 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93db6d57-c38c-49fe-b072-7f863238e733" control-id="pl-4">
+    <implemented-requirement uuid="0c0db8de-aaa9-42d8-b3a6-9b3471138c3a" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt.a" uuid="11d5b9e9-3181-4c8d-b623-08838c47e2b3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e54dff22-535a-47eb-ace3-6aa600549226">
+      <statement statement-id="pl-4_stmt.a" uuid="2b08835a-92bb-4eb1-899a-3f7aa979d943">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.b" uuid="11d8f3c9-a357-4309-9930-1164b6ea4a43">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="73688ba6-7bad-4b65-874d-894ade9aaf70">
+      <statement statement-id="pl-4_stmt.b" uuid="f9ecc899-861e-4122-b0dd-c19d20c60e3b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.c" uuid="ad997f1a-69e4-4b37-9683-09110d057994">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4a77a508-96ba-40ef-8426-c13e24b8e476">
+      <statement statement-id="pl-4_stmt.c" uuid="f13de092-1212-4991-964c-2228d884171d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-4_stmt.d" uuid="bf50513e-b6f3-42c4-917f-643e56a52e5f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b03983d7-2fc3-4998-b4e5-8c4271583b28">
+      <statement statement-id="pl-4_stmt.d" uuid="acad6217-b1e6-47b9-9aae-36a8b4baacf2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5740,10 +5740,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51d7ad31-27ba-45ec-952e-309406c26737" control-id="pl-4.1">
+    <implemented-requirement uuid="e0add23a-efc5-4e09-872d-93407df52408" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="88a5ae73-63e8-41ec-a1de-4faec989bbca">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0b8be1d0-6508-4fbe-8baf-7e3f631b1f23">
+      <statement statement-id="pl-4.1_stmt" uuid="3970ca01-c0fe-4e34-ba4f-c4807e7f6f89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -5751,26 +5751,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9e6c48e5-1ad1-4487-8565-718b97c89e6f" control-id="pl-8">
+    <implemented-requirement uuid="caea3767-a4fd-4cfc-84d1-59074a1f10a9" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt.a" uuid="a38d95c7-25d3-40ec-b312-50f87f83d175">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a706c22f-a81b-4d9f-b03d-7bfd5bd0674b">
+      <statement statement-id="pl-8_stmt.a" uuid="d5908a05-a474-4d88-b542-e56555f2b5cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.b" uuid="0b39d887-5996-41f6-873d-ae1e9c8946c2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="82109a41-eca1-4e1e-8c57-35cbc1e9a969">
+      <statement statement-id="pl-8_stmt.b" uuid="4857d403-3431-493f-b89f-fc49b8900320">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pl-8_stmt.c" uuid="5d4610a1-ac97-45e7-89af-d2e3b0104225">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="31ace7a5-89c6-41d8-ac6f-06a9ec591ca1">
+      <statement statement-id="pl-8_stmt.c" uuid="502e1e80-ea60-46f6-890e-032cb77e921a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -5778,10 +5778,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf82557f-f4de-43d2-9738-f658f201c495" control-id="ps-1">
+    <implemented-requirement uuid="84fa0851-5291-4f57-b0da-86a38d7f2982" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="348a37f8-d025-4523-b471-dbd4ce5e1c35">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="611d3b10-fd38-4fb0-a590-ac6e65faba95">
+      <statement statement-id="ps-1_stmt.a" uuid="9213924d-1488-4be4-bd6a-cc5efa99876f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5789,8 +5789,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="3931ae37-de3c-4146-a5ae-3a169fe2facf">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ac8a3911-c39d-4730-938b-0263230ea69d">
+      <statement statement-id="ps-1_stmt.a.1" uuid="da2613d9-5c1a-47ec-adb0-ebaad4ce9c16">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5798,8 +5798,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="80f452e5-ced5-4c32-ad50-7df04e98c9ec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="afa0b732-f06c-4e23-a9fa-efa050dce205">
+      <statement statement-id="ps-1_stmt.a.2" uuid="1efdb8a1-467f-40af-a50e-1cdf32e1e90e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5807,8 +5807,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="308060a4-624e-44f8-91f2-d6cf73971c1a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a3bc8a48-f652-48b2-a616-fe415a28c9ac">
+      <statement statement-id="ps-1_stmt.b" uuid="f30e92b7-4e27-4c5c-a3c6-8350752dbcf9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="115ee815-286c-4c88-a826-6b98653cc1f9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -5816,8 +5816,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="acfe12be-6670-4e88-9ad4-54afa2b0815c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b7de1d3b-9b53-4206-a6d1-63a318a52973">
+      <statement statement-id="ps-1_stmt.b.1" uuid="cc3171f5-1472-46c0-b23f-2d94cb548882">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5825,8 +5825,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="9faf2258-bd02-482d-a7d0-a5f15ea329e7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e61e6f61-2b14-453c-9781-3f754bee5c8b">
+      <statement statement-id="ps-1_stmt.b.2" uuid="3c05a938-986b-4b8a-ac65-8e4baaadebfa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3303bd8-57b5-4828-8b5b-031879f157e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5835,18 +5835,18 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d09a7bb-9cfe-467e-aace-3b117b3f5dbb" control-id="ps-2">
+    <implemented-requirement uuid="e834884a-c809-44c5-a9f1-79134132c383" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="19a4c84e-a2b2-4c57-aaec-4fd096c7cc45">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8aa71e6f-9be9-41f2-83cb-5b6d7760a705">
+      <statement statement-id="ps-2_stmt.a" uuid="8d06a4af-de17-4158-8055-d34a8cace546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13b7d353-e385-42fb-9e2a-e61c6b0879ab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="d12e39d0-47ed-4e09-99d7-c9e922ea1320">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="968db3c4-34da-4da9-86f2-c666f7e7bcb8">
+      <statement statement-id="ps-2_stmt.b" uuid="b05c1d64-086f-4bc9-88dc-7f04768be288">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="92e499d3-e65d-4b2e-a421-4af961b84fdf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -5854,8 +5854,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="f9e1c924-fb32-46cb-9191-c670600782b7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="505bfce1-1bd3-4852-b845-0f2a1ce3f454">
+      <statement statement-id="ps-2_stmt.c" uuid="f9e0ef0b-25ba-4a88-ba45-bf8ca190ed05">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e3f2232-2b16-4ba1-bf6f-e674b556db84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -5864,10 +5864,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0188dbcd-72a0-47fa-8830-c85df5b611f3" control-id="ps-3">
+    <implemented-requirement uuid="89fd10ff-caf7-4598-b7ea-7d9ca1e5cd7c" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="f4d6f173-6ec3-401a-bfaf-057e2f4b5a3a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a31b4e44-786a-4730-956d-231e8efc45e9">
+      <statement statement-id="ps-3_stmt.a" uuid="a619cc9a-42cf-4af9-a620-42c536650484">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3873dc66-8e97-4c5a-a184-83b4cd93f73c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Host (RHVH)
@@ -5875,8 +5875,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="cf313c26-9821-454a-adc2-210cc0bc8698">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="90ebbe3e-4365-4956-a618-d7ef78bafeea">
+      <statement statement-id="ps-3_stmt.b" uuid="dd01c751-379c-4a36-a81a-db402d39ce38">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5c7bde33-4798-4c3f-aeec-b5365aee9a50">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -5887,10 +5887,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="518ff3c2-2e7d-428e-8c54-880be616b7b2" control-id="ps-3.3">
+    <implemented-requirement uuid="2876c776-a18a-4c1b-89f9-90238c88cef0" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="f6dfc728-51ab-40a9-80d8-ca6397218c68">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="780d4878-3de4-49a2-ab3d-ec3885920ccd">
+      <statement statement-id="ps-3.3_stmt.a" uuid="fedd2790-52eb-4858-9190-7ef23d64a7c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4edd1808-6619-4e1c-a8ed-79fa33630f96">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5900,8 +5900,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="7cb3f658-eba5-4f8a-847e-444d4a1d2725">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="78122bc2-7312-413b-a718-424a85202ed8">
+      <statement statement-id="ps-3.3_stmt.b" uuid="8cf1e308-8488-4631-b8bb-ebbdf91a3ced">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="551ef7f2-9cb3-4a96-86f4-583ecb369531">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5912,10 +5912,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c5ef1be-9b2b-4e5e-b555-5c9ddd016f11" control-id="ps-4">
+    <implemented-requirement uuid="612a0c80-52c1-4f04-94e2-d18b940dde95" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="b1aaff3b-51a0-4f60-b6cd-6f8cbc04c1a2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9d43ff78-24aa-4c7d-917d-62ad027c895b">
+      <statement statement-id="ps-4_stmt.a" uuid="8f5ab02c-a8e1-4678-848e-34d79fdfaa4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8adb751c-8bf3-4e25-85a5-c0994cb40d6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -5924,8 +5924,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="6828787e-323b-4a18-bd60-20ba3838cdb4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ca8913e0-c0a5-469d-ad9b-136561802475">
+      <statement statement-id="ps-4_stmt.b" uuid="3f61a87d-9371-4b96-82a5-6fd30a3f6f74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39706fde-a5eb-4dab-8aa6-7a01c74c3691">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -5934,8 +5934,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="8ca6b583-eec6-4a8b-bafd-f482610d4f9d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="706e3854-5a5b-45f9-82d1-5d41318646e6">
+      <statement statement-id="ps-4_stmt.c" uuid="de300ea9-b5c7-4ffb-9930-6f4ac2a2bca4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75c9f933-0fd3-4d95-8865-0ccbc03cd6e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -5944,8 +5944,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="8a322056-6666-44c2-9b86-7a1b06211e66">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e88887ba-af02-4473-bfb0-46360f2a4b16">
+      <statement statement-id="ps-4_stmt.d" uuid="591cec48-d427-41d7-804a-efdcfd2bbd06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf7eb54d-a450-46f2-ad69-ac1984b55eda">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -5954,8 +5954,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="54a54a9a-2728-4707-8f0e-e3bb41860f58">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ee088d24-2a34-45dd-8151-d65a5640a7a8">
+      <statement statement-id="ps-4_stmt.e" uuid="7ee3cb63-1f1b-452e-93aa-a6f2a5d9f985">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93634a54-407f-4527-9a28-e2d7210c0520">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -5964,8 +5964,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="87d63097-18e4-47cb-adc8-1e7ae3922124">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="965c6b08-b8cc-4d0e-89a1-49b7ada947d3">
+      <statement statement-id="ps-4_stmt.f" uuid="360cf1f6-2876-424c-ad24-af3a67054b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3591532e-af31-4580-85cf-551c084ed643">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -5975,10 +5975,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81afc211-1372-45f4-ada3-97c1da1337aa" control-id="ps-5">
+    <implemented-requirement uuid="0c906102-fa0a-46f0-971b-8f1e2edc9ff1" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="1906ab67-23dc-44c7-97c9-d28c3eeba2c3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a93906a7-dccd-48a0-95fd-7c14df03f641">
+      <statement statement-id="ps-5_stmt.a" uuid="dac52aba-aacb-4a15-924e-4dcc42c6b3b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad0ef460-d521-416a-b989-1d90f6d2d657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -5988,8 +5988,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="0111f860-fbf5-410c-b683-70cd7f2399d2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b7821a65-ef5c-4246-aa45-8068679910c7">
+      <statement statement-id="ps-5_stmt.b" uuid="34ef076c-a762-4404-a186-b759ae59e9b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9244b67-8356-459f-99cd-ce8c2c7ba68f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -5998,8 +5998,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="ce45673d-7846-4d90-bd91-d39b3a29e7b7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="56dd62b8-1b45-48a2-bbc9-bbc5f3fcda4e">
+      <statement statement-id="ps-5_stmt.c" uuid="980c4738-bc5e-4b3a-85c9-d250d4011be0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d22bff25-1b86-47f2-847b-a027ea5a7854">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6007,8 +6007,8 @@ or transfer are outside the scope of Red Hat Virtualization Host (RHVH) configur
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="bbcfe011-361d-496f-8979-e58837b032e4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d1e12590-b1a7-4c1d-969a-fe294aebe157">
+      <statement statement-id="ps-5_stmt.d" uuid="9f87a8d5-3677-494b-89dc-92b8c83f2351">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f15c433c-50ca-4da9-91d4-ee59dac63996">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6017,10 +6017,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90e5a02e-df7c-46cc-b708-e104745d4f71" control-id="ps-6">
+    <implemented-requirement uuid="970d4ceb-dea7-423f-83b9-a7dc36452960" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="37a9b4b4-0707-4936-85d8-787d1434e1ec">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f31a98ec-ccc1-4bb2-8e54-b0b281df4d23">
+      <statement statement-id="ps-6_stmt.a" uuid="83ed6df6-c2b9-467c-81d3-f4e8daf86d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14d8f40d-e8d4-4b52-8d15-c567f239a9ac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -6028,8 +6028,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="08d90742-5f41-4523-9460-cb29cde26a2d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="74755541-c79d-4286-81b1-1ed451db62d8">
+      <statement statement-id="ps-6_stmt.b" uuid="d504491c-ff57-46ea-b170-d3bc4b8495ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="231b3495-646e-4034-abce-ae9880df32f0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -6037,8 +6037,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="a4b58b42-becf-4e97-8805-c7149c4b9130">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="18268b41-0a4a-479e-90aa-56236059fd71">
+      <statement statement-id="ps-6_stmt.c" uuid="56333d1e-033c-4ed0-a411-f6740b9d1d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6046,8 +6046,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="c810ca8f-bcd2-4998-9078-bb294c2ebd7b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5d9444f7-3c3f-4213-86e4-abe941ec4c89">
+      <statement statement-id="ps-6_stmt.c.1" uuid="4fc4f46a-b906-4e46-9cfe-431d1c12c30d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6055,8 +6055,8 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="8ab7c5dd-d453-4f7d-9f30-65088fa101ce">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b9be0a4b-010b-42df-8b73-425a053a94e5">
+      <statement statement-id="ps-6_stmt.c.2" uuid="d70730a3-b03d-4fad-b388-ac103cc47677">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e57b768-9eda-4a97-9714-ccf1f49ca644">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6065,10 +6065,10 @@ access agreements are outside the scope of Red Hat Virtualization Host (RHVH) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbd14f10-9000-4494-88a1-3b5eea503dee" control-id="ps-7">
+    <implemented-requirement uuid="fac24704-d248-492e-9bd8-a0c280f2fc1e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="8d4d5923-a843-42bb-bcd3-8b981c9a642d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b21c4113-0e41-4b7e-a46a-b0a6b3635065">
+      <statement statement-id="ps-7_stmt.a" uuid="b7c98a12-b8b8-4851-88e9-e2f9ab7f5804">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="96520830-f9ad-4d71-bb04-d5a410cb455f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -6076,8 +6076,8 @@ outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="9f6c037e-23d0-4fe2-8e4b-7c75cb55128b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7cb18475-e076-4457-989f-5aae2cdd13a0">
+      <statement statement-id="ps-7_stmt.b" uuid="fd580b3c-1de7-42cb-b66c-7ca16e2f962c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7f901d41-b1b8-410b-8e4e-ccd4ca080dc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -6085,16 +6085,16 @@ the organization are outside the scope of Red Hat Virtualization Host (RHVH) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="7be97561-1856-45c5-a213-561b629591b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1416e194-f991-4423-93fa-feb011e32ffd">
+      <statement statement-id="ps-7_stmt.c" uuid="5dec03dc-dd4b-4505-9bd9-5ef5deb78d88">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f4ee0740-bb4c-463e-9a82-3da7afc81ac8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="2ece04d7-a43d-47a9-bc27-9abeb948c79c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b9de296a-f3c5-4d0a-98f0-f1d37b979589">
+      <statement statement-id="ps-7_stmt.d" uuid="6a3a7403-eb49-4e7e-95a6-ad9013979d87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b6659f23-ba9e-4232-a865-05ec205d1d46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -6105,8 +6105,8 @@ scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="952b00a2-0bb3-43a4-9265-350aabe78af7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3358d6f0-37a5-47d1-8a65-c13207aff04b">
+      <statement statement-id="ps-7_stmt.e" uuid="1ef73a4d-839a-4b55-b11b-8257bec2fd45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3eebad91-c8c0-454c-bf7e-6f0a8d0fa4c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Host (RHVH) configuration.
@@ -6114,10 +6114,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09e82c58-5bff-441a-9a70-e889e8d5ac92" control-id="ps-8">
+    <implemented-requirement uuid="c1618cd0-ecac-4cc8-8ec7-2f1554f45d1c" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="d689b35e-1441-489f-9650-68fd2f8c624d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="33d8867a-7f76-4db9-9907-5f9481d5260a">
+      <statement statement-id="ps-8_stmt.a" uuid="b6e8dc70-4100-4376-b47c-a732a5e6c553">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0c700116-2ff1-4ae4-bca8-4f1c9fbefbc7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -6125,8 +6125,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="3e71dbd4-2ca0-4f2a-872c-db26c60c5eba">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b6aab42c-866f-4471-bd45-41b43355bf9a">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -6136,10 +6136,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1730818b-1473-44b2-a300-b16b2d26e950" control-id="ra-1">
+    <implemented-requirement uuid="bb9c2283-c424-4c07-af4f-a28d0e31d667" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="1ca76ffb-9169-47fc-9447-06b00eefcaa3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="86058899-fda3-4c0f-93cf-fe7a41f3e653">
+      <statement statement-id="ra-1_stmt.a" uuid="ffcde792-2e83-4d79-8eb8-c1fdd1914001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6147,8 +6147,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="ad21774e-6c3c-4eb0-ab83-34c8bdf163fe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ac17ccc1-ac57-4593-b887-b974021ade25">
+      <statement statement-id="ra-1_stmt.a.1" uuid="ac25bf60-f6fd-47e8-aad1-3ad084f6fb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6156,8 +6156,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="c0ba8f9e-bc8d-4178-b6b1-3bb3b547a121">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3b666ee9-00b9-400c-93d7-a8fd3c42c0e2">
+      <statement statement-id="ra-1_stmt.a.2" uuid="7c0b8357-7e32-4dee-a23c-7ea5790b9972">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="479eb718-4195-4ac1-a6bf-821e56b68e14">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6165,8 +6165,8 @@ and procedures is outside the scope of Red Hat Virtualization Host (RHVH) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="3d351f58-7b73-4530-b2df-53fe2e3aa681">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8925bd6b-5ed5-47d1-852d-5d7088912899">
+      <statement statement-id="ra-1_stmt.b" uuid="3658d5a7-8cf5-41dc-83e2-25adfbaf181f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6174,8 +6174,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="24bc0778-6190-4a88-869c-9065b30e1231">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e40cdc96-9c0c-4983-b1bc-9e43dc08413f">
+      <statement statement-id="ra-1_stmt.b.1" uuid="fe8f2864-1648-4a81-bb6d-3a4b8a304fd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6183,8 +6183,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="a522bf3c-4640-4572-ac5e-4a502cfad588">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4800fd1d-0b17-43c7-b6ea-0dbeb8be059e">
+      <statement statement-id="ra-1_stmt.b.2" uuid="46ef312b-fe1b-44d1-a414-aa73bf7fc817">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4459d86e-4186-4871-9de6-aec8c09b26ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6193,10 +6193,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68e80f86-2f25-480f-9f2f-62b4ed137c95" control-id="ra-2">
+    <implemented-requirement uuid="94569d4b-4741-408c-b03f-7171d11cd216" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="a5027c5e-53d3-46d7-9789-b24b37bd2ff9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="98e8b3d8-67bb-4690-a901-8d0f96898ff2">
+      <statement statement-id="ra-2_stmt.a" uuid="87ae68f6-0ec2-49aa-bdc7-34fb3ba4778e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a20a7b8d-5d92-4463-be70-70921bca333d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -6205,8 +6205,8 @@ guidance, are outside the scope of Red Hat Virtualization Host (RHVH) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="85c8d7ed-a3fb-433c-a03f-2cd76fb61172">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3f433de3-2b94-4e20-87ba-48aeb6975eaa">
+      <statement statement-id="ra-2_stmt.b" uuid="7ba08607-3ece-4f07-bfa3-2b522fedfd0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1e56041-35d4-47b7-8afb-999d308c6e86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -6215,8 +6215,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="b484efcd-144d-4fdd-809c-68c702cb3170">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="86a49329-660f-45d5-a5a3-48f7f6fb888f">
+      <statement statement-id="ra-2_stmt.c" uuid="e091d042-ce3b-4138-ba8e-1e862ebce5d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d809a202-a485-4fa1-ade4-8e6f49148653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -6226,10 +6226,10 @@ the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b21dfc8-9f8e-4c1a-8215-e517be50b459" control-id="ra-3">
+    <implemented-requirement uuid="6acffac5-0e06-4584-893e-5c489d9c432b" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="4ff5178e-aa93-4305-ba5d-5da833f4fe61">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e1ef95f4-b9f7-4d6a-b26b-5a41808bc0e1">
+      <statement statement-id="ra-3_stmt.a" uuid="e6303230-4559-4a5f-9af9-68be90981c45">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="929c2e09-70c4-4be4-bf68-ae55747ef24b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -6239,8 +6239,8 @@ transmits, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="124bd989-d1ba-4d37-840a-9dd1978e90ff">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ee6931df-353e-4ba3-a45a-0ca484d05ba6">
+      <statement statement-id="ra-3_stmt.b" uuid="7f84310e-5fbe-494d-9beb-a7a2a8b74b6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6de19af8-7c17-4e8e-a9be-72f20f05165a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -6248,8 +6248,8 @@ documents, are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="62a064fe-d8b0-4a5b-9781-8369afe8e68d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b64a93e6-1f01-45f4-92cb-5de06951a7b6">
+      <statement statement-id="ra-3_stmt.c" uuid="3b91cd21-746f-4b5f-8de0-da385081d364">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553933dc-e764-43d3-8f5d-c2227c679f68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -6257,8 +6257,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="67506006-27b3-45b2-b789-bdc1388c861d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8c873cab-19c6-47d4-94f0-4e0f87d3fc63">
+      <statement statement-id="ra-3_stmt.d" uuid="262e0842-f1d5-4688-a504-e22df92a3187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a55ff7e-5b8d-4d09-9c85-eacdf924c0e3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -6266,8 +6266,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="d3842477-b172-4920-9a83-a181e40c6be5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2c29075f-4419-45a6-a361-cc4763fce746">
+      <statement statement-id="ra-3_stmt.e" uuid="45d54b78-4e15-4abf-ab45-1f5f7f4dff0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0be82016-6e9f-4c36-bb75-f1f91f9015ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -6279,10 +6279,10 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="870775a1-8a74-43ef-bff9-b0f4ee216df9" control-id="ra-5">
+    <implemented-requirement uuid="1e80c085-6c6c-408c-989d-d37048edd298" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="b2ab98ad-f0f9-4b56-a864-2eb6fdadf0b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1abed183-fd8b-4b03-85c6-85801c860c42">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6290,8 +6290,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="fe78004e-cd60-43d9-95df-561514e19e13">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3ca3d4ee-9d88-4c3b-a4f3-bf8faeae3f40">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6299,16 +6299,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="82370e1d-fa14-4ef7-97a9-b2a8d8ba3cfe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2143b291-1ef3-41b7-b231-08e7b39e1661">
+      <statement statement-id="ra-5_stmt.c" uuid="dfbeeee4-4a89-43d7-8cb4-b213da619959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="d747f260-1e24-4b5d-85c1-9d8ecda99b39">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d32651f7-b1cf-4da1-8b74-37d77f776a71">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6316,8 +6316,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="311b1876-32b0-41fc-80f9-aec1c2e5945a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b38920e7-e1ff-4d4f-bf8e-c5c7c348b52d">
+      <statement statement-id="ra-5_stmt.e" uuid="ec8f09ed-5645-493f-9723-79faa9c9dda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cf5bf54f-10e3-4517-b21b-dccfad84b100">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -6329,10 +6329,10 @@ of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="127721ad-1a53-4730-a1ec-bfc5963d81ce" control-id="ra-5.1">
+    <implemented-requirement uuid="25e0e198-6272-4100-aacc-c751b1d866e6" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="e7ef7e9b-d8bd-4c76-b268-7fb803f26bcd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="63d1dfe5-5f3a-4d9b-9069-7ecefab9aab5">
+      <statement statement-id="ra-5.1_stmt" uuid="d8e4be41-53d9-4ebc-bbfa-1f575d095b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6341,10 +6341,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2786fc4d-4fc0-48bc-887e-5df20e534965" control-id="ra-5.2">
+    <implemented-requirement uuid="c03894ab-c36f-481e-84cb-f4d553d3e7b4" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="15e3d59f-e631-4be6-b441-9fb5d8eeb508">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7d8b9d6e-00e5-48a8-b156-0696e141258a">
+      <statement statement-id="ra-5.2_stmt" uuid="5adb3817-da95-46f9-851a-615b5e4e5b3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6352,10 +6352,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54f5bd80-1215-4508-bf42-009e59ae7509" control-id="ra-5.3">
+    <implemented-requirement uuid="097372a4-d124-4484-9a98-e789732a960b" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="afd81b4c-0936-47f2-a9c2-cb7656da9d79">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2077e55e-6fb6-4ab0-9ab9-0c009db8abdf">
+      <statement statement-id="ra-5.3_stmt" uuid="8b973f17-674b-470a-a534-d73dab830849">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -6363,10 +6363,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b84c51e-4c42-431f-bb70-c0799bf0613f" control-id="ra-5.5">
+    <implemented-requirement uuid="85d3387b-07ff-4c11-9afe-62dde7b4b20b" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="3e73e0d4-289d-451f-bbac-ed1cef2c7bf3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="717b1e01-6de0-4ef3-81dc-ccc4fc419974">
+      <statement statement-id="ra-5.5_stmt" uuid="56153afb-5fff-4d83-a274-c80dbe05c2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6375,10 +6375,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2bdd94c9-beac-4b11-a540-dac2f9640c63" control-id="ra-5.6">
+    <implemented-requirement uuid="631f32a6-79e9-4c7e-bce5-dce1e05fb448" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="85473a66-6a79-4f1a-a9d7-31e6be64a471">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a0097ca1-ec71-4059-9897-d2920cdb57ed">
+      <statement statement-id="ra-5.6_stmt" uuid="ce8738be-55d6-4014-8ce0-9fa3e2e06d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6387,10 +6387,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c655406-1084-4d4d-812d-975a27a07cac" control-id="ra-5.8">
+    <implemented-requirement uuid="37be01e9-ed18-4570-a6a3-891fd8e2a47b" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="c854bb7a-931f-4d72-bf37-4a47e16de4ef">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ddf1c9f4-2e8b-492b-97e6-b8f602274adb">
+      <statement statement-id="ra-5.8_stmt" uuid="361cb116-1925-4019-9852-13d964fa2108">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e053e2d8-71a5-4a5b-a196-c1628465e902">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -6400,10 +6400,10 @@ Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2193608c-70c9-464a-b548-2331cb8ad666" control-id="sa-1">
+    <implemented-requirement uuid="fdfa2836-e0c0-4a53-a520-1cd8fd2d0371" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="8fa70d9b-551c-43a1-9cc7-26c013e218a5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="44409ba5-9816-4f8c-bfd9-c3ffe875f482">
+      <statement statement-id="sa-1_stmt.a" uuid="da233118-e5a1-419b-8ef9-d74cf88ec9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6412,8 +6412,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="8cfabac3-7a5e-41af-96e6-2b3685cde6c4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a789ac59-6550-4b72-a7c1-1e54b70222a9">
+      <statement statement-id="sa-1_stmt.a.1" uuid="4d4e8f4b-2459-40fc-8a2b-cef39e7a5565">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6422,8 +6422,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="05733530-2c78-4cf1-adde-832eb5dfe8d4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c20e5f40-4e35-48df-a01e-d2d8858d8067">
+      <statement statement-id="sa-1_stmt.a.2" uuid="2a8c9751-bb38-4a01-a49b-e9a73fd0937a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2653b7db-7b14-4dc2-8cd0-7c8fa4731145">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6432,8 +6432,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="48a68923-8a48-4a29-948c-78436df54c72">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ca258f8c-aeee-42de-a5a9-40b0c5924f04">
+      <statement statement-id="sa-1_stmt.b" uuid="b243136b-348e-41d0-a36f-7a01b53932a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6441,8 +6441,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="d97f5f40-64c4-4140-9932-d6b7d0036b62">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="754bc1ce-0307-45d7-bb8c-89f0e785bc88">
+      <statement statement-id="sa-1_stmt.b.1" uuid="9339a14d-436c-4ad3-9b60-4289811e48c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6450,8 +6450,8 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="18976c3c-d848-4750-94da-6b182e65043e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cba4e7ee-a863-456e-ab77-fb8d787de83d">
+      <statement statement-id="sa-1_stmt.b.2" uuid="e765aa23-fcba-4668-9c64-00191c316f57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2c2fab1-58bb-4f0b-8546-395384a50372">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6460,10 +6460,10 @@ is outside the scope of Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="964b06e3-9204-4b9c-a386-0c5a041e8d38" control-id="sa-2">
+    <implemented-requirement uuid="80720690-1e69-414e-aec3-f6303a2723dd" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="d326e200-d864-46ca-8ba5-421b055ab005">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ffff0b78-2513-4344-a4af-0078a4c2e1f2">
+      <statement statement-id="sa-2_stmt.a" uuid="70fbe520-9c80-4883-ad01-032d06e754a6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="824db0f4-1273-41f6-8617-9b0796e3140b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -6472,8 +6472,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="8b6d38e2-2146-451d-9048-8fb976cb0f76">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="63dac8f5-ce15-4c37-9914-0a71d4d3a6c5">
+      <statement statement-id="sa-2_stmt.b" uuid="e2deed58-ac14-44ef-9fe5-4b0d10845768">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e6859d4-0559-4f4b-8d46-01d46a13d3b1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -6483,8 +6483,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="3f6de82e-606f-404e-9d87-0c95aaecd952">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ba3f58f9-ad02-4bd7-8ab1-6225b18003ca">
+      <statement statement-id="sa-2_stmt.c" uuid="1c1599e1-37ac-47cb-9a06-f84758267703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1260d5ad-f1e3-4b2e-81a0-9d05686f06de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -6493,10 +6493,10 @@ documentation are outside the scope of Red Hat Virtualization Host (RHVH) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39a8efc6-42d0-452a-b94c-8088c85df37a" control-id="sa-3">
+    <implemented-requirement uuid="5e984ca2-a2a0-4b61-b837-f1f2aef74c43" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="1d99e621-4b31-4b21-8829-7413b05d1cd1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cbb5251a-0459-4097-b2bd-1d4f0c6729f4">
+      <statement statement-id="sa-3_stmt.a" uuid="a77b59ac-1444-4c7b-9b75-f7504c5dac4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4e3653f-212d-4d7e-b613-cc64927606d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -6505,8 +6505,8 @@ of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="6777a731-00e5-4a4b-91e8-3368866aae5a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="305d1d4d-ddff-4fbf-8f90-8b97e5b18b92">
+      <statement statement-id="sa-3_stmt.b" uuid="c2138e4b-f580-46fa-812d-9c695c306382">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f36e31ba-00fe-461a-8f8d-50956846bf60">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -6514,8 +6514,8 @@ life cycle are outside the scope of Red Hat Virtualization Host (RHVH) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="67b6d771-6086-4e71-a908-da772f920a67">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="71c70062-8306-42fc-ba83-0c3e51c8b004">
+      <statement statement-id="sa-3_stmt.c" uuid="c57c5c36-96ce-4b82-ade8-71472cfdd0a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7fdc08e7-548e-4102-a52e-4afcf59054a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -6523,8 +6523,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="81df6eea-139f-4492-8c2e-6b6d348183c2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="31b0a09c-3ae8-42ff-9c58-6c92023c6875">
+      <statement statement-id="sa-3_stmt.d" uuid="834154bc-a9ad-4b29-9da9-689e209e5b9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314f63ca-ee21-4db6-9698-8c9537441f8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -6533,10 +6533,10 @@ activities are outside the scope of Red Hat Virtualization Host (RHVH) configura
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4f5a626-cd78-47a3-9f55-f5f1fabd667c" control-id="sa-4">
+    <implemented-requirement uuid="7f7ce6f2-a54c-4be9-adb2-cef1cb1bb5cd" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="bd5000ec-aae4-42d1-9f30-0aaef478a80a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0120ebcd-8bd2-449f-a951-60110d7ea29c">
+      <statement statement-id="sa-4_stmt.a" uuid="8477982b-4daf-40d7-a996-90a3f891ea00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aeab4dc1-ee7b-4c48-8886-cc74d87df81a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -6544,8 +6544,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="d2df2d3d-4bd3-4a58-9760-ab3fc09e379d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="84e3c152-e239-49fd-bb54-3e17bf40f555">
+      <statement statement-id="sa-4_stmt.b" uuid="ad50360b-72d1-40f3-8434-0ac78128fc91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39d0a219-ecda-477d-a17f-db06df2f54a1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -6553,8 +6553,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="94d76567-59d7-4e7a-8891-d1f73bebbef5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5fc229d4-91a2-4d6b-b9dc-eda6474b551e">
+      <statement statement-id="sa-4_stmt.c" uuid="80ad4a69-2f94-4877-968a-67583be09daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78883912-eaad-49aa-b2c1-32077d1b6715">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -6562,8 +6562,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="fea92896-a744-4b33-98d2-8e6c881a4ca5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fde9ef0b-8286-4f91-befc-ddb346f4f295">
+      <statement statement-id="sa-4_stmt.d" uuid="02579e51-d88b-47f5-9856-22fb80fc80cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cc18f9ac-4f27-445f-ae6f-615f205fcee7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -6571,8 +6571,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="ceac5384-3e17-4395-a772-463f44b111e7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a9bb68e9-1abd-46d8-915d-1fd52339d415">
+      <statement statement-id="sa-4_stmt.e" uuid="6dda20cb-aa6c-4e67-b666-aab9c5645d9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ea03972e-988b-4b12-ab49-176c6bd56b01">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -6580,8 +6580,8 @@ are outside the scope of Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="7761df30-6053-4c38-9fa4-63c5fbf7b8c5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bce49e8e-8db0-4d97-a21d-9088ea2d6f8a">
+      <statement statement-id="sa-4_stmt.f" uuid="76068ac0-6f9b-4a77-8b1f-e792c6335219">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e5ac5c9-e113-44d1-bb5a-aae2c3300727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -6590,8 +6590,8 @@ Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="ac86c7a2-cea4-4caf-815a-a41590a6f46f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="582d8d24-f4b3-4736-bfa0-8a15ce805cde">
+      <statement statement-id="sa-4_stmt.g" uuid="0390dd8e-4476-4e8e-8f49-ef97ec4cd43c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14e27f1a-92ae-44a1-9a1e-8cb5c2cd6baf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Host (RHVH)
@@ -6600,10 +6600,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08eeab9c-5a31-4df1-a949-c83295c13dd4" control-id="sa-4.1">
+    <implemented-requirement uuid="c852b8ed-46e8-49a4-942e-02ad98e2145f" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="08474448-9327-431e-acc7-b18df66e25d6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f7350212-8881-481a-9b63-4b6e7bf29970">
+      <statement statement-id="sa-4.1_stmt" uuid="5f744a19-86b6-458e-ae5b-9391fdaaf2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d0b45d5-3df5-4226-a89d-858eb0881fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -6613,10 +6613,10 @@ https://projects.engineering.redhat.com/browse/RHV-22638
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1caff5a8-f90e-428d-a436-f08f96082a54" control-id="sa-4.2">
+    <implemented-requirement uuid="494cce61-f250-443b-86bf-6428be908965" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="d309d64f-af57-434d-a4b6-81dc0136c4ee">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d5ba9c1e-c85a-478a-9bb3-cc51d856e06e">
+      <statement statement-id="sa-4.2_stmt" uuid="fe19e678-d406-486d-a68b-a93da729dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a090f9c-dcc8-4565-95ba-9da0c5baa527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -6626,10 +6626,10 @@ https://projects.engineering.redhat.com/browse/RHV-22639
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22c5d567-340d-4b17-aee1-150041fac3ea" control-id="sa-4.8">
+    <implemented-requirement uuid="f576d7f5-7768-4335-8d9a-6a92332f08f0" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="54aecf38-3a56-4cae-82c4-9fb287944025">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f8122794-195b-408c-be8f-dbb3da7ce6c0">
+      <statement statement-id="sa-4.8_stmt" uuid="3d81371f-0030-4269-8918-c09b32dabcc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d4765e6-3e2e-4e4b-afbb-5fb77763e42d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -6639,10 +6639,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="266ea716-41d2-4c9d-96fe-bd73b0a54bcc" control-id="sa-4.9">
+    <implemented-requirement uuid="183aecf0-bdf4-413f-8de9-fcbde8bda9b2" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="4f167e01-b255-4364-9f98-27f6ad4c278b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d33782e1-68ba-4e4f-a06d-256f5491a8d7">
+      <statement statement-id="sa-4.9_stmt" uuid="57789a83-af12-481f-8fee-d2420e3b5e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61c674b5-dda5-46f5-96ca-871e9452030f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -6652,10 +6652,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e810ea39-d992-400d-94bb-32a9e3b600fd" control-id="sa-4.10">
+    <implemented-requirement uuid="3c8a4e03-42e8-4617-ab5e-809b0a1a56ca" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="18098530-8065-4de0-bb4d-fd1fb4afe2f4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e6a12cd2-dab8-42e6-8125-80034fc943e2">
+      <statement statement-id="sa-4.10_stmt" uuid="7f01eb5f-fddb-48cb-84bf-9663cf946e1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6663,90 +6663,90 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b248986-1479-44fa-a453-f36c595cf3b1" control-id="sa-5">
+    <implemented-requirement uuid="1075b91a-26d4-45ab-af5e-7efa9804df78" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="d59c741f-9a10-4553-a52c-be475e776464">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="985090d0-c77c-46c0-ab8c-c02541769453">
+      <statement statement-id="sa-5_stmt.a" uuid="cae1dc20-dc61-44b5-9a37-62f6f2cb410e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="088a1225-78e0-4de7-b934-73a6f8e9c906">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="022431c3-89cd-4647-8795-712ec2f84032">
+      <statement statement-id="sa-5_stmt.a.1" uuid="99b3a3d4-5328-43f2-a5d9-89f8184c882e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="74be58de-1e68-44c3-8934-0d9359c3ccba">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="20a0b2dd-f828-4cbc-809e-2435d76ab7a2">
+      <statement statement-id="sa-5_stmt.a.2" uuid="537f69f8-4ba4-46c9-be59-efe10637c240">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="0b3c3205-b343-4684-a34b-b6a0e331ccb8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2c65b7a5-c5a5-4c05-b00a-0d4843073b83">
+      <statement statement-id="sa-5_stmt.a.3" uuid="784f11f5-4b7d-40ac-a76f-58a9fdad9064">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="35bd7279-62b4-4cd9-8a4d-5b0391d7a6fb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="711bf388-0949-41f7-bdef-30df6667ef7d">
+      <statement statement-id="sa-5_stmt.b" uuid="0d18c19a-6577-4de0-a417-58649b39ae33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="20871d82-4ded-464a-82b3-e09bd4ea686b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="919a71db-0db5-4093-b36f-c7ca00955f57">
+      <statement statement-id="sa-5_stmt.b.1" uuid="2935da53-589c-4942-873b-17308b1db3e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="33a3d37e-b4f6-4944-8d4b-dcfaa0db27d9">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="73d3780a-30cb-4ea4-945b-8fabeecc9baf">
+      <statement statement-id="sa-5_stmt.b.2" uuid="59237e65-7285-4421-9360-23c2f5dd49de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="1bd60fb3-a5f3-4c48-b4f8-5a6321d6236f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cb4b89d1-c0bd-42cb-8c78-a36e6004f8ec">
+      <statement statement-id="sa-5_stmt.b.3" uuid="8412a76c-28a1-4c2a-a792-8fe5f8ddb978">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="67c9cc58-f368-43cb-933e-e175b95b1b90">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b824d670-6340-49ad-b48d-ebd1005d0bb0">
+      <statement statement-id="sa-5_stmt.c" uuid="8d9619be-592c-4025-b179-cff67addee3f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="c72ade1d-baa0-4140-8be1-451d5e7f1058">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9f3109e2-98e8-4f8f-9e8e-c6618dc379cc">
+      <statement statement-id="sa-5_stmt.d" uuid="662de344-472b-41be-91e7-f36b324438fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="ea215d11-c841-46bb-bdde-a052a946dfba">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bc0fdac8-5352-43b3-bb49-1a7d00c40403">
+      <statement statement-id="sa-5_stmt.e" uuid="8282b696-60a1-4f72-9c01-43c4fd6970e9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6754,10 +6754,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6db73af9-15c3-4ea9-9cd0-cf2c159098e0" control-id="sa-8">
+    <implemented-requirement uuid="8782f8bd-c4de-4614-b56f-4f650c950f28" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="4a1d3977-e872-4b45-8e60-28c61e221ede">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0f9411c4-32c2-4aac-b4dd-a416601d6da6">
+      <statement statement-id="sa-8_stmt" uuid="053e8088-1e23-4e80-9cd7-17d29def757b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6765,26 +6765,26 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f113735e-eff5-417b-b342-bd404d9948e6" control-id="sa-9">
+    <implemented-requirement uuid="5fe8b02d-1c13-4fa1-8b41-93a5262cc178" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="8078196b-8829-49d7-93a8-899123d2e515">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="65e02c9b-912c-4a78-8878-9e03b9adfb59">
+      <statement statement-id="sa-9_stmt.a" uuid="ec90d1b9-2433-47bd-95f3-db9ba1cc3b62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="e46a46c0-072f-4813-8847-0f0688070e83">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3a5d7909-87e1-4a6a-80a0-c4314d81e060">
+      <statement statement-id="sa-9_stmt.b" uuid="af646d19-e251-4f4c-a698-0079392edb9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="e0e3f437-95df-4ae4-9e82-91546214900d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3ebc037e-1a58-41af-b61e-bdd894bf3fda">
+      <statement statement-id="sa-9_stmt.c" uuid="d6abc2a7-08af-4f36-8ef5-481871de8fba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6792,18 +6792,18 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0aa5229a-9c88-43d0-94e4-49a7eef2d10d" control-id="sa-9.1">
+    <implemented-requirement uuid="7d75ce32-d4ed-4628-90b5-3f2b2ccec246" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="ca7d7844-4d73-4ec5-9923-e39d664e4192">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17f7e80a-b1e9-4693-9f17-aa84ef4d275b">
+      <statement statement-id="sa-9.1_stmt.a" uuid="6a02e26a-fe5b-4fe7-8d36-a495ae86ef74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="177ce562-cef1-4711-9acc-7acabd5e565b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a1acb12d-312d-4c0a-8b75-7f5440d622a9">
+      <statement statement-id="sa-9.1_stmt.b" uuid="8319b719-d06f-4ebe-b40f-c684d701527f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6811,10 +6811,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87edd3ba-376d-4004-b808-ec3837902281" control-id="sa-9.2">
+    <implemented-requirement uuid="75209627-7a51-49ac-95b5-5a12a3d034c9" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="2e0f739e-d907-480e-a7de-fbef5101df6d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="83e73ef2-f0d6-4bad-985c-2ebdc2fb8eab">
+      <statement statement-id="sa-9.2_stmt" uuid="62c5ecdc-7fa0-4b8d-b632-fdb896811077">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6822,10 +6822,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ea28166e-7057-4d82-b61a-6ebbd7ca4354" control-id="sa-9.4">
+    <implemented-requirement uuid="554f2b84-c67a-43f8-8204-869620c499ea" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="2dec4deb-730b-44d7-8ef2-2af7c7afe372">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b062a232-2c05-4cb8-90b0-4ccd26edfafd">
+      <statement statement-id="sa-9.4_stmt" uuid="eb13716e-ee14-48bb-977f-d85331e28df2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2434224a-755a-48d5-981f-f980b736ec46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Host (RHVH) configuration.
@@ -6833,10 +6833,10 @@ applicable to Red Hat Virtualization Host (RHVH) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf0bf365-bf3e-4b07-817a-da1098c53ed3" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="01d6dcfc-c26a-478b-a448-3af9c258d852">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8d875d2d-d49c-490d-9c2c-42623484b457">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -6846,10 +6846,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1f68cc0-08ac-4f70-9ed8-15e97e1da1c7" control-id="sa-10">
+    <implemented-requirement uuid="293f268f-39a8-47da-85fb-b1aa98f204be" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="3ac89bdc-66db-475a-8d28-a8a22c092a1b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17d715a9-e331-4784-932c-845ad1fce7fe">
+      <statement statement-id="sa-10_stmt.a" uuid="148daf57-78dd-44f4-9034-2a5a5bf501c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c007989f-6207-43a4-8a0e-c4bbfbcbcfc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -6858,8 +6858,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="c334087e-b8b2-4b51-8951-a2bb7a222bbd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bc295927-31e0-477e-b263-85c38d619844">
+      <statement statement-id="sa-10_stmt.b" uuid="5c2cc993-ddab-465b-9f1d-e46d3e024e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfb7401e-c900-4ced-9a20-2bee25790497">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -6868,8 +6868,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="54bb8902-9cda-4ab8-9ac6-443d16164979">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="311d6394-85b8-4620-a74d-46d382f94198">
+      <statement statement-id="sa-10_stmt.c" uuid="f1413046-1128-4cb3-8268-177393cfdaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b14ad649-026f-462d-849a-0cf4e092d2f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -6878,8 +6878,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="614f9808-7c23-4d42-a0cc-7b43e2239164">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="65fbd4ab-5cd0-4016-b9b7-5b7aa2925802">
+      <statement statement-id="sa-10_stmt.d" uuid="9d632fcd-3f58-441e-8adb-cc1c3dfa0bca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49544cdb-c4a6-4185-80bd-2b5ecb724ab7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -6888,8 +6888,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="d70ef8c5-485a-4e67-b3ea-ae1be53b427a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7ff0a6b2-7fe9-463a-994d-a90787810726">
+      <statement statement-id="sa-10_stmt.e" uuid="2f1236ef-8afa-4b2f-899a-156aa02be068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2706133d-eb66-4fff-939a-950056d0e299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -6899,10 +6899,10 @@ https://projects.engineering.redhat.com/browse/RHV-21061
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c4f6521e-5cad-4a47-b2a0-9249b5749823" control-id="sa-10.1">
+    <implemented-requirement uuid="adc8007e-d183-4e3f-aadc-c49f3d8d4132" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="726ffade-5db1-4bd2-8899-f6a8b49e55b7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cc5d5a91-3f94-4ac0-830d-c3097b7c8ecf">
+      <statement statement-id="sa-10.1_stmt" uuid="22ec1ae1-100e-4b20-9cc2-3402cdeaef57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec1c56ee-d6ab-4f33-9e0d-279b141d27a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -6912,10 +6912,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0a4ec4e-82f9-4d91-b985-5d7f04df77bb" control-id="sa-11">
+    <implemented-requirement uuid="3793a082-b793-4415-a3e2-a5617d4a09c6" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="b4a03310-4560-4f89-adee-53ce506921af">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="bedde0cb-d7d8-4e0c-999b-f6c2e9c01366">
+      <statement statement-id="sa-11_stmt.a" uuid="cf46ba78-5a5c-475c-be80-c5b57ef96281">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36a99276-5f2d-428f-9816-f2e4786351d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -6924,8 +6924,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="a2bf9173-1c3b-4755-b394-b7bf2f1b3e3f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9ed6d6c7-bc41-4740-a90c-b62158a33661">
+      <statement statement-id="sa-11_stmt.b" uuid="061e3634-d640-4dab-be4b-e30bfe16c61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1937705b-ad55-4470-85df-afd21c29d99f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -6934,8 +6934,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="0a17723c-843e-4f5d-bdf0-0ff0bf0abcf6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="93e3142d-d0e6-467f-aa12-1a3002921136">
+      <statement statement-id="sa-11_stmt.c" uuid="b76445b3-6271-4033-bc41-0f358e6badbb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4863aa6f-1480-476e-b863-25faf09c8469">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -6944,8 +6944,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="e9c2e1f8-0416-4f5d-87f8-2921cf657c15">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d63567f7-9878-4562-8570-b508d661b77a">
+      <statement statement-id="sa-11_stmt.d" uuid="0a2f3d54-2762-41d6-8713-c22e8832c84b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="681bd9b0-f378-4bfe-a3b4-14cc0fc1c799">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -6954,8 +6954,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="f30c2567-e1e2-4fdc-8dbd-11730afec2a6">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f7109a64-adef-4713-a592-15fc6ba4671e">
+      <statement statement-id="sa-11_stmt.e" uuid="713f2000-3e7c-40d5-a3c9-b40edd933abd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9b31e1-662d-4c73-8b23-53ee3a1234e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6965,10 +6965,10 @@ https://projects.engineering.redhat.com/browse/RHV-21062
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="976dfd6e-ae7c-4633-882b-98df589bc368" control-id="sa-11.1">
+    <implemented-requirement uuid="f4654e5b-5c8c-4556-acff-4a55e2d7a462" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="6f29a95e-8c1c-4ae5-a8ce-44bf88736ed2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="de09c7c5-acab-4763-981e-0f695a361d8a">
+      <statement statement-id="sa-11.1_stmt" uuid="499fdb69-b5bd-40ba-addd-0e0c310ba5dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a5e446a-ffc4-4b73-b1ee-fd52746fdc16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(1) is planned. Progress
 can be tracked at:
@@ -6978,10 +6978,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a659634-99dc-425d-8f6c-b20a906dd42d" control-id="sa-11.2">
+    <implemented-requirement uuid="ddb2c3a3-ecc2-4a77-99fd-6f779f776f71" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="19cc57b8-5bad-4137-8001-53e8fdc8e619">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4484444f-f169-47c7-8e8c-620bb3172631">
+      <statement statement-id="sa-11.2_stmt" uuid="dbc9c3c0-0d9a-4da6-b616-af78319989cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="888ad617-e394-456e-a020-63a4f9bcf251">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(2) is planned. Progress
 can be tracked at:
@@ -6991,10 +6991,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="360ce8f6-c709-447b-9c4f-ea0cd9ecfd23" control-id="sa-11.8">
+    <implemented-requirement uuid="431a7e86-4fa6-41b0-a14e-8a7b40f965f8" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="93186c3a-bb09-414a-8d71-cb6a3c0f259b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a71722ba-874a-4aa2-a9d4-cc342df7abc2">
+      <statement statement-id="sa-11.8_stmt" uuid="c329c78b-2ad2-4474-9716-37bad9f62df1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20dadd46-daee-4ac0-a03d-61a01669d400">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress
 can be tracked at:
@@ -7004,18 +7004,18 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0e4c16a-63a6-44f6-9f9f-fb86d3fccfda" control-id="sc-1">
+    <implemented-requirement uuid="446eb7f1-88f0-417d-8c9f-2b714d7c16c0" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="c7fdc75b-332b-463c-b0f4-e261c846c416">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="905d6c10-adc3-4de7-9e12-d510b39534b6">
+      <statement statement-id="sc-1_stmt.a" uuid="d66866d3-3daf-467e-8c02-2894866405cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="119ef317-a571-45ba-a51d-af963e511e29">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f39e4b5f-e248-40a7-b4b2-16836f51b2fe">
+      <statement statement-id="sc-1_stmt.b" uuid="cb24c54e-8e75-4647-9a5e-add0f6b2cc1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7023,10 +7023,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1ffee0d1-a844-47ee-b95c-efced76b3ca2" control-id="sc-2">
+    <implemented-requirement uuid="70da8442-3398-457e-b7c3-f7fc3dae5909" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="7a7d692e-7bc6-43f6-b267-e01d9d0419f5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6d75e7ca-231c-466f-8e3b-7b023b811091">
+      <statement statement-id="sc-2_stmt" uuid="44acc704-1e60-4fd5-abe2-024d5664d1aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4d9884-03fa-441f-b60e-dcc41011bfec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -7041,10 +7041,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c63be1b7-1daa-46c2-88d1-35e8c0eee59e" control-id="sc-4">
+    <implemented-requirement uuid="5682e79c-2a44-4798-a0b2-f3380e749850" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="bd7e0f3b-bf07-4d28-973d-ef32e2136afa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="32a938b5-5c57-496f-9804-6590355eb4f9">
+      <statement statement-id="sc-4_stmt" uuid="59fce0b6-f3c2-477f-8f72-105d101d9c08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f71cd20-c3ff-4a42-bebf-207b35e29b8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -7058,10 +7058,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9d25746-d27b-44fb-a4ed-eac879e5144b" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="39fcaced-5b73-47c7-9631-14f4f102d075">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="0968938c-ca93-41e4-8aa1-2e042a19f8e7">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7071,10 +7071,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79bd2063-0b8f-42c6-98b2-3bfc5b7ac07b" control-id="sc-6">
+    <implemented-requirement uuid="82bbbda7-2397-43ce-8a91-45ebe78b28d2" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="162de718-2fe6-4ca2-bd7a-d98936cef70f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3b290582-ad19-4f40-8dfe-2ec110a1ff48">
+      <statement statement-id="sc-6_stmt" uuid="b13d5767-f2bd-4b7f-abb7-098b2d703125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b1aa9cb-3e60-45d5-a0cf-18dfeb9a218c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -7089,10 +7089,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbe0c987-37f1-4d71-b3ce-9d2a51878907" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="d62bfd8f-f2c4-4bb6-a67f-32009c3bca3f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a87093e3-1a1b-4ffb-9aed-aa3a81bdd5aa">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7101,8 +7101,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="939add17-a9c0-47e4-b013-5f32bd5f4d27">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e24bbc41-8fac-4c98-8057-96c75f0df96a">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7111,8 +7111,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="40443ee7-1171-4f9a-aeab-43636c8f1e48">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d6901ca4-73c7-4649-81cf-d574e6ebeb6e">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7122,10 +7122,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b495bfe-a50c-40ad-a5ae-78250ea2588f" control-id="sc-7.3">
+    <implemented-requirement uuid="bd054bfa-4fc7-4624-91e4-6bf2052ee2da" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="7f1513d2-5148-4b82-b673-06eb5ca85c1b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="29adf1f7-f86f-48c3-ba85-851a7df2d0c0">
+      <statement statement-id="sc-7.3_stmt" uuid="bd50dd22-917d-43af-be8e-58c4da6d8e02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="755d6cf9-a601-470e-95e6-6a9d439390c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -7140,42 +7140,42 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0918d405-7673-4095-b868-0926ed093452" control-id="sc-7.4">
+    <implemented-requirement uuid="4b69ec5f-f303-47e5-b420-7c78eee3fa86" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="fe3c2ba4-f0ec-443c-96ef-3c9960e20b09">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d989e247-3715-4907-a1ac-cfbae9fd1eea">
+      <statement statement-id="sc-7.4_stmt.a" uuid="13f63240-7427-4acf-877d-7c0f33b770c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="296d98b3-5702-4d09-b1b1-8ff4719df727">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="17824160-bee9-4e35-b080-b87c32600445">
+      <statement statement-id="sc-7.4_stmt.b" uuid="5d366d42-087f-4a96-9e36-fb36f15e60e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="b19bf7e0-c58e-4262-8c6a-b739bdcda99d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="29a1488b-d407-4a41-ade4-706d44277bae">
+      <statement statement-id="sc-7.4_stmt.c" uuid="deb5035e-509a-48f2-9bef-f8a5ede07738">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="9e9195ac-7a55-4269-a4c4-742289b8154a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="34edbfcd-4819-418f-90be-6a9a6824b363">
+      <statement statement-id="sc-7.4_stmt.d" uuid="0275262e-03e2-4989-ac72-fbb54699b65d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="2bc02558-a783-4438-a60a-92105d2dcbda">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="163ac2e1-c33f-4483-8a94-c5111a103eda">
+      <statement statement-id="sc-7.4_stmt.e" uuid="438501f8-6120-4d9c-b05e-f811caa38465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7183,10 +7183,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b278969-077f-4cc0-ac85-4095c70b4865" control-id="sc-7.5">
+    <implemented-requirement uuid="6352f83a-1990-4f77-b7d4-20477ea193fc" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="15870a54-f825-4fe6-b424-7f7e0a51dafd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a3898768-0478-4904-88a5-665f6c556350">
+      <statement statement-id="sc-7.5_stmt" uuid="77c7eed5-e937-431d-9ecf-06142441cead">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017bbc7a-e859-49ef-99f5-32b45c249480">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -7200,10 +7200,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb1dbc00-48f2-4b58-a1ec-3c109afdd51a" control-id="sc-7.7">
+    <implemented-requirement uuid="f47db4c4-4330-4c63-b5c5-68aa8efa7631" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="53c05e23-4887-4328-a2b8-4b4235496fac">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2d0d9802-82fe-4c8e-946a-f8d41ccb2ffc">
+      <statement statement-id="sc-7.7_stmt" uuid="d7ff8ec6-8e83-4999-97bb-989a4fd41c03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a8ab2c1-dedd-470c-97b1-30ad1ccebea5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure Red Hat Virtualization Host (RHVH) nodes do not act as proxy or relay servers between
@@ -7212,10 +7212,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="36461e22-002f-4f40-a14f-b75fbe18503e" control-id="sc-7.8">
+    <implemented-requirement uuid="c27f649c-058c-46d1-af09-2651e9668239" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="ff6c723a-b8b9-469b-8afd-ae359ef55c5c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="89c9c5a6-1003-4322-b100-07cb765ba2c4">
+      <statement statement-id="sc-7.8_stmt" uuid="d2cb6062-09d9-4314-9a79-1a3b3bb55fc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7225,10 +7225,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c508fb0c-34c5-4f7d-a9df-da9b14726a4a" control-id="sc-7.12">
+    <implemented-requirement uuid="88cc2cd2-e8b8-474c-a3f7-e1da1d36e3c6" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="89e09be2-88f2-49fd-80d9-0d7fd59c9157">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="742a9b54-c4ef-4620-98c2-966816ddb1e6">
+      <statement statement-id="sc-7.12_stmt" uuid="47ea0ad6-5d46-4f24-a661-403095ebf876">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c52e724-9ba0-4f88-bf6d-10dc91dee8d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -7242,10 +7242,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98399f70-41f0-4abd-abc1-078dd93fadfc" control-id="sc-7.13">
+    <implemented-requirement uuid="f209172d-ae02-488c-b1c5-90b2d42249b7" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="1ea2ff18-d7a2-4072-a7d4-c940f17f7fc4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9d06a913-f703-49cf-8151-731e09291f5d">
+      <statement statement-id="sc-7.13_stmt" uuid="409504e4-57cd-4141-9f27-f90b352d97b5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dccbab9b-0adc-4777-9ebe-f76d78a8b46f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that Red Hat Virtualization Host (RHVH) is
 isolated from other internal information system components by
@@ -7262,10 +7262,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c3ebf500-a024-405d-8a34-866640149220" control-id="sc-7.18">
+    <implemented-requirement uuid="005ffd60-e29b-4bb5-a964-7ef65783f3d6" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="1f952f31-ec27-4e6a-853f-d7acdba755b7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3444e33d-2adb-4b83-ad59-43770cf971f3">
+      <statement statement-id="sc-7.18_stmt" uuid="00c478bf-252c-4c48-91df-18734f3c248d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7275,10 +7275,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6f7255a-af41-498d-911b-39893bb2763a" control-id="sc-8">
+    <implemented-requirement uuid="6ebf81ff-2d9d-48c9-bc42-2cf9637471d8" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="e1a20a4e-0394-4860-b7c8-f024bf38a0fe">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="47eec348-fa82-4b4e-a628-ce2bfd182510">
+      <statement statement-id="sc-8_stmt" uuid="49e34fad-76b9-4853-9a6a-5d5de9b11158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7288,10 +7288,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aaa0862e-ffe4-4973-87c8-d7e02d3412e9" control-id="sc-8.1">
+    <implemented-requirement uuid="1263ce60-fead-4fe3-91c1-2c246a05e045" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="cf5e836e-2ae7-4d8d-9591-156db9ddd53e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="06cf7ebb-ebfc-4cc8-ba85-941b8f53c723">
+      <statement statement-id="sc-8.1_stmt" uuid="e8d6016b-24d2-4229-94ae-3de7956621a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7301,10 +7301,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ccd638a-50b2-4130-ad22-8f216dd65a3b" control-id="sc-10">
+    <implemented-requirement uuid="e5a2c493-ec0e-491d-86e3-7b162bdb4ef3" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="765a8eeb-5d91-47c2-ae2a-619d11038033">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9519d3ab-2eb7-4da5-9618-dea174148ecc">
+      <statement statement-id="sc-10_stmt" uuid="ee7681ec-31ee-4c11-8ab4-7777139adc68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc326e1e-9b29-46ee-8e79-35af828fc76e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -7319,10 +7319,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="114edb05-a250-4915-a9dc-2f7f7bac41e1" control-id="sc-12">
+    <implemented-requirement uuid="020c4c07-e9b7-4492-b6e8-c7dff5e18fed" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="e2c5ad83-2278-47a9-8d90-e689f1778720">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9fb11e3d-7ee9-4243-a5dc-8c9fb762e20f">
+      <statement statement-id="sc-12_stmt" uuid="50788e68-a89d-4186-affb-16ee5c3769c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b2d725b2-fb78-46d9-bb72-3cd88ac8bfe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -7341,10 +7341,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64ba4ac0-3138-482f-a24d-08afc3ad3860" control-id="sc-12.2">
+    <implemented-requirement uuid="4d4f5d27-f723-4222-939b-a20a7b8f0b43" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="00964139-d2a4-4fce-8109-a89a15c8db00">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d2981d7b-70c7-4411-a821-fcfb0c9df0c1">
+      <statement statement-id="sc-12.2_stmt" uuid="a5a12b62-f938-4920-bb4a-79a0fe345369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7354,10 +7354,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31e664dd-7df6-4b79-a2ff-882f6f58d565" control-id="sc-12.3">
+    <implemented-requirement uuid="08160e29-14fc-4dd7-b5b6-fba597db4b6e" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="89384349-5858-4020-a0d4-b553a28aa008">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="51dc11d8-9083-40ba-8f3a-c4a2853a9ed3">
+      <statement statement-id="sc-12.3_stmt" uuid="84f2cc66-d583-4e4f-abea-1ec72a4c573b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7367,10 +7367,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05df66a0-18f8-44e1-8705-9343da0368f0" control-id="sc-13">
+    <implemented-requirement uuid="f298b315-5458-4a40-b974-c940e05a6d9c" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="bd157532-910e-4435-8cef-fe7f0c960766">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="37d343da-5a3d-495d-bb7a-9cc8e59e4fe8">
+      <statement statement-id="sc-13_stmt" uuid="6c7fbd19-4670-4988-a837-308fdc161851">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74c0f9d3-e304-4102-8b71-c897d213fc58">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -7395,10 +7395,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce8e3837-b160-497b-b159-41e6661daa59" control-id="sc-15">
+    <implemented-requirement uuid="ff2a4f17-3134-4017-994c-ef6973cb8dd6" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="5cea61c2-aa0e-43ef-a740-dc3f5b74bb8a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="86d00994-5b76-453b-8152-ec78d37b2475">
+      <statement statement-id="sc-15_stmt.a" uuid="9cbda246-5497-4d1e-9bc8-15f212d3f971">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7407,8 +7407,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="785d4838-4393-462c-a5db-43bd597f312e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="94e861e5-f26c-435e-a0ae-e400001a0887">
+      <statement statement-id="sc-15_stmt.b" uuid="857f6d9f-6f6f-42fa-9ff9-0c7efb5b7b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad9bf71-2fcd-4a25-9d32-a051468affe7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -7418,10 +7418,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e22b9e16-a385-4d4b-8828-b621c398a879" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="a746e445-7b8f-408c-899f-d742cd9abe82">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="409b555d-25cd-4725-90d9-96a695b3abd2">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7431,18 +7431,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9a125b7-7ea0-4906-b3c0-d96427a4f439" control-id="sc-18">
+    <implemented-requirement uuid="5d3f05bc-c7c8-470c-914d-ec87c04ee392" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="d335cee1-066a-4a97-9990-83236d482c1b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8496470a-75c0-4fa5-b51a-83b7c86d4f6b">
+      <statement statement-id="sc-18_stmt.a" uuid="288c4934-cfa1-43b0-80b6-2c17d0c59fb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9bbcb63-8565-4eae-b386-70f3337b4970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining acceptable and
 unacceptable mobile code and mobile code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="17eb7fff-442e-4c2c-b131-8ab0b70eebc1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e5211728-c224-4c6b-a5c8-69552a2c6d24">
+      <statement statement-id="sc-18_stmt.b" uuid="f2075982-e716-4d6f-b59f-fb353c22add2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="300a4a3e-4553-45b6-9fa6-64fb56470ffa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for establishing usage restrictions
 and implementation guidance for acceptable mobile code and mobile
@@ -7450,8 +7450,8 @@ code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="0313c14c-4690-4c41-bae3-0fd51f09a64f">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e05cbbd5-6e77-4103-a5cd-e23341f5a79d">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -7460,18 +7460,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="806344b7-3a24-417b-8d22-155c17e55baa" control-id="sc-19">
+    <implemented-requirement uuid="6106cc7c-0a57-4740-9d9d-ff2259591c26" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="e38330db-07be-485f-bff7-5f1409fc30ef">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="93c531a7-74dd-4eb1-a9bd-4d4a1433d6b4">
+      <statement statement-id="sc-19_stmt.a" uuid="5451183d-ff3b-47fb-9b72-51655cca3074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="043ff7db-5c7d-4197-9bfa-b25d882c6b29">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d51be809-c880-4016-ae78-38831c81f2df">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -7480,10 +7480,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="042a4a02-ed4f-4eb4-883b-276f1562a6f5" control-id="sc-20">
+    <implemented-requirement uuid="13d07e43-538e-4555-a7a4-a849d30614a6" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="38831d54-d92f-447d-9730-df3a2af8f5fa">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b1de1e15-ede3-43b5-b17d-2c5e203068b8">
+      <statement statement-id="sc-20_stmt.a" uuid="9b3841e7-06b0-43de-8176-0403c350e22c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b673a29b-5ef5-4775-b02b-9f8a0ddffc6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -7498,8 +7498,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="d09ecb49-f2ca-40d8-a601-fcafd0949254">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8a9cd091-f6c6-4930-a67e-e13e46c93748">
+      <statement statement-id="sc-20_stmt.b" uuid="f6c89107-60df-4621-98d0-84ce19c2b83f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bed2578-f811-4697-a21f-4b423a65142f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Host (RHVH) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -7515,10 +7515,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="62fbe4b2-cd2e-4a40-a507-5a95da475246" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="c8826233-fefd-43f4-b086-ec5ddc163d03">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a6c8a832-38e1-4d1f-8b53-dec925e05deb">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -7533,10 +7533,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73b0cb4b-a063-463e-9f09-161324dfecbc" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="5344eec8-4752-40c6-9fc8-de8bcb5774d5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="090a9f09-2111-4802-9ae3-4e66d5e847e1">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -7545,10 +7545,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7af6f3d0-e8be-4a5a-961e-8ba616c9b7b3" control-id="sc-23">
+    <implemented-requirement uuid="28c49b88-5b53-4b72-a6bf-66216e571cb8" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="fc61e90a-d7ef-49ab-9375-37016bc689a3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e16dcd61-6ef0-474a-97f7-f8a74bb82e71">
+      <statement statement-id="sc-23_stmt" uuid="a49c993a-d648-41fd-8316-e7458d19ef89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6536c089-9c3c-4f8a-920d-67bf4b6e55e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -7568,10 +7568,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6a6e476-90e3-4533-bdca-a42e029fa63c" control-id="sc-28">
+    <implemented-requirement uuid="5369e7e4-4f63-47a4-a269-858e0d726ed2" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="f1dabdd2-cc0f-4280-b329-02137a82b491">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="97b2addb-600a-4763-8652-5662f0a07236">
+      <statement statement-id="sc-28_stmt" uuid="3c623361-fd52-46c2-b652-86f40cfbf05c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7581,10 +7581,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ac2632b-bd11-4489-856c-3e2f78a4b60b" control-id="sc-28.1">
+    <implemented-requirement uuid="61959263-ad0b-4e37-8cae-0f31856c2e0e" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="80d1b528-17a1-4b83-84bc-9f64e0977a8e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7db82551-e696-4f67-ba89-26ad7d3a88a8">
+      <statement statement-id="sc-28.1_stmt" uuid="112e2e75-aa8d-4b39-b010-207a36f8297c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="69ce2f8b-e0a3-4bbc-9951-4b7a33805851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -7605,10 +7605,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6daeadda-ad12-458a-845b-0630acd2e38f" control-id="sc-39">
+    <implemented-requirement uuid="c85bb898-b489-48a1-b71a-e74625f7b216" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="408516c1-421f-4040-a07a-726044c8608c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="669ec46e-5b22-4793-a09d-d0c7f5487d2c">
+      <statement statement-id="sc-39_stmt" uuid="33337f99-eaa4-44de-81e2-877df2ee77aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24b4672f-398c-471e-b8a0-14388d77a318">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks must be enabled to satisfy this control:
 
@@ -7630,50 +7630,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="476c26a3-adf4-4a85-beff-409474895b57" control-id="si-1">
+    <implemented-requirement uuid="5d7e07d9-4558-4bf9-9b56-8ddea777b5d8" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="75b8c0a1-f90f-49bf-a825-3a6ac5fe33b1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="94b0881c-bf28-458a-90da-8e646bf28183">
+      <statement statement-id="si-1_stmt.a" uuid="8787884f-585d-4aab-99df-a609926f4b91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="fdb5c0fd-404a-48ed-89f8-908e1f1a2a58">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9c0f8923-97c0-4da3-b64f-c8a2babf2aee">
+      <statement statement-id="si-1_stmt.a.1" uuid="8c07c419-6245-4a61-826e-775f5052f045">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="93fa8e23-f3f6-4d3a-b506-6a87bbf4d6f5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="91b10700-5d8c-42a0-9a64-606482f0a210">
+      <statement statement-id="si-1_stmt.a.2" uuid="3d0ab5fe-cc7d-4301-8ce7-6810ad62390e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="74372ccd-0a8f-4a69-9a98-027158a52fe0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7ef08e50-262b-4dd2-9f06-bd1656b74b68">
+      <statement statement-id="si-1_stmt.b" uuid="df847d3a-bcb9-444c-9e18-c555eeff1492">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="abc9ec73-d93f-41ee-89a4-c96c00f5c725">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3c2127ce-7c4a-46f1-8780-bd72df7ab65e">
+      <statement statement-id="si-1_stmt.b.1" uuid="23ab5b73-bdc4-4884-b80e-14c8c704508d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="29924c86-67fa-4df7-a30b-c3a0030e2a77">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f1c43a8e-4fd4-4bb3-b70b-527cd4a97b2e">
+      <statement statement-id="si-1_stmt.b.2" uuid="cfc702c2-8138-43fb-ad59-b9273ce1ed9b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7681,10 +7681,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a9a5c2f7-a2ed-407a-ae80-1a0ba92c668d" control-id="si-2">
+    <implemented-requirement uuid="dc0ee075-4b67-4ca1-80de-e12ad3054399" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="d928a290-e287-45ca-8fe2-b7b3852e4c64">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1003d2e1-2ea1-4dac-9c7b-b2ae631f8600">
+      <statement statement-id="si-2_stmt.a" uuid="ea7e76cb-cded-4c89-897b-67b0f6290878">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="00c6f6a5-bcad-45d7-aa86-099ad8ff7902">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Host (RHVH) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -7694,8 +7694,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="13a4e268-c99f-4bc6-88ce-4d96a3c00065">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5eaed7d0-2b2a-422d-9711-d27d4a68ef64">
+      <statement statement-id="si-2_stmt.b" uuid="c93b23b0-3685-4e74-8a11-e9130f2b17b3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3e3cc16f-0b1c-4966-ab2c-a775e94deb09">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Host (RHVH) updates
 related to flaw remediation prior to installation. A successful
@@ -7705,16 +7705,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="35da5013-3cf1-4c34-a2fe-34ab0fb68848">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="04f5576f-321d-479a-9800-57c0bc6b9aca">
+      <statement statement-id="si-2_stmt.c" uuid="af9092b1-daaf-492e-9691-de3ee7c94546">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="9b166a7f-c43b-485a-8683-bd469fd93de1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="2d1bd5ff-b6ed-46d7-9474-a4ed5c696f4b">
+      <statement statement-id="si-2_stmt.d" uuid="9da7889e-0085-4023-b7a9-6a88c6e7a420">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7722,10 +7722,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="272a1498-2d84-4cb4-ab61-542f100104ec" control-id="si-2.2">
+    <implemented-requirement uuid="f39f62f5-798d-48f5-8703-27d537979525" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="61f6a32c-9b93-46d1-b590-98a0c30ff22c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a2c4ae21-7e0b-4ec2-9dee-d14e3124c662">
+      <statement statement-id="si-2.2_stmt" uuid="2fcbc796-5a33-4953-b75d-ed3bbf6cd579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d37014f-dd7c-410f-8ccd-f0873ee726fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -7743,10 +7743,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1bc60d5f-69bf-42f9-91fe-5cc20886ba2d" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="369c76a4-e6a3-4183-a749-8b722c234f0d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1475d628-7eb3-46cd-91d5-e7d3393d537c">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -7757,8 +7757,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="1bd7c71a-1e14-4a72-9154-9fb132036d11">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6a049ddd-7de2-48a1-a45b-7c458aea2f1a">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -7770,10 +7770,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58b05b20-baed-4a4f-8b0a-16bdfed29807" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="0baeb0af-5426-4032-8ea5-5182d7a90202">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a074170a-860b-4104-a3ea-667ce098f781">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -7789,8 +7789,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="dba4d836-b64c-4f67-af36-861bcd8e5a47">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="876bbfc2-3c69-4ebf-a745-c9d7704ba220">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7799,8 +7799,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="897e4de5-20aa-418f-953c-6f67ca803a83">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4cb2bf41-bc63-48be-90f5-44031f9fa76e">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7809,8 +7809,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="37bf4e77-ca93-44e1-8f9b-a9da1d2092b5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="ae09661b-6def-4511-9b68-8e3203ebc67c">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7819,8 +7819,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="6e8deda3-13ee-463c-8712-e5ed122a8053">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="615d8498-4d2e-428a-b5a0-7e0086ec6ee2">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7829,8 +7829,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="c8c527e8-37b4-4f5e-b16a-2f6915921a29">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d33f0415-866a-4715-9f51-eba8ca3e767a">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7840,10 +7840,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="03f7ee23-0afb-42e8-912b-1c45e05ea967" control-id="si-3.1">
+    <implemented-requirement uuid="3ebea031-233c-464a-998d-c0c3d922b851" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="cf2110bf-22c6-4a58-ac96-0c3d02c0cecc">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="212ae7c4-afab-4952-acc6-2c106b294e2f">
+      <statement statement-id="si-3.1_stmt" uuid="9e989886-07e9-4d4a-98ed-be98fb1368ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c58ac54f-22ef-4855-adb1-33eee390792b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -7859,10 +7859,10 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6de28d2-4f2e-4b11-913b-bf38b7dc7241" control-id="si-3.2">
+    <implemented-requirement uuid="67609e78-72bc-40fd-b9f8-0728765cfc5a" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="981ec616-39c2-4d56-8ad6-9812fb1492c8">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="13f1ab3f-7709-4da2-8857-6fc989faa3c6">
+      <statement statement-id="si-3.2_stmt" uuid="b0ad1bcb-2da0-409a-bce2-8c8dce7b4539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071bdb1c-8691-40b5-b1e8-17d54c02caa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -7878,10 +7878,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a86d7a2-fca4-4805-acb3-1783c21b8a84" control-id="si-3.7">
+    <implemented-requirement uuid="e0f1ca33-2212-4e02-bea8-2b2961431e00" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="81f23041-3779-455a-ae31-0b252110494b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7295f78c-9488-4852-b09d-48f912c11005">
+      <statement statement-id="si-3.7_stmt" uuid="c197c739-ab67-4d4a-89bd-78bc67721465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98787694-bec5-4c19-a079-27ca4960a28c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -7896,90 +7896,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec6e8e75-7883-4574-91ed-7730f27b9770" control-id="si-4">
+    <implemented-requirement uuid="59b20aad-49c3-4881-9195-6a89041b5906" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="bb1c2fa5-9424-4caf-99ce-c22ce07b4d71">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="c8437aa2-4ddf-4e7f-a0e5-243eae15b99b">
+      <statement statement-id="si-4_stmt.a" uuid="dba40fba-14cf-469c-8411-389d0906fecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="62873863-f35d-440c-abf4-e3765d19e991">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3b391cde-9fb0-4c25-8bd9-99c36f4d3f45">
+      <statement statement-id="si-4_stmt.a.1" uuid="8f062e56-42ed-480d-be3a-a084a404a92d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="8fb83749-bd7a-48ee-b815-3d425f61e741">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6286f3aa-6f96-4c20-b643-dfdf27cbeed0">
+      <statement statement-id="si-4_stmt.a.2" uuid="c99eebf6-76dd-4834-a8a8-702955f0de22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="b463583c-61a2-4c51-aa9d-5afa056195e3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="5a23405c-f5d4-49c5-8a99-3e366a8cb711">
+      <statement statement-id="si-4_stmt.b" uuid="8b63244e-e370-45c1-93e9-8fa3167757c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="0a2bf387-2db3-4aaf-942d-a7af02c72b3e">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fbcc3935-5769-4120-9d12-fe1c1403fa28">
+      <statement statement-id="si-4_stmt.c" uuid="6654702f-0944-4119-b792-9d5d62145d8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="1ef174b3-c219-4db4-83be-d6ce695d5ed2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="8bc0f0bb-3d53-4363-9e09-c637eeb7d697">
+      <statement statement-id="si-4_stmt.c.1" uuid="ec5b5673-4f98-4232-8b5f-d5a55003f609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="c51fd4b8-e325-4216-a519-4284d8e481ea">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="47c1d543-f051-4a2f-b040-ed3d1fba2916">
+      <statement statement-id="si-4_stmt.c.2" uuid="779ce949-375f-49de-91eb-8cca14636ad0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="41b98816-201a-4982-9bbb-9076917d62ea">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="de752421-94cc-4c7b-b0c7-f1fe193c8a9e">
+      <statement statement-id="si-4_stmt.d" uuid="14feaa64-7bc3-4db9-bb76-2e714e9407e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="617a7f5c-1354-4009-b2be-a2a1fbbb3ed0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4501b9d3-4433-4c59-b7c9-cd27ecadd655">
+      <statement statement-id="si-4_stmt.e" uuid="b3cf0398-2a1d-472d-b11d-a4f66f126706">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="7c78a98d-5b8e-4395-9066-6e66a8ec17ab">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="f11f06f7-eb49-4435-8e9d-2731f89df497">
+      <statement statement-id="si-4_stmt.f" uuid="6b46395f-a140-4b9d-b9cb-97333f90e885">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="8686dc3b-8c71-453d-90cf-77a92195dac0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="910bc58a-3e54-4ea5-b837-b1eeaf532491">
+      <statement statement-id="si-4_stmt.g" uuid="bc73ebf4-bf15-4a47-bad0-533a3fcb8b25">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -7987,10 +7987,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7abe3277-19d8-40d8-b744-6dece022b9ea" control-id="si-4.1">
+    <implemented-requirement uuid="4bf5835e-47ab-4a5c-ab5c-0f6be46315ed" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="b70c22e9-7fcb-4a8f-a080-4fce80c6c242">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="3f7bdd6d-5f07-4f16-aa5f-553e0b3b0c2f">
+      <statement statement-id="si-4.1_stmt" uuid="f8cd313a-2042-44d9-b3d5-b988f1c08bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="af343765-d8cf-43a1-8385-42f27bddcb7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the Red Hat Virtualization Host (RHVH) environment, and documenting how this
@@ -8007,10 +8007,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="959cdc3c-1651-4825-92dc-780af2fe7bb8" control-id="si-4.2">
+    <implemented-requirement uuid="283ad864-6082-4571-848c-9fd3accadf1c" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="e8d498c0-4015-466f-8418-e45a1a80135c">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="daf44dc5-3823-460a-b9c2-576547dfe022">
+      <statement statement-id="si-4.2_stmt" uuid="80a356fd-653d-432a-bfa8-eaaca3b3cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bf351-1106-49a6-9dda-1dda289ea4db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -8029,10 +8029,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1a3963f-ed57-44b7-bcd4-be7da979cec2" control-id="si-4.4">
+    <implemented-requirement uuid="16783170-544f-41c7-9a13-99abdbbd9c36" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="6ee3b160-f1b6-442a-be07-312c7878f17b">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="e4708175-d2a7-46c8-900c-bd1dc1d5f8e2">
+      <statement statement-id="si-4.4_stmt" uuid="c2cf100d-6819-43c6-be66-ea9fb2012e61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d2ca56b-bd9b-411b-bb38-3e205fc8d841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored.
@@ -8045,10 +8045,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ff4422b8-7ece-4e92-a40f-c547c2bbb06d" control-id="si-4.5">
+    <implemented-requirement uuid="5396bcbd-5df3-468b-a6fc-70f008a8c1b5" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="4e091a3b-b969-44b2-9718-b895b47a9261">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6a9a18c4-7616-435b-b797-a83887760354">
+      <statement statement-id="si-4.5_stmt" uuid="7d4e1aa3-8989-4b97-8cb1-1b607440335b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c63bf7-e4b8-499d-8db7-bf313c017b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -8065,20 +8065,20 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="111764ee-6c2e-44ee-91ab-9851d5d9a5cb" control-id="si-4.14">
+    <implemented-requirement uuid="bdb0ea51-ab3f-412b-88f8-ad75ffb8309f" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="cdb19019-8579-49e5-84f3-1bc265db8ee5">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="09da446a-4cb1-46a6-a8a5-37b0fb795191">
+      <statement statement-id="si-4.14_stmt" uuid="7675ef46-b5a0-4251-83d9-eadd20dcaa7e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77c6a1fe-41d3-4ac5-bc66-6224342a3c5f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An Red Hat Virtualization Host (RHVH) infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ed7b2b29-6aa8-47cb-8d45-1367b09e9431" control-id="si-4.16">
+    <implemented-requirement uuid="253bf33a-ac68-4dd3-b870-7700ee285f87" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="a0b0a77b-5e00-407d-8bf1-a5819f941490">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="261e8d51-46a9-4260-bcd3-5f9a52d31b72">
+      <statement statement-id="si-4.16_stmt" uuid="a152da88-93f8-4db0-81c4-cb866db6b80a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7452c87a-d7b0-43c2-8a16-d7f459271774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -8093,10 +8093,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16403d9f-c136-4748-ab27-4f0b5d415642" control-id="si-4.23">
+    <implemented-requirement uuid="919cd6de-1429-4daf-95b3-19aca7ee0b8a" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="b44a895c-2576-4486-98fd-12fc8b702ca3">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a929b6c9-c797-4e79-8a52-560f7123f078">
+      <statement statement-id="si-4.23_stmt" uuid="2bfeb2d7-99e8-4173-9fe6-308e019b794a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c3b8882-a814-401d-b47a-c6a32d2bb35d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -8110,10 +8110,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="909c0057-27d7-4009-b376-0ebcc3ce758c" control-id="si-5">
+    <implemented-requirement uuid="db26ba38-1239-4f83-9440-22b97f99486a" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="61f57570-8e56-4a91-aa8c-3e5f593438fd">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="37bd72be-4d4e-4b1a-beba-a18cefb5c408">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -8122,16 +8122,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="1f03a65a-c6ff-4fba-83ca-aa607e7aa87d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a1a9d624-427d-4dbc-9259-e3aeaa89cf36">
+      <statement statement-id="si-5_stmt.b" uuid="e6f52326-2876-4f3c-91b5-c584a78c6b76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="918d998a-df76-44ac-8ba2-e991fae92e96">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="6a7e4b22-1e95-4acd-ad89-d08e78257bfd">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -8140,8 +8140,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="7c216476-f92e-48ac-8be3-f6b400c96466">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="b312b830-863f-412b-aac8-e9d89024629c">
+      <statement statement-id="si-5_stmt.d" uuid="9cbc5870-d294-43ae-92c1-7c3ca5d92a36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a25ca5d9-c4d9-4a36-a0b3-b7eee7e3f58e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8149,10 +8149,10 @@ applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d261878-5ab3-4727-bcb0-887fb18b98d8" control-id="si-6">
+    <implemented-requirement uuid="38b01b39-5943-49c8-b108-044a6e4bacd8" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="c8a54d86-b2bf-4bf2-9363-93feb5fafbcb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="19b5e9dc-1d0d-487c-abba-05f04a5845d6">
+      <statement statement-id="si-6_stmt.a" uuid="d64f2de2-7f02-4e63-aaff-02696686cb5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a447dc-056f-47a6-933c-b570d8213b54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -8167,8 +8167,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="f7b4d9a7-1ced-4488-adb2-69ffd7e643cb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="4f2dd1cc-ac56-47ad-84c8-c41598546f77">
+      <statement statement-id="si-6_stmt.b" uuid="d22f4f0c-240f-4b13-bdc9-47cce702cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8177,8 +8177,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="bf3325fe-04a9-4733-9498-b86a672a4905">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="a9af3784-ccf4-4d5d-bbb7-813e2903df39">
+      <statement statement-id="si-6_stmt.c" uuid="4bb561ed-8a3d-4fe3-9ca6-00b7213dc2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8187,8 +8187,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="b1ce5ab6-935e-4b17-beca-c3009745d3bb">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="aceb683c-4730-4774-bba3-9e26a9e60a6d">
+      <statement statement-id="si-6_stmt.d" uuid="2d6bd4eb-8197-41d5-9e13-023435276675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8198,10 +8198,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="278e1671-bdd3-4839-aebf-207093344e8b" control-id="si-7">
+    <implemented-requirement uuid="fd45ca54-ac27-4043-9523-cb122d75ef7b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="c1a6b08d-784a-4370-8334-3ed132761dac">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="cff3fe90-a802-4b85-aeb7-1ec25b51f59e">
+      <statement statement-id="si-7_stmt" uuid="2d2570a5-feaf-4efa-9783-099aa818c505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff0de457-49b4-4344-8372-7c7e6a4164cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -8216,10 +8216,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3c6d2e44-803e-45ff-a870-8c577d54baf6" control-id="si-7.1">
+    <implemented-requirement uuid="3c62e9a0-e77d-4915-b5bd-d8e7c7cebf56" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="6e357146-0293-402f-86c8-27f25ed090b0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1f265f10-c04a-4048-8e8f-e3750ff330f0">
+      <statement statement-id="si-7.1_stmt" uuid="a3e8de9b-0300-45f9-a7b7-2d965e7a83ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db598211-5d2e-4a86-b372-f2d6a2f5c9de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -8235,10 +8235,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6c23141-3197-4852-bfa8-514c53bd4cfa" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="94f1d901-79f3-45a3-aac3-7a7bf97a930d">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="9a75eb81-aa23-44d5-895b-099b1ba7cd6f">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -8250,18 +8250,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adeed334-fe43-4685-81f9-139693ee4abc" control-id="si-8">
+    <implemented-requirement uuid="f4e92b38-9c3e-4adb-9bef-fd56ae03f510" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="1b335467-ce82-4543-a48e-ba7b34bd48d2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="872086c2-dc86-41e2-a187-9aa43451f27d">
+      <statement statement-id="si-8_stmt.a" uuid="6d2494f7-e034-4cc8-8edf-258385e2195f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="a551f8b4-b385-42d3-925f-d63cb59253d1">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="1f016e02-bd39-4d30-b727-a3855d53c6a9">
+      <statement statement-id="si-8_stmt.b" uuid="3710b24f-249c-48c0-a9de-3fd0fdcbbc5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8269,10 +8269,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7a1d533-3126-4411-a3aa-736c72f258a9" control-id="si-8.1">
+    <implemented-requirement uuid="63342f57-2aae-48d2-801d-98704088e1a5" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="82795268-4ad0-443f-afdb-7a262e6cefda">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="123b9b45-b54d-4e03-87fd-15afbed63d42">
+      <statement statement-id="si-8.1_stmt" uuid="b7f7cf43-6ed6-41d5-834c-4b5a6691c670">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8280,10 +8280,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e2a6d5f-40df-4b8a-946d-cb9308b06dc8" control-id="si-8.2">
+    <implemented-requirement uuid="b1265444-eb20-45aa-bb36-90477c38fd67" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="7951fc2d-8aa8-42ed-89c0-83efa74a02a7">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="497f5816-8876-4fee-bdd5-d412dd974bb0">
+      <statement statement-id="si-8.2_stmt" uuid="d452429c-f034-4e71-9611-5724b5968524">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dc721d57-ae71-4476-ba39-281cd24a0533">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
@@ -8291,10 +8291,10 @@ are not applicable to the configuration of Red Hat Virtualization Host (RHVH).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8e65477-9750-43fa-86fd-ef70ff128386" control-id="si-10">
+    <implemented-requirement uuid="a692ad57-9df9-46f8-9f6b-9cfdc5eb8331" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="59c4fd25-e35b-4054-8c79-1fe5b9b0389a">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="37c1f3cc-c7e7-4439-b750-d4b7a80aecc2">
+      <statement statement-id="si-10_stmt" uuid="5653a342-a850-4ce4-86c7-ee90659a39b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f5633d-efbc-49d5-9e55-9124a516abe3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -8311,10 +8311,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b2be7f5-16d8-4cab-a19c-f97685e9a87f" control-id="si-11">
+    <implemented-requirement uuid="b3a5c29e-0faa-469d-b445-999334811b7d" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="ac7d6d17-f9be-44a8-8350-5106dc7456b0">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="d996912a-2268-4651-a8e1-d5e04c86d7ac">
+      <statement statement-id="si-11_stmt.a" uuid="96e25551-2aaf-4632-aede-caced5280e5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="336b8f57-a23a-47a8-b9d6-99b085addd75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -8330,8 +8330,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="35d71549-c1a0-41cb-a6be-85d9bd487683">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="41d21bbd-bc93-4791-bd0d-526892106927">
+      <statement statement-id="si-11_stmt.b" uuid="865efc56-48e7-464c-9d66-8d1fd50b47ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad9a4e66-e871-4618-ba62-7d464c99668d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -8346,10 +8346,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f1f6de9-e653-42a1-8713-a1371c91eab4" control-id="si-12">
+    <implemented-requirement uuid="09e0132d-6ccf-49ac-a537-29560849f42a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="1c94ae44-54fc-4b53-bf0b-0bfa64d39dd2">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="fc430687-1ff2-4ddd-a981-134eb0c74af7">
+      <statement statement-id="si-12_stmt" uuid="5dc6c15d-d248-4165-b960-af8e7fc3acd0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7efcd9c4-a080-4cc4-955d-96131fd8f0bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Host (RHVH) in
@@ -8363,10 +8363,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c36bc29-a85a-4fc8-afa2-7e4987dceba5" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="70275103-60ee-4447-b029-0a811c9dfbc4">
-        <by-component component-uuid="29b5b68c-2aa1-4fe0-9f4e-83734f73dfd5" uuid="7dc3706a-016f-4fcd-9261-dc46a85d47b1">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/virtualization-manager-fedramp-High.xml
+++ b/xml/virtualization-manager-fedramp-High.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="093ee64e-bce6-48b0-b4b9-2f9aade0c3a6">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="7a7f827f-102c-4b4c-897d-7d76705bfae4">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:03.03+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:21.38+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="ae3d1b65-72bc-4e01-8a0d-bf5c0f16382a">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="77cf7398-9635-4e2f-bdde-30416264c97d" control-id="ac-1">
+    <implemented-requirement uuid="935fc585-8c0d-4e23-8c2b-8d1a82bc6de5" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="df118f54-c0fd-4afe-a8e8-43fea320fafd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="43e8d13c-631b-487e-ba13-3ed8f4b85aae">
+      <statement statement-id="ac-1_stmt.a" uuid="cc53016a-7b4b-43c2-a7be-d7e3881ffc09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bc7848e-1ff5-456d-bb50-4c66da19c7ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="3690320d-62b6-4e9b-a9f6-f3a0d67c472a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="00e890de-b8bf-4a00-8e41-e1b8f70eb3e1">
+      <statement statement-id="ac-1_stmt.b" uuid="14971f3c-d3c7-4586-ab6c-e96a64f00105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192a21b9-f20e-40b3-be11-4658c5b10f4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b6b975c-3781-4a9d-8724-a4d16de1c592" control-id="ac-2">
+    <implemented-requirement uuid="f67d4ab2-d0ea-4ba7-9451-88e518020d4f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="eaf5fd55-a8a9-4f8a-a3e5-4f7681be575a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ac6a74eb-f98d-47b5-9799-a08af070b1e2">
+      <statement statement-id="ac-2_stmt.a" uuid="9fbdf8ad-2b9c-4abe-a179-df8a0cf999ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0948d8a3-d0de-4772-8129-51d7044bc708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="cf963ff0-4c0d-414e-b515-edfe850b9bff">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="80c3ff09-c277-4562-ae7a-d6face66b428">
+      <statement statement-id="ac-2_stmt.b" uuid="37679c35-79a9-440a-b0ba-70bf1adf0843">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e397b49e-743d-42f7-9b6e-c27d903220d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="3b7469bc-b7ac-4382-a471-1fbd7ac4e433">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d66ce44d-b1f1-44d1-9f9f-adb41fe6f8c0">
+      <statement statement-id="ac-2_stmt.c" uuid="57796f3c-04d2-48e7-b548-9f7cc23dfe1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5372385-2e96-4f5c-b3c9-dedd9fa4768b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="079d0824-6e41-4ce9-82b7-ef1b238f7b42">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="23d08b75-6a44-4c97-9722-2444fbad50e8">
+      <statement statement-id="ac-2_stmt.d" uuid="16e7b8f5-72fc-463f-bcf9-dff9f1a98444">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192c3c92-4449-46db-bd35-3b3baa1a8e6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="5171a4eb-282d-4c88-a149-f3f1c4b08adf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="739407ed-57fa-4062-bfe7-0a4e7f8a9bda">
+      <statement statement-id="ac-2_stmt.e" uuid="85035d84-9393-43dd-8d99-c4e3338892e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="354d4cb1-65e7-4f33-a3b7-3659e7d47759">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="e8a0a3f4-1eb3-4228-b4f8-8604c7b2f710">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="aba8b910-d5dc-409e-b4e3-28e837c06d02">
+      <statement statement-id="ac-2_stmt.f" uuid="8b9e97ff-b352-4097-a6b1-73095aaef138">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cb7701-547c-4964-a739-069548f34e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="254ea947-f96d-4f11-935e-0de2c3b8f025">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e59687d6-f01b-46a9-88e8-d8fcce2253ba">
+      <statement statement-id="ac-2_stmt.g" uuid="4f167f93-f6cf-48a2-9cd8-eff8812dd65f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5025090f-c1f8-4dba-bcf6-04b6e53d5135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="b1684de4-7f6b-4717-add8-f45f82598b30">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c0a1ad17-c64e-4599-bfdf-c4799fd1b879">
+      <statement statement-id="ac-2_stmt.h" uuid="140deaea-5b89-406d-b8cf-e0067c52c4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f73dfb7-a97f-4283-b843-3c45bba5d201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="be647273-e438-40d0-9e4a-f607509424f8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="65248ac7-7fa2-4b5f-922c-827dffda597a">
+      <statement statement-id="ac-2_stmt.i" uuid="96e1e1b0-69f0-447a-b451-0c237009cf21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a143884-7ff3-4077-ab98-a8e3ec37f214">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="f45a5a11-6913-4e43-bf42-38ff8c5de4cb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f19e5f35-ebb2-41fc-b4c7-5684a7b6c6aa">
+      <statement statement-id="ac-2_stmt.j" uuid="218ada72-ea7e-4142-ace7-16852053482b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9688aeda-4137-4df5-842d-43e0a620fc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="b70888c3-a10c-4f48-a797-73284c4c4cf5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3e629404-5622-47df-88ed-892bc6ceb803">
+      <statement statement-id="ac-2_stmt.k" uuid="be123a77-9ada-4c78-834b-1d8f12977e36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723be80f-78e5-47fc-b9b5-123a1ab7c7b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b6e799f-6724-4c99-84cc-c0c3af9c617c" control-id="ac-2.1">
+    <implemented-requirement uuid="9715651b-80fa-4d22-8bee-37a82e36f37f" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="32b6ad36-7be8-4488-8542-c12f9f25b973">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="30751224-5bcd-43b9-855d-da3940c0d71c">
+      <statement statement-id="ac-2.1_stmt" uuid="0b81d118-447c-418a-ba20-583f601c82ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34148e4a-d2f0-445b-a912-24cbb554682f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) components of the system support automated
 management through monitoring of accounts and system
@@ -604,10 +604,10 @@ https://projects.engineering.redhat.com/browse/RHV-19937</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1e7fb3f-4168-4d68-ad9c-8e6ba886e83a" control-id="ac-2.2">
+    <implemented-requirement uuid="29407e38-674e-4b6c-ba4a-71366b8bf0ca" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="143bd608-f49d-4620-b221-dbff91272533">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3559c6de-9ca5-4989-9f10-ebae4b20bf9c">
+      <statement statement-id="ac-2.2_stmt" uuid="bae8eb29-5a04-4606-94fe-1f7d26ad0114">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb7a3500-065e-48d1-a512-7ab26eb568c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) does not have the capability to automatically
 delete guest/anonymous accounts or temporary accounts. Any
@@ -617,10 +617,10 @@ identity service (e.g. Active Directory, LDAP, etc.)</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c24072f6-2dd4-44a4-874b-c98cb6a5aec1" control-id="ac-2.3">
+    <implemented-requirement uuid="704d6fd5-d8b8-4452-9429-bcdc9d2d31e5" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="7c702bd8-8a20-4a43-925e-f80b3e6c798a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="28670902-c001-42f5-b4c3-968419241e5d">
+      <statement statement-id="ac-2.3_stmt" uuid="2793ab65-312d-41bd-9540-f3525fc62391">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="381e0da0-8465-4ad2-ad7c-29ec45d6079f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -629,10 +629,10 @@ https://projects.engineering.redhat.com/browse/RHV-19938</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f45ce7-f6c8-4631-8b96-d8946bb9a0bb" control-id="ac-2.4">
+    <implemented-requirement uuid="27d8f87a-5fc4-47af-8466-b3411e509250" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="9ab73628-80c9-4254-a4e4-00ae31542109">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fe3be346-3769-462e-aa5f-74177c3ce53e">
+      <statement statement-id="ac-2.4_stmt" uuid="eaebd66e-070e-4cd7-a27f-a1f698b92a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="beb2350c-a692-4a5a-8336-d126cb5462a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -641,10 +641,10 @@ https://projects.engineering.redhat.com/browse/RHV-19939</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c3e5759-ba8f-4422-b630-4f5b266f80d9" control-id="ac-2.5">
+    <implemented-requirement uuid="dd5e5105-d2cd-4733-9fd5-fd3020397f4e" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="b06af429-10c6-41a6-b5f0-2812bfa2850c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ffd21d49-f3aa-48f6-bd8b-d5795fe413b9">
+      <statement statement-id="ac-2.5_stmt" uuid="3c6eb3c7-fc42-4181-a8ec-da4f7e3b6b9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2645dafa-cbbb-4d6a-84f0-4d1ce85741c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -653,10 +653,10 @@ https://projects.engineering.redhat.com/browse/RHV-19941</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e7887be-cee7-48e8-95cc-06621ec96754" control-id="ac-2.7">
+    <implemented-requirement uuid="9268ed20-31b0-4df0-bd0a-80416e29ddd1" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="476c50fb-153f-4643-94d0-3b41ba068146">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ae72469e-f1bf-480a-810a-09010c20f68c">
+      <statement statement-id="ac-2.7_stmt.a" uuid="f19cdaaf-9b1e-48e4-9b3d-2b356087abe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e056b0fb-5e60-4904-90b7-a7a6f3936b64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -664,25 +664,25 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-19943</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="47c1bd08-2806-41db-87d7-e0a144ee92c9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1c45389d-87eb-4e54-8ae6-9c6056b393c7">
+      <statement statement-id="ac-2.7_stmt.b" uuid="ed3ffabb-c47b-4c81-8730-7b4e3f9dcef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4496e10-886b-4309-97cf-44271743c943">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Manager (RHVM).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="22d395aa-c22e-471d-b3f5-115b41850aec">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a9efae25-b38e-4e68-bb9e-10ae9afa2657">
+      <statement statement-id="ac-2.7_stmt.c" uuid="bce80856-3d60-40c2-99b7-ad08cf5df799">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4496e10-886b-4309-97cf-44271743c943">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Manager (RHVM).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="217aa3f6-937a-42d0-90a5-77db5577f92e" control-id="ac-2.9">
+    <implemented-requirement uuid="8e61c5f7-a4e4-4704-b012-0aecab349f9c" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="3d1dabd2-2a96-4d24-9ebe-fe5e384c597c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="13c96e51-98ec-4dac-9459-dcc0b6ffce54">
+      <statement statement-id="ac-2.9_stmt" uuid="5df1697b-7fe7-4fdc-a5e6-44eb181ea9c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e160bbd-eb3d-498c-b364-71ec5c51130c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -691,10 +691,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5407e874-12b0-4490-b134-55f9d6810ffa" control-id="ac-2.10">
+    <implemented-requirement uuid="bccf9c5e-a4d7-4085-93b6-d3744f75f95e" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="50cc6ead-d715-4fd2-9c18-cc4a613a0c84">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b13d56a0-c9e4-4766-b88c-9fab5385f9f4">
+      <statement statement-id="ac-2.10_stmt" uuid="e4022c08-bf1a-48b3-9b1e-de84af44a65a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e160bbd-eb3d-498c-b364-71ec5c51130c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -703,10 +703,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9c47f80-11f6-47b3-9569-49c28a39ee73" control-id="ac-2.11">
+    <implemented-requirement uuid="fc70d9c9-e756-44a7-a30d-d35546199359" control-id="ac-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.11_stmt" uuid="c45f2beb-a3ff-4158-b700-9bbe8420b7b5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c1e19d3e-ecde-40a1-95ad-f2264bff123d">
+      <statement statement-id="ac-2.11_stmt" uuid="206b41d8-0aa3-4d1e-9ab4-c14bb493d908">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5f9fadb0-2ae3-4603-af48-640a639f9981">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -715,10 +715,10 @@ https://projects.engineering.redhat.com/browse/RHV-19945</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17b9d9bf-04e7-4d2a-971a-955d505d1c04" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="29450bf3-fd02-42a3-9c7c-98139619e100">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="addc5384-fd54-47dc-8288-3a0e89e1daec">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -726,8 +726,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="1a954b50-bd25-41ca-9e41-35364d09c2f0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="56b32622-6c41-45d4-a99b-faf7b5839df4">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -736,10 +736,10 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c361cac5-c4af-4add-a083-a5b1b5dd39c5" control-id="ac-2.13">
+    <implemented-requirement uuid="9acf0cc8-f955-4bdc-b6ba-168f06052b5e" control-id="ac-2.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.13_stmt" uuid="c2b7b448-ae3e-4bfd-8ff7-a951021b0b80">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="51492616-3c7e-4ed4-98eb-ad8839feafff">
+      <statement statement-id="ac-2.13_stmt" uuid="f102a128-ddfb-41e6-b2d0-93af2e08babd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74cf5a18-ead4-4dc2-a5ef-b0e174d6435f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(13) is planned. Engineering
 progress can be tracked via:
@@ -748,20 +748,20 @@ https://issues.redhat.com/browse/CMP-211</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ae4993c-7fa0-4dcd-b1f3-ff3c053bb9fc" control-id="ac-3">
+    <implemented-requirement uuid="28464255-c97b-4c55-9e87-f9276306d86c" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="458eb114-3375-4bcc-bd78-54d3c287e37d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5d629fa5-e739-4add-a02a-932c351eee76">
+      <statement statement-id="ac-3_stmt" uuid="826d29a9-48d8-40b2-b9f7-10cd9b1d5b1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75430695-3c06-4a3d-b50f-5da476b1efa6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Manager (RHVM) enforces logical separation through
 role-based access control (RBAC) and VM pools.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6e4c9c2-6e26-4a91-8b67-2b2500684ad3" control-id="ac-4">
+    <implemented-requirement uuid="fb206e6b-1e3e-463a-9813-1054cf5eb413" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="a59a7697-431a-40dc-9dea-c7d9d04fd536">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d10f5074-037f-4a1a-90bc-d91db2e7c2ed">
+      <statement statement-id="ac-4_stmt" uuid="431a8b3f-25c1-44d5-b6bf-f6e13d08bf46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d03a35b-2b3c-46a6-934b-24d7d32561c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -770,10 +770,10 @@ https://projects.engineering.redhat.com/browse/RHV-19975</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aaab105e-5c38-466a-8115-9d56163ea645" control-id="ac-4.8">
+    <implemented-requirement uuid="b3434369-e9cc-4b1c-86fc-20dba450a462" control-id="ac-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.8_stmt" uuid="85286976-13c2-47d7-a330-c7423f28c052">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6f0598f4-bc2e-4900-bef8-37a8bdcf459f">
+      <statement statement-id="ac-4.8_stmt" uuid="7695bb28-9f62-4734-984f-ae6336dc9f1e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13f7b221-9cc5-43d3-8086-48b4dbf97f53">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -783,10 +783,10 @@ https://projects.engineering.redhat.com/browse/RHV-20076
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b07cc950-35e2-4983-ad0c-f715c1892c7a" control-id="ac-4.21">
+    <implemented-requirement uuid="552e2d31-d520-4e5f-bdf2-fa21f7df835e" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="d9ae7798-4a66-4cd9-b812-df7061d82001">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3153472b-30d6-4b8d-b78c-927d32a6cfb3">
+      <statement statement-id="ac-4.21_stmt" uuid="a45d1455-852a-47aa-a2d0-c063b9663faf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314eeab2-b5af-48d9-a8d6-b30a00f379e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -801,10 +801,10 @@ https://projects.engineering.redhat.com/browse/RHV-20102</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c22a12f-2435-48b9-8cf9-a1d0167e101e" control-id="ac-5">
+    <implemented-requirement uuid="f9218ad6-810c-4b3e-9276-46079139b6c1" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="1897c7d5-75d0-42e6-8328-50d0fdf0a718">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="32bc66ac-653b-414a-900e-9b92f5eb7089">
+      <statement statement-id="ac-5_stmt.a" uuid="519ead93-eaaf-4e22-90b7-177f13f4bacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7721745d-042f-42e9-989b-9de0c2d07e5d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -815,8 +815,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="039d5987-228d-4949-a622-713a8f5390e1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="683ec7db-06b0-4433-b744-d4ecffb6ae45">
+      <statement statement-id="ac-5_stmt.b" uuid="4a08086b-3d21-4e41-b6c2-469ac14be0f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f7c1c6d-f12c-4f6e-af99-ecf352cfffc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -828,8 +828,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="983e0af4-25ff-4a4b-8864-f425b28c1a12">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="520b06be-870a-4550-a5a7-266b14c3b0d5">
+      <statement statement-id="ac-5_stmt.c" uuid="bba22151-a82c-40cf-a8df-8765cc27156c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40ce6ba4-739a-40b4-a1ca-1482bd036c2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -842,10 +842,10 @@ user is allowed to perform a given action.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a39656a-1e1b-4465-b2fc-5014c747c63e" control-id="ac-6">
+    <implemented-requirement uuid="cd068943-85d8-4507-bfc6-c1b5ac06fed1" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="67b51ea3-400f-45cb-b9e3-dc56ebc8d22f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fb06e185-adbe-4cb5-b011-04f792e821d1">
+      <statement statement-id="ac-6_stmt" uuid="395124ff-7909-468c-8c26-9c019a94a445">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12714d47-155a-4a25-8adf-0c9fa759d3d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -855,10 +855,10 @@ https://projects.engineering.redhat.com/browse/RHV-20104
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="137b5dcb-1fa9-40fe-933b-e40162f4fa45" control-id="ac-6.1">
+    <implemented-requirement uuid="79009ec5-feda-41fd-9466-3d1170902932" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="db723c3c-7da0-4bbf-8fbd-f770b5a092bd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d2e3ef4c-88db-4ffe-bb34-140b997235db">
+      <statement statement-id="ac-6.1_stmt" uuid="bbedf025-0a76-4145-a3a8-e0772c011e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e72751f-1477-4bd5-9b86-4079f8d1c129">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -868,10 +868,10 @@ https://projects.engineering.redhat.com/browse/RHV-20105
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="237b3cc5-33f5-492d-b245-09cf63cc84b3" control-id="ac-6.2">
+    <implemented-requirement uuid="7c835bf6-c66d-473a-a4dd-6b7a1266c57a" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="686a010d-50f2-476e-b1d7-4390786457b9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="40261d9f-8d3e-40d2-8b97-2c3b2fdf26a2">
+      <statement statement-id="ac-6.2_stmt" uuid="ddaa3277-0e5f-4c48-9b7e-83c783c6a950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa9ec760-7bbc-4979-adeb-6d1e777a7c51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -891,10 +891,10 @@ https://projects.engineering.redhat.com/browse/RHV-20126
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fadfb307-ed33-4989-bc79-72d7e31ca279" control-id="ac-6.3">
+    <implemented-requirement uuid="62d6d75f-1ef7-43e7-be3a-407a04af09c6" control-id="ac-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.3_stmt" uuid="ebcdbdce-12a9-49d6-b795-3a16507695cf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="94d5497f-e8d8-40f5-865f-1b674d6c33a2">
+      <statement statement-id="ac-6.3_stmt" uuid="80514836-07d6-4043-9368-5da868c37e01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4da87f82-32b3-46e9-82fd-600ead90dad9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -904,10 +904,10 @@ https://projects.engineering.redhat.com/browse/RHV-20143
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c16a448-eede-4871-bb84-abb6090413bf" control-id="ac-6.5">
+    <implemented-requirement uuid="d7189002-409d-4c4b-9b90-56b0e74688ec" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="b8af7506-c85a-40d3-9f4c-eb71dcb5399c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0a8673cc-bbe6-4ccb-96ea-358d78e77e1d">
+      <statement statement-id="ac-6.5_stmt" uuid="9d630a05-593e-4d15-aabd-319f21f5f23c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017c4528-e1ae-4187-a8e6-fab33c96d350">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -922,10 +922,10 @@ and login with an account that has received appropriate RBAC rights.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8513c5a1-d421-45b9-9ba9-c0acfc17878a" control-id="ac-6.7">
+    <implemented-requirement uuid="1da88063-f450-4002-85a7-ec930007ea14" control-id="ac-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.7_stmt.a" uuid="d2c1771e-b7fb-4e4a-afef-8032192e83bb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a8998fa0-1cb7-46a0-92dc-37e321a1ecfa">
+      <statement statement-id="ac-6.7_stmt.a" uuid="ae170e4c-af7a-4b6c-91af-afd2f3f98307">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abce6ee4-7da9-4eea-9fbe-33a5e6570a16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration. It is up to the organization
@@ -933,8 +933,8 @@ to review and validate users permissions and privileges.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-6.7_stmt.b" uuid="d863175c-914c-4c05-a802-66f0d761ee2d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="090d55b3-7613-43f5-bc60-151d3034c1c2">
+      <statement statement-id="ac-6.7_stmt.b" uuid="6ff66e64-8f7e-41c6-a63c-7eeee9a7a9ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abce6ee4-7da9-4eea-9fbe-33a5e6570a16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration. It is up to the organization
@@ -943,10 +943,10 @@ to review and validate users permissions and privileges.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="edbb48f6-b000-473a-a9b7-7b71530adf93" control-id="ac-6.8">
+    <implemented-requirement uuid="3c24a783-e449-42b3-8784-1575ff12643e" control-id="ac-6.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.8_stmt" uuid="a90dd86a-0d9d-452a-9903-4c0ffe2ffb0e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="139c6914-56fe-419f-8695-fe121c9c8b1f">
+      <statement statement-id="ac-6.8_stmt" uuid="766832b9-f295-4797-bf46-43a31e220f63">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="31e2fe07-d678-489f-9b11-cbbe9bac93f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -956,10 +956,10 @@ https://projects.engineering.redhat.com/browse/RHV-20148
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e86012ac-bfa9-4253-bc2e-b7e4a73cabcb" control-id="ac-6.9">
+    <implemented-requirement uuid="435c04e1-8c27-49fa-8e5a-112bf8ed04af" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="8b3db05b-e877-4f2c-bdf4-531eaa6d0842">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="703f69ea-79d7-4e69-a5c9-b1db94418098">
+      <statement statement-id="ac-6.9_stmt" uuid="4dec473d-de52-4b32-b0d1-cad9f73f8cfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023ccb0e-4287-4b46-baf4-be96cd66a27f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -974,10 +974,10 @@ https://projects.engineering.redhat.com/browse/RHV-20149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1607ad8d-403b-4ee7-97ef-5e143743a56e" control-id="ac-6.10">
+    <implemented-requirement uuid="7949fd53-0e80-4c80-bb4b-9a7c96bf9e66" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="20ee4e8c-5db7-4797-8056-5188f1311dd3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="108fabee-4279-4a51-8af6-4692c5b0d265">
+      <statement statement-id="ac-6.10_stmt" uuid="f4f90226-de6b-4803-b91e-66e2e0913185">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d898ce-e363-48cc-87b7-0b6b804c10c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -993,10 +993,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a06c8c32-6158-4ce4-96db-736d1862573f" control-id="ac-7">
+    <implemented-requirement uuid="761f627f-cf3b-42d8-b82b-6a1c4723948e" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="ca00d3d9-0aba-4900-a133-1e63a60a542f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2b35365f-8589-47c9-addd-88f6387038c9">
+      <statement statement-id="ac-7_stmt.a" uuid="2a696c96-a01f-4a4a-9223-54b944accd33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1004,8 +1004,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="38bd4479-b799-44b5-bbc1-4c7fccc6f8a0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d4ada164-2c2b-4139-a824-93865c9071b0">
+      <statement statement-id="ac-7_stmt.b" uuid="843983ad-bd02-4b99-9e32-735a65349fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1014,10 +1014,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="089656ac-3849-4092-8480-58a1de943e6a" control-id="ac-7.2">
+    <implemented-requirement uuid="aa694f62-0bc8-4575-b4c4-d358d91bfc13" control-id="ac-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-7.2_stmt" uuid="baf71097-b770-44c5-8599-3875a86808e1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5948d172-da37-44a3-93f9-745013789187">
+      <statement statement-id="ac-7.2_stmt" uuid="928766cb-f8d5-4db9-b47e-7e828328567b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="051cfb6e-d1bf-400a-bbd8-36a351251400">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Management of mobile devices is outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1025,10 +1025,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c13ea14-cf5c-48aa-9fa7-f327566a9e96" control-id="ac-8">
+    <implemented-requirement uuid="44a4224c-e76f-463f-b5ad-5b9e20d17871" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="d0253c88-7481-43a1-8148-ebc69cc3e680">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="822f9082-6c5c-4bc6-867d-3e8ec3ba4d77">
+      <statement statement-id="ac-8_stmt.a" uuid="3483450d-de7e-43d1-bad5-66d9e0a227ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1037,8 +1037,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="d96e8882-b7b6-4f10-bedd-b70bb772f65e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7d7bd112-afe1-4590-ba8a-46968816048a">
+      <statement statement-id="ac-8_stmt.a.1" uuid="c713ced8-a4c3-441c-aef0-773b700b4013">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1047,8 +1047,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="6cbdf9e9-816c-4b4a-8b0f-2382216051ef">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6f963909-b35a-4d6a-86c2-c160785fc372">
+      <statement statement-id="ac-8_stmt.a.2" uuid="65992988-917c-4f28-9826-1504e479c581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1057,8 +1057,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="5dddf6ff-0d29-4630-992b-d524370dc690">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="59f7239d-9fd6-42ca-8fed-a7978cf6d2a5">
+      <statement statement-id="ac-8_stmt.a.3" uuid="15178095-1d4c-43e9-bf09-f914bcab2f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1067,8 +1067,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="230d66eb-7529-4b15-a2c9-15e6c1d96d2e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2f25b34a-d59e-4552-b9d0-b95b05b0826c">
+      <statement statement-id="ac-8_stmt.a.4" uuid="c5b5cd5e-6256-4bfe-893c-20f356c6b541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1077,8 +1077,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="76cff9af-9e41-49f8-bcce-71b1f10211cc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e02be037-43c6-4353-90b0-e5628b387808">
+      <statement statement-id="ac-8_stmt.b" uuid="cb1fec5b-ae91-4800-96b8-f438c632bc87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1087,8 +1087,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="4c008dd5-2950-49d2-baa2-1031406176d8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0cda1b94-3feb-48fa-adfb-8ffb381bcdc3">
+      <statement statement-id="ac-8_stmt.c" uuid="894aa761-37c6-4c0c-8089-4d2b1deb8edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1097,8 +1097,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="4d74cbd4-67b1-435a-859d-33979f2f7c11">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dfd22120-43c8-4274-9484-cf95d377342f">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -1110,8 +1110,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="c95aa741-85f2-4449-98f1-91fbdcd00852">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="64c5f9fc-5cf8-4f25-a520-24a5aca6d903">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1124,8 +1124,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="767cb208-7e2b-46c2-b0fb-4c49d41e5e08">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="914e03d7-5430-4ce0-8a54-7b8bb4f2f566">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1141,10 +1141,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f4d7a66-367e-4670-abec-3490a3d14858" control-id="ac-10">
+    <implemented-requirement uuid="658dfd46-01b0-44b2-9e87-8b8c43b810fb" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="c91ebee3-c1bc-4619-88d4-51458bae6cfd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4559708a-7a52-48b8-8cdb-1e7b6e685e92">
+      <statement statement-id="ac-10_stmt" uuid="77d6b558-3a40-4f35-b6ed-4d29c010404a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24c2c079-5b6d-4e1e-a549-72a4a6046ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1159,10 +1159,10 @@ https://projects.engineering.redhat.com/browse/RHV-20220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5184a32-0d69-4313-a536-5f3e45f15602" control-id="ac-11">
+    <implemented-requirement uuid="de47af6d-3ab2-4ccf-be56-0e9d1b328c6c" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="1c71d45f-98ac-4d43-b2a0-150cf6cf5637">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9cbbe5a6-49d1-48f1-9e89-8b502a81bb5b">
+      <statement statement-id="ac-11_stmt.a" uuid="4322b9cb-3cc1-4b1c-aa75-ee0f7d42d6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1171,8 +1171,8 @@ https://projects.engineering.redhat.com/browse/RHV-20311
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="1818ac75-655f-4e5f-88af-21eed2978725">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7d5707dc-a723-4ae7-8652-1da84edd14de">
+      <statement statement-id="ac-11_stmt.b" uuid="afe463cd-920f-447c-8ef4-0c01bc1d59db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1182,10 +1182,10 @@ https://projects.engineering.redhat.com/browse/RHV-20311
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cc38e08c-5a52-4f9c-9686-76201818ed9d" control-id="ac-11.1">
+    <implemented-requirement uuid="9186ba2c-900a-4af7-b19f-bb180f5b2a76" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="16cfb28e-57ae-447b-bea2-dc786f195585">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d9747245-da94-4b58-bacf-c41aa6e15c09">
+      <statement statement-id="ac-11.1_stmt" uuid="9f71193c-566a-40c0-b07e-a386d1989365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33f20195-3d93-43ed-9b21-63e4c9107fd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1195,10 +1195,10 @@ https://projects.engineering.redhat.com/browse/RHV-20312
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdade14b-d110-4115-9711-06a3b1b2dcfa" control-id="ac-12">
+    <implemented-requirement uuid="e31814b1-e9f1-4f64-803c-4d8a3773aeed" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="a46c6b70-d78f-402e-946e-c5c428393273">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c3f478f6-220c-4601-ba19-7760bcf5de5c">
+      <statement statement-id="ac-12_stmt" uuid="90b59e85-2cd3-45ff-b096-a35056dd4d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b753ca6-6101-42a2-98ce-14b9560c501b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1214,10 +1214,10 @@ https://projects.engineering.redhat.com/browse/RHV-20313
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40317962-0716-4def-9316-aa36eba87d2c" control-id="ac-12.1">
+    <implemented-requirement uuid="8b96ff26-c23b-40fc-b815-0251803b0720" control-id="ac-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12.1_stmt.a" uuid="7a9da5e7-b2dd-4e76-bc81-88c6db453f73">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3a9fe008-9151-4e67-b3aa-ca4733e17533">
+      <statement statement-id="ac-12.1_stmt.a" uuid="33c688ff-702f-4b79-95d9-c6b6f67c42f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b37a5084-c9ca-4c11-bb94-67b3383a8f00">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1226,8 +1226,8 @@ https://projects.engineering.redhat.com/browse/RHV-20314
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-12.1_stmt.b" uuid="6064b340-4c00-4a3c-9621-099ba7a2842f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cc191da7-430f-43a3-a3ff-52f2a9a1cf9b">
+      <statement statement-id="ac-12.1_stmt.b" uuid="c91bb6bf-4780-4ca8-bb2d-7b774ba1aa6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="58ff5eb8-9b58-4b37-93e1-a7cde0e44c0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1237,10 +1237,10 @@ https://projects.engineering.redhat.com/browse/RHV-20315
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f62f1d22-3dc4-4672-9688-741132863a7a" control-id="ac-14">
+    <implemented-requirement uuid="e51e582e-b200-4523-ae86-adb9167bc5b8" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="3d445812-959d-4ec8-88a3-525b3b5b709d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b83332e0-c219-418b-953d-5e29629c29ef">
+      <statement statement-id="ac-14_stmt" uuid="28d9020c-55d3-44bc-ad3f-27406a65c4fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a16e91f-5966-4db6-9ed1-47240cc81350">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Manager (RHVM) without identification
@@ -1250,10 +1250,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df1b1798-ca43-48fc-ad2c-4066d84b46fe" control-id="ac-17">
+    <implemented-requirement uuid="4a111d5b-6ac1-4941-9c0a-c24eef46e2ba" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="7a089c3b-7129-44ff-8b1d-71e78090e108">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b3958f75-697b-41be-afa0-364ee04e8076">
+      <statement statement-id="ac-17_stmt.a" uuid="c8a02a7d-08f1-4192-a892-9159f8a19ba7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d722ad06-ab06-45d4-a05e-04c143007431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1262,18 +1262,18 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="9c4fa468-58de-42a0-81ad-4827d8e57d9a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="af84752d-4d1b-44fb-ae63-b2ddfd34955b">
+      <statement statement-id="ac-17_stmt.b" uuid="66024b1b-269f-49d4-a238-a1bc5b390733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="833ec1af-cf7a-477d-a49a-54545a6a6f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7d313563-df86-454f-a258-ffabc2634143" control-id="ac-17.1">
+    <implemented-requirement uuid="2c168041-4ca0-48cd-9b1d-43827a6bfb6b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="f828ed2d-b06f-493b-95bc-d24fab647d6c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d73722ba-a2a6-4c7f-b74b-f753e1b4ab30">
+      <statement statement-id="ac-17.1_stmt" uuid="779cdd50-e242-4ef3-8fca-6512a0d0b012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70e205b6-1bc3-463b-bc62-fe2f320ba8ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1283,10 +1283,10 @@ https://projects.engineering.redhat.com/browse/RHV-20373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04ebf3fd-cf99-41c2-ae34-194342c73fa6" control-id="ac-17.2">
+    <implemented-requirement uuid="4ca77273-9117-40b2-983a-4dd5040356ce" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="54be5313-9f07-4bf6-93b7-5884ffb5c983">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="38ae062f-0a01-48c0-9092-a47992f8acc6">
+      <statement statement-id="ac-17.2_stmt" uuid="1ce07c9f-0df5-4991-b8fb-98fbac3b4bf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dce36b4a-1920-441f-80d1-3e68abe7fff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1296,10 +1296,10 @@ https://projects.engineering.redhat.com/browse/RHV-20374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e4c86d8-e843-4b72-9950-adf58f8c40e3" control-id="ac-17.3">
+    <implemented-requirement uuid="bc44a17a-d305-40bd-aa49-f123590cef90" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="35d23bc0-8ff8-484c-98ba-09a2ad625a6c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c61d3946-2304-409f-866a-d2be8933b9d5">
+      <statement statement-id="ac-17.3_stmt" uuid="42eb896e-2e27-499e-a0f0-578bb7b8ce33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d263384-2276-4a13-9725-cc474255f41e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1316,10 +1316,10 @@ https://projects.engineering.redhat.com/browse/RHV-20375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52630cb8-9642-4990-88bb-7526cd86019f" control-id="ac-17.4">
+    <implemented-requirement uuid="601d7507-7916-4d74-9366-bce72369763c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="43c9ff94-709a-43b7-bb34-0d0ca2887d03">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="084516a6-d750-4e48-971b-88383f184b85">
+      <statement statement-id="ac-17.4_stmt.a" uuid="e376c343-772b-42ff-9c33-17681b5bc45e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1328,8 +1328,8 @@ https://projects.engineering.redhat.com/browse/RHV-20376
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="ea2a8f76-cf76-4ac4-9594-d7b44ab51f8d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4556346b-b22a-4415-b243-375e63e82ea3">
+      <statement statement-id="ac-17.4_stmt.b" uuid="4b4c9a85-6a8b-44e1-adca-dd63c6562b7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1339,10 +1339,10 @@ https://projects.engineering.redhat.com/browse/RHV-20376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="300f8c89-8281-465b-8d4b-595cd8b94bed" control-id="ac-17.9">
+    <implemented-requirement uuid="66dd437d-56d7-4764-8ece-c0b14f740b76" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="36b75a29-36d0-4221-9f37-5a66638bec0a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b7326d4b-6cd4-4764-bf2c-8ea9c96b28d8">
+      <statement statement-id="ac-17.9_stmt" uuid="2d36a737-6c55-4cb7-9857-d4a7f80f0721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc46be39-19af-49c0-9d51-fc3c706dadc2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) utilizes the firewall technology named firewalld
 that allows a system administrator to configure host-based rules which take effect
@@ -1357,18 +1357,18 @@ https://projects.engineering.redhat.com/browse/RHV-20377
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35855e43-5db4-4a95-a869-49ef118f2dc1" control-id="ac-18">
+    <implemented-requirement uuid="c1873412-3837-49db-b8ae-069923f0727b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="400a5ca4-ccbe-49b7-964a-1760fc7386ff">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f9b99241-3d99-4ce1-beab-e403a29f21a9">
+      <statement statement-id="ac-18_stmt.a" uuid="f1d58d58-5159-4102-8696-b8a0440484f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb3356fa-980e-40d8-8f64-dfca6267031b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="e7760918-249b-46aa-874a-06507b274e9b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5c44ae10-d8cf-48bb-9f6b-7ff8b56433f2">
+      <statement statement-id="ac-18_stmt.b" uuid="39a8576c-b896-4866-b189-21aa6b8d48e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597ce99d-7e33-42d0-b1ee-44a03b15cb19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1376,10 +1376,10 @@ system are outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b60be0d3-99b6-44ab-8464-6fd9befadc0b" control-id="ac-18.1">
+    <implemented-requirement uuid="738b24a2-ebe0-4d52-8c93-1b0dbf2d5561" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="7c467399-2e03-4cd8-ba87-0c46c6b992d4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0f74fe82-f35c-41a0-9d4b-eaed3babc1fe">
+      <statement statement-id="ac-18.1_stmt" uuid="04f38577-1377-4db0-aab9-a097ee829f7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0080bfe5-159f-4980-bb1b-225d86076927">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -1387,30 +1387,30 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="239e184a-24f7-43fe-a591-20523467b27e" control-id="ac-18.3">
+    <implemented-requirement uuid="18d97c75-ecf8-4edf-9e03-f3f283e94408" control-id="ac-18.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.3_stmt" uuid="6ea267d9-d10d-499b-9fe8-bdd34b0da63b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eb37ab86-d2c2-4f5b-870b-ffcb5aac727c">
+      <statement statement-id="ac-18.3_stmt" uuid="557ffee5-c456-49b5-b145-de925d5eb8ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67905869-7b1d-479c-af96-e5aa1ebbd324">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e68a98e8-cef5-41fb-82ea-37548320c2ac" control-id="ac-18.4">
+    <implemented-requirement uuid="1adcd1f1-f849-4522-9bc3-7a154444a7d1" control-id="ac-18.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.4_stmt" uuid="87efbf0a-a599-4835-a61d-c03d861cd3a0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c32046bd-140e-486c-8841-35af43ba7f3e">
+      <statement statement-id="ac-18.4_stmt" uuid="34dedeeb-8a98-46c0-973b-8556774fd0db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67905869-7b1d-479c-af96-e5aa1ebbd324">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="68a4e680-206c-42ea-9366-e97b6b59108c" control-id="ac-18.5">
+    <implemented-requirement uuid="1e2a95e1-5b59-4764-8524-28c5e157bd84" control-id="ac-18.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.5_stmt" uuid="ee4bb9df-b2eb-40e4-80bd-6b06704863ce">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a2ddedb8-d94a-49bd-8864-a8ef0b103e87">
+      <statement statement-id="ac-18.5_stmt" uuid="18876752-8221-44fa-b5ad-419eedd65c89">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="347de088-a7e7-4d13-b2bb-1a315e9b6fc9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Radio antenna selection and calibration is outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1418,18 +1418,18 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b66616a-8689-4d86-b6c0-c147007077fb" control-id="ac-19">
+    <implemented-requirement uuid="fb790932-cf12-4fb9-8968-1871d9a4b396" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="54867288-e009-4085-9ba5-853abe9c8e32">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8f929f42-d6b7-4637-bca2-181d8c03fc0b">
+      <statement statement-id="ac-19_stmt.a" uuid="241910b9-cef8-43e3-8c5f-85fabe70defa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d8234d-bb8b-41c8-92ac-7e8d4691ba62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="1b319bb6-a37d-44fc-a514-467d71f818ca">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="112c6bda-6d87-4caf-82f1-e58b06113de3">
+      <statement statement-id="ac-19_stmt.b" uuid="a46fae67-24c3-4f6e-991d-1486d06e1a7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8863c77c-6449-4252-b60d-21f8c96bcbdb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Manager (RHVM)
 configuration.
@@ -1437,10 +1437,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07b1033d-687f-4240-846c-2693c3d166bf" control-id="ac-19.5">
+    <implemented-requirement uuid="d8a39712-92a1-4fca-a7f6-c5e85de27fd2" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="66c70950-14b1-4e63-8ee7-dc1f761eb6bd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1fa9c28c-9daa-4716-b552-5d5233ca3fe5">
+      <statement statement-id="ac-19.5_stmt" uuid="7f224c08-cf70-48f0-b76a-d566b556b8fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b2365f1-eede-41d3-8949-26df982ee48b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1448,10 +1448,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="358c92a4-4b3e-420d-bbd1-906482f610c4" control-id="ac-20">
+    <implemented-requirement uuid="c34ea5da-47da-42b6-85b5-fca636c9b75a" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="f71833d9-8ec1-4094-b27c-8d1a89f11d4c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cb5a8888-654b-4c41-95c0-658f570c97dd">
+      <statement statement-id="ac-20_stmt.a" uuid="6d0c7514-1991-476c-bc2c-3d8611a9e19e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f2fc23a-e940-43ab-b1b6-1fcb8f008b05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1459,8 +1459,8 @@ systems is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="436b614f-0bca-4bb2-82f0-69eed1e3ea1e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="74afe325-738a-4a4d-8cf3-07255ef29af1">
+      <statement statement-id="ac-20_stmt.b" uuid="a46036f8-a251-41dc-b2a3-bf7906b3dd39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b4bf9b-c190-45df-8e19-d02c1fb0f8d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1470,18 +1470,18 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="744bcf50-4400-4f49-ab6f-8961a88bf566" control-id="ac-20.1">
+    <implemented-requirement uuid="d320e0a4-eb93-450a-848f-89cc28a05301" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="44ac2e36-50bb-481f-a786-5d6e13619e23">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd13f7d9-b404-4a6b-bbad-48fdfa526d85">
+      <statement statement-id="ac-20.1_stmt.a" uuid="8346f2b2-b1d4-4afe-ad6f-68cf1272fe66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81b4bb58-9128-41b5-800e-6457785f93ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="acfcd7de-549e-41f7-9a9d-38c8d2780169">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cab023a2-4ed4-43a7-8287-fc0038656555">
+      <statement statement-id="ac-20.1_stmt.b" uuid="cb91fee2-6858-431b-af3e-b8c41b1d90e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a776194-2066-4f00-bd4b-a0e4ecdc8aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1490,10 +1490,10 @@ information system is outside the scope of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48c862fa-afef-413e-87c2-79543312bff7" control-id="ac-20.2">
+    <implemented-requirement uuid="0931dbac-0a01-4f99-ae5e-23f499876459" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="770f1fad-777a-4297-a2c3-aa391ab558a9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5c9da664-462e-4a16-873c-c09ec044b4ba">
+      <statement statement-id="ac-20.2_stmt" uuid="6ea83c05-9fef-40c1-8340-eee8c04b4874">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffbfa92c-648c-48d4-8d9b-2c6197aefe51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1503,18 +1503,18 @@ systems is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ab7c026-5d1f-4ef8-b69b-f2cd37c4c88f" control-id="ac-21">
+    <implemented-requirement uuid="cc0dd4e9-d0cb-4ce6-97a8-d7dd7f340645" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="b9e38184-83c0-4f02-bb48-46691b9ee8db">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="71aae071-edcb-4f1d-be47-d8287a2fcffd">
+      <statement statement-id="ac-21_stmt.a" uuid="fac6665a-63cb-4d7f-a4cd-60826603a24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abb1d154-fdff-4675-a2c3-67358bdba6a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="315d4aec-0764-4b11-9c4f-453077758975">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e1309453-17ac-42dc-842f-53ab8066e1b2">
+      <statement statement-id="ac-21_stmt.b" uuid="559726f2-d3f1-4290-97a3-b6fc25d03563">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89973b8e-f1c4-4db4-96f9-56b06603f5a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1523,10 +1523,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b253e797-9899-4ee6-9e94-ede6556fc2c3" control-id="ac-22">
+    <implemented-requirement uuid="ca09818d-ee7b-4091-a831-6da3befbd076" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="21cf8cb9-fceb-463f-8a3d-f2b7b217c51d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8dabca2e-429a-4ad8-807e-a34a9bc5be95">
+      <statement statement-id="ac-22_stmt.a" uuid="2ac78e26-4472-42d3-a251-887f1d03237b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44a457bb-3906-4ed6-b02a-cc696670129e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1534,8 +1534,8 @@ system is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="7047b187-3c2f-40a1-9890-f632762fda3b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c1f49827-7b74-4f0f-a0df-daf004063efb">
+      <statement statement-id="ac-22_stmt.b" uuid="8b2c06aa-d7a5-44c7-860f-ea27cc42545f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d29cdd-993b-47d6-8f28-b8716cc70fa4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1543,8 +1543,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="584681e0-a2f9-48d1-baa3-cd6b142db3be">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0c5594d3-f03d-474c-b33a-a70eaa4cf043">
+      <statement statement-id="ac-22_stmt.c" uuid="07007492-71f3-436f-a4f3-5933c095645a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a0e4b22-0898-44e2-8097-fedc799a5436">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1553,8 +1553,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="c7f6e3ff-484b-42b9-a2ff-041f4c30e67a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="68cadd10-b01a-4fa2-be70-f74a4d59d5f1">
+      <statement statement-id="ac-22_stmt.d" uuid="eefd0fea-5edd-4f8f-9873-d094ad7bdae9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4539a35-9259-4cbe-86ca-a4c2cece9e62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1564,18 +1564,18 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="147fb469-ec59-4421-8644-af39ea885e41" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="f44150df-de50-45f5-b600-af3a1050a985">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5dd8e99e-c9f2-451c-94e1-2ae6ab3c179a">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="f088b2e9-ec2f-42b0-a2bf-bd26a1b37496">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fddd2ec4-2203-4e58-9aed-a001acbcd69a">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1583,26 +1583,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1b3da61-195d-473d-adc2-d92d1932c30e" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="f1ddfd81-63ea-44c9-9fd1-161ca1eb0fc9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ee4d5d86-4717-4fef-baba-1ae4cfa5e605">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="23eb438c-46cd-4964-8388-ddcde1e521c1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9d486efd-5bba-4fef-b5d5-e0adff20772d">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="f8071d83-964d-4f5f-a47a-c17e01dd9f04">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0f909c5f-a645-415c-9b3a-0d61ae8b3c34">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1610,10 +1610,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="915c9f1d-7a24-4b76-a77e-98e551654dec" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="8d8a513e-2ad3-461e-b88b-68136c463e6d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="582a9ba7-1f8b-4f72-9df4-302486bcbadd">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1621,26 +1621,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fe844ec5-26c8-4c8a-9f6f-cacc60b2478a" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="e0dbd1e6-d426-4e18-98ee-bcaff8b52f40">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ed298764-6d73-47f2-bac8-6a91721c4e78">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="78793b17-880d-488a-aa20-6e2a7763e428">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fa973ea6-c254-414c-b1f5-cb393ae59fef">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="aba7a326-7ff0-4bbf-b6b5-03b9a91fb8c9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="954718db-bd00-4b82-99d1-01619c394547">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1648,10 +1648,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bd53edc-2a97-4787-bc8c-872309ba4245" control-id="at-3.3">
+    <implemented-requirement uuid="60a1baef-90a2-4386-95d1-67bc0cac3143" control-id="at-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.3_stmt" uuid="107b9689-02c6-4029-9ce8-55c66c900d07">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="95e1fd93-53d6-4034-aa9a-9d94ff3aa8e0">
+      <statement statement-id="at-3.3_stmt" uuid="0615dde9-2371-44b0-99f9-314729a2ac31">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1659,10 +1659,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7cf864d-a0b7-4ef3-b202-3122e9ce5f4e" control-id="at-3.4">
+    <implemented-requirement uuid="4e1b516b-90f5-4543-8add-c1421d1690c9" control-id="at-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3.4_stmt" uuid="4cd1317e-be43-435e-a5f4-cce6dee35ab3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="466de21f-1f6e-455a-93a5-93e4ac64322f">
+      <statement statement-id="at-3.4_stmt" uuid="ed3cb1b5-cde2-4534-a9e0-5bb306499e60">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1670,18 +1670,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17068726-16ec-4c75-85eb-e4dea45e8e09" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="a6adeccf-3e87-4ba8-9b59-032b0eb104af">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c2ac8257-6def-4594-8659-5041624f6ad4">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="bccb3d2e-c9f1-4079-9290-5df569fea4f8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b36a1e0f-1fed-40b4-92b5-b7382f3283c6">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1689,18 +1689,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95cb6270-a582-44eb-b056-314005fc5b9c" control-id="au-1">
+    <implemented-requirement uuid="e9cabea3-f6c5-4b2d-9b6e-608ecb5a2d60" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="4f8f863b-8e3a-4fd6-94cd-a8f13cc3756a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5c91c033-709b-41db-9df5-dd9760c1104b">
+      <statement statement-id="au-1_stmt.a" uuid="b4704272-5e35-4d61-a3e7-4c41b2c3e331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecad1585-1c8a-4c21-b344-710da9629818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="56165109-0442-4a0e-89bd-d8076a5e930a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ffed7ece-64fd-4ed6-b618-e1e1214628f8">
+      <statement statement-id="au-1_stmt.b" uuid="b5bab3ed-bf6d-401d-b248-9cf9f4385e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b81de348-a2de-48f2-95d5-0e9c52b81473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -1709,10 +1709,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88f47754-03b1-4fdc-9ec3-ee6c70d71495" control-id="au-2">
+    <implemented-requirement uuid="f37536df-2d1d-45bc-9bc5-955338dd25ae" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="769caa74-60e6-4328-84e7-c04571129d73">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="02dbb428-97ef-411d-a045-853b89f3a789">
+      <statement statement-id="au-2_stmt.a" uuid="a9a07f46-29b2-4398-b64d-3f2baa5a4866">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90dfd323-b412-4ed5-b8ce-f8a55d91887b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1744,8 +1744,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="e81eaaff-a8fc-4570-9e9f-40c3de130e7a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="34bb62ea-76e9-415d-8178-1df5c2a06f43">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1753,8 +1753,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="856c1a2d-6f5b-40cc-bfce-53b0fa42ba90">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cded1bd6-b77b-4a15-89f2-7a31afb9627e">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1763,8 +1763,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="90fb5536-ee47-4ca8-a0fc-398d71022e9e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f6b89b23-e249-4dd0-869d-12978a0bb0ed">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1776,10 +1776,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d120fa25-8eb6-410f-8ed9-ed87cbf18cb4" control-id="au-2.3">
+    <implemented-requirement uuid="66779f5a-6540-4359-b6bd-2177bc68b5a2" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="e89c4933-4cae-4a3e-a287-84bda5133f45">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="af791bd3-223a-4660-b819-c2d163f26349">
+      <statement statement-id="au-2.3_stmt" uuid="a5296cf2-5ea8-4b11-9cb8-425f430601a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="772c7da5-2040-4c26-ae48-d5d0f25dcc6e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1787,10 +1787,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9ab1f956-2be6-4250-98a4-4b2f9450ca79" control-id="au-3">
+    <implemented-requirement uuid="613f15a9-4b0a-4484-9d9c-35c37b801eb3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="daf75477-2c25-4bf2-9f04-a63fa6866d53">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ac9b4946-d5f2-4db5-a533-d2188a4312d1">
+      <statement statement-id="au-3_stmt" uuid="abff9881-4373-417c-88b8-9b9dccc3b074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce2d9ba-344e-4481-9e1b-e2d83e094b5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) audit records contain
 the required information and cannot be configured to be out of
@@ -1798,10 +1798,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c095cc18-49d3-4894-bf38-2496c701233f" control-id="au-3.1">
+    <implemented-requirement uuid="be77b6c8-342f-4bc5-b488-a40884a0f1eb" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="c8e1167f-55fc-49b8-bb2f-c683a5619a0b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a7041804-1c10-47d8-a871-4b127f68d2c3">
+      <statement statement-id="au-3.1_stmt" uuid="f04ec7dd-9f1c-45e1-a32a-eb05a6a66d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1810,10 +1810,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b24176b-14a7-4383-9239-3726310f55e4" control-id="au-3.2">
+    <implemented-requirement uuid="f82154b9-bdf4-4b76-8c2c-be7363a4a05d" control-id="au-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-3.2_stmt" uuid="e640fb88-bda5-4bc8-92a2-ac5478a50b98">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="af46e6a4-7706-4b64-a563-22943286c7c6">
+      <statement statement-id="au-3.2_stmt" uuid="cc7c27dc-4a84-4626-a76f-f4151896c73f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1822,10 +1822,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="424256c5-1201-454f-a9c7-5a2a7cf041de" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="7a215b91-d14f-483a-94c9-afd053464224">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8777ebab-692c-445f-ac3a-a924b5037fa6">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1833,10 +1833,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e78935a-0465-49a3-a2d6-d0dd26183e85" control-id="au-5">
+    <implemented-requirement uuid="1fd1013d-f125-4909-bccf-7bded096a777" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="4d58770b-5fcf-455f-ae82-d7aa888f32cc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="aa334aa8-a1b4-4cae-8434-2785f9a87aa1">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -1847,8 +1847,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="3d58ee16-f2b2-4b3d-a221-10e9d016d740">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2a614c9b-f3d5-4e8c-8df7-7c461a4ed006">
+      <statement statement-id="au-5_stmt.b" uuid="cab92b87-4307-4c56-8c92-3babc223a754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d394fda-b268-4b77-b11d-8a9b88b52eba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1856,10 +1856,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f324290a-916e-4397-a7ba-2367532575a2" control-id="au-5.1">
+    <implemented-requirement uuid="8c3d93b0-4822-4367-a117-91d11275e75d" control-id="au-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.1_stmt" uuid="002c9cf9-37e2-4f9d-a9be-e287dfec6632">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8e607438-66c5-407e-8a6f-471a3b989af0">
+      <statement statement-id="au-5.1_stmt" uuid="a7086d1e-a2ba-4be6-a457-74a656889790">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3bd1204a-09ec-4c7c-b874-236b60988b7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1868,10 +1868,10 @@ https://projects.engineering.redhat.com/browse/RHV-20422
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f60458b-014e-4323-8cf2-af604f89f410" control-id="au-5.2">
+    <implemented-requirement uuid="81485c46-078e-41e9-bbce-bf9916b52681" control-id="au-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5.2_stmt" uuid="1bba5b87-60ce-4b2f-ab8f-374f6f98d58f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8806e3cd-b7c7-4091-8d15-e7d802fd3a9a">
+      <statement statement-id="au-5.2_stmt" uuid="4daad5ef-5158-4ff5-ad8c-e6e7a00e4107">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="040caf93-bdd7-4e33-88ff-7e4af1224149">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1880,10 +1880,10 @@ https://projects.engineering.redhat.com/browse/RHV-20423
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64ea1284-09d7-4677-90ca-14f727c951c5" control-id="au-6">
+    <implemented-requirement uuid="51fe15b0-044c-4985-afb6-baad7f178a5c" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="1e1da293-fc7c-463c-8ab9-f00610012d04">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dcb87725-b5fa-41f3-946c-2db7ddb11423">
+      <statement statement-id="au-6_stmt.a" uuid="7b1dcbde-95d0-42b1-b013-a780f0e83bf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8acf550-693e-4f5b-b155-0273ae0eb7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1892,8 +1892,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="a06bf4d9-8c91-4f15-b1ed-6f67c3eed2d2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bf4ef464-f297-468d-8588-0b0ec61dc215">
+      <statement statement-id="au-6_stmt.b" uuid="e7b9cdd6-1b82-4291-9758-47f8dc6fa43f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e1c7703-df09-4498-8d8c-89b24eead496">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1902,10 +1902,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="354cd9e6-86ae-4f90-ae21-8822ff3978de" control-id="au-6.1">
+    <implemented-requirement uuid="5a24e207-00e7-42be-ba1e-74832d3813c8" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="ff857652-4a0c-40fc-909a-d20e9c701182">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="14cfc588-a4de-4e6a-9919-e428ccfb29b8">
+      <statement statement-id="au-6.1_stmt" uuid="7e1c0b9d-8939-42ef-8cc1-dc58203888eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32e41f4c-71cc-4f96-abcf-1a199a4c0ae9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational use of automated mechanisms to integrate audit review,
 analysis, and reporting processes to support organizational processes for
@@ -1915,10 +1915,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e374296-d6c0-48c8-9a98-21dcdb8415a9" control-id="au-6.3">
+    <implemented-requirement uuid="7540e26e-108b-4cfd-91d6-1335e152fd90" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="077f4e0d-8d11-42fe-9954-e881d4707ea4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ece68071-d508-44f8-9028-1c296a822d66">
+      <statement statement-id="au-6.3_stmt" uuid="62b889e6-f75d-4da3-bee0-415b87f3ef8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a57151a-70a0-4008-8a9f-1f2cb0d2fc90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1935,10 +1935,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a6dcc20-71a3-4439-8b34-f60c012298a5" control-id="au-6.4">
+    <implemented-requirement uuid="8f8b299a-6947-4e25-a1df-15ef09a95640" control-id="au-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.4_stmt" uuid="30255c9f-5d74-4333-a93a-30e211b5a9e0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="33b68748-529d-43e5-b3ff-22178fb0b56c">
+      <statement statement-id="au-6.4_stmt" uuid="04499e49-6dde-4306-aa19-b1a75f1235d8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34b5c2e0-d0d6-4b28-a9a8-c16c6c172073">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to centrally review and analyze
 audit records from multiple components within the system
@@ -1954,10 +1954,10 @@ applicable.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c5a39e2-d78f-4c1e-894e-59f9dfc25d87" control-id="au-6.5">
+    <implemented-requirement uuid="2d8899b0-6f96-469a-98dc-ae6dcc22b8ff" control-id="au-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.5_stmt" uuid="cf259e7e-e877-4a9b-a5b8-4c63943479e9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b8995114-eade-4c08-b13e-8966d90b2916">
+      <statement statement-id="au-6.5_stmt" uuid="29ba5976-3ff5-4bb6-ba92-59e929ec709d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="07e2712b-3ddb-464a-aa95-5c15de8abb3a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to integrate analysis or audit
 records with analysis of additional organization-defined
@@ -1975,10 +1975,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8527ad5e-b9b2-493f-8b14-4f29c463ec1b" control-id="au-6.6">
+    <implemented-requirement uuid="7e73cf22-12af-4e20-8b55-d238b5ca24a4" control-id="au-6.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.6_stmt" uuid="94b27e03-5fca-4c75-987a-4e9bc91bbd03">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c3f91480-7f34-4687-9126-97eb11f2f14c">
+      <statement statement-id="au-6.6_stmt" uuid="82b54e1e-f49a-42d4-aaf0-a12774b77b1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d17924f8-9384-4024-8e9c-edf8fe07de42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational capability to correlate information from
 Red Hat Virtualization Manager (RHVM) audit records with information obtained from monitoring
@@ -1996,10 +1996,10 @@ logs with physical access data.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11f8b839-d122-4923-ae03-fe6b15a0dbe3" control-id="au-6.7">
+    <implemented-requirement uuid="f5220edf-46fe-46a8-99f4-a8fdd04952f6" control-id="au-6.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.7_stmt" uuid="52960bf3-04a2-45a0-8eac-e32fe38478f5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="795c6a55-c2ba-4771-be29-59653e6ce8b0">
+      <statement statement-id="au-6.7_stmt" uuid="ab99e9d3-cc54-4f52-ae60-6330ce2c541b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9105f3e6-5a7b-430b-96a8-c6516c6920ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational specification of permitted actions for
 information system processes, roles, and/or users, associated
@@ -2009,10 +2009,10 @@ information is outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91402b3c-1a0a-4da7-a425-a45327be8143" control-id="au-6.10">
+    <implemented-requirement uuid="66164fcc-aef6-4dca-812e-ad04f59881a0" control-id="au-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.10_stmt" uuid="08d56bfc-aa92-493b-830e-13462d0b1c87">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="432a453b-4bfc-4f7c-9eef-e5642d1e027b">
+      <statement statement-id="au-6.10_stmt" uuid="db7768e3-968d-4c73-ab10-778cfe2acc23">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7885825-7e8b-4c63-969a-be70cefedab0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational adjustment of the level of audit review, analysis, and
 reporting within the information system when there is a change in risk
@@ -2023,10 +2023,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d93a5fd7-bd51-4fe1-bafc-af08f6b5796b" control-id="au-7">
+    <implemented-requirement uuid="9d404010-fdda-4aaf-883b-c36e2876d5c8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="51b6d6e8-4c78-4f90-b4d5-417b5fca3f65">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7536a351-8c0a-4d07-9aa7-04cda6ed0fa8">
+      <statement statement-id="au-7_stmt.a" uuid="32c2238f-fc50-4cf0-8789-85635ac69e09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2034,8 +2034,8 @@ https://projects.engineering.redhat.com/browse/RHV-20424
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="7b2c5535-64a2-4cbd-b559-26eab9f3d004">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6c38ab1f-88a3-41f3-8122-afa5a134d89a">
+      <statement statement-id="au-7_stmt.b" uuid="460204fa-d554-49cc-8aee-1e7b603104a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2044,10 +2044,10 @@ https://projects.engineering.redhat.com/browse/RHV-20424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf308b0c-7708-46e6-be6b-fbf80b4a46ef" control-id="au-7.1">
+    <implemented-requirement uuid="b714e1ac-5385-47db-b004-f4538318cbd4" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="85222b6a-9366-4c73-ad0b-eab3b52dafba">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1f1446b8-1ac2-4142-9136-54e5bcde9e6f">
+      <statement statement-id="au-7.1_stmt" uuid="6b9632dd-07c3-406b-a28f-0dfdaf45a47b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34dc1b8b-6c3a-404f-aa23-7106d0a34670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2056,18 +2056,18 @@ https://projects.engineering.redhat.com/browse/RHV-20425
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1851082c-668e-40dd-825a-5efa5b865f54" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="c3b0136d-1206-45b1-97bc-e1cab7b4736b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fac68e83-946d-4ab8-b836-92833a912f63">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="158a3d0e-3e95-4c2c-bd34-0dc07572bf3e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd97dc32-00a4-44b6-a1e4-77609c595b08">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -2081,18 +2081,18 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86da8c14-e1fc-473d-94b2-5b33e9312d75" control-id="au-8.1">
+    <implemented-requirement uuid="0e971d45-90fa-43f7-8bab-c986504dc178" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="921da6ea-3bcb-4e21-8b8c-bc92a9c1e07c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de47166c-e38b-423b-802d-f3cdcbcf30a3">
+      <statement statement-id="au-8.1_stmt.a" uuid="2d7cdc2c-3501-4a42-a939-7d8ece4fe973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bd61434-c1de-4925-96ff-0e211dceea2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://projects.engineering.redhat.com/browse/RHV-</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="4ca3c937-3e76-4c9e-8bd3-3c99f562fe41">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8a19d0dd-7b85-4009-8ba2-21a80dcfde09">
+      <statement statement-id="au-8.1_stmt.b" uuid="3fd7490c-5aca-4e1a-89a6-51b03cc5e487">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2101,10 +2101,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5179bec8-7059-4716-8652-40cc60a4f98a" control-id="au-9">
+    <implemented-requirement uuid="89bcf6ba-66d0-4a48-91b8-c67eee441ddb" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="57db53ff-dc2b-468d-8acd-0f7aae48cd3f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ad4e24e0-cb70-4f54-bb16-8207507a7b3d">
+      <statement statement-id="au-9_stmt" uuid="b46b4b6d-f09a-456b-bf91-242c0686255e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bd61434-c1de-4925-96ff-0e211dceea2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2112,10 +2112,10 @@ https://projects.engineering.redhat.com/browse/RHV-</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f910b59d-3340-4169-bfd0-abd5ddf0360d" control-id="au-9.2">
+    <implemented-requirement uuid="77852b60-b78c-4db8-8ce4-a0dcca222199" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="873991a2-58b8-4cbd-aa81-6f927bc816b7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fc9303ff-4ff4-4974-8094-d7894b793daa">
+      <statement statement-id="au-9.2_stmt" uuid="5fd279ce-ed77-4061-a510-ac5232ed1258">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bce79094-0534-4af1-b1a0-332c5f43b2be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -2126,10 +2126,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fca70a60-9465-4f15-ae86-a940925738fe" control-id="au-9.3">
+    <implemented-requirement uuid="a5e74e11-8643-4dbb-ac02-daca0922814b" control-id="au-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-9.3_stmt" uuid="79703ca9-a683-4563-90cf-4f749c7db9a4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="da67e391-cdb5-493f-b583-7e21037f5027">
+      <statement statement-id="au-9.3_stmt" uuid="92f5c843-cf9c-43af-8ea3-b937491a2e27">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="63f75f53-0b47-4bac-903e-543524221a4e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcement of cryptographic protectionm is the responsibility of the centralized audit
 facility, and outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2137,10 +2137,10 @@ facility, and outside the scope of Red Hat Virtualization Manager (RHVM) configu
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4cc73c88-858c-45fc-8261-90e9317fcf5a" control-id="au-9.4">
+    <implemented-requirement uuid="a265c8f6-0497-4ffd-baa0-bd923d1b9308" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="bfde8672-8601-4be2-a6fc-1046e1c12849">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7a74455e-73b2-45c0-a02e-35e1f0f20759">
+      <statement statement-id="au-9.4_stmt" uuid="9be4ed66-62d1-4775-aa28-bb2096f5649d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20adb15-f43b-4008-bf7e-2fc6ac84b3f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2150,10 +2150,10 @@ https://projects.engineering.redhat.com/browse/RHV-20506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5644e607-85ce-463b-8580-cb812ac9c2c2" control-id="au-10">
+    <implemented-requirement uuid="f7d29850-e5e2-4981-9871-4cf543c9d84a" control-id="au-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-10_stmt" uuid="67199db5-ba85-4f73-a1ca-5c66e2cbd461">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="97e454b5-f36d-45ec-adf2-7dec5f08f8b6">
+      <statement statement-id="au-10_stmt" uuid="50600659-6ac5-47da-995e-05004e011e8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ff78945-8e66-4f26-a163-481253a4dd3c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2163,10 +2163,10 @@ https://projects.engineering.redhat.com/browse/RHV-20507
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de937cf7-641b-4020-bc5d-6739050aa17d" control-id="au-11">
+    <implemented-requirement uuid="edbeb994-318a-4120-b241-1bc4aded0391" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="60e38df6-6f66-465b-88f5-9130453df766">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ee918963-f2a7-4884-b368-ca5c505f888e">
+      <statement statement-id="au-11_stmt" uuid="26eb54dc-8093-46aa-909c-020a5e1db4e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f08406ee-76f8-4183-b6e3-1607ae2ced7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2183,10 +2183,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58a4ba51-e54f-46a1-8de7-009b6c3c2363" control-id="au-12">
+    <implemented-requirement uuid="38d49d2a-f4d9-42d8-a3fa-b31d7132e244" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="7572eb06-6e9c-42b3-a19c-ce65b3cf4848">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="771c5932-339e-4f54-a98e-93be5b313efb">
+      <statement statement-id="au-12_stmt.a" uuid="225fa91c-7d1b-4e58-aae6-3e6281bd76d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2194,8 +2194,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="6606a827-1fd9-4d22-a12f-96a8d60078f6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="08243034-1be3-4a39-ae7f-0316d39b38b3">
+      <statement statement-id="au-12_stmt.b" uuid="a6084a76-0615-4445-900b-1ecf686ac4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2203,8 +2203,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="ff7f6731-b20e-4c80-8203-0c1a0fd9f542">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="762c85b8-29b5-4638-8bbc-e37616b9f4b7">
+      <statement statement-id="au-12_stmt.c" uuid="2d8026db-7a9c-4bc6-988e-3154a0654906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2213,10 +2213,10 @@ https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5b0fae84-802d-495b-8c95-1fea7fd8ca1c" control-id="au-12.1">
+    <implemented-requirement uuid="3be7e549-d455-4b66-8e0d-ab8573b4b798" control-id="au-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.1_stmt" uuid="edc85d25-cdbc-4f2a-b993-b1153932620e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c4b8cb5e-d785-4c7d-88eb-7a46bb7b856a">
+      <statement statement-id="au-12.1_stmt" uuid="9244732b-0047-4ecf-a489-f4a882799001">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9ab5fd37-9f44-4383-939b-e3ac2a6f0967">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2226,10 +2226,10 @@ https://projects.engineering.redhat.com/browse/RHV-20514
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6019301-edd8-4586-bd25-9ae3e9c94a86" control-id="au-12.3">
+    <implemented-requirement uuid="97b0a277-679e-4c64-a1f0-4f4f51206520" control-id="au-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12.3_stmt" uuid="747e3f22-8f12-4844-90dd-0bcea301d336">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3759f0ab-5938-416f-9cce-a6040416a39c">
+      <statement statement-id="au-12.3_stmt" uuid="bd2359c3-6887-48fe-b556-cacc6d6db85b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c2af807-7d1f-46ad-8096-0f23cf70ac35">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -2239,10 +2239,10 @@ https://projects.engineering.redhat.com/browse/RHV-20515
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d9decece-c95f-40a1-98d3-6c37f617dfb9" control-id="ca-1">
+    <implemented-requirement uuid="8cbbc6cf-9345-4f6e-b104-c8db9d8f9d89" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="65b43931-ee48-4bb7-8867-abf70fcf77c1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9d3cf071-8ead-4167-b05d-7d89ff6d694f">
+      <statement statement-id="ca-1_stmt.a" uuid="a0253951-4a7e-4254-bb33-1b97d9a24513">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2250,8 +2250,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="b06e504f-84b8-4943-b013-151742bcec3c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e370796d-ee41-4599-951e-2bd86437bf79">
+      <statement statement-id="ca-1_stmt.b" uuid="6469ba5f-5046-4d1d-85a9-677b23d18a19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -2260,34 +2260,34 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72504b96-7f0c-4b9d-9b52-d928a5284352" control-id="ca-2">
+    <implemented-requirement uuid="8c763ab6-9d10-4826-8b45-3effbdfbe4d9" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="346bb48e-dcdc-4a1e-adb5-6523fce6242f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="639b9530-d690-4588-be9c-a779ed7383a4">
+      <statement statement-id="ca-2_stmt.a" uuid="626ecdc7-b47b-4fb6-9459-bfd2fa8ffcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="4c14aee6-4c84-416f-9562-5f279a3e1588">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="72cd0bc8-9262-4f2e-b5f9-14f475cbd061">
+      <statement statement-id="ca-2_stmt.b" uuid="925f0019-139e-4452-a753-b210216ba834">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="45142593-17a8-41dd-b548-a5df07ef1a71">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b63feda2-e063-4d01-85fe-2493e99bb133">
+      <statement statement-id="ca-2_stmt.c" uuid="0f171c67-efaf-47b2-8078-b9903c8ae8b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="a31c5372-987e-41ae-bed4-e055a577cf37">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4f5da7af-7a52-4893-8587-ede7d314e07b">
+      <statement statement-id="ca-2_stmt.d" uuid="8d798b0b-6546-480c-95ba-3fc01fe6c200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2295,10 +2295,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4103d354-d015-4727-a446-30e4547447a7" control-id="ca-2.1">
+    <implemented-requirement uuid="76b67f0e-9f42-4293-8c48-b7a65c41c682" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="2f293662-444d-4e07-9f54-e446893f4327">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ffbbff5e-d4ac-4301-8945-a8cf673a13ac">
+      <statement statement-id="ca-2.1_stmt" uuid="09078d4c-092e-40cf-a917-e92667347b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="834a2feb-b1b6-4d62-a47e-0c3ae4349529">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2306,10 +2306,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb2e4bcc-11a1-4278-94a7-3f01dde0cfa1" control-id="ca-2.2">
+    <implemented-requirement uuid="db49b140-100e-45e5-aba4-ad89745dfc1a" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="260309f5-b8fd-4f8f-bf61-d4c4d16a325a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f023740e-80ef-4e87-b3a8-d6656aa1a7e7">
+      <statement statement-id="ca-2.2_stmt" uuid="26df812a-16fd-4b18-bed2-60483bbeaeca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c871d43-f32b-4649-8a62-b9d1d6ecf0b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2317,10 +2317,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de014cf0-c37d-407f-84b8-659b5990fb0e" control-id="ca-2.3">
+    <implemented-requirement uuid="a97a0ced-d7be-4471-b78e-c63ee591b721" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="5003fc75-729e-4757-8106-ac4d78fd41bb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="71568447-de69-4667-9a49-b695ce8d8d3d">
+      <statement statement-id="ca-2.3_stmt" uuid="508e8310-ecaa-406d-a74f-852950564c4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eddf5da7-9406-451a-81f5-e133c3078bdd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2328,10 +2328,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1a7ddde-b758-4bac-aee7-b346c796d9b4" control-id="ca-3">
+    <implemented-requirement uuid="f5960985-7eb0-49cf-9b7f-376a4d3d1ac0" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="5dc934f7-7ae1-44a6-860e-c89116f46a0e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="777bebcb-68cb-4332-bdec-1e8c08130bb5">
+      <statement statement-id="ca-3_stmt.a" uuid="f93c7647-10cc-4268-84ca-8f629b37ac10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -2339,8 +2339,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="031e8551-a90c-4fcb-baed-1792854a6b61">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4af0a8b4-c76c-421a-9989-82eebd69bf6f">
+      <statement statement-id="ca-3_stmt.b" uuid="568429c3-01ef-4b4a-9190-79d0d39b3583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a002fb44-9bc4-4d24-b1c6-19e9dd0048cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -2358,8 +2358,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="1b195ae9-3e69-45ff-9efb-0ed6cc897051">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="661078b2-0386-4f6a-87e4-9c7ed37388c4">
+      <statement statement-id="ca-3_stmt.c" uuid="5cdab430-5333-47e5-a48c-27c3c6b8c64c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -2368,10 +2368,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b984f761-2c21-424a-8d22-75e981d60ff7" control-id="ca-3.3">
+    <implemented-requirement uuid="a15d4db1-5953-45de-b527-11993db07cc2" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="dcc7ac3c-9ec5-40f0-94d4-4335bfb256e3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eec31d6b-5407-4b1e-945a-122081bb227e">
+      <statement statement-id="ca-3.3_stmt" uuid="4f45bb7b-51fe-4d1c-b827-8f5b87c18aaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="974bb17d-4ccd-4c35-ad6b-706eb2ea17a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2379,10 +2379,10 @@ Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8764ca2-a3eb-4fbd-9ac9-cd1ba3bbf656" control-id="ca-3.5">
+    <implemented-requirement uuid="4aeaec96-0a8f-4f73-87cc-c339578c7fa8" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="214f2b2a-16ee-4bd7-8fab-2242e853aa22">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f402cb90-b86f-4c6c-af39-10e0faddd897">
+      <statement statement-id="ca-3.5_stmt" uuid="a1e3cb3e-ce49-443f-aef9-b438272829d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ff8ea56-f1e8-4fd9-92bf-ad0a693de964">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to Red Hat Virtualization Manager (RHVM) and applicable
 through host-level firewall rules.
@@ -2394,10 +2394,10 @@ https://projects.engineering.redhat.com/browse/RHV-20516
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4eea1b6e-d4de-4338-acc2-210f0fbcee51" control-id="ca-5">
+    <implemented-requirement uuid="916a5a45-7e51-49b7-892e-440ba9d04f38" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="26542bd1-7a9d-40f7-be34-7df93a07861e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2d894d14-89f7-41f4-8e57-60449f37d102">
+      <statement statement-id="ca-5_stmt.a" uuid="42fea6ee-b53f-4c1f-aa5d-474ee3dddb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7874121-b842-41ab-9612-07bb4b21d6b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -2405,8 +2405,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="1214149d-cc91-42c5-9abd-85d86a0f321b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a130598a-2e16-4580-bced-3496f4afd2b8">
+      <statement statement-id="ca-5_stmt.b" uuid="b4827a86-e5eb-4620-9e4b-919ef5614254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8061e04f-b49b-4260-a7e4-1a24bb30d0ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2415,26 +2415,26 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration proc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a06612f-e3b2-4b1f-b442-02658f6ce92f" control-id="ca-6">
+    <implemented-requirement uuid="e77dc7d2-9b46-4183-8c94-e99507c06928" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="6553ae2f-cc89-4a5b-b559-20f7dfaeb4d5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="512c504c-de6d-4200-99f6-115cbc20001b">
+      <statement statement-id="ca-6_stmt.a" uuid="f60bab46-13ed-43e1-9850-62104b44dae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="0f6de987-3c22-46eb-926b-cf91a3298808">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e74e0786-f423-40fe-9aa4-a8dfddf693cc">
+      <statement statement-id="ca-6_stmt.b" uuid="6575c90e-d09d-4ce5-84a5-9d899f39067a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="6ad56ac3-07b6-4dca-a1ad-3110564ea8f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5f0134cd-376f-46aa-86fe-34b8eceab183">
+      <statement statement-id="ca-6_stmt.c" uuid="be0641aa-a2f1-43e0-add3-d3e0d11d710e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2442,10 +2442,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7ba7ffd-48e6-4728-bfb8-ca0699fd5b6d" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="43fa335d-227d-4630-8965-a76e4a6d891e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f960b1a3-c74d-47d3-980b-1d4a516f8dbe">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2453,8 +2453,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="ec74752f-272e-47c2-8dd0-bc0d811f1700">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6e32392a-f9b8-4cfe-8a3a-0fca0b5c033e">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2462,8 +2462,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="ebcb097d-49cb-45e4-9bb6-1ebd1d25f576">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="49ed512b-28ba-4302-87ef-b79152030821">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2471,8 +2471,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="c2cab9c9-900c-445c-a9b1-bae80a07cf28">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e8fdd909-7bfc-42b1-aefd-e4f297c3a5e3">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2480,8 +2480,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="1beb5d3c-8b6c-42f2-9e95-d05aec9c3f4c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7441c60b-9e55-4628-a785-32315a224982">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2489,8 +2489,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="e70626e2-9e6c-426c-af6f-13510fc6cc55">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1b32d195-0d22-4eed-af3d-71aa7c9886f4">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2498,8 +2498,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="5fc21024-0563-4032-b14c-f511952d2342">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ca96f93c-e7f8-4404-9310-a94317db0833">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2508,10 +2508,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bfa801b-6d83-4036-a793-56452e45fff1" control-id="ca-7.1">
+    <implemented-requirement uuid="e17499b0-5110-43e9-ba2e-f6d5079b846f" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="4cb732b2-7306-40bd-9e6e-8b0e80085ce5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="85d71ad9-1e55-4687-b6be-553190b926ed">
+      <statement statement-id="ca-7.1_stmt" uuid="bda2872a-093f-49d5-8fbb-3c3fad811419">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0281eacc-f30b-41e5-88f5-30515ef38569">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2519,10 +2519,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="360f3c75-5795-4f93-a4b8-1da6fea8a7d0" control-id="ca-7.3">
+    <implemented-requirement uuid="277bd2a8-9bc2-4235-8ffa-e4a743fbe86f" control-id="ca-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.3_stmt" uuid="2eb994c4-b50d-470f-9ecc-ada42e67e8ef">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b7a312e9-4e12-49bc-b20e-1a9412f91036">
+      <statement statement-id="ca-7.3_stmt" uuid="e64cdc15-6f46-4cb5-862f-e5d2c7807153">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15ebece4-6657-4f6f-b957-48935a5adf7b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational trend analyses processes are
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2530,10 +2530,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidanc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26c3d550-1adb-4d8b-9db4-7aae697bd5a4" control-id="ca-8">
+    <implemented-requirement uuid="6a1d4558-5f7e-47c1-a9ae-09fda4e1ee90" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="977aa8d8-d6b0-4d07-85af-9e35e7594735">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5b494fcd-7a85-4c1d-a0dd-456a12637571">
+      <statement statement-id="ca-8_stmt" uuid="58038235-64b4-4903-bd13-53886ee0c53b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d75cb0b4-d1be-496a-89ea-616e3cf323d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2541,10 +2541,10 @@ Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2aaee4ea-f990-477a-88d7-0b425a63cf61" control-id="ca-8.1">
+    <implemented-requirement uuid="24b00d0a-dad5-47c8-932b-f2c24d341160" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="46360a46-8099-49db-8dcf-8f503aeeaab9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="be4ff053-175f-4ffc-ad56-98cb1504cfa2">
+      <statement statement-id="ca-8.1_stmt" uuid="50eb7175-9c37-4f43-b0dc-cbd36d0a5cb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e8a0ee7-e840-45ed-bf6d-fcebb96b502b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Virtualization Manager (RHVM) configuration
@@ -2553,10 +2553,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="854e0ae7-2370-4b0b-b28c-91423242f271" control-id="ca-9">
+    <implemented-requirement uuid="45ea858f-bfa7-4ae7-8719-983784957410" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="8957decd-0b90-4917-bbb5-9f0c1d1f99f5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4774b51f-70fa-464d-b217-d83ecf82dac7">
+      <statement statement-id="ca-9_stmt.a" uuid="631e344c-a84b-4f5e-94a3-07f5e67a31c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a3ee2b7-20d7-4ad2-ae09-7b3f216bc65b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -2574,8 +2574,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="e5266b50-e593-4d84-9e66-d845592342c5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="99af52e2-f5f0-4fc0-89fd-771f0069b473">
+      <statement statement-id="ca-9_stmt.b" uuid="a8a307a1-8a60-4450-8dc6-f1ddfae3fda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fc22de-738a-495d-b232-35a18545f791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -2595,18 +2595,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6390894-dc4b-4967-b43b-c863468071d7" control-id="cm-1">
+    <implemented-requirement uuid="1c8b54fb-4325-41c9-a1ca-37c68f28d3fd" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="5c3ba27b-fa43-453c-a68a-5884ced94d7f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ed989115-57d1-4e07-9163-61dee4515e3d">
+      <statement statement-id="cm-1_stmt.a" uuid="174b8ba1-a971-465b-8641-9e998f2439c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102ce2d9-1875-4b4b-9293-c9f1a3980e18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="a064e0e0-8065-47e3-9001-b7f5acf72850">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fdbb8d09-fe57-495e-8038-1045a7f7480e">
+      <statement statement-id="cm-1_stmt.b" uuid="928f676b-41ef-425d-be9e-5bd02f0ef36a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60c97a59-a5bf-4503-800b-e4e898136392">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2614,10 +2614,10 @@ management policy is outside the scope of Red Hat Virtualization Manager (RHVM) 
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="537f9022-6b46-4e90-acf5-ecb2b2828897" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="4fbed807-d5f8-4227-934d-04cb20280a5f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e69549dc-6f42-4b3a-9d62-70d772c30d48">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2627,10 +2627,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b55f8e2-9df9-4c51-8505-69d90a04eefe" control-id="cm-2.1">
+    <implemented-requirement uuid="1175aab2-b8fe-4b48-a82a-54c02ce8b030" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="d5ea5a2c-7ea0-40b1-99a8-a04d56463132">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="78ed0dea-6a5f-4808-b3f0-939f3561de05">
+      <statement statement-id="cm-2.1_stmt.a" uuid="c70cb871-7647-4a19-9e18-25d13e0c8134">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2639,8 +2639,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="e6dcbd62-d2ac-4301-bf3f-648e863b6672">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f29a986f-0a3e-4649-884a-d144e3f084e4">
+      <statement statement-id="cm-2.1_stmt.b" uuid="02f6ac89-58fc-4803-9ca7-d8ba052bdb7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2649,8 +2649,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="0891087a-db2c-4d61-aebf-f874d285738d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3530ad82-fade-495f-96d6-33c189e66493">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5c60f968-1ec3-4d42-a3d5-6506b6229de3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2660,10 +2660,10 @@ https://projects.engineering.redhat.com/browse/RHV-20520
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="919c001c-7ec7-4933-bf24-65a542fe7b7e" control-id="cm-2.2">
+    <implemented-requirement uuid="70c0fb30-fa81-406d-9884-90eda4617fae" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="948d2baf-3e6c-470d-944f-a45f48e2593e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5c690383-5a11-4bfb-bdb8-5e567afe5c2c">
+      <statement statement-id="cm-2.2_stmt" uuid="ad22cfd3-c298-49b0-abc1-f14139cb228d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c82280c-9d27-4e3c-bfcd-2cf177e34ba4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2673,10 +2673,10 @@ https://projects.engineering.redhat.com/browse/RHV-20521
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c242260-0efd-4d65-913c-7b4a67081d5b" control-id="cm-2.3">
+    <implemented-requirement uuid="25e98aef-d677-4c77-9d54-2973e72f1750" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="05f2d074-3351-4c59-bb4b-4efe56eab8ee">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b64cc0a3-1ccf-4b2e-b350-9645ddee54c9">
+      <statement statement-id="cm-2.3_stmt" uuid="9120376e-fb5f-4f88-84f4-5bd32d647c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d33969d0-128b-432f-b439-dc4f470e4466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2686,10 +2686,10 @@ https://projects.engineering.redhat.com/browse/RHV-20522
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef24ab9e-4314-4aff-aba4-b4adb87acc36" control-id="cm-2.7">
+    <implemented-requirement uuid="5af15dba-e95f-4efd-8fff-6c9f14020489" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="a2952536-28d4-4333-b8ce-e60a15b71917">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="768ca318-c1bf-4303-9071-2bd7e1d4c68a">
+      <statement statement-id="cm-2.7_stmt.a" uuid="35f3ac0a-3c3a-42ec-8a4f-546ed6c4496b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46038ae2-5727-4c4b-b676-e473645059c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2699,8 +2699,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="32cede28-6f44-411b-8d9f-cbf3f4f0e281">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c80f1b59-b099-425e-b10d-da6d69053644">
+      <statement statement-id="cm-2.7_stmt.b" uuid="b31ccc86-2005-402d-a5b4-58e1572a3f3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0596ea37-1b58-4d6b-bc15-aa3d156641d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2709,10 +2709,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6c12ca1-085c-448a-8e38-7631dfe86bfe" control-id="cm-3">
+    <implemented-requirement uuid="22352fe7-ba54-4934-8dd4-9e42cd2b5021" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="39d4b0c7-5b8c-4e5c-bf30-f663f5a2de88">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e346218d-f486-420f-87ac-d3d022e29dba">
+      <statement statement-id="cm-3_stmt.a" uuid="42365f59-42dc-47f7-8da3-2d45e8a13a76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2721,8 +2721,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="46fedc77-676b-4b69-973f-ed8edce05b2b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="013dda56-2d94-4a85-b5f4-f552384d0e05">
+      <statement statement-id="cm-3_stmt.b" uuid="1b035e1c-2536-48b3-b14f-f55f3da4cae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2731,8 +2731,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="f64e7827-7de6-4da8-bd9d-901232841864">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="099adfe1-8055-4323-ad20-4e7221fa51d3">
+      <statement statement-id="cm-3_stmt.c" uuid="8236707a-18a5-4ca4-8be3-7c39745b62a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2741,8 +2741,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="e7c1857b-fcf0-4649-97ff-5a783a12c939">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e1d61537-4ad5-4cee-ba49-9878600f5b92">
+      <statement statement-id="cm-3_stmt.d" uuid="637f76df-2369-481c-bd48-6a7e18bdbecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2751,8 +2751,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="bd12e14e-1a55-4596-b65d-fd67985a8c26">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="87a646be-c34d-433f-a2e6-7e7052e2257e">
+      <statement statement-id="cm-3_stmt.e" uuid="3cd7556c-0293-4c0b-8c95-66a14873b29c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2761,8 +2761,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="27e63f80-44dc-4b59-9f41-d449cd604623">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e3705d53-69eb-4845-a6d3-2d5b083d80ca">
+      <statement statement-id="cm-3_stmt.f" uuid="eba81077-99e6-499e-a7a3-f7e96ce35b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2771,8 +2771,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="f6ee67a4-5b23-4410-b41b-a0816a9735ef">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="09a3a644-7bfb-4d6c-9971-5c1b556c1dd9">
+      <statement statement-id="cm-3_stmt.g" uuid="73a7cff6-a632-4769-b7c4-359fdd83e4e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2780,50 +2780,50 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c69f8dc3-dcb2-4af7-8912-cc106293e522" control-id="cm-3.1">
+    <implemented-requirement uuid="953ebd59-90dd-4b76-9541-2814c2e185f1" control-id="cm-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.1_stmt.a" uuid="a613614b-330f-49cf-9532-16d719a48624">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d3c91c44-e092-46b2-8c20-4d810d4cc50b">
+      <statement statement-id="cm-3.1_stmt.a" uuid="19fdf290-e4b3-4d41-b87a-b51a8818b0f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.b" uuid="a2d2d269-c52d-47fb-b8e4-56c558c25894">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a061908c-0d7d-4a50-b77f-9992f42061a4">
+      <statement statement-id="cm-3.1_stmt.b" uuid="5eeb89fc-23af-44bc-8d90-065224fd65f3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.c" uuid="37c8498e-b414-426c-804a-ff0846e7c0ff">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="69441026-75fd-4f97-b630-7f43d1672c9b">
+      <statement statement-id="cm-3.1_stmt.c" uuid="65a75e43-e49a-4c95-bafb-758ca7267468">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.d" uuid="f789f6ad-8d9d-4ce9-80f9-41a6e2b9585f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="79f18f8a-67a6-49d2-a405-81d662097d3c">
+      <statement statement-id="cm-3.1_stmt.d" uuid="1154a8e0-2f77-4031-9e23-ec3606187e42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.e" uuid="c0414690-de2c-4d33-8f99-06ba93398b10">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6905830e-5436-4287-9d96-c38204b806f4">
+      <statement statement-id="cm-3.1_stmt.e" uuid="18a75db0-d0a1-47e4-bcf0-591484067ccd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3.1_stmt.f" uuid="5c49fe18-2aa0-435e-bec3-cf8c275bbe35">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4d49364e-8b5f-4746-8560-bfc386237fb1">
+      <statement statement-id="cm-3.1_stmt.f" uuid="a04b238f-e70e-4473-b0e5-4f9c54953af9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2831,10 +2831,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81c5c08c-0863-41e7-8804-c0dbf0613b97" control-id="cm-3.2">
+    <implemented-requirement uuid="c83135cb-1a96-4ce2-b22b-1d8eef0020d9" control-id="cm-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.2_stmt" uuid="e340b2f7-4de9-4d52-8b46-a9deba660187">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="14dc41f8-76df-4fb2-a971-5bdbee7ccb5e">
+      <statement statement-id="cm-3.2_stmt" uuid="98fdc354-8e91-4cc7-ab93-d35e8a558c2f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2842,10 +2842,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9a83e8a-b827-424a-a72d-386cc0b6a824" control-id="cm-3.4">
+    <implemented-requirement uuid="b75ee7cb-ec63-4496-9ec4-cc79fdc2ff9f" control-id="cm-3.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-3.4_stmt" uuid="524c77bc-4f49-425b-b4ed-3d7603460e99">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="277f84a1-7170-4955-8cc6-3a7936fb6fc4">
+      <statement statement-id="cm-3.4_stmt" uuid="d4e370de-94a2-481d-95da-27934aec819c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13e3861a-5406-4706-8f32-f82187c2af9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The requirement for an information security representative to be
 a member of the organization-defined configuration change
@@ -2854,10 +2854,10 @@ control element is outside the scope of Red Hat Virtualization Manager (RHVM) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75b073c1-a08b-4c26-9996-5da10fc4a4da" control-id="cm-3.6">
+    <implemented-requirement uuid="eef84164-f35c-4497-85d5-87de0c51ddbd" control-id="cm-3.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3.6_stmt" uuid="ba968a88-80c9-4a1a-a505-80ad379a25b5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7c4e1e9d-6860-4c8b-bce2-ed5e346c52bf">
+      <statement statement-id="cm-3.6_stmt" uuid="9a12befa-c59b-4763-a387-02ba48343857">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2865,10 +2865,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="16991105-3501-41a5-aade-733f93a1322f" control-id="cm-4">
+    <implemented-requirement uuid="63d595c7-8d11-4911-8177-e162e11285a9" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="fe5d98a9-95d5-421e-8c72-cc7d550d667f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="44b94d5c-bc64-43a7-b6cf-0d15770590f1">
+      <statement statement-id="cm-4_stmt" uuid="482a2d9e-5114-44a8-9d6c-27ba0e1e0394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b824338-6e70-4964-904b-130716a616e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2877,10 +2877,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fd0de3a-4ff0-4fec-8005-34fe88bd25e0" control-id="cm-4.1">
+    <implemented-requirement uuid="a996903d-9b56-4109-8890-b5db8bf3e703" control-id="cm-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-4.1_stmt" uuid="777f6182-1f57-4aaf-8b40-f6865c07e1f2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f03cb4b9-f42a-478e-b131-2214b66debc1">
+      <statement statement-id="cm-4.1_stmt" uuid="3f2a5ca9-c8d2-4fc6-acf3-376fbd7c82f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2888,10 +2888,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f904ce72-2f70-4577-947b-4f7b7fd5a4b6" control-id="cm-5">
+    <implemented-requirement uuid="9f708a89-8399-4d08-b0f1-daeb58dae350" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="cf87a34e-bea2-4777-8620-cc5cebb67211">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7c12ae19-989c-48d5-a53b-e502dc888839">
+      <statement statement-id="cm-5_stmt" uuid="d4061f56-cb87-4aae-903c-636462701d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2899,10 +2899,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bdea4db1-8e68-415a-a555-452c50f5c4ab" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="cf849e25-2119-4510-9b58-f897356d1a6f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6f4cceec-eba0-4a60-88b4-13cea1fff3f6">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2912,10 +2912,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef2e8b37-aedc-40f9-9898-389896fb8e8e" control-id="cm-5.2">
+    <implemented-requirement uuid="7b33156c-7105-4b26-84f5-2165e41e91d2" control-id="cm-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-5.2_stmt" uuid="b7fa5758-fdc3-4431-9261-8203c1afc113">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="836e4394-b29a-41bc-85e7-95d89a42b677">
+      <statement statement-id="cm-5.2_stmt" uuid="acabec84-b903-4c01-a31e-9f86466beaf1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2923,10 +2923,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="465e693b-5418-41c3-9f56-e2fc5350c3b2" control-id="cm-5.3">
+    <implemented-requirement uuid="8bd4800b-4d23-4722-b068-f53f04d79298" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="80cf8f03-07df-4a91-9e51-f4dbd5d7988a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="46c249c4-ac94-4341-afab-f4c5addd2b93">
+      <statement statement-id="cm-5.3_stmt" uuid="1a42a7ca-52dd-4fc7-a4c6-db20e4737bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="020466c9-c44d-46eb-a233-a4b3e05d72ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2936,10 +2936,10 @@ https://projects.engineering.redhat.com/browse/RHV-20591
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b3d42f4-3fdf-44f3-b7d2-a0204c451a10" control-id="cm-5.5">
+    <implemented-requirement uuid="a9fdce8c-4397-4ef8-9831-f28efb08595d" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="48f6d0db-03ea-41b9-a6ed-79aa23b97fb7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f6749894-d88d-46cf-b712-2bc1b452d770">
+      <statement statement-id="cm-5.5_stmt.a" uuid="dd60c188-efab-41b2-b837-9dd1fc6e0744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1444903b-5a53-4300-bf9a-f0c65262db2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2948,8 +2948,8 @@ https://projects.engineering.redhat.com/browse/RHV-22703
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="268f0569-658a-4d77-ac6b-d27b9b37427f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="601d0b98-6c96-4140-996d-8f3b81c8e0f2">
+      <statement statement-id="cm-5.5_stmt.b" uuid="ac1d1b81-21e6-49e9-a4cd-018202635442">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2957,10 +2957,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7ddb446-f3da-4111-a378-f8a46d85b8a5" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="6ae11c6e-d5e6-4cbf-a48b-ebb5d63b7226">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bb3bfcb8-9588-4530-8b5e-182f0e285011">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -2974,8 +2974,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="d08e2767-4254-4383-8f39-486f68d07adb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7103b905-627a-422e-93be-8c3c58fd5dc7">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -2989,8 +2989,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="5356229b-fc62-47ea-b81c-8bdc70ecc496">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fcda01b4-dd82-4263-b45b-796c4de8460e">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2999,8 +2999,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="004d92fc-5ddc-493d-959b-f5e0b4485f02">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e440e601-f282-45e7-beb6-febe055a3b37">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -3017,10 +3017,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26ba6932-30fd-4358-87e5-e3177a872c43" control-id="cm-6.1">
+    <implemented-requirement uuid="856967aa-a9a0-488d-8182-c49747d9d848" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="186f3e56-d1f2-4f9d-885a-78fa3ca596e2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3f9d0bd0-a482-472b-ad16-d816270e0ed0">
+      <statement statement-id="cm-6.1_stmt" uuid="413e2e1c-43d7-45ab-8c9b-c76ed699a071">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44ea72c2-dc7d-4422-8f76-6ff1f5ad4e68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3030,10 +3030,10 @@ https://projects.engineering.redhat.com/browse/RHV-20524
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11abed72-2d80-44f3-b318-59fe9bbd5c8d" control-id="cm-6.2">
+    <implemented-requirement uuid="a6cfa392-7136-499b-9840-96237efcbce5" control-id="cm-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-6.2_stmt" uuid="3c40b830-fc5f-44fa-900f-2e9a63518c9c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="309df676-7f55-48c0-81d9-333736453947">
+      <statement statement-id="cm-6.2_stmt" uuid="4f16bdce-55e8-4717-9b13-82ca3d80f67a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -3041,10 +3041,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebe056e8-510e-4906-ab6e-3c1ad2c98e21" control-id="cm-7">
+    <implemented-requirement uuid="561ea0a2-91db-42a2-b53d-eb884dec4f5e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="94449bab-6241-4b89-aa9e-0124db13d314">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7d9fc4b5-ca1e-42f0-b482-d7437f09b8ab">
+      <statement statement-id="cm-7_stmt.a" uuid="a4606d24-0ffb-4ffa-916c-3d1cbb7bcbd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee69df66-379d-4c22-85b7-764d5297fd9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -3055,8 +3055,8 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="4e36c757-df3b-46d2-9cfa-a349fdba996f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd84a768-42a4-428c-8fab-7725e2f7f04e">
+      <statement statement-id="cm-7_stmt.b" uuid="f69cf7cc-8bb2-4015-83e6-84507b776058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102260a9-4802-4b23-91dc-0a6863b8747d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -3067,10 +3067,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="df59e7ee-5635-48b2-b9df-a1478a43bf88" control-id="cm-7.1">
+    <implemented-requirement uuid="9df378ad-07af-4f16-8970-7121beb0b4c0" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="b2af1ca3-c4ea-4c79-a447-0eca323e54f2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a2607374-feec-4a60-84ce-f3ff39d16e9a">
+      <statement statement-id="cm-7.1_stmt.a" uuid="4990b97e-55cb-437d-b94b-c67fbdd00243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3079,8 +3079,8 @@ https://projects.engineering.redhat.com/browse/RHV-20525
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="091ce04a-66fa-46f3-bfa1-4aae9e674a40">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a0c92879-0573-4da9-aa5b-bc8c897b79c3">
+      <statement statement-id="cm-7.1_stmt.b" uuid="bdf67c38-65b8-4222-a28e-94cde8b3f1d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3090,10 +3090,10 @@ https://projects.engineering.redhat.com/browse/RHV-20525
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8542abdc-49e6-466f-8b1e-ffc853e18f27" control-id="cm-7.2">
+    <implemented-requirement uuid="d7ae7ecb-9b0e-4166-9b23-6a5583c845c4" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="640524fd-e99a-469b-9786-e628c9d52eed">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7457c28e-7f0f-4b10-9ecf-3e751a100973">
+      <statement statement-id="cm-7.2_stmt" uuid="713b03e4-4959-4cd0-830e-ea99848a6d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce0022ee-1dff-44a4-903f-ec64de590727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3103,10 +3103,10 @@ https://projects.engineering.redhat.com/browse/RHV-20592
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="446ec31b-033b-44cf-a62d-241fa7cde2e4" control-id="cm-7.5">
+    <implemented-requirement uuid="606826ac-a5f3-412f-9951-0b9330d1c7d0" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="83680a3c-05f0-4d5c-a073-684413f162c5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6132580c-cbb9-453a-8f92-54a6d0a56fc1">
+      <statement statement-id="cm-7.5_stmt.a" uuid="0c69d796-a67f-4a62-a30f-59a3998fa9e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3115,8 +3115,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="3658d3e5-9cff-4785-a56c-c03f0f97ac1f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bcec5f62-e8f9-4e26-94f4-abcf2fd8dd45">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a04d7c8d-a185-4c75-b689-e74cf9229520">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3125,8 +3125,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="bc05a4d0-513e-4594-85b1-5e4902bc0aa9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="89778cb9-7614-4e60-9f6c-5723b648b903">
+      <statement statement-id="cm-7.5_stmt.c" uuid="0f2c54d2-4592-4240-8750-55533c426bc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -3134,10 +3134,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6117950c-1fc9-4ea7-84f0-92b581a63d5b" control-id="cm-8">
+    <implemented-requirement uuid="79c169b4-bf05-497c-a8b1-dcef13806a00" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="21ac2ab5-8dca-492f-9632-94dd1c17ad67">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ddee86f3-f7e6-4ae1-af1f-932405adbb61">
+      <statement statement-id="cm-8_stmt.a" uuid="3c5ff47e-7ec6-44b7-bd5e-78045d54ec5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3149,8 +3149,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="681caa73-43f3-448f-b162-d868a15cc087">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de8c601c-054d-4082-b652-7314d232b5d0">
+      <statement statement-id="cm-8_stmt.b" uuid="82d686fe-390f-44e1-909d-20019a30cd8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3163,10 +3163,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="985a427f-7bbc-4b71-8e52-65704b886351" control-id="cm-8.1">
+    <implemented-requirement uuid="d918bbaa-fa67-4981-a6cf-c1fb58598ed0" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="9fee3bd1-0958-48c8-a6a5-4e4891f66f13">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5d3cb75f-2475-43db-8d50-f68cab2b3084">
+      <statement statement-id="cm-8.1_stmt" uuid="98c82f1a-8fba-48c6-a2f3-50b707fa6cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f086a431-fb22-4d02-86b9-ec0947418fe6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3176,10 +3176,10 @@ https://projects.engineering.redhat.com/browse/RHV-20780
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afc3fa25-330c-4951-8e3f-a2a548358de2" control-id="cm-8.2">
+    <implemented-requirement uuid="3de338f4-d4cc-4381-b26f-273f58d3749d" control-id="cm-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-8.2_stmt" uuid="3a3dfdb3-e170-4403-b6ef-ae9ecabf16b0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e3e26a6c-cf41-4c90-9e76-f86f526ca95d">
+      <statement statement-id="cm-8.2_stmt" uuid="cbb2d979-2dc7-4b9d-a188-75044f9d6cd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3189,10 +3189,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="168e802a-0042-49e4-b49c-9929f6515579" control-id="cm-8.3">
+    <implemented-requirement uuid="f2b54bf3-daf5-44c2-859c-d06bf379b306" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="b24b1c6e-db4a-437f-95f3-c11f4ca6b7dc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9814914f-344f-40b9-be62-08dff7db25d7">
+      <statement statement-id="cm-8.3_stmt.a" uuid="66d965d3-4618-43ea-9ea0-c9790410ba10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3201,8 +3201,8 @@ https://projects.engineering.redhat.com/browse/RHV-20595
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="26eb78aa-6893-4647-a22d-dade54e9f328">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cdc950d2-0827-49d2-bcbf-b6dde77590fe">
+      <statement statement-id="cm-8.3_stmt.b" uuid="f4777728-b259-4f4b-aa37-d73575034a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3212,10 +3212,10 @@ https://projects.engineering.redhat.com/browse/RHV-20595
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70bb9595-b7c4-46c6-8673-67cc5337995c" control-id="cm-8.4">
+    <implemented-requirement uuid="8ca84a47-7eab-4028-8121-b55a050962d7" control-id="cm-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.4_stmt" uuid="f107e07e-36dc-47b5-bb53-500e65e9a13e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7283ec8d-7c8e-4091-9cf7-6e8e3b34b721">
+      <statement statement-id="cm-8.4_stmt" uuid="44aa83bf-05c4-493b-b987-88e53fb49a0d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c75bb858-f996-421b-b17d-28cd2a9af4fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include in the information system
 component inventory information, a means for identifying
@@ -3226,10 +3226,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f7a041ff-31e0-4ee8-bee8-36f30ba4349f" control-id="cm-8.5">
+    <implemented-requirement uuid="7d60c73b-ad5e-4c32-a838-721ff73d347f" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="0356d1b5-8d1c-4a7c-8260-8f4b257b3ad0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="67f169a0-9e1a-4b2f-955e-716e864fff22">
+      <statement statement-id="cm-8.5_stmt" uuid="2030fafe-0bb2-449f-a487-21f4bac6906e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="641262c8-fe04-4638-ab7d-f103028868f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -3239,34 +3239,34 @@ inventories is outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e85f791-c4fb-4ef2-9f63-a93d83de559d" control-id="cm-9">
+    <implemented-requirement uuid="ce16263b-74f6-4858-a655-9c8f3262e36e" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="c5bc66a4-27da-478d-b023-329ff3359e34">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8bbf3fce-ef82-49b2-ad14-e89a2c352342">
+      <statement statement-id="cm-9_stmt.a" uuid="75c3aa3c-b803-45f1-8d84-818539eda6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="ad3db450-e17c-4ede-9e1d-d9cf725455da">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b4198b3c-9cf7-4289-bb42-4e1b11ab385e">
+      <statement statement-id="cm-9_stmt.b" uuid="611c14ab-733a-4eee-a2d4-2f97fd5e89fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="e9292e43-a2fb-4140-b8a1-435ca0258f9c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6b23abef-9b97-4175-9499-9bee34e557d7">
+      <statement statement-id="cm-9_stmt.c" uuid="e0477be6-92bc-4086-b6f2-33083b6b236d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="c1f64ff4-db1f-4f91-8983-d4c7703fe3ab">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c4da1bcd-58ba-4bcb-8886-8d7779b4e750">
+      <statement statement-id="cm-9_stmt.d" uuid="79287362-1802-4c81-a479-db771b47b5a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -3274,10 +3274,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2088ff93-4656-4034-bf4f-b356bf7cb52b" control-id="cm-10">
+    <implemented-requirement uuid="212372d7-17b0-4c31-97d7-1852edcf0ff3" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="57da1d02-3c9d-4489-a64c-60c2182c7f31">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8b9913a3-c157-428b-a89a-8f2d2d27f134">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3286,8 +3286,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="6ea422ce-e570-4e53-9405-300078d39447">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6ddce788-c6c7-4e3c-9e8a-d892fd44fe18">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3296,8 +3296,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="808990b6-aac1-4fb0-9d21-73176b58a9aa">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="632d638e-065e-4c61-a240-5dbb4d7b19dc">
+      <statement statement-id="cm-10_stmt.c" uuid="c7e6da74-487f-4a2e-9eea-a88e1c27503b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3305,10 +3305,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2eb3b2d-da6c-4ecc-aa63-ac3a474e9569" control-id="cm-10.1">
+    <implemented-requirement uuid="865e730f-a041-4c58-b656-d8a1de79a4a0" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="0376fe7c-68df-4643-90ef-76ee4f226070">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="da1faff5-5939-4f91-bcbe-01e4cd5e3950">
+      <statement statement-id="cm-10.1_stmt" uuid="baeb0478-1cd1-463b-a6c0-ae5b4e184049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f14d1188-97fc-41de-b6cf-14640585a522">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3316,10 +3316,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6bd1150-39e4-4adb-8563-f8d6837aecd4" control-id="cm-11">
+    <implemented-requirement uuid="a9f52025-43c4-4f61-93d2-a98b2c60d563" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="945bd0cd-e639-43f0-9fab-e6bd912d78b0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4bd90805-4acf-4427-97c8-50a1318ab2f1">
+      <statement statement-id="cm-11_stmt.a" uuid="1cab1caa-5580-4ed2-8424-6cfe2b65ff97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5783ab5-0535-43ae-bc60-fade80694031">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Manager (RHVM) nodes. The following are suggested
@@ -3338,8 +3338,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="f6b7263b-2091-4998-b8a9-5d65247b6006">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a85777ff-f6b5-41b0-8810-4b67d1bf466a">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -3356,8 +3356,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="9e530f52-c17c-4e44-b8d6-728e1ccdc99b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a9e2da35-bbdb-4e73-a3a3-cd48cdfba842">
+      <statement statement-id="cm-11_stmt.c" uuid="726caa7d-38cd-4199-9e94-f4e4739123c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3365,10 +3365,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e959da4e-b9f0-4458-ae6a-841259b31732" control-id="cm-11.1">
+    <implemented-requirement uuid="97ec37be-cdf5-43e7-9437-0b575ffd9d2f" control-id="cm-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-11.1_stmt" uuid="462b499f-a5bc-4098-87f2-d567a91ea242">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a293f392-2a92-4f70-a81b-340e109d2dcd">
+      <statement statement-id="cm-11.1_stmt" uuid="dda5705e-7480-425a-ab96-d25ed45617cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29fc46a9-4423-4aee-bb79-02d19d199eb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -3378,18 +3378,18 @@ https://projects.engineering.redhat.com/browse/RHV-222709
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50c7e400-ba94-4985-a266-d25f1a195254" control-id="cp-1">
+    <implemented-requirement uuid="94fd9d87-eef1-4ee9-a6b4-2513764aa623" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="822a2493-67a2-47ab-bbe9-89268066dc38">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c50617c4-9105-4ca9-bb34-36db35edcc9b">
+      <statement statement-id="cp-1_stmt.a" uuid="4606f193-8cfd-4aba-bfcd-a2c14fe88b17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="a2b3b333-f69e-4368-8385-870ab010952d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="33ebe749-789f-488c-89b6-9ff5750fb821">
+      <statement statement-id="cp-1_stmt.b" uuid="bbd89b79-7bca-4cb5-b926-c67d1cb70a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df78838f-634d-4325-838c-4b8f271f8b34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3397,34 +3397,34 @@ policy is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="13434b34-be3c-4f4e-86c0-3ef1a946b0b6" control-id="cp-2">
+    <implemented-requirement uuid="5be63def-f217-4ff2-8546-9e1a25a88095" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="cce6e084-380d-4d1d-aeac-5cb98c0e99ba">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a8f661f8-37cd-4937-b97b-f9c274dfdb46">
+      <statement statement-id="cp-2_stmt.a" uuid="51fece35-394b-427c-9acf-2f7a56ef7aa4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="75e96108-dcb3-4db0-b02f-a21f9e0ef693">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bd1f4674-a94b-44db-ba20-24a9e0fd261f">
+      <statement statement-id="cp-2_stmt.b" uuid="e1ea39b3-9ade-47ea-8a1a-aa597e92509c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed5f1a2-a796-4faf-bf82-bbdb8c32a470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="2846888e-2598-44ec-b889-e717706df4f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e1cec014-f4dd-4038-ab21-c843b3a4c652">
+      <statement statement-id="cp-2_stmt.c" uuid="e4ba12f5-6b75-43a3-8183-75933ffbc39e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4de58bb-0b92-4d0d-9c6f-8ae9063a8cb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="a1d3623a-2a0d-4cc6-9a16-c36fa0d68782">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6d3a8665-5011-4058-9a21-ae92529cb58f">
+      <statement statement-id="cp-2_stmt.d" uuid="58bc51ec-35cd-430d-b9f8-6154022256a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cc6ee67-b8d2-4122-9e62-c26bd331e237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -3432,24 +3432,24 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="e4db6245-7aa0-4328-8f61-c92c5abee7ac">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="deb20636-5b98-4f9b-b8fb-5c0ccb6016e7">
+      <statement statement-id="cp-2_stmt.e" uuid="68831a9b-b5d0-4c23-aaf2-a7bcbd78b0ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="125155a3-5e64-49e7-a25d-fe1a5411a01d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="48aa1604-d3ea-4227-b0d2-dc875d15d96b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="43411ece-58bc-4cbd-94b0-6fbf5837d621">
+      <statement statement-id="cp-2_stmt.f" uuid="d268656f-9f1e-41e3-8038-788c94b5d7db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87062d43-0fd7-4631-914e-0816520851d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="e7b8da28-b75d-4e1e-b049-60ac0d94b850">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b103516e-d170-4a76-a6c3-94d4fdd28d29">
+      <statement statement-id="cp-2_stmt.g" uuid="126666e0-1012-48eb-bb3f-86f4dc04349c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="940539c3-1e0b-4ee4-bbe6-76f6a4434309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3457,10 +3457,10 @@ modification is outside the scope of Red Hat Virtualization Manager (RHVM) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4c4a47a5-ea2b-4926-b4f9-9d9f84871410" control-id="cp-2.1">
+    <implemented-requirement uuid="ebbb14e7-21ad-4cf3-86b2-04bf457a59a7" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="247ee817-0635-437b-8f0c-eb7f56631439">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9c4cde46-886f-44b6-b1f0-f5f1eb56976a">
+      <statement statement-id="cp-2.1_stmt" uuid="0cebb033-0531-48ae-8448-e574e89b1051">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a6c4f02-70ac-4bdb-8b2d-b775e5a17cf5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3469,10 +3469,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b63ca178-a0f0-436e-ad79-49174e11cdb5" control-id="cp-2.2">
+    <implemented-requirement uuid="f63bb2e5-2786-4d3f-8124-e09a15847cc4" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="b489f429-74c9-4c98-8f2a-6f1409fc2bee">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="557523ad-eb9d-4796-99b6-3551715c115b">
+      <statement statement-id="cp-2.2_stmt" uuid="d4b2afc4-dce2-41ce-9731-4c54f6f0d25c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20eab3e7-d9a7-43c8-b847-14de3ee49657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3482,10 +3482,10 @@ https://projects.engineering.redhat.com/browse/RHV-20781
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="15347af2-ab9f-43bc-a307-534d49f2adcd" control-id="cp-2.3">
+    <implemented-requirement uuid="2de3b427-45f4-4242-a2e9-de014d7bbe2e" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="1b01c164-0f7a-45f6-89d9-d47be4d9afc3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6854723f-daf8-4aff-b2b0-6b3762e8b4e1">
+      <statement statement-id="cp-2.3_stmt" uuid="a480c9a9-877d-4d4b-ab52-f2f14fd2bf6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="839fcd1f-a824-42d7-84b0-4ee818e2ad76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -3494,10 +3494,10 @@ plan activation is outside the scope of Red Hat Virtualization Manager (RHVM) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="351a7dba-f235-43d6-b166-170dd4c007cd" control-id="cp-2.4">
+    <implemented-requirement uuid="b4057311-34e0-479d-bd0d-abd8cc56f2f7" control-id="cp-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.4_stmt" uuid="efc4af02-07e7-4010-8d02-c915f3bfd0bf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dd1a702d-a041-4ec5-af6c-a8a95c510df0">
+      <statement statement-id="cp-2.4_stmt" uuid="25c1fb85-32ba-4f6c-ab64-6642ed8e2454">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="79e15ef1-1049-4a95-9486-f947d8287705">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of all missions and business
 functions within an organization-defined time period of contingency
@@ -3506,10 +3506,10 @@ plan activation is outside the scope of Red Hat Virtualization Manager (RHVM) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b7011f4-5328-4d0c-8390-447e5ecec3e3" control-id="cp-2.5">
+    <implemented-requirement uuid="61dd20c8-0c04-4de7-a00d-5dc51646a835" control-id="cp-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.5_stmt" uuid="f46cee8f-8be4-4f2b-a6ed-623b81bb6a6c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dd6a1444-cea2-4909-b79f-5631969e6fbf">
+      <statement statement-id="cp-2.5_stmt" uuid="7ca30511-5a73-4435-a068-6fb353da462b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="14d92133-083f-4064-bf3c-17b809853537">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the continuance of essential missions and business
 functions with little or no loss of operational continuity and
@@ -3520,10 +3520,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1478b70b-8c2c-405e-b9c1-ff87843e4e62" control-id="cp-2.8">
+    <implemented-requirement uuid="fa0252c8-7d41-4727-a891-5dce072696c1" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="d68e2b67-cb74-4bb0-a88f-d07b7924045b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dda4abcb-22fc-40cd-b0a2-f9074c11027a">
+      <statement statement-id="cp-2.8_stmt" uuid="1cf24495-43de-41fe-bf88-2b4aa7b565ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3531,10 +3531,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e84aae0d-0c97-4f11-85eb-dbb3a8e1aca6" control-id="cp-3">
+    <implemented-requirement uuid="77fd7c71-2983-49c2-87b0-d365a779d34f" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="475a77bf-d300-4bbf-8830-ceca63e763ab">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cdf756b6-e9e8-4791-b6f5-12c668080f7d">
+      <statement statement-id="cp-3_stmt.a" uuid="5d12514d-8d69-4301-b10c-c7a450bad0c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="180e2f38-0c8a-4a5c-9f2d-bc493074566d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3543,8 +3543,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="b955eafb-4a37-441e-be82-c51d3cc005e1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1c39df23-9b2a-4466-aa4c-db9ba2f7842c">
+      <statement statement-id="cp-3_stmt.b" uuid="6354df03-8e96-4446-b298-736abebc922c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d206f41b-3100-4686-bc8c-4bef56754e65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3552,8 +3552,8 @@ system changes is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="cc5d8285-5759-4646-addc-7c192854a77f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="76d06336-123b-4681-b8ca-d83499b72a21">
+      <statement statement-id="cp-3_stmt.c" uuid="9c8ec9b8-186d-47d0-b6ea-1237205b8548">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="682e9951-3a64-421f-b29c-dfb1abc45d23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3562,10 +3562,10 @@ frequency is outside the scope of Red Hat Virtualization Manager (RHVM) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70d076fb-ab3a-4e07-9603-9ecb8c8cfb45" control-id="cp-3.1">
+    <implemented-requirement uuid="2a4dcfbc-bd4b-4b60-856b-96abaf32163d" control-id="cp-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3.1_stmt" uuid="68fa2a78-098f-4358-a0f0-c788a05f7e7d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9f8ee13e-42d2-4e29-9964-b85ae549e98f">
+      <statement statement-id="cp-3.1_stmt" uuid="72060001-5e76-4553-97e9-1391edcb1503">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2926f282-5b53-4e58-b506-451c04c91dab">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Incorporating simulated events into contingency training to
 facilitate effective response by personnel in crisis
@@ -3574,10 +3574,10 @@ situations is outside the scope of Red Hat Virtualization Manager (RHVM) configu
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="183fcd6a-3889-4aa3-a269-61aa2da30019" control-id="cp-4">
+    <implemented-requirement uuid="6d1d21ea-64b9-4cfa-8db5-2647bd354b53" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="be5def8d-14c3-441a-9b20-a6c3a5a7653e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5dd614cc-c0a6-473b-84dc-798e1df6edd2">
+      <statement statement-id="cp-4_stmt.a" uuid="2b26ec0b-3a47-439b-8af5-a354417d354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e14a882a-1808-437e-b859-5d650dfcfc80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3587,16 +3587,16 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="47c6e719-d949-419a-bf71-265e06994e91">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="50695915-d2c6-4fa4-b50e-1fd882e7231d">
+      <statement statement-id="cp-4_stmt.b" uuid="11dc66c7-9ead-407f-aff8-e01e30ea36bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7712450-e25f-472a-b052-42ddc560b339">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="be01c35f-f85d-4ce7-97b2-2f1767c35e99">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de2bbc03-5004-4b21-819e-a448fbc4b337">
+      <statement statement-id="cp-4_stmt.c" uuid="8354574c-c5e0-48bd-8496-2e47579499d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37a66071-7cb9-4803-8e60-77c475929537">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3604,10 +3604,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c1149cf-0106-493a-801d-dda9343f82ea" control-id="cp-4.1">
+    <implemented-requirement uuid="21a9e92a-0e98-4b65-b3e1-d06ecc6177c4" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="0652b934-392c-4132-8525-f78b2d396266">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3e031d41-5954-4314-9a8e-d2e50fd13041">
+      <statement statement-id="cp-4.1_stmt" uuid="23f04288-80ca-48dd-addc-f66a8c731a91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="786fa4f6-edb0-416c-8ea1-a7cc647abc7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3616,10 +3616,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab296cdc-abbd-46c4-924e-5846c464e1bb" control-id="cp-4.2">
+    <implemented-requirement uuid="645b915e-abf5-4cf8-a837-62a2ac1b8532" control-id="cp-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.2_stmt.a" uuid="fc296139-f874-4f96-9041-fe8df1f2e8ca">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ed50878f-9fbb-45f9-abce-813b6e1c4f95">
+      <statement statement-id="cp-4.2_stmt.a" uuid="f878e412-c7e0-42b4-b4a8-31a3e4c2be35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="412fe27d-10e5-49c2-8163-7fa670d0a4a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to familiarize contingency personnel with the
@@ -3628,8 +3628,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4.2_stmt.b" uuid="c071ebc6-766a-4f57-8d0c-850e7c427319">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8e271ebf-32fd-40c7-ab47-3180401e2d85">
+      <statement statement-id="cp-4.2_stmt.b" uuid="5cc5a972-83a8-4c87-a591-e33013fa3511">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="393ff067-a6fa-4d58-bbde-83b395f39fe4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational testing of the contingency plan at the alternate
 processing site to evaluate the capabilities of the alternate
@@ -3639,10 +3639,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="746c212f-d484-4def-af24-9daf6caac2c7" control-id="cp-6">
+    <implemented-requirement uuid="aacc6393-23a3-497f-869d-329be8a7e192" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="0b7a8800-981b-4f0e-bc3f-79f9ffb238fb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0157bad7-ec0c-4cb9-8c48-af9fa3db5323">
+      <statement statement-id="cp-6_stmt.a" uuid="3629face-e3f3-4691-914f-16d42cfa027c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34700da0-3ff6-4235-b2e7-123ee7850c24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3651,8 +3651,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="56a4ef3c-3edb-4293-9d5e-8898169f7cec">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="257a1a86-4a1d-4067-ac52-fd0f7e917ae3">
+      <statement statement-id="cp-6_stmt.b" uuid="e765749c-a6da-4941-bc4a-54a30e367994">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d5ef1b-09ee-4d53-b768-a1e8d221b0c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3661,10 +3661,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9fa90ed7-f1d0-46dc-85f0-f41adf2bba46" control-id="cp-6.1">
+    <implemented-requirement uuid="52e1bf95-d65c-432d-af16-c76e82cb99c4" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="336436c5-0f81-4326-8f1f-0dd3b5018915">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b611f9ef-49d7-4bb3-a105-c6871c1fe45b">
+      <statement statement-id="cp-6.1_stmt" uuid="b65e666b-2708-4948-9f82-331ecd9686c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="544b36ed-7a77-4f89-bbee-907c5f2bd757">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3674,10 +3674,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="605442c8-07f9-4395-a55c-21f4d606568d" control-id="cp-6.2">
+    <implemented-requirement uuid="39e79591-028f-4612-bb6e-f34cc8346c10" control-id="cp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.2_stmt" uuid="29781703-1e00-4675-99de-5dc8d2b485f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="416fb25f-903b-4d85-b851-dc1bf2dc5c2f">
+      <statement statement-id="cp-6.2_stmt" uuid="cfdb1f8b-28b6-4d44-803a-f9f10f0ff780">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3685,10 +3685,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbb3bcce-a5c6-4bdf-a8a9-a5e6353347ef" control-id="cp-6.3">
+    <implemented-requirement uuid="f11d9fee-fe1a-43d8-b242-e10422130239" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="bf9eac6a-e426-447c-a621-de69e61d02c7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f584bc46-e796-46db-8c3f-75b2e0ce2dcd">
+      <statement statement-id="cp-6.3_stmt" uuid="ff9e2a13-70bc-4635-a49a-3abb5499801f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74389a35-dd1e-41cc-966b-0ddd28eab010">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3698,18 +3698,18 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9a9fb4c-9bc7-4215-9295-bd6e54dbb3ad" control-id="cp-7">
+    <implemented-requirement uuid="38de22bd-b4d9-48e4-b2c7-38781b5b488c" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="74068cc9-11ae-4daa-9a53-d313fc668c26">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fbacbcca-3e76-4ed8-b28e-da7deb4014a2">
+      <statement statement-id="cp-7_stmt.a" uuid="294005bd-b34a-488b-b84a-de0032311646">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="5b253318-177d-4dae-86fd-b56a8af0db75">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="23165531-e157-4917-8777-ad60113e9c68">
+      <statement statement-id="cp-7_stmt.b" uuid="a0f1dfbe-434f-4a8f-8f3f-802800025991">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c9ac56e-812a-4721-baff-1bb201292bcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3718,8 +3718,8 @@ https://projects.engineering.redhat.com/browse/RHV-20598
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="15d8ae13-0b8f-4976-972a-5d134aced383">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="89cce92a-0315-431e-840f-f9606f0c78a8">
+      <statement statement-id="cp-7_stmt.c" uuid="1102769d-5d32-48a6-b22f-95e2631de36f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3727,10 +3727,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a027fb4-d815-4614-b1de-1e6d1fc315ac" control-id="cp-7.1">
+    <implemented-requirement uuid="d040b58e-1c83-40f5-9f24-220e6f3249e8" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="09c1e9f0-0508-4d4d-a68e-27ec145ff8be">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ef4ce7a9-dd57-45d6-8261-ca8329d4d72b">
+      <statement statement-id="cp-7.1_stmt" uuid="7d8f6d99-1a7d-4d0d-b358-b542d5c50a48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2590d25d-e107-496c-b31c-0c3f86841913">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3740,10 +3740,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="52ee89ce-d28a-4744-92bf-2b15444bee33" control-id="cp-7.2">
+    <implemented-requirement uuid="d809046b-378d-441e-b083-1127bbf74ff6" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="8d9fb404-48a7-453f-bdf4-d3a060bd980d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd4e8694-ed09-49ab-a8b3-5223997669ee">
+      <statement statement-id="cp-7.2_stmt" uuid="d58d938e-10a5-44ad-95c6-de322f5d443d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e750ec9-7062-4a41-8771-9d69a0785694">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3753,10 +3753,10 @@ actions is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="790ed192-4a3a-4705-901a-414ccadb842d" control-id="cp-7.3">
+    <implemented-requirement uuid="1cc217ba-296f-4a50-9c87-96a6f8cd2264" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="965979b5-04f7-4c4b-a683-2e5397b199bd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d465a41a-8cb3-4ffb-bba2-aab5efaf7217">
+      <statement statement-id="cp-7.3_stmt" uuid="d8c4fa74-6603-4d25-8708-fd581fe5f582">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43239c9-8b54-4e2d-bfe8-2b38d9d90d84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3766,10 +3766,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a00614f6-dab1-4c0a-8402-bdd0f78a6773" control-id="cp-7.4">
+    <implemented-requirement uuid="88912fdf-0392-4ea5-8494-a5bdb7dd2f43" control-id="cp-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.4_stmt" uuid="fd1e5afb-f188-4cf9-ac09-a28a144a46e7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9581d466-b617-4f24-a907-131d9c0610a0">
+      <statement statement-id="cp-7.4_stmt" uuid="f55ad8b7-a2d3-446f-a223-e56a84b31a1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3777,10 +3777,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f0597e3-98b7-43b2-8722-e756983dceb2" control-id="cp-8">
+    <implemented-requirement uuid="f27082f0-8010-4d25-ac1a-5296a61474b5" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="ecdfdc3a-7184-403e-bcca-5fef4b51b082">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="73b9e1bf-68bd-44af-ac41-7954c319ff61">
+      <statement statement-id="cp-8_stmt" uuid="17594190-820d-4302-85f6-84b8e99327b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="010e3ecf-ffe5-4b48-910c-3bbec2af00b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3788,10 +3788,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38dff385-ef88-44b7-b1d5-b7724adbfaab" control-id="cp-8.1">
+    <implemented-requirement uuid="a24372f5-3549-4b0b-9037-21e04d7d8103" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="aa63fa8e-a2c1-4f93-b750-31272ddb9e5d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9f376882-6aea-40de-aeb1-978e60b63ed7">
+      <statement statement-id="cp-8.1_stmt.a" uuid="2ecb50cb-e56e-4df3-bbb2-801f4be0c688">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17e55bfd-487c-4aa3-a67c-1b67440da396">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3800,8 +3800,8 @@ time objectives) is outside the scope of Red Hat Virtualization Manager (RHVM) c
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="24f0efc5-c1e9-4bcf-8bd0-420b6d0a0a73">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c8f16c07-627d-4ba7-89cc-9d498113ebd0">
+      <statement statement-id="cp-8.1_stmt.b" uuid="621f3641-6f33-4355-8781-14e62cc01439">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bb74ff0-7a2f-4de9-b88e-1ed1b3c0a410">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3812,10 +3812,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="262f22cc-bada-46bf-92e6-e4b49044e193" control-id="cp-8.2">
+    <implemented-requirement uuid="6a5f96da-9e27-4ae1-9249-f0d4cbde244c" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="0e6d91c9-1eb2-4a15-b41e-05f9a32c1a4f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="90efbd3f-c060-48bc-8f58-131dfe24632a">
+      <statement statement-id="cp-8.2_stmt" uuid="ab859b33-5a8a-4920-9b78-8b05c6b0d8f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4076ac7a-37ea-46bb-b471-c30180085c38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3825,10 +3825,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c469fe1-cdb9-4142-b39c-8269a9860f27" control-id="cp-8.3">
+    <implemented-requirement uuid="e641abf3-8111-4fca-bee4-43660870de91" control-id="cp-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.3_stmt" uuid="801a1dc7-b0ee-447a-bacb-5e80b2d08083">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3482ce70-0ecb-4e16-9c20-e2ab19f76415">
+      <statement statement-id="cp-8.3_stmt" uuid="59bae88c-acbd-4458-bb5d-de2eacbe12bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c446c47-1ece-4e51-b3f9-de21e5a833fb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services from providers
 that are separated from primary service providers to reduce
@@ -3838,10 +3838,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="70e441bc-5f7a-42c4-8d43-eab23e21bb66" control-id="cp-8.4">
+    <implemented-requirement uuid="3f1ca0ae-bfa0-48fd-bee3-4257155866b2" control-id="cp-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.4_stmt.a" uuid="293ddc31-0816-4f21-9617-39cb93f80e2c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="98ad93b4-9f3b-4e9e-86e4-ec55f16517a5">
+      <statement statement-id="cp-8.4_stmt.a" uuid="71ffaa64-863b-42e2-acf1-dbc41c768843">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="338c1f2a-3768-4642-becd-dbb4513d17db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requiring primary and alternate telecommunications service
 providers to have contingency plans is outside the scope
@@ -3849,8 +3849,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.b" uuid="751160cc-b7ba-4485-86a1-4b82f1e4bbca">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d8d45897-d667-4129-803b-e97a628cbc7b">
+      <statement statement-id="cp-8.4_stmt.b" uuid="0559111a-b79e-4b1f-950a-44684f7bf314">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e066d6bf-332b-4eee-8aae-666efcece114">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing provider contingency plans to ensure that the plans
 meet organizational contingecny requirements is outside
@@ -3858,8 +3858,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.4_stmt.c" uuid="e863bac6-a3e1-4273-be8b-81a3bd8a9629">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4bde2666-b144-4452-a91b-037faf6801d0">
+      <statement statement-id="cp-8.4_stmt.c" uuid="c0435105-ad64-460d-b356-34fd029587dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d782bc3b-7861-4d8a-b9a1-5857b15140f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining evidence of contingency testing/training by providers
 at an organization-defined frequency is outside the plannedscope
@@ -3868,10 +3868,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="add9f511-1c37-4f74-99d7-2e8772a6244e" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="3ed32cc6-1582-4020-8464-1fd471444a59">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="78823ca5-1559-4cf2-b308-0b5a3ec1bf56">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3889,8 +3889,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="31c99563-1b15-43db-be43-d031fedad857">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6745927f-4628-485a-87b9-d065640c8777">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3908,8 +3908,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="a36de291-85e4-4deb-8bb3-c3cc64201948">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8ebe944a-934f-43b4-b52c-9ca47a14492f">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3927,8 +3927,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="68283d21-26d7-496e-b4a9-31557b9c5bcd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1185ece0-411b-4d1f-975c-e88623a2e14f">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3946,10 +3946,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c34ebea3-3a68-43e9-ab68-228e3a7642df" control-id="cp-9.1">
+    <implemented-requirement uuid="f85b417a-a21c-4e46-b3b0-3ecd96cd3fae" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="1c2d872d-95e4-4c54-bf47-41f86e88f726">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cc252db9-068b-4d61-9663-a44384f6d821">
+      <statement statement-id="cp-9.1_stmt" uuid="d2d01e73-c3bc-4b90-9b32-0faca8c4040e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2f2fbae-d6d0-4a49-9a77-a50d0057c301">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3958,10 +3958,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8011433b-50d3-4dc2-8e97-5ebe268cec28" control-id="cp-9.2">
+    <implemented-requirement uuid="10b743bb-51b6-4079-b30a-5bcfba17f1bd" control-id="cp-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.2_stmt" uuid="9c4c944f-c36d-4cf8-a46e-a77559ee96f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7707abb4-5362-4701-aa2b-095081acd7e4">
+      <statement statement-id="cp-9.2_stmt" uuid="e07b6f6b-127c-4b2a-a017-0154446e60ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a27dd3d-c601-4472-8f5f-0cd2601bf4c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 using sampling data is an organizational control outside the scope
@@ -3970,10 +3970,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cba3db69-a4ef-408d-b3af-b4a2aab81203" control-id="cp-9.3">
+    <implemented-requirement uuid="26e51a6a-29c2-47b7-aa79-3f180fcc991d" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="1acc15c6-b8ca-4656-9266-64ba61f9af53">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a6eb5d26-a93f-49a7-a8f1-23aa15de8b96">
+      <statement statement-id="cp-9.3_stmt" uuid="05bb07ef-52b8-4bed-a618-477e48238237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ec168c8-b0f2-482e-a012-f1b40286f743">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3988,10 +3988,10 @@ https://projects.engineering.redhat.com/browse/RHV-20782
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0eccea8-9b51-4bc0-b4e4-a2dc48a08de0" control-id="cp-9.5">
+    <implemented-requirement uuid="df29190a-f37b-4bfd-94f0-f11d12c4c298" control-id="cp-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.5_stmt" uuid="cac2d712-214b-4611-9d64-b10d785a0de6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8b206690-13fa-4078-9ba7-cb6ccdd79c38">
+      <statement statement-id="cp-9.5_stmt" uuid="3192990c-06e4-4ac9-9432-1973768c0e2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3999,10 +3999,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2218c31f-623f-4292-a92b-eef2f0a25114" control-id="cp-10">
+    <implemented-requirement uuid="8de00722-2d4f-47ee-a9b8-9c752caecd5b" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="f9846f35-6984-435f-8f23-cb88f9f986d5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b5e80ef9-b2cc-4b09-a7e2-f6e20cd841f7">
+      <statement statement-id="cp-10_stmt" uuid="05fbd0da-7a83-4c99-8b87-de3cee556d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="891ee6cd-8cd3-401b-8521-4719de6de859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Manager (RHVM) environment. A successful control response will detail
@@ -4016,10 +4016,10 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="80e481df-ce59-49df-93d5-d1297c4ce9e0" control-id="cp-10.2">
+    <implemented-requirement uuid="017891bf-c8b4-4f68-b52f-e0542ba52071" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="80e73b01-a1cc-4b57-920f-762e0a47a275">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="70dd62f6-a4ec-4ceb-9082-8eaa3e8c9c45">
+      <statement statement-id="cp-10.2_stmt" uuid="f11afd16-7d89-4edd-b7fa-c4f69dd2e646">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4027,10 +4027,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fabb6de6-e315-40fd-948d-a085692611e2" control-id="cp-10.4">
+    <implemented-requirement uuid="a9d5d4b5-c0cb-44f6-bcef-49a49d8b80f2" control-id="cp-10.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.4_stmt" uuid="e99b3a17-a907-46ba-a40d-80b91beaa480">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c1e5a586-03d7-4299-a1a7-83418dd1797c">
+      <statement statement-id="cp-10.4_stmt" uuid="98e2619e-8034-4218-a56a-70e0070b5a29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4038,18 +4038,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f09dd9d-f377-48d3-8d76-d0f0ed01c552" control-id="ia-1">
+    <implemented-requirement uuid="2f3b1020-66be-47d7-a27b-868ac082de53" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="4418f89b-1d7b-418b-ac29-28901d3f50db">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9c173ea2-94c4-46ca-9b5b-a94dc5e3532c">
+      <statement statement-id="ia-1_stmt.a" uuid="f29dbb7a-a552-44b4-b173-b9cec76a4e2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3af05d0-0b99-40f0-a835-c48cd64e7d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="c08ad001-58fd-4ba1-85bf-b8695da8c838">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0b79936c-0354-4909-b6cd-1a81e4ced247">
+      <statement statement-id="ia-1_stmt.b" uuid="0fff2124-8eb8-4f7d-afa8-846a004019f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="261111a2-f9a5-481b-a7c2-c287c360b653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -4057,10 +4057,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Manager (R
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5f35aae-b892-4d3b-91f6-042722416c0d" control-id="ia-2">
+    <implemented-requirement uuid="f55156c3-dbd3-4e17-b67a-635142694cac" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="b0a35a09-2ac7-4170-b8fb-f949553eb630">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="acb4d616-916a-47c1-a5c7-1f65cb5d5ff8">
+      <statement statement-id="ia-2_stmt" uuid="f76099a9-754d-4fa1-8311-118e38567e0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ebf37cf8-ce97-4664-9ee9-53dc8ff8490c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4069,10 +4069,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="26917ea0-eed3-443e-a64d-96e5064c6d3d" control-id="ia-2.1">
+    <implemented-requirement uuid="7ba01777-86d4-48e5-b3fd-7bedbc360dd9" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="6fe6b1c4-38cd-497c-99e6-007ed33e4487">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="40594277-f774-4a7a-8a28-8529145723ee">
+      <statement statement-id="ia-2.1_stmt" uuid="652e20a2-8b06-4be3-b875-0332f361d163">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f005b4-3ce5-44f8-94b0-73508ababd84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4081,10 +4081,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca5bd8fd-0dc2-4f1e-8b21-b23aabfc396e" control-id="ia-2.2">
+    <implemented-requirement uuid="4d53d68d-2c6a-4a44-ac8e-b76051289b92" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="0a193c8e-3ee6-4468-825c-636ad8c61c8a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d0535e32-5b85-4d89-99a4-698922e5a177">
+      <statement statement-id="ia-2.2_stmt" uuid="bed222c9-6c1f-436f-8941-21b3fc8c8a1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c48dbeee-587a-42e2-ab32-91162f251ece">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4093,10 +4093,10 @@ https://projects.engineering.redhat.com/browse/RHV-20682
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb63cc84-43f2-4bd1-94e5-b1f65ea489e8" control-id="ia-2.3">
+    <implemented-requirement uuid="fa8b4f31-4204-401a-9799-bc98267d9a68" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="741bc075-1d8e-4f79-a951-338c856bc0a3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3a8fc359-11bb-499a-9ded-6292e57ca6f7">
+      <statement statement-id="ia-2.3_stmt" uuid="90feaf4f-ad6b-4839-a0e6-f8b56c15b37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="321738ca-31a2-4b1d-b1b9-0b6c6f4197ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4105,10 +4105,10 @@ https://projects.engineering.redhat.com/browse/RHV-20683
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbc4ffbb-ab22-4fb7-9803-17ff2f923e49" control-id="ia-2.4">
+    <implemented-requirement uuid="79f713e6-7a81-434d-97e7-a5ab65db29c6" control-id="ia-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.4_stmt" uuid="e59a6add-dc3a-4993-a117-78a1a1b5eba2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="67f46199-de09-484c-9c3d-1193d677fe43">
+      <statement statement-id="ia-2.4_stmt" uuid="6dc700d8-3b4a-40dd-9cf7-af9b8be508b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b1b377f7-aac9-4640-bcb5-eb683895b532">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4117,20 +4117,20 @@ https://projects.engineering.redhat.com/browse/RHV-20684
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e5a163-cd98-4c20-b237-2d49b92b480d" control-id="ia-2.5">
+    <implemented-requirement uuid="616cdfcb-1fbc-4491-91ab-4345b58ed394" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="ac1caa2d-c6a0-498d-a86e-3554d5dd31cf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="543176ff-c8b8-4ec6-ad47-5fb92994f81c">
+      <statement statement-id="ia-2.5_stmt" uuid="b75413d7-831c-4667-9d20-ef3a4fcb35bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c3738e-386d-4537-89af-516d111565e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Manager (RHVM) does not support or allow group authentication.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06998ede-75b1-4e0b-8427-d6d7fcda9fb8" control-id="ia-2.8">
+    <implemented-requirement uuid="9324c09e-ebd4-4f86-8ccd-94c47ea733e2" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="ebb07c88-5e57-4d29-8929-5c0ca6e23c68">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cab44cb9-9115-4699-a6fe-b73fda9e04f8">
+      <statement statement-id="ia-2.8_stmt" uuid="19a4afe9-da23-41fc-986c-259ff51f0050">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f77256-ecf7-440f-ba84-714f7912e4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4139,10 +4139,10 @@ https://projects.engineering.redhat.com/browse/RHV-20685
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24a27a16-1fe0-4c23-baa8-8148a3490479" control-id="ia-2.9">
+    <implemented-requirement uuid="79687eee-90bf-4d14-8ee8-bb24a27b7542" control-id="ia-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.9_stmt" uuid="054d2396-8dc1-4a4f-b48e-a09a1bfee13b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d7ce38af-099f-492e-b03d-3d299a8074cc">
+      <statement statement-id="ia-2.9_stmt" uuid="d22159c4-a093-4897-8943-0e9036aeb824">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e8e7cdc-15fc-4d15-83c3-55455d777501">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4151,10 +4151,10 @@ https://projects.engineering.redhat.com/browse/RHV-20686
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d18487e-dc58-41ff-9f43-8cead05b78cb" control-id="ia-2.11">
+    <implemented-requirement uuid="3b0bc4d2-9c8b-40b2-832b-47105fd850db" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="d516080e-ae01-416c-ba70-3bf70b337b74">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4d7fcf26-06e5-4979-86d8-026f399832be">
+      <statement statement-id="ia-2.11_stmt" uuid="d5bdb471-f0d9-46bd-8b40-ba71fc204f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe551ed6-c765-4dea-98a6-4bf2b88d82c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4163,10 +4163,10 @@ https://projects.engineering.redhat.com/browse/RHV-20687
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="967111bb-8d01-4410-8b93-18cb3bd87c54" control-id="ia-2.12">
+    <implemented-requirement uuid="4a97d0f3-d836-47e5-a3a6-4b7aad438a32" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="173315ce-b8ba-4abe-bdda-28569857fdf9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="48c0bffe-56ff-4b2b-b51a-5ecc44d9d4b3">
+      <statement statement-id="ia-2.12_stmt" uuid="099f7acd-ad66-488c-971d-8e035fe74120">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d18528b9-1a11-4602-a574-dd3eaa7c4125">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4175,10 +4175,10 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f0b9cc1-7c2f-4697-a68b-395e18d84f7b" control-id="ia-3">
+    <implemented-requirement uuid="813ba8a3-1cc8-4e5b-8c64-22a599c8634f" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="c4d1a157-3ea6-4088-a503-7ef88e050b9d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e5982200-de75-44d1-b7d9-3cb92506af85">
+      <statement statement-id="ia-3_stmt" uuid="fe4a9b85-3267-485e-a6b8-1c4190d9b864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0289593-6a95-4233-8e1a-780edff8a21d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4187,34 +4187,34 @@ https://projects.engineering.redhat.com/browse/RHV-20689
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="faeba500-1dbb-4598-bd1a-419218b0868f" control-id="ia-4">
+    <implemented-requirement uuid="f22c4227-9a59-474f-a12e-f819931abe4d" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="c7219d3f-8c67-49cf-b1f4-a66c3f3cec17">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9049c192-0bad-4520-8624-d2e0a839689d">
+      <statement statement-id="ia-4_stmt.a" uuid="c167bcfd-1c81-48f9-8253-738b08b79d70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="eed36f63-13bc-496c-81fa-b0a8d8782955">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1a4e9ddc-6d48-4f9c-b4d3-310b0128d510">
+      <statement statement-id="ia-4_stmt.b" uuid="049da705-362b-41a8-b560-518ca8365ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="fc694032-1e44-4082-a2f9-059e369ebe5f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7a346e9b-907e-4904-a836-d224ee842db4">
+      <statement statement-id="ia-4_stmt.c" uuid="392c1e50-a521-4659-a51b-9777980657ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="1e1e5eb8-000d-41dd-a385-b0bf3ba75f59">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9556ba20-699e-4d4f-9e22-41dd082f1356">
+      <statement statement-id="ia-4_stmt.d" uuid="e96f4007-63aa-4366-b552-17cf998650fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fcb766d-2f87-4259-b20e-980df6842530">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -4224,8 +4224,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="42b7b3cd-d73f-4210-9101-c00ab9250a1e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3996b5ce-ee72-4da7-9994-d0b1c1940f47">
+      <statement statement-id="ia-4_stmt.e" uuid="c12dd478-a4bd-4ae0-afe9-803f7fe47e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1290e859-497c-4528-9276-c533a1beac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -4240,10 +4240,10 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4989b40-d3bd-41ce-b4d1-a44da44ba4ec" control-id="ia-4.4">
+    <implemented-requirement uuid="2be69012-2d24-4210-99e6-998ca2328576" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="261dc3c6-2e0f-4c78-b288-35acfed1e83d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a5b5024c-f4cd-49bc-b99f-ac464de65576">
+      <statement statement-id="ia-4.4_stmt" uuid="39765129-14c3-4158-9aa0-88530f3040eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -4251,18 +4251,18 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3d5c034-074f-4204-ab65-df248c3531cd" control-id="ia-5">
+    <implemented-requirement uuid="3dbd5d5f-c89f-4286-ae21-2099b279f150" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="8f437ee7-0871-414c-bef7-17a4ab1a5921">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5f45322e-4639-400a-be0e-61fc7723e799">
+      <statement statement-id="ia-5_stmt.a" uuid="7b0a503b-79cf-4f86-8477-64651d2c6e78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="baff315c-aaf0-4c63-99ef-08c760f29d87">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ae1cdad2-cfbb-4dfd-ab93-f69d621e7ecc">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4270,8 +4270,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="d3b36023-c6f5-4f70-ab02-0c0d8ef2c6f0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d6c4cd6f-dbb4-44cb-b352-b28ab5f6454d">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4279,16 +4279,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="31269e71-be2b-4f19-9aad-b2aeb1154e46">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9ca65bf2-4668-416f-b745-d8ed993cef49">
+      <statement statement-id="ia-5_stmt.d" uuid="5c386be2-b297-4853-9a7e-9307940b9f1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="39f0403d-c082-47ca-9045-a2a3925b555a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9bb335d8-282e-49ad-bb68-ab49cd331030">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4296,8 +4296,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="99782b5d-d84c-463d-864a-48d6e39f82d9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a7f0de4f-3c24-42ab-b345-8cb900306071">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4305,8 +4305,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="ed98317a-005b-4bb0-a99b-40fa8242ccc5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f8bf208b-19f7-4ed5-8ef4-81bed6e223f3">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4314,8 +4314,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="e6dbe07d-90d6-415f-b21b-53cfc12d9d28">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="042eb86c-e5fd-4a2b-b553-8f729c91d21d">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4323,16 +4323,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="0b575503-275a-476b-9fe0-ab8c6138cfff">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="227a2050-0702-4756-9a0b-27f8a090919e">
+      <statement statement-id="ia-5_stmt.i" uuid="8cd40f58-98ac-43cd-99fe-c51dbfa5e016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="60b669a8-50a8-4bfb-b98f-c3e3d6849b91">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2108637a-16ee-4513-bd44-18c217d28d53">
+      <statement statement-id="ia-5_stmt.j" uuid="160b8f2b-8776-4a5e-af26-1df569e42d5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -4340,10 +4340,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3634210c-3064-4696-a6be-6c7abc4d02c6" control-id="ia-5.1">
+    <implemented-requirement uuid="9a10ca43-6f11-4a52-8567-4bcbd544ab73" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="ecc2ccea-4d13-4c72-ab43-050b214eb01f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="20373e99-9a01-4080-b074-3432ac6e7937">
+      <statement statement-id="ia-5.1_stmt.a" uuid="2eb87715-5e65-4cac-a28a-4a5ab19266c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4351,8 +4351,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="c2590bc8-4969-4804-bebb-746812c719dd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d4f868ad-7f31-4aa7-9e78-47b34dbeff02">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c88ff946-4f4e-48f3-abc5-f8b8a5d5f370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4360,8 +4360,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="b184af14-bfdf-474e-8146-f7b67df5fb67">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="759b2d5f-5da8-4369-9232-f74f05fda8ae">
+      <statement statement-id="ia-5.1_stmt.c" uuid="2f0ca946-a3ab-48e1-afc2-3feaefbb1ebc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4369,8 +4369,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="38ab8e8d-0727-4c62-9344-6de4b1864961">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5e8acdfb-c56e-4d58-bb85-ebb38330102a">
+      <statement statement-id="ia-5.1_stmt.d" uuid="2fe55d3b-2ca5-4fd1-8132-fbd0b6367481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4378,8 +4378,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="af943f8a-3ad4-4416-88c8-4ffa8f741666">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0afab40f-ec44-4ef2-a91e-a4b75137c8d1">
+      <statement statement-id="ia-5.1_stmt.e" uuid="b4d6cce9-c6ff-4f4e-902e-0cbee43a557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4387,8 +4387,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="fd19fc07-a252-4739-aca3-bd9b21703f2d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="81d084ef-1add-4a8c-b1b1-acb76c55a585">
+      <statement statement-id="ia-5.1_stmt.f" uuid="48c96ae6-37ae-422d-9ff0-4290751a74dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4397,10 +4397,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5922253b-573b-459e-8a06-369df5675212" control-id="ia-5.2">
+    <implemented-requirement uuid="a6b20dac-858f-4432-a9f8-454c24473d75" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="72f8600e-f020-4236-9188-193c0b362dbc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8b27b391-ea05-465d-9b65-5edc7fb36689">
+      <statement statement-id="ia-5.2_stmt.a" uuid="260426ad-e896-4c8c-bbbf-f9954d38e3bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4408,8 +4408,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="84de95ad-a2b2-45ba-b469-663a6495baa4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="59bbec47-5d24-4b98-a2dc-d164204159b0">
+      <statement statement-id="ia-5.2_stmt.b" uuid="6a899cdf-1ff3-40d7-9f3e-d85b26f43e7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4417,8 +4417,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="abc461a6-6a95-440c-a23d-480a5dd2921d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f476f542-46bb-4378-87d3-8f8bb6424396">
+      <statement statement-id="ia-5.2_stmt.c" uuid="5bb16a9b-a53d-486f-b097-939d1300eb80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4426,8 +4426,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="d0a9d9b8-02e0-4b9e-99b6-ea515395dc50">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4fee3122-933b-4a8f-a2dc-cd7dfa6e5a00">
+      <statement statement-id="ia-5.2_stmt.d" uuid="5c943719-8bae-40cb-96a4-29de69026782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4436,10 +4436,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7143679f-d9a5-4cf4-8a2c-b44079a5ebec" control-id="ia-5.3">
+    <implemented-requirement uuid="4006bb15-2593-43b1-a664-3bb5e3e8fed9" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="f656d813-63a1-4f27-b389-c3f040bf4e72">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="70b3dffd-c383-4d71-8233-a908b4989c8e">
+      <statement statement-id="ia-5.3_stmt" uuid="30aec275-5150-4906-8e11-fb0a34d4f06b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcadda7b-71db-424d-90d7-0c4f9774894c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -4451,10 +4451,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92d5dd9d-ab4d-47ef-a290-4612fbea3406" control-id="ia-5.4">
+    <implemented-requirement uuid="94607c21-260c-4efe-949e-59ccb3c94b40" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="38b7aa83-a6d3-4400-b946-a5b4aab850dd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a8b54622-6aab-4149-81a3-26d858d0c68a">
+      <statement statement-id="ia-5.4_stmt" uuid="516d6712-007c-4d1d-a6b6-825b46552ab6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4463,10 +4463,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3edb84e3-0a4e-44bb-a968-848a0ba0e9bc" control-id="ia-5.6">
+    <implemented-requirement uuid="fd0192e7-e957-492e-966a-4e640178f91c" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="04450c7e-bf9b-4155-9f47-c41bd2f29575">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="78ad7ff0-3abf-4646-948b-01a48255512f">
+      <statement statement-id="ia-5.6_stmt" uuid="0d3c7248-39e9-4229-b6f8-d8885bbad9a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -4474,10 +4474,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="02319df5-7246-47e2-8dfb-cc038fb6204d" control-id="ia-5.7">
+    <implemented-requirement uuid="19ebd989-8420-4755-ab4c-0bcec6997600" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="5d7da010-f2fb-4764-80a0-329b72fb1faf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b0e25c2c-bbe1-4b07-995f-78d739cb1c4f">
+      <statement statement-id="ia-5.7_stmt" uuid="7f6fb122-c12a-4362-8ec5-47258add160d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4486,10 +4486,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6967207f-d8ef-4d63-b945-454d62ae50c8" control-id="ia-5.8">
+    <implemented-requirement uuid="27b452d0-db7f-454b-adc8-dfce01236e80" control-id="ia-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.8_stmt" uuid="b5b4114b-8076-4b20-ab4f-9c6205fe3d88">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7d2eb78b-392b-427d-a1ed-a5b1a63c66fd">
+      <statement statement-id="ia-5.8_stmt" uuid="04b67386-ba9b-41be-ba05-e4bd26ee499b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907e2c4-ddab-4a60-963f-c8e2396e2333">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational implementation of organization-defined security
 safeguards to manage the risk of compromise due to individuals having
@@ -4499,10 +4499,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78646abb-d4ff-453f-8029-e5db1b5c7984" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="b99949dd-ddb7-4645-9a67-747dac86bad1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="40684a7c-a1a3-437b-8c1c-24d2aa56a939">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4511,10 +4511,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dcd6cf05-0da8-4976-9ac9-a312ec225ed1" control-id="ia-5.13">
+    <implemented-requirement uuid="4f206a52-a096-4779-94d0-5d9a35f4146b" control-id="ia-5.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.13_stmt" uuid="42cc979d-c1bc-492d-8034-0ab11ad11c96">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0d2368c2-48f9-4f0f-93aa-0ec1169c2646">
+      <statement statement-id="ia-5.13_stmt" uuid="08de25f5-40a6-4869-8ea2-352293f9697e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4523,10 +4523,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f963bc1-e31c-40f2-bca6-c11034cd1a8a" control-id="ia-6">
+    <implemented-requirement uuid="022887aa-4532-4de0-9f39-837ff9bb0039" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="9f9f84b8-1778-4951-9ffc-df347ef66223">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2576b0f7-579d-4754-a5ed-b3b4eefa4b9b">
+      <statement statement-id="ia-6_stmt" uuid="c69f5a79-fc8c-42d1-9d9e-3dcbf71d7fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5702a69f-2325-4eb2-b49a-28fc0805096f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) automatically obscures
 feedback of authentication information and cannot be configured
@@ -4539,10 +4539,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c4a8fd8-2252-4720-8a59-6c5131a08a4d" control-id="ia-7">
+    <implemented-requirement uuid="83da2df7-d021-4c45-96df-f2724a8346bc" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="e3500b75-619f-40d4-9f93-434573ebc2fa">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5ba6473e-c975-4e7e-82f8-9902c83db0bc">
+      <statement statement-id="ia-7_stmt" uuid="9fbba9ca-a1f5-438f-85a7-93516e6ce37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="718d669c-6b16-4974-b480-636316eefd8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4551,10 +4551,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="246b979e-cf81-4c33-aa17-e47aa49e0e74" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="10bc16c7-a9aa-4a1d-8e2c-80c2967d5c16">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="66a861af-7cac-4db3-b34c-50b82aae1571">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -4564,10 +4564,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="812f139e-a6bf-4e80-a759-2d585f57638d" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="6237fb21-f07d-4f5c-951f-176ef3f9f31e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3c77d78f-7b04-4707-b3d0-ce8e34532557">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4576,10 +4576,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b54e28b2-966d-4f8a-8c3c-949e98052486" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="5f8539b5-6b8d-4fa2-9270-68374147057a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="95e7605c-1fb0-4e2f-a3ac-d5e5da572ba3">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4588,10 +4588,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="363724c6-2a51-4939-b4fd-9847aa87f2e1" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="8afd0264-8c55-444e-a179-09ff7050b2f1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1405fd92-3766-438f-946d-514d59b3c1d1">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4600,10 +4600,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67b45b0b-532a-4346-b78e-4abb5595d67f" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="4476b867-345a-48e6-a295-82ac9dafecc4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d221bb02-2feb-47e2-9490-62f65a1afc5a">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -4612,50 +4612,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc06fe8b-8d99-487d-9f37-95a9ed5c2b84" control-id="ir-1">
+    <implemented-requirement uuid="3240daee-30be-4876-ba10-7269c896711d" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="3c22c0c5-4f20-4dcc-9c45-3b9807137fa5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="07dd0d9d-329e-48fd-ad66-fefe4bd7fc64">
+      <statement statement-id="ir-1_stmt.a" uuid="7a9bac04-55a7-4332-8bb1-661acbf6603a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="6a5bbbbc-aab8-40a9-a434-59675a8688d0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e70d9b16-e98b-4638-b757-324f64c86350">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a0f17d3d-926f-4d88-948c-47ddbd989dcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="3fff875e-000f-4651-8507-c214b37d2dd6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="490ebaa2-0266-4fca-be44-5464317bbbd7">
+      <statement statement-id="ir-1_stmt.a.2" uuid="11e3a4a5-07b5-437b-91e6-47d3d4459389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="4f50500c-1a56-4de2-a7d7-e76b86a5a661">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="aa7bbec1-7db3-46da-9998-90f5de8f44be">
+      <statement statement-id="ir-1_stmt.b" uuid="001fcc6d-73c7-4c36-8212-ea870c51eb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="42735df0-8ffc-45d2-8eb2-b937c847590a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a6a23776-9878-4034-84cc-b5af505bbbb9">
+      <statement statement-id="ir-1_stmt.b.1" uuid="e77b8f95-f72d-49a7-9be9-cb6a9548fa03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="092f6882-4e57-4113-a4d2-a18d96987eb3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9ca3d075-440d-4578-835e-e84edaf2b77b">
+      <statement statement-id="ir-1_stmt.b.2" uuid="1ab303e1-20cf-491c-b402-28f04e190fd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4663,26 +4663,26 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="77944fc1-e7bc-472c-95be-222885cfe4f7" control-id="ir-2">
+    <implemented-requirement uuid="6dab2fe3-8e32-4952-b163-f79148aa1035" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="9922d9f9-26d4-49c2-bfd2-c3fa0f36befc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e5d49a79-3462-45ed-8ed0-fede6e1e3a76">
+      <statement statement-id="ir-2_stmt.a" uuid="dd62a057-8077-49c7-ac5f-1fb9656a0e69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="9fc6cc2c-e40f-430b-9da9-b6aeb3300bfb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fad3663e-9aa1-4c4e-b4f6-7413023c4a51">
+      <statement statement-id="ir-2_stmt.b" uuid="050ee893-949a-49a4-b8a0-3288b4aebe74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="b08bdaed-f5a2-4a8d-9eaa-4a91aa2ffd43">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0fd951ee-dbfe-4616-aee5-bc67b470e829">
+      <statement statement-id="ir-2_stmt.c" uuid="90e22189-04f6-4dc2-a3ff-482921aee142">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4690,10 +4690,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1182c479-3b27-44e3-90be-2d446e9b2c85" control-id="ir-2.1">
+    <implemented-requirement uuid="a3034009-f4f9-4f83-b23b-c743ed53f0bb" control-id="ir-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.1_stmt" uuid="710644a0-e81d-4688-bbcd-1849f29503b3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2cbe70e3-6f01-4be0-8997-64b0882568b9">
+      <statement statement-id="ir-2.1_stmt" uuid="f03634fa-4822-4a5a-bb3e-37562f08ff5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4701,10 +4701,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="392de2c0-f3e2-4966-aa5c-8eb1093d5462" control-id="ir-2.2">
+    <implemented-requirement uuid="1c7fc40d-5b99-404e-873d-4f4ac597f035" control-id="ir-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2.2_stmt" uuid="8c1b5de4-b357-4076-94d1-3e8086382385">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="79c6c2b1-5df2-4f88-afd9-925e465d6731">
+      <statement statement-id="ir-2.2_stmt" uuid="20684e08-3f8c-474e-b908-aaa67c2848b2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4712,10 +4712,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9b7d27b-eb95-4a0f-8e17-f4369db8326a" control-id="ir-3">
+    <implemented-requirement uuid="b269290c-8e58-4628-8786-e2d1c130604f" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="8408bffa-d110-4929-bc58-358e94d830ad">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d726a5d6-c13f-442f-b8f8-209a737de3cb">
+      <statement statement-id="ir-3_stmt" uuid="f892bc89-30b6-4fdd-ac2c-3146a3e30328">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4723,10 +4723,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27908220-2f3f-4065-a36c-f1fc88ae4a66" control-id="ir-3.2">
+    <implemented-requirement uuid="3f2cdf17-d059-4d7e-ab78-4afbd737e92f" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="80caa901-3f20-4041-a0eb-e27ce323460a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a78782e8-02ea-4e58-9e33-65a613dc0f1d">
+      <statement statement-id="ir-3.2_stmt" uuid="f42e1a68-8813-48be-8af2-9569d928c6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4734,26 +4734,26 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8307122e-b118-443d-b6c4-d43300263627" control-id="ir-4">
+    <implemented-requirement uuid="1155072e-5be7-426f-8051-6ad707df4adf" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="621b1a6e-f813-4814-b8fd-d5c29a9ce4a7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8c6562ac-02a4-4a32-9a27-ea42ae8f5d25">
+      <statement statement-id="ir-4_stmt.a" uuid="d7396185-ef72-414c-9685-a82b7865b70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="acd9ab4e-f6ab-47be-9d36-cda6e769e097">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5a5dde49-4400-4402-957b-c52be54ea66a">
+      <statement statement-id="ir-4_stmt.b" uuid="3f4818ef-7b32-46ae-822e-9ecbbbd81883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="1eaf518a-d307-4575-89f7-4836ef658bc9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a8ebc915-7572-4fda-b4b1-e16e1029fea3">
+      <statement statement-id="ir-4_stmt.c" uuid="2f72cf07-e50e-421b-8661-3845a296db7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4761,10 +4761,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="268acdcf-92bb-4918-a58f-88e0c0e66416" control-id="ir-4.1">
+    <implemented-requirement uuid="3d182f97-7b64-479a-bd57-23016ea6623a" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="20b75501-342e-4cb6-ae34-24df6f89c6a5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="04797443-61fb-496a-b564-f904c4809503">
+      <statement statement-id="ir-4.1_stmt" uuid="b1fb5ce8-22c3-45dc-ae46-99c68bb075c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4772,10 +4772,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8a11856-3433-49f3-8ac4-304bc4f01b0a" control-id="ir-4.2">
+    <implemented-requirement uuid="2775c79f-397c-425d-bd23-5c12ff848a48" control-id="ir-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.2_stmt" uuid="54fb4a17-ddc0-4223-88e2-2ed086076a38">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="84262e85-183b-4a77-9e8f-ff412426942a">
+      <statement statement-id="ir-4.2_stmt" uuid="ba26996d-2c04-4c0d-93cd-a9ea06a88591">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4783,10 +4783,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="302ea7b2-0210-4208-b056-e2fbc20e5f43" control-id="ir-4.3">
+    <implemented-requirement uuid="ad5e77e8-fa72-48d0-904a-5bfba64f1146" control-id="ir-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.3_stmt" uuid="26db4c08-d201-4a3b-b633-b7a2aec5139f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0797707a-88ee-4498-9f87-6493a0b1161a">
+      <statement statement-id="ir-4.3_stmt" uuid="af9123a3-2575-4dfb-b974-5b4a79e5393a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4794,10 +4794,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ba0a370-108b-4fb5-8d11-84dc1e203d16" control-id="ir-4.4">
+    <implemented-requirement uuid="4cafd76e-f350-4344-ba00-5722b461cb50" control-id="ir-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.4_stmt" uuid="95fa29bd-8f58-4612-a051-fc8a5c9ee6fb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0c151494-6f7d-410e-a699-181486e73db6">
+      <statement statement-id="ir-4.4_stmt" uuid="d8ffe903-0639-4444-9e88-7e0b0557c294">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4805,10 +4805,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="86e7e737-4763-40af-a820-f4bcb478fa16" control-id="ir-4.6">
+    <implemented-requirement uuid="e37e6531-dcae-4565-bf70-7a0aa6555bc1" control-id="ir-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.6_stmt" uuid="b266cee5-a9d0-4523-b4db-1174511c948f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d883c588-7460-4b8f-87fd-88e98f7beed6">
+      <statement statement-id="ir-4.6_stmt" uuid="461aecdb-b77f-4f7d-a75d-747bb562332c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4816,10 +4816,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3b65347-362d-468b-ae16-dedc165f4846" control-id="ir-4.8">
+    <implemented-requirement uuid="1ed5cd93-3b6e-4f0e-9f46-2e2fc590bca2" control-id="ir-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.8_stmt" uuid="4bfad444-4a87-4871-98f0-7c3258aab217">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5dcf8ddc-301b-4d5b-a29f-b1d8e46e2919">
+      <statement statement-id="ir-4.8_stmt" uuid="33be4168-e08a-4df8-b251-d30d016b5fcb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4827,10 +4827,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf8e6130-deb4-4ebf-958d-0d241db06715" control-id="ir-5">
+    <implemented-requirement uuid="1e48707f-48f7-4759-9469-03b2c024f350" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="44df3bc0-9815-4109-9c83-ced2a0fd70ab">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9b70f237-8cc0-4faf-ad72-e074d8444b50">
+      <statement statement-id="ir-5_stmt" uuid="80d2a2ec-8bc0-4799-8052-9cecbdea4e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4838,10 +4838,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb0a5b2b-a862-4066-b995-66815015add1" control-id="ir-5.1">
+    <implemented-requirement uuid="24dd362b-4efd-4f2a-8a4b-53b14089f0bc" control-id="ir-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5.1_stmt" uuid="223f7695-65df-4f59-9c39-420dcfbd0d76">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5e0d412b-54ca-4c84-8800-e48b0ba5d2c2">
+      <statement statement-id="ir-5.1_stmt" uuid="bed8de64-747c-4e11-a04b-9a3f5d5cf29f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4849,18 +4849,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c205f45a-9c4c-4c38-b59e-f541bff520ed" control-id="ir-6">
+    <implemented-requirement uuid="2d2e105e-5a5f-4c63-a0d9-8fdee571c5cf" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="55462a40-13ce-4424-9650-175fc6f4052f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="866fbffd-3a78-496d-b5f6-c3fbd3b91dba">
+      <statement statement-id="ir-6_stmt.a" uuid="b83624b2-4873-4a2f-9824-5dc52eb52a13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="eb759f10-8eff-4251-9959-fc0d21565800">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="40bc65b9-9020-4a61-9d8d-67a13c52561e">
+      <statement statement-id="ir-6_stmt.b" uuid="054880bc-4ed1-4ef9-bcf7-be11417fb024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4868,10 +4868,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a649b144-00cc-47b1-8abd-db47bacdfabf" control-id="ir-6.1">
+    <implemented-requirement uuid="5112de95-2735-413f-8b80-68e24f81e1ab" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="0f8aaa27-edb2-4dbe-8fb1-b73dbbcb35d9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6e637337-be41-4931-b3ee-2f5c1333edf7">
+      <statement statement-id="ir-6.1_stmt" uuid="b0ebd5fa-01ad-41be-8ad1-95e3fa47ba49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4879,10 +4879,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="30e1c6d5-e45d-4eb8-8633-282bf503bad6" control-id="ir-7">
+    <implemented-requirement uuid="3f425480-b8e7-4177-b13a-33ba3b91d721" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="19793e78-940b-4c88-867e-68832808186a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c7117d41-4dce-4c1a-bf72-e17e9f7cabcb">
+      <statement statement-id="ir-7_stmt" uuid="d9cdcde0-b75d-4101-9cda-8d35144e7488">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4890,10 +4890,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a475f3a-4ea7-4d79-a788-1f66ad4572c3" control-id="ir-7.1">
+    <implemented-requirement uuid="c1478f62-2c26-44d0-b938-a5e8cdee6537" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="26fbb57c-f441-459f-9e66-a574caed28c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="70f7a9ec-27ec-45d5-8f88-60f7d4a6630f">
+      <statement statement-id="ir-7.1_stmt" uuid="47534123-7068-4d35-b381-bbf90556c0c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4901,18 +4901,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa3afdff-ffb1-4eef-bb4f-f729a8c7cc03" control-id="ir-7.2">
+    <implemented-requirement uuid="c33e7808-2fd5-4f78-8a24-f8ec8a166b06" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="5618cb9a-738d-4b30-b5d9-953c1d1ae9d4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7e0b2833-100d-4a40-96f6-60f444b2e78f">
+      <statement statement-id="ir-7.2_stmt.a" uuid="13c7c613-6d85-4bfe-a288-87ddfa035387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="20fb443d-421f-4899-b90d-bb4cfdf59414">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9395389f-052e-4a3f-b334-835635913503">
+      <statement statement-id="ir-7.2_stmt.b" uuid="097701db-7c15-4855-b266-24a90fd7b49d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4920,114 +4920,114 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ecb87113-d4f1-4048-9f65-69ebf122d148" control-id="ir-8">
+    <implemented-requirement uuid="967e97cb-b9b3-464f-afaf-eb257e79a9d8" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="a5e8ac29-efc0-47d4-a4fe-03369e1531f2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a8d56896-dea8-4872-9ba5-78b5716ae356">
+      <statement statement-id="ir-8_stmt.a" uuid="cc8f2bb6-6e14-4297-bc04-25d74cf2d795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="b408eda8-cd7f-41d9-836a-9a291960bbd5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5a9fa1d5-1500-4ad5-b547-49d15e72fa05">
+      <statement statement-id="ir-8_stmt.a.1" uuid="9b5a26d8-abfe-484a-a7a4-518decf26f32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="ffe0ceb2-28f2-4131-b1e5-e99f8349b599">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="01d2dde2-d6fc-4467-a0e3-f51b5adae9a8">
+      <statement statement-id="ir-8_stmt.a.2" uuid="2e063b17-fee1-46a5-9aaa-f976e6829ae8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="12833f6b-7d07-40ad-a790-d37fa33d03ed">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2a869fd6-1771-4d8c-8888-920a62ec5621">
+      <statement statement-id="ir-8_stmt.a.3" uuid="e17ca486-9878-4f4f-862d-35cf728f9dab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="92141a28-14a5-49eb-b7fc-d18278f393bc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="507ff4d2-b348-47ea-80ae-879bc42731a1">
+      <statement statement-id="ir-8_stmt.a.4" uuid="f409d770-51db-4a9e-aacc-f444c7334037">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="9e0d14f1-f389-48e2-8061-b6edff6868c2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e1a49fb4-ecbe-4fb6-a76d-9e10b4148054">
+      <statement statement-id="ir-8_stmt.a.5" uuid="9ecdfeee-c454-45da-9772-8819ac9eb51a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="1939b3b3-34bc-4789-a3ac-123b5c55008a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b78005e1-84cb-47ef-9142-eb9ef79f46f2">
+      <statement statement-id="ir-8_stmt.a.6" uuid="d36a19fc-8360-42d5-bae0-dc72f837945e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="f868a9f6-cec8-4ba5-b059-8c86dfebf899">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4ff4d018-f6c9-4396-b103-b3060f0bd6f1">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d5ff6c68-b16b-4143-96a5-cd6511d31b7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="521f59b9-0835-4831-b75f-86a89cbcd8e5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b743cff1-2f7b-4632-b916-0d6675d77e66">
+      <statement statement-id="ir-8_stmt.a.8" uuid="5b4f8897-2628-46dd-b058-283e27888b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="db489be6-6f41-435b-9fb2-c5d31ef0f556">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9d51bcb1-3e69-4549-9d4b-7e43042a3c9f">
+      <statement statement-id="ir-8_stmt.b" uuid="2c2a5c3f-56b8-4129-857d-eec9c7cd0e0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="9dd87529-7c84-4a49-a532-8e471bb4d756">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3def7eea-6952-43a5-8c38-bd99e20de421">
+      <statement statement-id="ir-8_stmt.c" uuid="5462a597-ce52-4d20-a027-2350d4f05779">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="2c562a49-e252-4c09-bb5c-986db3ac5df8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4dd4fed5-0aa0-4feb-a892-105728d3e19b">
+      <statement statement-id="ir-8_stmt.d" uuid="5ad0a837-3c8b-45be-9cd9-b7260d3ce617">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="0fa5e6f4-7b09-428c-97f9-58f7f8a68acb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fcdf9941-9742-489a-a650-677b1339c041">
+      <statement statement-id="ir-8_stmt.e" uuid="8c8f9a0f-5052-45a7-9f20-0096cec25c09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="dc727321-8bfc-4a7b-984d-afd939768ad7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bc75b5f4-ed53-4811-acfd-1d6817b8d139">
+      <statement statement-id="ir-8_stmt.f" uuid="b94c4a7d-f35e-4cd5-9db8-cee39d2ed822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5035,50 +5035,50 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6324925-640f-4cf4-aa70-006b54047676" control-id="ir-9">
+    <implemented-requirement uuid="1c6b3117-4021-44ac-9245-603f7fa79bf2" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="a5e1b57e-5669-4cdf-b9f7-67efbd184b19">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="affd2813-f3dd-47c0-8dff-136ce34e251b">
+      <statement statement-id="ir-9_stmt.a" uuid="06bcdf67-876f-4b0a-a61b-691f4524a753">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="849a318c-00c9-4cfb-a490-c332dd148f2b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="899555d9-2661-4b5b-a2f1-ec09e3086c69">
+      <statement statement-id="ir-9_stmt.b" uuid="32b03a4a-531f-4c74-9aec-2e15fd173dc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="7692188c-4c8f-4dfe-801b-41cce3067c8b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bf486692-0c88-453c-8f3f-36896f1ed54f">
+      <statement statement-id="ir-9_stmt.c" uuid="749a44a8-e6c9-4c73-85d6-382e1a18a478">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="ea13674d-a920-4dd1-a3d0-7c9fe1b7abcb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f66aa6be-1bc7-43e6-b7f8-256be35b7c43">
+      <statement statement-id="ir-9_stmt.d" uuid="82a45b26-8d2f-45ae-be30-6dd4acf4cb85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="8d3e614a-c034-47c9-ba13-43e88061d1f1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4b8ee4cb-cdf4-49e5-ad77-88339a053893">
+      <statement statement-id="ir-9_stmt.e" uuid="29b7f249-0b28-4634-a204-ac053f80084d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="dbf1ce1b-cfaf-4cab-b4e9-531b5aff5d51">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="444a67ef-3731-49d5-8d1b-e983526a9d0e">
+      <statement statement-id="ir-9_stmt.f" uuid="2dfbee00-5db5-43dd-99c7-131a27804956">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5086,10 +5086,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8bce1655-6c6b-48fa-823b-55b88d4a8bc2" control-id="ir-9.1">
+    <implemented-requirement uuid="c7fd67e1-7589-4a5d-a698-95740328359b" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="f2cdcaf9-ba4e-4d19-b571-dce61e42edcf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="93e4811a-8b06-45bf-86a5-8fdb13a36f81">
+      <statement statement-id="ir-9.1_stmt" uuid="a959e5cf-3777-4cac-b73d-e4d375119041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5097,10 +5097,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3870975-249b-4a84-91ed-32cb6e3c405c" control-id="ir-9.2">
+    <implemented-requirement uuid="d655dd6c-5107-41ac-b8ba-6fc4a2bd7230" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="2849cae7-f767-45fb-8b80-91278c22b996">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c53b8ae9-450f-47d5-bd30-5dd496967ddf">
+      <statement statement-id="ir-9.2_stmt" uuid="db9488da-2b33-4cfe-be53-bde44aff97ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5108,10 +5108,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4603a4d2-18b5-4bf4-8f41-aa1b392cbcb6" control-id="ir-9.3">
+    <implemented-requirement uuid="e66be561-ec5e-402b-be11-89c9cc2d6a03" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="7dfeea5e-37bd-47b4-a457-1ad68e52a4e3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="819e6c06-7215-4a1e-8120-0025893e5168">
+      <statement statement-id="ir-9.3_stmt" uuid="f18c8ce4-99b9-4d25-8255-61fdd485f54f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5119,10 +5119,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f1da40f1-3507-4685-9969-836735e844a3" control-id="ir-9.4">
+    <implemented-requirement uuid="eccff598-379e-45fd-9d5c-65773e649950" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="aa9b1921-2bf5-4e3d-bffc-8f41008b8330">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="01228290-edfc-46b7-9c94-44e9bd344e9a">
+      <statement statement-id="ir-9.4_stmt" uuid="1e2e089e-bdca-4823-b35b-dfd53e798318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5130,18 +5130,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9fd5892-49b0-4418-aee5-198485af3bfc" control-id="ma-1">
+    <implemented-requirement uuid="79bbe60d-fb10-4957-8236-c6012202d83a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="ef51a117-3008-4c15-ac33-04d34793b0de">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="143f7f38-bc05-4eb5-8fa7-e6f4909efb56">
+      <statement statement-id="ma-1_stmt.a" uuid="9330d002-55ee-428a-b026-9534632ae9bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="a7fd2483-5cc4-4ed4-b30e-a8291811cf43">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c6852ed2-1425-42d8-b53d-17a3999b14ec">
+      <statement statement-id="ma-1_stmt.b" uuid="01d928ae-fba4-4073-bed0-d2b7b996e31c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5149,50 +5149,50 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="803a46c6-1596-4846-b5d9-51e98ce535c7" control-id="ma-2">
+    <implemented-requirement uuid="2c7f66ff-b53e-4cf1-a882-4224dfd66064" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="5e729b73-bbbe-426d-b082-d07f362aed5c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f2ea32b5-ed59-4eb7-992f-0cb807126a52">
+      <statement statement-id="ma-2_stmt.a" uuid="4effddb8-e41b-4761-b7f3-1e725cd04b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="83fca691-20f1-4300-a311-b76678aa8b50">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2b354806-0df2-4bb9-97ca-59c4a8a667da">
+      <statement statement-id="ma-2_stmt.b" uuid="b62298fa-b158-4c85-88ac-04e00acc41de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="cad5df3a-5bdf-437b-aba0-0a55536723cc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="36bec797-902c-475d-9828-1627a18e3783">
+      <statement statement-id="ma-2_stmt.c" uuid="a077c965-9ef7-43eb-a00e-0eecd8465d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="83f01a8a-4997-47d1-9ff9-36ef423ad2a0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="78aaedbf-ece4-419f-99f7-9ab7c0208954">
+      <statement statement-id="ma-2_stmt.d" uuid="71605f10-203f-4d37-8a73-60acf1a19490">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="d4f3c2c2-d8d3-499a-9dea-8d444f1efb4c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b06535ed-66cc-46b7-a76c-6dd596d62a27">
+      <statement statement-id="ma-2_stmt.e" uuid="8059b9a5-9327-4fdb-9fb4-1817ef4b8282">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="af021443-7902-4816-951a-fb7cbe353388">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="af7dcdd5-22d7-4c9a-98da-ed9b268d2857">
+      <statement statement-id="ma-2_stmt.f" uuid="c07f9d07-d835-4f83-ac78-1b754f3787c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5200,29 +5200,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb3afe4a-9e08-4d16-b6e9-b801cc21b209" control-id="ma-2.2">
+    <implemented-requirement uuid="c1329ebe-2e83-4592-ad1b-e9aa2bf95071" control-id="ma-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2.2_stmt.a" uuid="b69f3e0d-f010-4531-90aa-b8aa2711100c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c618b6e8-96f8-4ddf-a76c-be7c4b123bd5">
+      <statement statement-id="ma-2.2_stmt.a" uuid="05abfc9b-ae47-494f-84c8-261d279516bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2.2_stmt.b" uuid="19130421-d469-42c2-9402-1d5f89ac586e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8fb32e2e-1d49-459b-af34-54e3f9d582eb">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedures/policies, and is not
-applicable to the configuration of Red Hat Virtualization Manager (RHVM).
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="a31a0a2f-52fc-42af-b6ba-8842e8c8f81b" control-id="ma-3">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="1a6adfab-9d4a-47e7-9e87-d834f53f628b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d96e6b08-dd90-4e62-9ac6-ee5534990405">
+      <statement statement-id="ma-2.2_stmt.b" uuid="93167c41-c77b-4d41-b511-410cd15550c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5230,10 +5219,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53c09822-4bf3-4055-a164-511ffe298fa4" control-id="ma-3.1">
+    <implemented-requirement uuid="51b43dae-6063-4771-840a-2b754cc4de6f" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="a7311257-cdfc-4341-ba07-d256773313a8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1e4d8684-eb11-44a5-bf5b-9786fc0b226d">
+      <statement statement-id="ma-3_stmt" uuid="4e16e51f-09a5-44b7-b8c8-c67a986e4696">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5241,10 +5230,21 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="922c675e-fcb5-4324-95a9-e19d45738ff4" control-id="ma-3.2">
+    <implemented-requirement uuid="c6eb59d8-cbe3-4917-8513-d3acfa8615dd" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="3d1cd5aa-4c4c-40e9-b8b9-0b2e7ffef5d8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a10b6a11-f53e-4c0a-9482-c5de0fa25427">
+      <statement statement-id="ma-3.1_stmt" uuid="ff72aece-fe26-4415-b968-def1751b528b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedures/policies, and is not
+applicable to the configuration of Red Hat Virtualization Manager (RHVM).
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="dea1f55a-e6d6-4ea3-8fce-46c277263b97" control-id="ma-3.2">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="ma-3.2_stmt" uuid="2f5b836d-5e91-4478-9895-7ef7e5f4dd18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20d23dd-0409-470d-a95e-da34ecaf338b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -5253,10 +5253,10 @@ system is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5669e723-ffcd-499d-9c69-9e7b84c044c8" control-id="ma-3.3">
+    <implemented-requirement uuid="e28a7832-d6cb-4ede-aa99-d3586eb25645" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="facbb7ab-91a8-4bac-abb5-8062f6ddeb7b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3ed14f19-0efd-4168-8486-bf5efdd7a743">
+      <statement statement-id="ma-3.3_stmt.a" uuid="424133fb-3759-4764-9086-48c72b365945">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="778b0eef-a853-4532-8c1c-5dced7dd12db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -5265,8 +5265,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="2bd8f226-98e6-4f5f-a1d9-65a25f9e0e58">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5258307c-9e59-43f4-b203-4b17f8c3ea86">
+      <statement statement-id="ma-3.3_stmt.b" uuid="4e7e2816-1ccd-4b18-b8d4-7928146288e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd27ca69-2c2e-4f61-aa4e-04c7f350c60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -5274,8 +5274,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="5bcd5d66-9a2a-4fc8-b8a2-eebe4561a405">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9240fc94-092b-4825-9ee0-a371ff34b4db">
+      <statement statement-id="ma-3.3_stmt.c" uuid="be47dafc-6633-4cc1-bf6c-dc825ea3d933">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bde0f7b-2115-4c9b-beb8-f8261ce40a6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -5283,8 +5283,8 @@ facility is outside the scope of Red Hat Virtualization Manager (RHVM) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="9648795d-be86-43b4-9b7f-290e5379f102">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de4da181-57e7-4df3-8abc-0180a4305939">
+      <statement statement-id="ma-3.3_stmt.d" uuid="52945e7d-10ed-4ed9-9ab7-4e056d9d14d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9e558cb-7128-4261-b081-988aa504f75e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -5295,10 +5295,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60cf55cd-21da-4a5a-9155-3b19f30b5f59" control-id="ma-4">
+    <implemented-requirement uuid="712c9223-7d41-4954-abfc-9ddcc8bd2a96" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="aca48234-99ba-47bd-9f9f-d3ce504a2b85">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4dd400bb-6734-4552-a5fd-091ca17cbd39">
+      <statement statement-id="ma-4_stmt.a" uuid="2bf356a4-b2a4-4067-929b-74401aef9739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1256c0a7-6fc1-4515-82e3-6c020b38bbff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), all
 maintenance and diagnostic activities are monitored regardless
@@ -5307,16 +5307,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="30f1b07a-fd6b-4841-a6b1-587e9cf84921">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="36788f57-3112-4b03-a703-49456182ef22">
+      <statement statement-id="ma-4_stmt.b" uuid="33c06d7b-42ca-43a2-bf2d-b9452b3aa380">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="d45ae2ab-01bb-499c-ac57-b613456b1e74">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="daa13dc4-1b80-46cd-9237-df9f2f8b27dc">
+      <statement statement-id="ma-4_stmt.c" uuid="4072929c-605c-4829-ae5c-1c42f91a53e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ce23348-7b55-4f0d-9945-d882f911512c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -5328,8 +5328,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="709ba1a4-dbaf-4dd6-bd71-455f7288616a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4388b165-eb1a-46ae-ac87-31a401953a08">
+      <statement statement-id="ma-4_stmt.d" uuid="6219f076-9f22-4aad-947e-62fb9fe64cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66a7388b-468d-427f-a923-6ab2d04bc6ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -5341,8 +5341,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="5ecf74f9-af31-4818-8bd9-7d3877be89cd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="271cdc44-7121-46b9-9f62-ea85276586af">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5351,10 +5351,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="85dafcfd-29d2-4e96-af40-060824360c70" control-id="ma-4.2">
+    <implemented-requirement uuid="5da754c6-bbb9-41ed-acf2-bc9cb898d2e9" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="51d0a2d2-5525-4837-b316-31ff13ba16bd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b3bf4b97-1caa-444f-a5c4-cc1475213b5f">
+      <statement statement-id="ma-4.2_stmt" uuid="25fce7ee-55f0-440e-a747-1ef7cbedaeda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5c40590-7ad3-4049-8b16-b6bda19d56d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5363,18 +5363,18 @@ https://projects.engineering.redhat.com/browse/RHV-21014
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="afb40c60-1a3a-4d02-b7eb-ccd61e052c48" control-id="ma-4.3">
+    <implemented-requirement uuid="6babc9b2-0d8a-4ce3-855c-35958404d63e" control-id="ma-4.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.3_stmt.a" uuid="7cd13ccc-c675-477b-ad6c-5fea62153ec4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="68993161-3fe5-42df-9094-16c2b54a8b74">
+      <statement statement-id="ma-4.3_stmt.a" uuid="cd241630-fa6d-4a44-8d88-3eb510a1f7dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4.3_stmt.b" uuid="7aa61e53-97ad-4f03-9ad0-3e5a239d12c7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1fe0fd56-c6b7-40e1-a0f7-6df02b6797f5">
+      <statement statement-id="ma-4.3_stmt.b" uuid="dde90afe-8e20-4a01-864d-3df122a4e7e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2512108e-038b-49c3-bdb1-2f1f934f8050">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5383,10 +5383,10 @@ https://projects.engineering.redhat.com/browse/RHV-21015
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3da5d2ff-5918-4dee-acff-701921342001" control-id="ma-4.6">
+    <implemented-requirement uuid="50a21906-c9a3-4643-b11b-9acf04f46697" control-id="ma-4.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4.6_stmt" uuid="dc9d4916-03a1-4514-b021-d532edc1ac6e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c9b06489-164c-4a20-acf5-81fb99b85d3d">
+      <statement statement-id="ma-4.6_stmt" uuid="8e9739d9-df9e-447b-8e01-148e463ead92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5395,10 +5395,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="620cdf8b-90da-4da2-b104-2adb8d6cf7f7" control-id="ma-5">
+    <implemented-requirement uuid="c6f2454f-6039-4a5c-b3b2-3a12d261e62e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="3873d6a9-5873-4fda-9c72-8ab4d4fe0e81">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="83f0d4c4-01d2-4df6-8046-cb2b358d4e57">
+      <statement statement-id="ma-5_stmt.a" uuid="0d5aa9e5-9153-4af3-a61f-86b82fefe5cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37184d7c-fae7-4679-a963-845c88234b15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -5406,8 +5406,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="a7309818-ba73-4526-8ee8-789831ae3aa4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bffe69a2-1081-4eee-81c4-4bc2bddade79">
+      <statement statement-id="ma-5_stmt.b" uuid="13062598-98ec-4b3d-b796-e16c64663d7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c08b5ecc-06df-45aa-925d-de541e2bb933">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -5415,8 +5415,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="22fc8a7c-4530-45fd-8e68-8c538d1c60f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7acfd71a-2857-4e89-80b0-73273cb3f12b">
+      <statement statement-id="ma-5_stmt.c" uuid="287bd11d-ca0a-4758-9af5-1063bcf335fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6551219-a954-46c0-bceb-0316c766710b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -5427,10 +5427,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="92d1dfbb-4ca8-4ab8-ac7e-2bbc2af63f58" control-id="ma-5.1">
+    <implemented-requirement uuid="54d68432-8279-4882-8396-98f6484351af" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="387f30e4-cc34-4754-8f4c-18c534a9695a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0c32fd72-ae7c-4582-9755-e1079931cf4a">
+      <statement statement-id="ma-5.1_stmt.a" uuid="2ffff01d-6c01-422a-b447-78bf8d19cb44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0586d5f-7b13-4bc6-a605-4f8274aa5b8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -5438,8 +5438,8 @@ citizens is outside the scope of Red Hat Virtualization Manager (RHVM) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="1618825d-1111-4e9d-abc6-980b4eafec2a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5671de52-cb86-4531-ab6a-709493feb88b">
+      <statement statement-id="ma-5.1_stmt.b" uuid="6b778f93-2407-4137-86c5-fc1f6f936d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e1fc1e-da41-4f7c-be05-bec4e101c33c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -5449,10 +5449,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="61530f3c-e9cc-4549-9b1f-8e3ef56f1b1c" control-id="ma-6">
+    <implemented-requirement uuid="32b69454-b03e-4bc4-ace8-f327d63813fc" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="449abbcb-5599-4c6f-89d4-10fdaf9106d1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="680e4e5e-b64e-417d-b957-96adbe3b1027">
+      <statement statement-id="ma-6_stmt" uuid="5a8fc70f-bcfc-4f12-b02d-011a5a8d8ec1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023e6e11-475c-46e2-86cc-7498a60ded11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -5461,18 +5461,18 @@ https://projects.engineering.redhat.com/browse/RHV-21052
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3a7a7b37-e49f-41e2-a69b-07581843c219" control-id="mp-1">
+    <implemented-requirement uuid="21e2fece-6fb6-4dc4-a165-885ee0319bb6" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="cf2dabe6-a801-487a-9ff9-cab0a147354f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5fba7f86-3df0-409e-bd83-a5296abf479c">
+      <statement statement-id="mp-1_stmt.a" uuid="54245217-533b-4796-9349-d7b78db1cb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="952bee16-5e5c-4c23-aeec-b39ea19df55f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a36f1f98-729a-4f17-abb8-4086d0d4c265">
+      <statement statement-id="mp-1_stmt.b" uuid="1fa9aa7d-9754-40d5-b9bf-7b514bc8bba5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5480,10 +5480,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc525a1e-a465-4bbf-a872-96631b4e3b2b" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="64cdec47-3901-4527-9135-9075866c1005">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="91052480-67b4-4e81-a463-4ac09e2c6add">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5492,18 +5492,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3561b8ad-264f-4ef5-b809-85ee890f0bd5" control-id="mp-3">
+    <implemented-requirement uuid="b6cbdb0b-c964-4d16-a682-016aac800494" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="6f3e67dd-01f6-4ee1-8e3f-00992ccd5208">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="30a2ec1f-6cab-49a4-8ea2-ba8a90af9d7b">
+      <statement statement-id="mp-3_stmt.a" uuid="06c5e5a7-3c34-48f3-8ccc-9bfebb9962f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="8373516f-2b02-46ca-a2e8-8289d134a585">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1a9cde50-e13b-496b-9b5b-d112a1b9b258">
+      <statement statement-id="mp-3_stmt.b" uuid="8404a05e-f27b-41dc-ae48-e935ce7cffa1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5511,10 +5511,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7796355e-7a89-4e6c-af39-c13b54010377" control-id="mp-4">
+    <implemented-requirement uuid="0ae07f16-fcd6-4ca1-af12-5484c7228ed1" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="0da55d52-7246-4117-a8d6-86413c52823b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="73ae1299-b38d-4a5e-94f0-ca3f78a7a458">
+      <statement statement-id="mp-4_stmt.a" uuid="b2c9bfab-6447-4a76-8556-1f3cf56f77b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5523,8 +5523,8 @@ https://projects.engineering.redhat.com/browse/RHV-21054
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="8db0ec49-3908-4682-b0b4-a19aa7457cfe">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7f38e35a-089d-4f1e-84f1-8550e57deab0">
+      <statement statement-id="mp-4_stmt.b" uuid="152c6172-3805-4382-af5e-3493779568ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -5534,34 +5534,34 @@ https://projects.engineering.redhat.com/browse/RHV-21054
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6ee90d19-0b68-44e5-9a41-901b833154b5" control-id="mp-5">
+    <implemented-requirement uuid="36916837-73ba-485f-8cbc-b952b06b4623" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="fe0faa66-0a15-499c-9551-8a2ad1bebab5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="45327ca1-0479-4764-b6b7-4cda2bb6d683">
+      <statement statement-id="mp-5_stmt.a" uuid="e0906ff3-f31b-4c8d-8aa0-0c4e4fa3a8a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="d19661ec-3e4a-4309-ad8c-acde90562597">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b2a24c35-4512-43e6-a1eb-ef608b8c3c38">
+      <statement statement-id="mp-5_stmt.b" uuid="edc5e494-f272-4d10-9df1-5871af42bb73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="b24723b4-3e9f-4db4-a3ae-e2abaaee1d27">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4490358c-51a7-42b8-8118-a2f9720cfbc4">
+      <statement statement-id="mp-5_stmt.c" uuid="a84b3aba-abb5-4393-9995-84ea457e87ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="f37d6569-6e8d-406a-ae4f-f91ff1f813ef">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1c2d364e-6789-4c96-868c-1eaf0359f529">
+      <statement statement-id="mp-5_stmt.d" uuid="a8df34aa-1c68-48fd-81a4-ae42dd813773">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -5569,28 +5569,28 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0ae65e7-51fd-47ba-8baf-3091ab98c7c2" control-id="mp-5.4">
+    <implemented-requirement uuid="43ab6425-7575-480a-bb35-97797d8dea5f" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="93b453a8-1488-4e3f-82e8-d3b956ad0382">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f95a44e5-9ef4-4d42-8b8e-310a2a6b0edf">
+      <statement statement-id="mp-5.4_stmt" uuid="cab7bc15-ef7d-40e5-9002-6298a3e922b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8674207-b085-4510-a002-2e84e8eac4d7" control-id="mp-6">
+    <implemented-requirement uuid="206115a1-32bb-45fe-b7bd-958b681716ef" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="5aea4762-aab5-4d17-975e-32b8789dfda0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5e304ec5-ab61-4f27-90b3-a5306683b62d">
+      <statement statement-id="mp-6_stmt.a" uuid="11e0e048-562f-4a5a-8100-1d226ba054b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="ffb83c3a-d0c8-4fb7-ad79-0e23757ed750">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a20a712e-e80c-444e-85f8-5dde50593425">
+      <statement statement-id="mp-6_stmt.b" uuid="bfe2ce74-209a-475f-8f81-b20fcb291d83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5598,40 +5598,40 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01a1ba91-414e-4ae2-80bd-8a24bd3ba8e0" control-id="mp-6.1">
+    <implemented-requirement uuid="05726c70-4e73-47b9-aa83-b4759b553fbf" control-id="mp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.1_stmt" uuid="4bc44317-f825-46c1-8bee-07a04cd6ec1a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d86743f3-636a-49b2-b9f2-1d70c240658a">
+      <statement statement-id="mp-6.1_stmt" uuid="b4dff112-46d8-44dd-9191-d75a4df386d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cbc58154-b76f-443f-b0d5-e63b484cc65e" control-id="mp-6.2">
+    <implemented-requirement uuid="0c5845cc-d95b-4184-bd4c-c6ed9526bb46" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="2a320c2a-6aa2-44d7-8fba-75345cde511d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2bf56594-d31c-4321-b68b-0f79dae7eaef">
+      <statement statement-id="mp-6.2_stmt" uuid="bee4acfb-7955-4781-8eb6-0516c31204bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9df494c4-2dc6-4f68-ac13-599afc8f3e39" control-id="mp-6.3">
+    <implemented-requirement uuid="431397ba-caf7-4459-9d3b-40062b1aafe2" control-id="mp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.3_stmt" uuid="d9200abd-b8cf-4ce7-84f2-ceb857ad6a9b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5bb97459-1412-45c9-a04a-15906655fb05">
+      <statement statement-id="mp-6.3_stmt" uuid="ade8bbcd-af46-46ac-b626-a033fc9750b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05de0af9-b0b3-4e48-ab94-0b11cb568e1e" control-id="mp-7">
+    <implemented-requirement uuid="beb2bb67-563e-4523-964e-e3f3311f8298" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="952adfb3-e0b6-4d98-97ba-bb2642e39591">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8438b2e4-ce52-4441-b94b-bd216c3f03ac">
+      <statement statement-id="mp-7_stmt" uuid="c569f073-ff56-4283-85df-edd9ea04a4bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ef5e981-f45c-4e6c-afee-b8b076d7f993">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Manager (RHVM) nodes, the following configuration check must be enabled:
@@ -5652,20 +5652,20 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07155d3d-ba32-4e6f-ac50-6411c6705a7b" control-id="mp-7.1">
+    <implemented-requirement uuid="c753c7a9-1b2b-4d46-84ce-900c8502562d" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="9164f911-c6b2-4e27-b8c6-0070cc77b4be">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="07c99bdd-d557-4e5d-8a36-e1c09ee8b8b0">
+      <statement statement-id="mp-7.1_stmt" uuid="2cea307a-9461-4ffe-86a3-aed7978ea58b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5802d136-ad94-4f3d-9805-658a5143f1a1" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="51c9a816-0d78-4674-85ee-f2431124803f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a5a5ee59-8d20-4e54-9bdb-0c6429235dbe">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -5674,8 +5674,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="d7c26517-d706-439f-a53e-727ab5c70e9b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ce9c3cfa-a0f7-4eda-9148-31e8e555fbcf">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -5685,10 +5685,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="23ed387c-c241-413a-8c2c-52d11cd6e7a5" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="8921a340-84b1-46ec-a8b9-69d3d7f8f45e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6b3cf74c-f860-4146-a9ef-d8f5ee89288d">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -5698,8 +5698,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="22d8bda8-713f-44f9-9a89-8106e2512c78">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e9f70a40-1f61-4ac0-89eb-575b39250e37">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -5707,8 +5707,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="c6c67a53-bb84-4da4-a428-204b8ae1332f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="da9e8d32-5d9e-4ab9-ad84-b6d6ede9f889">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -5717,8 +5717,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="bd143d81-c64c-4779-9d24-a4365d99152c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a5a41d2e-ceda-4351-8563-f9a9bddb29fc">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -5727,10 +5727,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="63d802b8-2a0a-4461-a6c0-a563e849fc92" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="8db575f4-2c6d-41ef-82d3-d481db49a3f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6494e807-7fe1-4711-a6a5-8b2b2a24d34a">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -5739,8 +5739,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="12f525fa-bdc5-48ea-a13a-e463fa903b39">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ed122254-fa6a-4dd3-a9b4-4d2a4a5e0261">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -5748,8 +5748,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="e697becd-88e1-416d-a1db-24e64efe46e8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7435cbe0-3357-4afb-8743-0970c3736ed8">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -5758,8 +5758,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="90a4108b-da77-404f-a1bf-cd578f89c8c1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ea6103d8-f1cb-4c51-a7c0-b1691925f410">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -5768,8 +5768,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="3f65acb4-83dd-4c03-92d8-fc977eaa3982">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="800ee379-8fe8-4f5d-a51d-e26bb1517852">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -5777,8 +5777,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="5c1935c8-7d1d-4728-a333-e2992de0e936">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f0bbfb88-39d5-433f-8d13-50d418a7fc79">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -5787,8 +5787,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="e2cbf4c0-69e3-49a8-8d1f-967676317271">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cb6f8bba-09ae-430b-ab54-4b21d37c3ffb">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -5798,10 +5798,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b7ca0ff3-5adf-49f4-895c-434cb8e56b89" control-id="pe-3.1">
+    <implemented-requirement uuid="e5c68a92-d4ce-41fa-8e1b-1063b64c6dad" control-id="pe-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3.1_stmt" uuid="d13039ad-5f22-4e93-9c43-4ecb76ff6949">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a6422f4e-1a08-4335-9621-32108b94da8d">
+      <statement statement-id="pe-3.1_stmt" uuid="06fd9321-0bf0-42e0-846d-db2e491efd5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6692dd72-82e2-4904-b978-57ab4fe9921b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations to the information system
 in addition to the physical access controls for the facility at
@@ -5812,10 +5812,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="220ad5f9-6552-4e1a-a5cf-4fdc65f5d3ac" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="9bf42ef2-b44d-46bd-87d1-2c730b434e9e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="307b2d20-4a06-472a-a818-b0d306a626c3">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -5826,10 +5826,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b2bd9f3b-fd81-42d5-a405-ee195ddc9b4c" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="e5f1c2ab-92c0-4cf5-84df-69161823168d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="80ff9558-e5ac-4721-8026-fede7fb82c56">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -5839,10 +5839,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79551e18-fde3-4e2f-91f5-25260c791a23" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="9b958127-bff7-434d-84f7-0c8208f7a4cd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c5907e5f-e080-474a-8335-65183d75e4b8">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -5851,8 +5851,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="7d6e6be9-dfa7-47ca-b87f-85a6473e2fd2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0420ee86-3e73-4075-8f11-4e75c9f6f1fc">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -5862,8 +5862,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="d787de54-2ed4-459e-9177-d2d90066569e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a2d0932d-7788-420f-b0ab-cb427bf6d915">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -5873,10 +5873,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="944576f0-5068-4816-84df-b5d2a60e3010" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="e68e273a-6f17-4578-a4ed-ca168bd635ba">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d9f8a9ad-b128-46e3-82f9-1c6e3a482402">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -5885,242 +5885,242 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="855cb85d-2d8c-4fe9-a69b-f77c07cc1f9b" control-id="pe-6.4">
+    <implemented-requirement uuid="cffd7586-cafc-4dc0-8d5d-8355c51c7bc0" control-id="pe-6.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.4_stmt" uuid="e597c570-353c-49c6-898a-c81a40808762">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="44111454-6ed6-41bf-ba61-7c6e7837242f">
+      <statement statement-id="pe-6.4_stmt" uuid="07ccd03e-df69-47ab-b63a-cacfb9eae5ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e10f2880-82e0-4de0-affd-31afef209568" control-id="pe-8">
+    <implemented-requirement uuid="8320c2c9-7961-4f3c-a38e-e9264bf352e0" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="e9df4e41-b3a0-4086-afa2-761f981b7a7b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="56f48707-81b8-478f-bd64-00723cc0630a">
+      <statement statement-id="pe-8_stmt.a" uuid="a118fbde-88f3-42fe-98bb-1251e82a149f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="898e8309-5ea3-4084-893f-1853dc0309c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bac0dbe3-f1ad-48ed-baa9-31a7e0cbd635">
+      <statement statement-id="pe-8_stmt.b" uuid="3ac78417-d2a1-4a9b-b566-644a13808b22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90b76dc2-1390-4a88-a48a-7dbd59aa6d57" control-id="pe-8.1">
+    <implemented-requirement uuid="5835de08-f063-42ac-826f-db20769cc6a5" control-id="pe-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8.1_stmt" uuid="149dd797-fa5b-4d42-b1fa-b45e0a52eca8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="42e49a4e-fcb1-40d2-a60a-004c77080989">
+      <statement statement-id="pe-8.1_stmt" uuid="5ca4f25d-2fdb-44f3-8008-0afa8f21176f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e0b9723-dd26-41f4-b0b4-5642d870cfeb" control-id="pe-9">
+    <implemented-requirement uuid="419aa702-528f-4137-9417-f8aee5b3e5c6" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="ab8d3351-4c4d-4e7e-a4b1-0f51055c24ba">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="11237e10-a6b8-4f89-8603-1d39dbd6b0bc">
+      <statement statement-id="pe-9_stmt" uuid="cbf78a0b-dde9-4922-b7ff-ed6274573a85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a8cc5fe8-d375-4c0f-9a8d-d27764087cf1" control-id="pe-10">
+    <implemented-requirement uuid="8ee0cc89-73e3-4aaf-816c-8b1717094049" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="adf6fb5b-6188-414f-95c9-89f2aef69bab">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="14d679eb-6439-4125-b99e-dd78ff5fe1a5">
+      <statement statement-id="pe-10_stmt.a" uuid="7c71b36e-3993-47ea-8e8d-bbd65a5df201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="f02f1ced-91da-4d5a-a006-21bc2b974688">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="857a4b2a-375c-42c6-9877-942e5387c019">
+      <statement statement-id="pe-10_stmt.b" uuid="48927301-9960-4664-acdb-dbf483363a92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="5617ae7f-90c5-46f3-81af-e112dd63e2f6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="51a98097-22d9-4b15-acd1-723766ea9b96">
+      <statement statement-id="pe-10_stmt.c" uuid="a8b7f3c6-6a8e-40b1-87f8-f72b43c24f6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b8f4714-1a6c-4b30-a28a-2e9fbf08900c" control-id="pe-11">
+    <implemented-requirement uuid="e66a774c-4e9d-4925-a354-98ca4da35b13" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="c68fc01a-8217-41fe-b19b-3093c1f1f358">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7eca656b-1e28-40c9-87d2-5a14b442f2c5">
+      <statement statement-id="pe-11_stmt" uuid="9c38de5a-67d3-4a00-bb17-d9517cae8d9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f70f211-c7ff-42ac-8675-ad27f45607db" control-id="pe-11.1">
+    <implemented-requirement uuid="c1c1a945-e593-47d8-8ca7-f630afccb69a" control-id="pe-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11.1_stmt" uuid="216dccc6-23d5-47cd-80c9-5d1c02e9c244">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8ecf08c0-d4d9-4ab1-88ca-50566763af5c">
+      <statement statement-id="pe-11.1_stmt" uuid="fd680276-14fd-4104-bd00-6611abbeab1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0bc9450-ce79-499c-a94c-f78b6132b641" control-id="pe-12">
+    <implemented-requirement uuid="6838a18a-fb90-4c6e-a008-a476bb0c63a5" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="b78c19d3-a668-48a6-9d12-840b942ba586">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="defdc75d-78b2-448e-b340-4b09e25d0b40">
+      <statement statement-id="pe-12_stmt" uuid="e6a116ec-fda4-49a6-ad02-e5fe48020d81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cdb1ef67-a261-49ba-890f-dcaef302c7b1" control-id="pe-13">
+    <implemented-requirement uuid="a6a6cfed-f002-4a29-861e-3dec20ca9722" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="4bbb7f9d-bfb9-42eb-9db5-3c996b5be9e9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b705fd00-70b2-42c6-8017-0c81b8def9c5">
+      <statement statement-id="pe-13_stmt" uuid="46ea2a14-ef47-42d4-a128-07e8622f9a69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b3538521-e1e6-45a8-8729-5c50e85ab09e" control-id="pe-13.1">
+    <implemented-requirement uuid="115cbbeb-a356-48fb-b13e-4ef22d379e3c" control-id="pe-13.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.1_stmt" uuid="becffb7f-a584-4c80-acf9-d7643c834965">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="73b96b7a-5257-4f57-8625-7adbd140f763">
+      <statement statement-id="pe-13.1_stmt" uuid="241c6fdb-8815-4e17-8205-bd5a6f08da6a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47c90137-895c-4bfe-a41c-0dedd839ace0" control-id="pe-13.2">
+    <implemented-requirement uuid="8bbf2198-c5dd-40c0-bd96-7457df4ebfa9" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="840c3a18-ad44-40c5-88af-0288fd56be4e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="94ae7a0d-751d-40a1-a840-9c30a7cb7b27">
+      <statement statement-id="pe-13.2_stmt" uuid="38156d05-4b08-4fcb-95e8-691bf5ff626c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f2fbfaf-05e2-4801-b621-cd48d5e5998f" control-id="pe-13.3">
+    <implemented-requirement uuid="ca388a07-6d5c-4dd5-9a4a-e245cf2cbeef" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="3d6efa50-1ae4-47df-bef1-54dd12114f65">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a2999dda-ec85-430e-8c94-688c48d211a7">
+      <statement statement-id="pe-13.3_stmt" uuid="f76fdb08-e44f-4c10-9254-52cf5e322a20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98701b4b-7c40-495c-a6c3-1c54fd0f7ece" control-id="pe-14">
+    <implemented-requirement uuid="9b806d64-c3c8-45ed-aea1-dbccae65b275" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="aadd4a67-c425-47f9-a4bb-2156ff969e32">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c84686c7-a60a-461d-8235-5d30024bacd4">
+      <statement statement-id="pe-14_stmt.a" uuid="51e93fff-5147-4e45-a169-fed84fd1f4a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="f6c6c0df-16f9-48b4-a320-a2833c413620">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d6c1cf3c-121b-4ed2-b706-5c9693069dba">
+      <statement statement-id="pe-14_stmt.b" uuid="9492c294-a053-476d-83b7-481034179948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8cc19ea-e640-402d-815d-a82e4c73afdb" control-id="pe-14.2">
+    <implemented-requirement uuid="99aad80b-2691-4d17-a6ea-cf4e33cff9f3" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="69bac02f-9d03-4a06-aba6-e18eeee0acf1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e123e395-f163-4909-ab0f-b7235cb14192">
+      <statement statement-id="pe-14.2_stmt" uuid="5cd207cd-e7c5-439d-a60d-74e3624bc9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a326f445-98b4-41e2-8b27-54d8313c0887" control-id="pe-15">
+    <implemented-requirement uuid="2bff9725-cc40-4d0d-8a46-3e0ff4392ca3" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="fcb32b08-ec51-4609-a491-541f24a64f83">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7cba043f-2a48-4aaa-899c-3c74cb2f75e5">
+      <statement statement-id="pe-15_stmt" uuid="2fedfbd9-eb4d-4b1d-a5a5-956dc3113cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91abb04b-d152-4429-b8c5-fea59fa1e424" control-id="pe-15.1">
+    <implemented-requirement uuid="52e5791e-af8f-42e4-b177-ada724c5fedb" control-id="pe-15.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15.1_stmt" uuid="0e5077d5-289e-4452-a9f7-21e2f71a0d8a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="923bcc11-2481-4533-8917-23caae1b1571">
+      <statement statement-id="pe-15.1_stmt" uuid="1c0ed3f1-e21a-43df-819b-cc20898cc49e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0777cdd8-00dd-40da-a94d-fec55ddcd9a7" control-id="pe-16">
+    <implemented-requirement uuid="e595f42c-de11-4e82-9d18-fabb75f17145" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="bcbf7851-8f9a-481d-80e3-f220f7ec766e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2ae173da-9b75-47b5-97e4-ee75b15111ae">
+      <statement statement-id="pe-16_stmt" uuid="7f5a2ee2-6937-4a86-aef6-151e852bee1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb8c7f7a-cb5f-4f3a-8d4c-682c9b8777f0" control-id="pe-17">
+    <implemented-requirement uuid="edef40ea-174c-4d4f-b75c-c0e7a27f27e2" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="ccfe0222-2da8-4815-a3aa-73b032f64dde">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="30484b35-24fc-4656-b4ca-07fcd706f786">
+      <statement statement-id="pe-17_stmt.a" uuid="dd42e137-c83b-4196-b228-f6b6b1952434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="9c8b81d0-1f78-4ab4-94bd-532402d7f2b0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6d6b5d20-3f09-481e-904a-e7bebf20256e">
+      <statement statement-id="pe-17_stmt.b" uuid="781d06d5-96a6-4df4-9a00-455fb8158814">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="17fe1382-f382-4873-853f-504de39c5716">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="601998e8-e82f-4a1f-886a-ff829fe52ff4">
+      <statement statement-id="pe-17_stmt.c" uuid="f494a87c-5024-40d0-837f-f324d8436ad8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5057922c-e79d-4227-bcfd-632364b44f17" control-id="pe-18">
+    <implemented-requirement uuid="0485ca6e-b123-493b-8536-724532b21207" control-id="pe-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-18_stmt" uuid="37cef1f3-8267-45b6-bbde-c16f07813748">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6d8d3c94-9be9-439b-a13f-916b3381629c">
+      <statement statement-id="pe-18_stmt" uuid="bc52765c-47f5-4675-b6f1-85ffe468a59d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="200c7738-82bc-4a8c-933d-d20aba00e0b8" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="0b4b1128-2faa-485b-8bb6-ebf258f9216f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="302a125b-7b20-45e8-a79b-7188d126d6c5">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6128,10 +6128,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="22803188-7579-4396-a573-4672880a1646" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="2d0554e0-9e3b-4602-8f13-225cd5c38d76">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dd52b631-97cd-4cda-bdc7-9803fcd98dd6">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6139,10 +6139,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5e66de0-2cce-404d-853d-0d115efc3055" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="c837d081-6300-449f-8ae2-2a2f232447d7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eb15c3e9-a719-4341-8d4e-952278ec3da7">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6150,10 +6150,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af7a627e-5eef-4abc-9b1d-7d74a85da69d" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="21ef45f2-f99c-425a-a88d-7459470cfd78">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cceaad5d-e507-4791-a704-54589d674c29">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6161,10 +6161,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fa0f4a4f-3bc9-4025-a8f6-72260e094004" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="c5b2a653-7753-4683-aadf-852a3f083cd0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7f279944-da02-40bb-b4e8-79af64b3a5c8">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6172,10 +6172,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ce3da66b-7ba1-4b49-bca9-64f32368381d" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="c1de547d-cd80-48a2-9472-bb4991e51079">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1cf9abf2-cdfb-4c6a-acc1-cf56f3e0ae79">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -6183,10 +6183,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3035691e-8e7c-46fb-a4b0-405a95c73cf6" control-id="ps-1">
+    <implemented-requirement uuid="93d1e507-8951-45a8-96c5-57a2597e1852" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="99624208-5763-4cf3-b7dc-9174bb8a7ae9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4003c85b-859e-4406-a288-efaa27ca0501">
+      <statement statement-id="ps-1_stmt.a" uuid="9a1d5fe5-b6b6-436a-bdc2-97245e2cf2af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6194,8 +6194,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="37f606c6-af16-4908-b547-e8e2100aafa9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b1e62ce0-42cc-4a00-b0e3-aefabc746fff">
+      <statement statement-id="ps-1_stmt.a.1" uuid="8bd33eb5-670c-4421-810e-3788087e21ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6203,8 +6203,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="6e34b1c4-5a8f-49fe-a118-de4bdd22a576">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dffc8f98-6b5a-4889-90e4-81f364e485cb">
+      <statement statement-id="ps-1_stmt.a.2" uuid="b381e8bc-dd72-4f30-9c01-80de40b9fd09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6212,8 +6212,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="9b11fbd4-e2f3-496a-9ce6-becb6b4ddccd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5552c6ee-a82c-4aa2-bc0a-0cb1e11cefb3">
+      <statement statement-id="ps-1_stmt.b" uuid="d5793809-eac8-4e6a-85e9-846e5c09d8a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c65f605a-8f0f-4eb4-8633-fc65d9734d42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -6221,8 +6221,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="de5f9238-c3ad-4ceb-b78a-23353c983490">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6909f1d0-8c75-4e0a-9a55-0690c9ce109b">
+      <statement statement-id="ps-1_stmt.b.1" uuid="6ec7797b-8ba2-4407-95da-bde11a63c8be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6230,8 +6230,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="c77c9ea2-d760-4291-b7d7-6cdee1a315c4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1c8e1c9c-16cc-43c3-aeaf-03caf868c97e">
+      <statement statement-id="ps-1_stmt.b.2" uuid="fa7b6a20-02e8-461a-9d2a-45340c6a5448">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -6240,18 +6240,18 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ff161b3-e633-42be-ae37-c97f744dc78e" control-id="ps-2">
+    <implemented-requirement uuid="02a20a00-7ff3-4211-b43b-c104cc3b6a9d" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="cef3dd7f-2583-452d-82d6-102c588504ce">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f882e46d-804a-447a-927f-ea2e83648445">
+      <statement statement-id="ps-2_stmt.a" uuid="6cfc9b43-511f-465c-9044-654e5fe87f77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad506da8-c0ec-48ba-97b5-16f6fef72a89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="6857e5af-3227-4c5d-bb69-9cc6665e1668">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dde596ca-5104-412a-b027-c0196e7f3ac2">
+      <statement statement-id="ps-2_stmt.b" uuid="4ccf8cb8-eeb1-4eb3-8d98-043269082fa5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a604cd65-e085-46ae-9208-9ab9455e1b97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6259,8 +6259,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="060c0242-49e8-4c0d-8cf3-48bd85db4d06">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dfd747e2-775c-4784-8f3c-06556af9da46">
+      <statement statement-id="ps-2_stmt.c" uuid="49f819b8-0769-467f-a8c1-148162cf7870">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09fcf4c-ceb0-4c42-8b6b-a2d20ecf7aee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -6269,10 +6269,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="682df0fd-d026-4ea1-a40f-f6baa2eb85d6" control-id="ps-3">
+    <implemented-requirement uuid="97381a61-dfe9-4a8f-a784-2a54978b29df" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="5ff58fd2-ac59-4d61-a89f-e5e28ad38e6a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fa75904d-19fe-4d33-acc0-f9a93122d780">
+      <statement statement-id="ps-3_stmt.a" uuid="729af710-a601-4b8d-9073-286a85ec0661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1de7d3-05c5-4397-a184-9cef0d215851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6280,8 +6280,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="08a73288-82a7-42e1-9e69-bdc662a3f235">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="da452e4d-b612-4eed-adad-61067c207c55">
+      <statement statement-id="ps-3_stmt.b" uuid="e81d4485-4e21-47af-bd94-3c3d8b7cdd40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78b3be79-a4bd-4282-8372-aad211307d45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -6292,10 +6292,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1c470f0-da78-450e-b930-2fc09ad7caa1" control-id="ps-3.3">
+    <implemented-requirement uuid="253cc88f-8e1a-41d5-a94e-01a1af3560b2" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="0ead9811-944a-4a7f-aa23-88ac849ec51c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4b631d96-e90f-45a7-886d-0bd1d8011164">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2b3959e6-65b0-423d-a942-789f1fc5b925">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8585c7d-7133-4f97-a317-3993801395af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6305,8 +6305,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="9da0a012-eb13-4782-8c60-9c4d3974c8fc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a048a37c-a0d2-4dc3-b5f2-5ca3e034f50e">
+      <statement statement-id="ps-3.3_stmt.b" uuid="27f42c8b-ed97-4d17-9bb6-e0fec70366f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c7cb230-6c65-4cdd-8dcb-04b43e7f58c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -6317,10 +6317,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f39784c7-08d2-4ae8-b476-778da33ecfd9" control-id="ps-4">
+    <implemented-requirement uuid="0e6a90ed-195c-4088-8519-f26013c7405c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="e613aeac-efc8-4427-8c5a-93c9be484d77">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e5a9a6e1-975c-41ca-8a55-d8a8eb34ae46">
+      <statement statement-id="ps-4_stmt.a" uuid="a8023110-58db-44db-91fe-d97f1798ef8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1404eeb-e2cc-4490-99b2-c19e8deca439">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -6329,8 +6329,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="b97e5363-11fb-4928-9e21-c68bda7a7860">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f629c354-84c5-4243-875b-5b493cd002b8">
+      <statement statement-id="ps-4_stmt.b" uuid="565c4b29-d531-4981-88a0-45547dc4e097">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28910026-6a47-467a-af9b-6f0ec47e6374">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -6339,8 +6339,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="8ca26b33-60b8-450a-890c-c7b690d6120a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="55192b36-8f47-460a-8a14-b488e3e62376">
+      <statement statement-id="ps-4_stmt.c" uuid="72aec3d3-80d8-45f6-8d03-cf9b201fa8a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b37e5a2e-159b-40f2-af13-28248cc0aa75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -6349,8 +6349,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="17205333-d221-4a43-9d65-f66dcad65d15">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="26bc2c1e-0b81-4f29-b131-95322687f5a2">
+      <statement statement-id="ps-4_stmt.d" uuid="8088243a-2a94-4ee1-800f-3369881614b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a79f6048-6ca4-4ec7-8f9d-e64fdbaac1f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -6359,8 +6359,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="716a8d56-0f71-4e93-89fe-6e8a341fac00">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="036817a5-713d-4ec8-b123-714ececf802c">
+      <statement statement-id="ps-4_stmt.e" uuid="f544df03-7464-47ed-9841-2e9062150d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59ecd01-7b04-44c2-a2ac-707c570e59f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -6369,8 +6369,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="2c010149-55e8-45f5-afcb-d77dddb3ec0e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="302f6ad8-be8b-4b57-a160-eaf3e86e2c4b">
+      <statement statement-id="ps-4_stmt.f" uuid="ac32121f-0381-469c-9caf-d4460bd7ced8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbbf7554-60f3-4b0f-8315-63a9bd26c505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -6380,10 +6380,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6725ac38-9629-440f-961a-0a8b59910f20" control-id="ps-4.2">
+    <implemented-requirement uuid="380a6d71-c862-42c6-8d2c-822b0ee8a798" control-id="ps-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4.2_stmt" uuid="d06011d6-530f-49f5-bb88-567398d7ee87">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dcab7d95-e088-4cfb-95d9-1ef5f9bf9942">
+      <statement statement-id="ps-4.2_stmt" uuid="6814789d-ffa5-46c3-b655-5dbbfcbc5e0c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="569a22b1-163d-4732-beb3-2258c1b6042d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of automated mechanisms to notify
 organization-defined personnel or roles upon termination of
@@ -6393,10 +6393,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="958adb57-e774-42e6-9307-ec3b365ed985" control-id="ps-5">
+    <implemented-requirement uuid="cd598627-3439-41df-b571-4a11593cc881" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="e2436588-a8e8-4bf5-b5b7-3bd8cf4284ce">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2ec057b0-aede-45f1-9bda-45ca2ed7c6cd">
+      <statement statement-id="ps-5_stmt.a" uuid="18d71eb9-934a-44af-895c-c2297d4f5a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7de8444-be5d-489a-bfa9-65b247e63be7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -6406,8 +6406,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="01385ed8-2385-417e-9d0d-37c07154d484">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="58bf9a0a-4f6d-4f18-94ed-9add8dd82b87">
+      <statement statement-id="ps-5_stmt.b" uuid="a0511f2d-f25a-423b-9de3-f72ddc023dd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d979dc27-c785-4757-a867-f69edf4c49e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -6416,8 +6416,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="d02c0912-7547-42e4-a9ab-220c6af16b62">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2ecf3e47-2745-43d8-8983-2e268e47a4ca">
+      <statement statement-id="ps-5_stmt.c" uuid="79299773-1e94-45ca-818a-6b44ff49f8c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7f89e6b-7ad4-479e-bf98-8d2ccd964ce3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -6425,8 +6425,8 @@ or transfer are outside the scope of Red Hat Virtualization Manager (RHVM) confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="78ceb492-5f9a-440c-987b-572e4a9c852c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2e3a74f0-b521-46bd-bfb8-f0ca033bf1e7">
+      <statement statement-id="ps-5_stmt.d" uuid="a7ed6648-787e-4ab7-ae5b-93de192eac06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cbb3c05-982e-466e-9515-d9abb34b357b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -6435,10 +6435,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f304f6f-1f03-45a1-b29d-534ad72f0f68" control-id="ps-6">
+    <implemented-requirement uuid="d90e7ad8-3c29-46e4-bb5b-bef781918e51" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="64515853-61e1-4df8-81df-6f5ade93aace">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f0a0f3ed-42c3-493e-9622-8d37eb4946ef">
+      <statement statement-id="ps-6_stmt.a" uuid="2d8b2dcb-5489-4e51-a83a-db6a26f5a4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7347cdf-4d1f-40c1-8cb5-bd6ef4a60ffb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -6446,8 +6446,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="9fd8ea7a-b2e3-4dbd-b54c-10282f423e5e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="90e6527f-6044-4ef2-a1b8-281c9a7326cf">
+      <statement statement-id="ps-6_stmt.b" uuid="f6f7ae39-b871-40b9-8d44-5a5bcf51350d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09056f23-47fc-43c4-a899-244bf39ca814">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -6455,8 +6455,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="b81b71c3-9ba1-455e-9331-3f73e6b39931">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="94af6e32-5ad8-4952-9912-930c2ee1c081">
+      <statement statement-id="ps-6_stmt.c" uuid="6e392695-59f0-4dc5-a9c0-80e340eb569d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6464,8 +6464,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="23e468cc-ee47-4509-bcf1-2533e2787c7d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="98b310f3-1009-4634-acfc-d6ed71e2febd">
+      <statement statement-id="ps-6_stmt.c.1" uuid="2ad016a9-cfec-47f5-bcf4-9f54605827bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6473,8 +6473,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="9aa79652-e2a5-4b87-aae7-9e9fa78f0be0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="450abc84-1dee-4662-ac1c-0e6832b3287f">
+      <statement statement-id="ps-6_stmt.c.2" uuid="2c0af91a-c347-43e4-bd2f-7ff47b39258e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -6483,10 +6483,10 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a56962c2-cca7-4b76-978e-f9b022a52780" control-id="ps-7">
+    <implemented-requirement uuid="e90d5213-ee27-4a47-9929-4f4851a4c13e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="ef5cbb3b-2a25-4e46-a7c5-350e725591fe">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7d8728d5-0538-4515-81d7-141ce4dcf163">
+      <statement statement-id="ps-7_stmt.a" uuid="6b876f4c-4d44-499a-91d0-6d66ad5d851d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13710e7a-11a5-49df-9cf1-5620861dea20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -6494,8 +6494,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="4ca92fd6-9f08-425e-a651-890892afe7f1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="61eeff79-1374-4b20-86d0-f878f8e99777">
+      <statement statement-id="ps-7_stmt.b" uuid="95bda73f-2c03-4b3f-ac60-bf47f0a89426">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11f7bf5f-4f0a-4273-bdc9-b664d512d429">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -6503,16 +6503,16 @@ the organization are outside the scope of Red Hat Virtualization Manager (RHVM) 
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="1ed4ae6f-568b-4deb-92d8-adccf8a5e06f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="150ca33b-a3a5-473d-8aa9-5ba77bb14e78">
+      <statement statement-id="ps-7_stmt.c" uuid="10765576-a41a-4bd1-9ec6-f62f07947d54">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef7d9a4d-5ee3-414b-bfe3-7287c70cde54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="c43e0936-c1cc-47d4-a7dc-3448763a44c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0f33478c-ceb8-4819-9acb-f07c1d373f69">
+      <statement statement-id="ps-7_stmt.d" uuid="ee923c84-ceb4-4fcc-b017-9575e996ef24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="278ad774-501b-42d7-8c90-3af58cc2c049">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -6523,8 +6523,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="5ac67caa-013c-4a51-8ce5-f6ca5707625b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ee625c66-fb88-42be-90b2-088ac54d70c1">
+      <statement statement-id="ps-7_stmt.e" uuid="100e63ef-5092-48be-84d9-4c1d180176dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b90694c-5c80-4865-acbe-b25f0a92c0dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -6532,10 +6532,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b23e8ff-13ca-4343-a6f8-1ca10d88e733" control-id="ps-8">
+    <implemented-requirement uuid="9000ddd2-1f58-451e-ac22-112f1e24834a" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="6e7d3f34-eb4d-4bfc-8edf-444504a595c9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="70737966-6fc5-4903-8b25-bc78d6a563db">
+      <statement statement-id="ps-8_stmt.a" uuid="a2da16b7-9efb-4ba7-adcb-660fab49c818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4380d5a-0e4d-4519-9ff7-d45b76504135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -6543,8 +6543,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="d5beee4b-bdda-4ae7-ad52-7e10da613ac5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="571e31b7-509f-43f4-9e27-a9c374f99c70">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -6554,10 +6554,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e428d11-4e1d-42e2-a5cd-25ab0679dcb7" control-id="ra-1">
+    <implemented-requirement uuid="44d5151b-7cd9-4df7-9782-2f19636ef16f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="2d8ec63b-4568-4b1f-ab90-df137e2c0950">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a465c2cd-6127-4201-aeee-326d8a6330be">
+      <statement statement-id="ra-1_stmt.a" uuid="611a8157-0211-45cb-9cb5-3a41191b55cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6565,8 +6565,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="e120aa61-9bd6-4068-93f7-9e41d32be6f7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="621481ed-b3e9-48e0-a2f4-5f74233621c4">
+      <statement statement-id="ra-1_stmt.a.1" uuid="c2c644cf-bf5f-45f7-9426-8ffd1e58bd2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6574,8 +6574,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="81b1c09b-3e88-4afb-8eb6-03f78d1f3994">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="72bac35b-448c-4e53-bdaf-7b7c86d6cecc">
+      <statement statement-id="ra-1_stmt.a.2" uuid="43048ae8-d506-42f9-8e29-c262f83261a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -6583,8 +6583,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="97f66550-e2a3-4eba-9509-5725983cde89">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="382e2857-6fc1-4a5d-afaa-810ac9e8a913">
+      <statement statement-id="ra-1_stmt.b" uuid="e9b70516-72ab-4477-8bd6-bcd12e4051a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6592,8 +6592,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="ef98d4e3-2627-402f-83ee-4bc4eb9e5473">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ccccc043-63b0-4f44-9576-610e372f5a31">
+      <statement statement-id="ra-1_stmt.b.1" uuid="2a36cb87-f7c0-43be-8aed-76456ce1a6b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6601,8 +6601,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="37ce32e2-bb20-4e9f-a0b0-087a889fa6db">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="48d67df9-2034-4c57-8228-0050ffe254a5">
+      <statement statement-id="ra-1_stmt.b.2" uuid="b15c9576-2e76-4357-8d59-32758d67061d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -6611,10 +6611,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f25ec92-4285-4f5a-9233-1b892d8a676c" control-id="ra-2">
+    <implemented-requirement uuid="0ab6a230-1abd-4c7b-a7ce-4d231dea47e8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="6c89c625-205d-4092-8065-f7686d650713">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a4e7fb2f-000c-4072-8b1a-e475a7107baa">
+      <statement statement-id="ra-2_stmt.a" uuid="f4541f8c-b79c-4ef9-ae8a-0d030bd01480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca47edfd-09f3-49c4-8365-53ec0d9f9e7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -6623,8 +6623,8 @@ guidance, are outside the scope of Red Hat Virtualization Manager (RHVM) configu
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="a301a86d-588d-4dfd-bab0-31b86397b591">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd017384-01b0-41e8-b895-211e9dcdb17b">
+      <statement statement-id="ra-2_stmt.b" uuid="b7676df9-5836-4d3b-a0cd-a2db0e8c37fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae86df2b-e64b-45ad-9165-1168e2f87afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -6633,8 +6633,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="577a7e78-1e67-4afb-b9eb-4a62c00548da">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="cdc24f4a-6472-43e7-9c43-9933fa3e3b51">
+      <statement statement-id="ra-2_stmt.c" uuid="65212924-f089-4cc7-b8af-53fd6a111ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91dd3cf9-5a59-4a54-b6fa-67ffc7f6e780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -6644,10 +6644,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53ba7317-e74a-45c2-9eb7-f95989ccfebe" control-id="ra-3">
+    <implemented-requirement uuid="15f5dd33-0cdd-4e59-a1cd-3c84dad5b12e" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="cf310d2b-3f4f-4e5e-a676-cf2b0a5e806f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fa258b26-7fb7-4ad9-b549-da9bcc3a8371">
+      <statement statement-id="ra-3_stmt.a" uuid="7f26caeb-eb87-4f26-950f-6a4b133440d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="825effd2-1fd5-4147-bca9-7282d6fbc19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -6657,8 +6657,8 @@ transmits, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="9ac461d5-aca3-4708-9735-3052478eb515">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f900e73c-c92d-460a-96b6-13673d1bb921">
+      <statement statement-id="ra-3_stmt.b" uuid="f79083ff-317a-449e-97f4-310242546dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0692007f-e7a4-467f-ae1d-64c3e2d8cb40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -6666,8 +6666,8 @@ documents, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="da7dbe11-59a0-4962-82ea-65154db56e7a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="870bb724-954d-4684-beb8-d0f96a6dc745">
+      <statement statement-id="ra-3_stmt.c" uuid="0dcd2f27-33d9-42aa-9329-472f8fa07cd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de13535d-336a-4db5-8cfb-af7e369f09a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -6675,8 +6675,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="dc762924-b6aa-4e9d-90ab-193644b9e1d4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e360348b-d1d1-4ae6-87ae-977ac5369a41">
+      <statement statement-id="ra-3_stmt.d" uuid="4c6ea21f-9eaf-470e-a2fc-4d4dfb06a46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3cf43908-7074-438a-89e7-2f60335176cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -6684,8 +6684,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="54fc06a9-d3b4-4b66-851f-31bc8d00acdd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6de48697-22d5-43cd-b0f9-7836a6180506">
+      <statement statement-id="ra-3_stmt.e" uuid="5b44cac1-93ec-418c-b42b-b7f26bb0794c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1d934df-406d-4e87-8e96-3d48fcac2aff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -6697,10 +6697,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1e60d499-af7b-480f-a3cc-4cb05b2c69d7" control-id="ra-5">
+    <implemented-requirement uuid="796d19ec-7ee2-48f7-8a58-46c76a50db80" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="91e52da5-639a-4f01-b5c1-36921cf633c4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d3afd343-4bd6-406f-a6ae-ab62e78bfa20">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6708,8 +6708,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="6f011dea-07ff-4f6a-b681-b9709c67c956">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="beffa372-cb6d-430e-906b-aa5bb02359f7">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6717,16 +6717,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="bcadb08b-eec2-4f77-900c-033cce5fe794">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c607381f-17be-4c8e-94b5-1d8f6612a028">
+      <statement statement-id="ra-5_stmt.c" uuid="2b015f3a-d332-481f-87df-0362eb31b0ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="ed58fcf8-9f07-4b94-8d86-7a9633e833fb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a4006259-582b-4b48-ab5c-4f59c494f495">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6734,8 +6734,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="58ec2f5b-5f9a-4457-ae4f-dc2065151166">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b3642e2d-565c-4559-b947-72b3b8aabb28">
+      <statement statement-id="ra-5_stmt.e" uuid="431ed74f-8371-44cb-8d48-682acd1bfe3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c1cf1b-136f-4647-86a3-b6055003ca11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -6747,10 +6747,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7f98166f-9a2a-4350-b752-6e63f0d1c2a5" control-id="ra-5.1">
+    <implemented-requirement uuid="25e0e198-6272-4100-aacc-c751b1d866e6" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="09aaedf5-d436-45da-9833-91e36687a337">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="03968067-03d8-4027-93b7-add281627deb">
+      <statement statement-id="ra-5.1_stmt" uuid="d8e4be41-53d9-4ebc-bbfa-1f575d095b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6759,10 +6759,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8335843d-9ec9-4d81-991f-b8298b5c093b" control-id="ra-5.2">
+    <implemented-requirement uuid="7971b674-5e94-4b48-be7b-78418fd916d5" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="84e1ec9f-0d98-4f1f-98e7-6a105e2394aa">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="41010b54-9023-4fb2-86be-e8e157924cf0">
+      <statement statement-id="ra-5.2_stmt" uuid="d82e932a-e687-45e5-911c-e662880898c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -6770,10 +6770,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04eeca27-7132-4ead-8b21-9423ce1fc301" control-id="ra-5.3">
+    <implemented-requirement uuid="1a4f081d-c680-46c6-9666-6c1296f9181c" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="6c5ac9c7-cf5d-42a9-836e-054e88d470d6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2d1aa78f-b7b1-4fa5-8f4f-c70e029d0166">
+      <statement statement-id="ra-5.3_stmt" uuid="8068b1af-dc82-4d4a-a1e2-ca7e8a23dd97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -6781,10 +6781,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33e81515-3512-49d7-b938-71e072bab7f0" control-id="ra-5.4">
+    <implemented-requirement uuid="9850ce77-ddbb-4279-a9f3-c805945b9b21" control-id="ra-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.4_stmt" uuid="240dc6d4-cf11-401b-a7ce-fe18abd112e5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="09dd1d87-6e1f-4989-9964-e5f4a2cc0e48">
+      <statement statement-id="ra-5.4_stmt" uuid="3fbd3577-f2a5-4ff2-bcde-7e929da889f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a494467-32fb-4bbd-9c57-df641a401d9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6793,10 +6793,10 @@ https://projects.engineering.redhat.com/browse/RHV-21056
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3384b2e-138e-4d00-b2e2-6b7b0456ad10" control-id="ra-5.5">
+    <implemented-requirement uuid="85d3387b-07ff-4c11-9afe-62dde7b4b20b" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="7e0d2991-f9a3-4d8c-a14e-2339b2eb788f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e0f41ae3-881b-4a9b-9f22-ffa5de2aa104">
+      <statement statement-id="ra-5.5_stmt" uuid="56153afb-5fff-4d83-a274-c80dbe05c2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6805,10 +6805,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ef7857a-52f3-402e-b48c-d05db64065c9" control-id="ra-5.6">
+    <implemented-requirement uuid="631f32a6-79e9-4c7e-bce5-dce1e05fb448" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="a3868dda-3bb7-4fa0-b6e3-78d6acac4b7f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5d28b205-36e9-4edc-91e5-7160836ba22e">
+      <statement statement-id="ra-5.6_stmt" uuid="ce8738be-55d6-4014-8ce0-9fa3e2e06d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -6817,10 +6817,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6b9a39d-b926-4c16-a94a-3e9e5da5010f" control-id="ra-5.8">
+    <implemented-requirement uuid="5acc9cfd-8e4d-44ae-a5a6-78f1b605c1f0" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="aa892ab6-571a-49f6-b91f-fdce5c5a1d70">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3225e622-b63c-439b-9205-b67e7cc1209f">
+      <statement statement-id="ra-5.8_stmt" uuid="6545d6a7-1e4b-4881-b6e0-6fe581dee0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed3dcc9-7caa-4944-9765-7e5c864991bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -6830,10 +6830,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5bbc726d-9438-486d-8163-a17efb7ce669" control-id="ra-5.10">
+    <implemented-requirement uuid="4625c35e-3446-40df-8e8c-5210a0a9e8bf" control-id="ra-5.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.10_stmt" uuid="34018db4-862d-4a3c-a0ff-90f425c02499">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c2f1fb3c-77fd-4e8b-8e55-2514cb47a8b8">
+      <statement statement-id="ra-5.10_stmt" uuid="32e8b53d-259e-4ada-85e6-3976e3dc29d1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd4f6974-67a7-4c63-8b0c-c9a6ffdf508b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to correlate the output from vulnerability
 scanning tools to determine the presence of
@@ -6843,10 +6843,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f3880bf7-666a-4231-892d-cc71cd61a687" control-id="sa-1">
+    <implemented-requirement uuid="a172707c-e357-4978-be84-30e20d476ab0" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="f63e1b53-462f-4b9d-8a51-cd312dfe20a6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f35f700c-d048-43cf-82b3-0e7878b9069b">
+      <statement statement-id="sa-1_stmt.a" uuid="a571b48a-fca2-459a-916a-d6a6f24deb5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6855,8 +6855,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="c774b4db-39f4-4c7c-8f42-badb0452ee44">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ad6ad5f8-c1ff-45a8-8fba-a9a49b9b8348">
+      <statement statement-id="sa-1_stmt.a.1" uuid="c7e3108a-d39a-4501-9232-187d48111480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6865,8 +6865,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="a18845dc-995b-4945-81ce-d9447dfffa1c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6e09550b-cb17-4061-8d33-403590311e71">
+      <statement statement-id="sa-1_stmt.a.2" uuid="13f8840c-c38c-4e70-8635-8cb5419abf98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -6875,8 +6875,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="e5b06c6b-1069-4d96-9f04-6287341319d7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="388e32ac-b07a-4af8-a1ff-1961e5a9c15e">
+      <statement statement-id="sa-1_stmt.b" uuid="f2bf354e-951d-4b99-8101-871827b86f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6884,8 +6884,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="0a0ca718-aa91-4922-a940-30dc0e9859db">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a969af95-3e1b-4461-a010-222ab606ecc0">
+      <statement statement-id="sa-1_stmt.b.1" uuid="d3bed5b6-3a90-43a6-a31c-2110bb93ae49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6893,8 +6893,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="fb675d5e-d0bc-4874-af80-c249aeb21a03">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="65cf9a5b-8c55-4423-a194-603ebbc75130">
+      <statement statement-id="sa-1_stmt.b.2" uuid="cb76ce98-b4b7-443b-b678-5d3295c84fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -6903,10 +6903,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f13127b0-7e5d-48d1-afd6-1ad1f24531a9" control-id="sa-2">
+    <implemented-requirement uuid="050a21c8-b6c1-4fb9-9500-c8fe7e4e80cb" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="80cd2e4f-16ad-439d-823f-44cefb566f68">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="406e9c1c-05ef-45f6-9b7f-af1d100cd21d">
+      <statement statement-id="sa-2_stmt.a" uuid="9a617d20-93f0-4558-9782-16e8b1cf2fb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68d0d4b0-c0d2-4acd-b8d5-b7737dd46b7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -6915,8 +6915,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="85238b96-954a-48de-9b68-852648c1f4f3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8c798dda-e51d-4bc9-95ab-653096962f42">
+      <statement statement-id="sa-2_stmt.b" uuid="4e0e53ca-f38d-4c22-8cad-26bfa4c4dbd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae257788-6a44-42b5-9e86-ce24b5d7dfb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -6926,8 +6926,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="11c0bccb-fb2a-47aa-9599-19a7925f27c9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ac5d0a63-d66f-42b6-b40a-27ba1383b1fd">
+      <statement statement-id="sa-2_stmt.c" uuid="483cd77e-9463-42bb-b620-df78fa0c5603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33619df-53cf-4942-b14b-df386101333b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -6936,10 +6936,10 @@ documentation are outside the scope of Red Hat Virtualization Manager (RHVM) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c28a1a51-3892-4cf0-a7e7-2a58fa30a96a" control-id="sa-3">
+    <implemented-requirement uuid="2defe23d-c379-4286-8dd2-f9cc601d209d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="a5b2c0c5-31c8-4b5f-8253-aa549c505ecf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1ded272d-4bcf-4d24-a6af-63ec16c3ba87">
+      <statement statement-id="sa-3_stmt.a" uuid="b107e4ab-86ec-4e37-a993-1653c35c3d46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f73b71c4-22a7-4d0d-b09e-1ed07d64c174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -6948,8 +6948,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="10d85517-7cc0-4bd2-a6a7-0dedec266a4d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e33e9124-d995-42f4-b12c-41c41325315a">
+      <statement statement-id="sa-3_stmt.b" uuid="5ed40cbc-20ea-4b20-8fa8-cbcfe6f4f38a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70f49197-05e3-4b11-ae79-720d5aaa677b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -6957,8 +6957,8 @@ life cycle are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="2f5dc7dd-4abc-4c5d-b1fb-f3b762d63ece">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3371d575-d763-4533-91ff-53f3786a145c">
+      <statement statement-id="sa-3_stmt.c" uuid="607967a3-21b9-458f-b9eb-f5785b8974b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017043aa-c72c-4e96-9ed2-6ec39b5742ef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -6966,8 +6966,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="f9f1a98f-e4ec-40e1-91be-f645ef046f9e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a899d047-d0e3-41e2-8c6d-bfb412fea651">
+      <statement statement-id="sa-3_stmt.d" uuid="928cbd83-6d80-4906-9edf-bbf9d55d98ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="426bc4b6-9812-4098-9cc3-b5dbf7d359d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -6976,10 +6976,10 @@ activities are outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9f01cbd-a20b-46a5-87d8-1b26ea13636c" control-id="sa-4">
+    <implemented-requirement uuid="bf3098f0-03d4-40c7-9745-d2235ee228c0" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="d1272057-6203-4fa3-ad58-8ae6da810593">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d56e2e04-c965-45a4-88b8-96541ec29ce0">
+      <statement statement-id="sa-4_stmt.a" uuid="d8407af8-acd4-4428-840c-efefa414e336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1552cce1-10a9-4a28-acff-0819cd1d5552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6987,8 +6987,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="b7c58c12-c677-45b2-8e70-8a045fbf6bf4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c1a12bf6-bc23-448f-b67f-660d13966cba">
+      <statement statement-id="sa-4_stmt.b" uuid="516ec171-7079-4c0c-b931-01cfa87d9f39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54666440-ddf1-495a-b24b-de93c187adfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6996,8 +6996,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="f68de96c-7a2e-440f-973e-d4eec3aba2c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6c9b9bd6-8fa2-4386-a010-008b9704856c">
+      <statement statement-id="sa-4_stmt.c" uuid="19367cff-d60e-42dc-aff7-5a3263f206c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a4549b6-b8fd-4d3b-a303-c815c6b65618">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -7005,8 +7005,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="59c84cab-d5b3-4aa6-8fc9-89614a9c0331">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5305cf4d-6404-4db0-9309-e245d899fa41">
+      <statement statement-id="sa-4_stmt.d" uuid="9e656b9a-3b82-47e1-82ad-85a95b2f3224">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4fdfc14-17e4-4910-82d8-60ad518cffb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -7014,8 +7014,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="6e2288fa-7945-4067-9caf-14a269e7ff57">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="98f6958f-a1fe-47aa-9360-439875fef297">
+      <statement statement-id="sa-4_stmt.e" uuid="ba757458-3c0c-4974-8eb6-04500d23ccc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="661ec3a0-e738-42f9-a92f-02d313d8e900">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -7023,8 +7023,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="a8433247-56dc-4db5-aef4-8336a9306c3b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6312937e-5c66-4524-8eaa-4ee263a99bee">
+      <statement statement-id="sa-4_stmt.f" uuid="04fa1d51-9152-46b4-b4ae-dc50924ba75e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45200b4a-85fd-4567-9c82-613516999bd1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -7033,8 +7033,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="7292763c-83a0-493e-8f2b-1e2c62396807">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1afb863f-880c-48c8-b93d-00bb1ec6630c">
+      <statement statement-id="sa-4_stmt.g" uuid="965605ae-2f59-4939-b51f-99c648774e29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd3b9e75-24f0-4011-8062-0dd44081dbe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -7043,10 +7043,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c84e751-c591-4cc6-b198-4f69756765d4" control-id="sa-4.1">
+    <implemented-requirement uuid="c852b8ed-46e8-49a4-942e-02ad98e2145f" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="bd97197d-9502-4dcc-8dc7-40b842509ce4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="204219ed-b2be-4b53-8f72-f69a810d1c44">
+      <statement statement-id="sa-4.1_stmt" uuid="5f744a19-86b6-458e-ae5b-9391fdaaf2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d0b45d5-3df5-4226-a89d-858eb0881fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -7056,10 +7056,10 @@ https://projects.engineering.redhat.com/browse/RHV-22638
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ab56a792-dbc9-4177-9862-7a4ad7b45f21" control-id="sa-4.2">
+    <implemented-requirement uuid="494cce61-f250-443b-86bf-6428be908965" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="2772ef86-7f39-4fe1-b60b-676970b02937">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f2e3902b-9fac-4d07-b755-9c6ff5eca649">
+      <statement statement-id="sa-4.2_stmt" uuid="fe19e678-d406-486d-a68b-a93da729dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a090f9c-dcc8-4565-95ba-9da0c5baa527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -7069,10 +7069,10 @@ https://projects.engineering.redhat.com/browse/RHV-22639
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c301f018-3e43-4ed5-96f8-c671268bb864" control-id="sa-4.8">
+    <implemented-requirement uuid="f576d7f5-7768-4335-8d9a-6a92332f08f0" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="00dd7ba8-829d-4915-9624-164e2053ef7c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7efa6242-2d23-46fc-b324-946316406bd0">
+      <statement statement-id="sa-4.8_stmt" uuid="3d81371f-0030-4269-8918-c09b32dabcc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d4765e6-3e2e-4e4b-afbb-5fb77763e42d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -7082,10 +7082,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20f7451f-42de-485c-be43-884631c5a881" control-id="sa-4.9">
+    <implemented-requirement uuid="183aecf0-bdf4-413f-8de9-fcbde8bda9b2" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="b98ff203-cc29-4fde-80ec-753bf18c25dd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5c5edc3e-5633-44b0-ad19-ac007a500c21">
+      <statement statement-id="sa-4.9_stmt" uuid="57789a83-af12-481f-8fee-d2420e3b5e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61c674b5-dda5-46f5-96ca-871e9452030f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -7095,10 +7095,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b8ef1d16-23df-446c-922d-4850663cab45" control-id="sa-4.10">
+    <implemented-requirement uuid="31e4296d-6361-496e-8531-b092d9a30955" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="c36cb516-de3d-490b-b025-d3ac3261733f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d1badef5-ca1b-4308-a961-05f7e88493aa">
+      <statement statement-id="sa-4.10_stmt" uuid="c7984646-15a2-4a31-983a-8209181d8242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7106,90 +7106,90 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a4f91c0a-21ee-448f-bd61-792c51167803" control-id="sa-5">
+    <implemented-requirement uuid="c927e6eb-cd03-4cfc-8370-e65bc1d08e8b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="fcf2a319-693b-48e3-8e77-37089ed5c24f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8a3cbf24-c6ed-4465-ac10-45fe632ec18d">
+      <statement statement-id="sa-5_stmt.a" uuid="4faea3e4-73a8-43e7-80fd-d83650013818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="62a852aa-8b53-4b54-89ff-10334fefce9b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4e9e096a-34b9-4f3e-8005-5a52115d1f2d">
+      <statement statement-id="sa-5_stmt.a.1" uuid="ae559028-e1e5-4605-8783-025c00f9a8a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="63342437-8662-483c-aeee-f047825f4d20">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="38825f6b-af3f-4372-9041-8a2be2dacc0d">
+      <statement statement-id="sa-5_stmt.a.2" uuid="397a73bf-b7a0-4aaa-bf9d-ede4ecf3685f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="f113c3b9-838a-4145-b4d4-6b59b5cea6d6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="257faaa8-38b1-45e9-a934-56af63972fdf">
+      <statement statement-id="sa-5_stmt.a.3" uuid="c9ced858-df8e-469c-afbe-1e88080e4ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="2fa4305b-c1bb-4942-a272-45bb53909817">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bc66a4f7-9bc2-43ff-b2a6-921da04be3f3">
+      <statement statement-id="sa-5_stmt.b" uuid="c1639c11-0075-422e-a3bd-a02e115d7a80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="22121391-2491-47ff-8ded-e21ee6655a87">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0b3f9b14-152e-46d3-b8de-2e256d8abbfa">
+      <statement statement-id="sa-5_stmt.b.1" uuid="a9909ce0-0b06-4bf4-83df-c013a2fdd5c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="006c1df5-0982-4d30-b64f-158cbe7037ba">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bd875cbc-8e6d-4e51-ad32-4cab89ac622c">
+      <statement statement-id="sa-5_stmt.b.2" uuid="10ef634b-6c51-40fe-a25c-4ad6ebba34d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="8528679f-e7c5-43ec-b59e-46e65cbb7983">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e1e672d5-84dc-44ce-b8ce-86eec3929164">
+      <statement statement-id="sa-5_stmt.b.3" uuid="da0b3f67-4def-4323-b907-0a8237c874c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="f07179a1-08c8-43f3-ac52-810f7e18dcc0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a0855705-7323-482b-98be-06d9f2aca607">
+      <statement statement-id="sa-5_stmt.c" uuid="7517ad19-1345-4b26-9f37-c21dc9721b39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="46de4794-3d3c-4c14-9719-1409d2e83271">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3f10eb47-e47c-4d63-a6c5-f27d55c8a5f2">
+      <statement statement-id="sa-5_stmt.d" uuid="44d3949f-6897-4950-ad77-aec1c2b4daa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="d407b829-303e-4170-96d9-96782baaf37e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7ee75b4c-8879-493a-a398-c5c7dd9e8577">
+      <statement statement-id="sa-5_stmt.e" uuid="38a8ddba-5efc-4f18-91bb-a8fec5728d35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7197,10 +7197,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59e9c8e0-b11d-4733-a24b-175f94b044e5" control-id="sa-8">
+    <implemented-requirement uuid="ceafc844-4178-4e7f-ac35-695b6b6023ef" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="47ff7a68-763a-40b6-ab19-0a4e63d0a70e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bcccda56-3436-456a-a203-0448289bd6dd">
+      <statement statement-id="sa-8_stmt" uuid="769f36da-b419-480f-934c-4f46d8487423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7208,26 +7208,26 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9aa0d5e6-7b04-44d7-8f06-73bf73d95859" control-id="sa-9">
+    <implemented-requirement uuid="0e348750-2071-4c59-a38c-68082ef7a9fd" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="6e848a03-6da9-412e-bbb7-ce24b7bffb5b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ecae7bb8-4e2f-40fa-894e-8c3bd79de502">
+      <statement statement-id="sa-9_stmt.a" uuid="26cf006d-8120-4aa3-b93e-2c88997ab89e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="0d9b496e-ecce-4c83-8a0a-9da153797bbd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="19ec2d7f-bbf8-4e53-acf7-6b900b261090">
+      <statement statement-id="sa-9_stmt.b" uuid="2830bcbf-b8eb-409c-b878-25d755268c11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="642e79fc-51f1-45b8-8a85-be8b8da33d64">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="58f79c58-013d-47e0-b051-460db93e8bc7">
+      <statement statement-id="sa-9_stmt.c" uuid="c356c752-c622-4e5e-ab13-8f1b11206e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7235,18 +7235,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bebd32c3-c9dd-4d7c-9b08-4894b63c0c8e" control-id="sa-9.1">
+    <implemented-requirement uuid="d7b28993-7eb6-4b88-95eb-f43087fbc281" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="9dca54fd-94c7-4ef1-b2cc-4be175acbc01">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="726ae5fb-8e18-4aed-a2d0-cacfb739fbf6">
+      <statement statement-id="sa-9.1_stmt.a" uuid="e96ba58c-314d-4bb3-9847-04c8248c51b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="ce3ff86a-01b5-480e-bd64-1532b936870c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8481cdf3-70f9-4b4c-add0-f2be8bd1ead3">
+      <statement statement-id="sa-9.1_stmt.b" uuid="d8b9bad4-3f53-4af6-81ef-ff09d46e41e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7254,10 +7254,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dfedce6d-11ee-4d39-88b8-fd303357f678" control-id="sa-9.2">
+    <implemented-requirement uuid="dc2401ea-3658-43d4-bb17-583affb252b4" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="72ee0ead-96ce-416b-9dff-36052570203a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="29dea436-39c9-4919-959e-99c875ad3bee">
+      <statement statement-id="sa-9.2_stmt" uuid="afa3ae26-8993-457f-95af-c4525ff4dd8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7265,10 +7265,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f99a5d3-3e20-4316-938b-791a0bbe3db9" control-id="sa-9.4">
+    <implemented-requirement uuid="390f46be-3165-4585-a4e7-1dfd25aed746" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="3cd18f31-b447-43e4-8e88-5d88e9179d03">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="943a63f5-3cb6-4a8e-b855-c9a4be29f4e7">
+      <statement statement-id="sa-9.4_stmt" uuid="efb69b66-26dc-408b-92d9-5ae526255984">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7276,10 +7276,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7b36af87-c109-4d37-a515-4688dbf338d0" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="da82e2a6-afbe-45a3-bdce-626b2cf5b62e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f107f0df-3de5-4599-877d-a4c7fbb297a7">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -7289,10 +7289,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f8b152f1-0f2e-40a5-a352-f339b504c1ba" control-id="sa-10">
+    <implemented-requirement uuid="293f268f-39a8-47da-85fb-b1aa98f204be" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="7c42dc41-75c9-4881-9ede-6f1189bba0c4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ac27a92c-2abb-4e9d-b36e-7b3962011287">
+      <statement statement-id="sa-10_stmt.a" uuid="148daf57-78dd-44f4-9034-2a5a5bf501c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c007989f-6207-43a4-8a0e-c4bbfbcbcfc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -7301,8 +7301,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="eb7d0028-0180-4b5a-8bb5-eeb4f8d63f06">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="860a92bf-79a5-43f2-b082-b4b8f75d413d">
+      <statement statement-id="sa-10_stmt.b" uuid="5c2cc993-ddab-465b-9f1d-e46d3e024e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfb7401e-c900-4ced-9a20-2bee25790497">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -7311,8 +7311,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="558ea69e-6946-4ae4-bb5c-950d3b77130a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b1792e62-57a6-4d67-b7cd-4e6a54f7a3b1">
+      <statement statement-id="sa-10_stmt.c" uuid="f1413046-1128-4cb3-8268-177393cfdaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b14ad649-026f-462d-849a-0cf4e092d2f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -7321,8 +7321,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="8b0f5dca-4cf7-4c0a-aae1-2587aabbda75">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f2d12f20-4bc3-42f3-b9de-85dcb7e3f335">
+      <statement statement-id="sa-10_stmt.d" uuid="9d632fcd-3f58-441e-8adb-cc1c3dfa0bca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49544cdb-c4a6-4185-80bd-2b5ecb724ab7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -7331,8 +7331,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="7bdaa02b-7743-4ecb-8cef-861ddc51be99">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="46b18de9-d7b3-4853-b7fc-c7966ad02281">
+      <statement statement-id="sa-10_stmt.e" uuid="2f1236ef-8afa-4b2f-899a-156aa02be068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2706133d-eb66-4fff-939a-950056d0e299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -7342,10 +7342,10 @@ https://projects.engineering.redhat.com/browse/RHV-21061
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79781667-d85e-4a54-b4bc-10cf63976af8" control-id="sa-10.1">
+    <implemented-requirement uuid="adc8007e-d183-4e3f-aadc-c49f3d8d4132" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="26f85f99-2290-49f0-8fdb-cfcb74a089f7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2119b12b-b34f-40e0-b59d-e5b9fef65d50">
+      <statement statement-id="sa-10.1_stmt" uuid="22ec1ae1-100e-4b20-9cc2-3402cdeaef57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec1c56ee-d6ab-4f33-9e0d-279b141d27a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -7355,10 +7355,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31a56852-f5cd-4fef-b869-763e74ebe650" control-id="sa-11">
+    <implemented-requirement uuid="3793a082-b793-4415-a3e2-a5617d4a09c6" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="0977f64b-f36c-4707-aa18-bfc643fb2f62">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a150e9e5-b57a-4eda-b81c-e5138241556c">
+      <statement statement-id="sa-11_stmt.a" uuid="cf46ba78-5a5c-475c-be80-c5b57ef96281">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36a99276-5f2d-428f-9816-f2e4786351d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -7367,8 +7367,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="055a95f6-03a3-4b39-af16-d972ffe049e5">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7c9e38de-1b88-4794-a6d4-85c6fbb182b2">
+      <statement statement-id="sa-11_stmt.b" uuid="061e3634-d640-4dab-be4b-e30bfe16c61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1937705b-ad55-4470-85df-afd21c29d99f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -7377,8 +7377,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="ddf9ace6-4c67-4983-a9d6-5939ed93d72e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="40d685d7-0678-4b6a-a5d0-f5b860eb1b1b">
+      <statement statement-id="sa-11_stmt.c" uuid="b76445b3-6271-4033-bc41-0f358e6badbb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4863aa6f-1480-476e-b863-25faf09c8469">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -7387,8 +7387,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="a2b47078-7e2f-41ce-a252-51ca6828ede6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f9a445eb-6694-44a9-954e-339c69fe9f35">
+      <statement statement-id="sa-11_stmt.d" uuid="0a2f3d54-2762-41d6-8713-c22e8832c84b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="681bd9b0-f378-4bfe-a3b4-14cc0fc1c799">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -7397,8 +7397,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="97695932-9efb-47fa-8935-006d5ba06a29">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5cfc0c9a-e9f9-4f32-97f1-be1cf568d85e">
+      <statement statement-id="sa-11_stmt.e" uuid="713f2000-3e7c-40d5-a3c9-b40edd933abd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9b31e1-662d-4c73-8b23-53ee3a1234e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -7408,10 +7408,10 @@ https://projects.engineering.redhat.com/browse/RHV-21062
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4059b29-c00d-4cde-a000-55d5eaa0bb3d" control-id="sa-11.1">
+    <implemented-requirement uuid="f4654e5b-5c8c-4556-acff-4a55e2d7a462" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="1a71a8fc-6eea-456e-8eca-445bae2c6726">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ab2fff74-11e5-4aed-bc48-3a3c79679f93">
+      <statement statement-id="sa-11.1_stmt" uuid="499fdb69-b5bd-40ba-addd-0e0c310ba5dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a5e446a-ffc4-4b73-b1ee-fd52746fdc16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(1) is planned. Progress
 can be tracked at:
@@ -7421,10 +7421,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf090b66-9971-4249-97a4-ffdbeff5fc4a" control-id="sa-11.2">
+    <implemented-requirement uuid="ddb2c3a3-ecc2-4a77-99fd-6f779f776f71" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="542e3d17-5358-4310-b8e5-87999ba78127">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="688f986c-2d58-48a1-937e-f6aa7816ecb1">
+      <statement statement-id="sa-11.2_stmt" uuid="dbc9c3c0-0d9a-4da6-b616-af78319989cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="888ad617-e394-456e-a020-63a4f9bcf251">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(2) is planned. Progress
 can be tracked at:
@@ -7434,10 +7434,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f469011a-5044-4057-a536-526ae44c1f63" control-id="sa-11.8">
+    <implemented-requirement uuid="431a7e86-4fa6-41b0-a14e-8a7b40f965f8" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="3c2c83e7-1157-40cb-86b2-2ed5363ce934">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0a41864d-c123-416e-b722-45f1fa8d031b">
+      <statement statement-id="sa-11.8_stmt" uuid="c329c78b-2ad2-4474-9716-37bad9f62df1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20dadd46-daee-4ac0-a03d-61a01669d400">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress
 can be tracked at:
@@ -7447,10 +7447,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="239746b3-4093-44c4-9559-eee5949f585f" control-id="sa-12">
+    <implemented-requirement uuid="c46a2ed5-c008-4ba3-9edb-58bbfe406a23" control-id="sa-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-12_stmt" uuid="b5c5e94a-93d6-462e-80df-0a05f4aa9218">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="65163271-75b8-4b91-8e93-293bf661b42b">
+      <statement statement-id="sa-12_stmt" uuid="98c287ce-9b4e-4997-9ed4-ada3ac794712">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -7458,10 +7458,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e308f958-b76e-4fdc-b2f2-2f860d60265e" control-id="sa-15">
+    <implemented-requirement uuid="f7d0453d-ac77-4a82-808f-3318129e53dc" control-id="sa-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-15_stmt.a" uuid="645d7f41-23bc-49c3-a7ac-a147bff495a0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="928139f3-fd58-441d-9209-15680cccc2af">
+      <statement statement-id="sa-15_stmt.a" uuid="c8a358dc-d179-4398-93fa-69344a0ac7a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ddc8226-8bcb-4209-8148-d8c43589a812">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a) is planned. Progress
 can be tracked at:
@@ -7470,8 +7470,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.1" uuid="0522f347-2a8e-4e0d-aa34-6623a18b8ffb">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1e101629-e62e-48b6-a5c7-a50567c1f40f">
+      <statement statement-id="sa-15_stmt.a.1" uuid="9c67a162-0a3e-4061-8b9b-fb9542c4ce90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d31d2ae0-e0cc-44bd-a884-964e21ed522c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(1) is planned. Progress
 can be tracked at:
@@ -7480,8 +7480,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.2" uuid="5052c3ec-a60e-41b0-b0e0-36b8072c76a3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="04218c55-7aa9-470e-bf09-6d5fd88bf4d3">
+      <statement statement-id="sa-15_stmt.a.2" uuid="acd44614-97ce-4e13-802f-e41adad6df00">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6e2bb82b-b86d-4092-be37-eb5505a8c341">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(2) is planned. Progress
 can be tracked at:
@@ -7490,8 +7490,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.3" uuid="bf5da398-6006-42c3-8dc2-5449b839c494">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="14354f3e-03dc-4d14-b381-e2e4688853a0">
+      <statement statement-id="sa-15_stmt.a.3" uuid="88fd7f6c-e422-429a-beb2-2026c28728a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="330b11be-8081-4060-9903-c8bf4ed13b10">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(3) is planned. Progress
 can be tracked at:
@@ -7500,8 +7500,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.a.4" uuid="92f451f4-1109-427c-a27b-ecb183092039">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="548fbcce-02b9-4f18-a754-b1718c18c1ae">
+      <statement statement-id="sa-15_stmt.a.4" uuid="32bf16bc-45ee-4023-8360-c6720239e664">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="468193da-e28d-4d52-8ad8-986a1af08a34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(a)(4) is planned. Progress
 can be tracked at:
@@ -7510,8 +7510,8 @@ https://projects.engineering.redhat.com/browse/RHV-21063
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-15_stmt.b" uuid="e0480801-ac6a-4821-bba8-54fada693b06">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="393266e9-44ed-4aee-a10e-7037828da10c">
+      <statement statement-id="sa-15_stmt.b" uuid="c5d7eb50-ecb5-4dd2-9ade-aea8497d5890">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29568523-98f7-4286-806a-fc0f4e0e75e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-15(b) is planned. Progress
 can be tracked at:
@@ -7521,20 +7521,20 @@ https://projects.engineering.redhat.com/browse/RHV-21063
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e2ea6286-9370-4f93-a39a-d84945d85b67" control-id="sa-16">
+    <implemented-requirement uuid="9bb3c0cb-a2a8-46a7-9ca4-b2a4e6f1ef91" control-id="sa-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-16_stmt" uuid="7b1755d1-4dca-4e41-ad9a-1f2f8608f945">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c67a2112-4e7f-48b3-9e52-84803baa3a8e">
+      <statement statement-id="sa-16_stmt" uuid="1b44cb72-6d8a-4a8d-8437-288906e1ddc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90480eb2-7f20-4b67-b557-b325700907b7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-16 is planned.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1affef29-eeb4-4116-a325-1fa1f513f039" control-id="sa-17">
+    <implemented-requirement uuid="782101c6-45de-434c-8a73-ca3d89fd5b5d" control-id="sa-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-17_stmt.a" uuid="078050c6-bee2-4565-b82e-e5a96de83552">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="23769f5e-ce58-4641-b2df-b3157983eac1">
+      <statement statement-id="sa-17_stmt.a" uuid="d213e9ce-09e6-4920-abde-111481c0ab10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="64639535-b475-4b1c-95f9-4872768e79b8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(a) is planned. Progress
 can be tracked at:
@@ -7543,8 +7543,8 @@ https://projects.engineering.redhat.com/browse/RHV
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.b" uuid="f6e7ba82-a797-4634-8481-0d4737218b4f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="655dd24b-b4af-4bac-b10f-243b32feb60f">
+      <statement statement-id="sa-17_stmt.b" uuid="cf7ad531-f3bd-4b92-9f3d-ef1920e53dfe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12d4cfea-e2bb-48b5-93c4-6c4338bebf1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(b) is planned. Progress
 can be tracked at:
@@ -7553,8 +7553,8 @@ https://projects.engineering.redhat.com/browse/RHV
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-17_stmt.c" uuid="33c25c64-0939-46b0-9bec-632c07e0d339">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e699e3a1-5c2a-4605-ace9-d4794951ac48">
+      <statement statement-id="sa-17_stmt.c" uuid="981fd123-1dc9-4b95-8cad-dcbdd7906278">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09ba63e-f021-48e0-81fd-f870b9d48d6c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-17(c) is planned. Progress
 can be tracked at:
@@ -7564,18 +7564,18 @@ https://projects.engineering.redhat.com/browse/RHV
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="140f6446-67ee-42cf-b1d0-dd593531fae3" control-id="sc-1">
+    <implemented-requirement uuid="b86cee4d-ce61-45cd-9e34-afdbef6abb73" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="8d92ffc0-5f52-4ee6-a5e5-db486c109e39">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e30b3ae6-1c73-4cdc-8207-5e01f89350ce">
+      <statement statement-id="sc-1_stmt.a" uuid="c470702a-260b-496d-9061-de3685081609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="a3f9781e-4415-406b-918d-4a62c452ce15">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4391b75b-115f-4333-bc7d-238b7757a1f9">
+      <statement statement-id="sc-1_stmt.b" uuid="ee59ae69-664f-40fa-b0ec-b0c276e6781e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7583,10 +7583,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="653d01a2-9c87-4e55-9b09-5a77873d059b" control-id="sc-2">
+    <implemented-requirement uuid="70da8442-3398-457e-b7c3-f7fc3dae5909" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="7ac0ac8e-ba91-4537-81c6-b2156224f97a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fe907262-4dcc-4e20-b325-7ef669a4eec1">
+      <statement statement-id="sc-2_stmt" uuid="44acc704-1e60-4fd5-abe2-024d5664d1aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4d9884-03fa-441f-b60e-dcc41011bfec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -7601,10 +7601,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50ee8e7c-c77b-439a-82fd-a711610d2cf8" control-id="sc-3">
+    <implemented-requirement uuid="4a079485-8497-4991-adf5-581471c1768b" control-id="sc-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-3_stmt" uuid="18f015a2-3749-4806-9d28-aa6d49998c94">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="78516b86-6cf5-414f-8946-1836a17da49c">
+      <statement statement-id="sc-3_stmt" uuid="bb181bc6-3964-4ffb-8b37-a3b674dce3bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcb46851-9f9b-4fca-9402-6eb2b3b16b4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for deployment utilizing namespaces,
 host roles and other features as well as policies and procedures
@@ -7619,10 +7619,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="464b66aa-1383-4d96-831e-31ceb935b841" control-id="sc-4">
+    <implemented-requirement uuid="5682e79c-2a44-4798-a0b2-f3380e749850" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="7ea03df8-a253-4815-b63f-4d42c1f279c3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c866da46-69d3-4e7b-9a53-2d5f24f87772">
+      <statement statement-id="sc-4_stmt" uuid="59fce0b6-f3c2-477f-8f72-105d101d9c08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f71cd20-c3ff-4a42-bebf-207b35e29b8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -7636,10 +7636,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d85d2cd-f90d-4d7e-a465-32872a62b775" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="e548470a-3ad9-4606-95c4-926898649b4b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5eddfd95-1db3-4d20-b341-548839d0c1e5">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7649,10 +7649,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5aef5a0d-b62b-434e-99e5-1e340de5cf8f" control-id="sc-6">
+    <implemented-requirement uuid="82bbbda7-2397-43ce-8a91-45ebe78b28d2" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="d56cd7e0-1559-4ea4-8f0f-4f7e6b1c6a5b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d011b53a-7935-4858-9cfc-8bf78801c105">
+      <statement statement-id="sc-6_stmt" uuid="b13d5767-f2bd-4b7f-abb7-098b2d703125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b1aa9cb-3e60-45d5-a0cf-18dfeb9a218c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -7667,10 +7667,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a21d0c04-6d0d-4743-b1a7-3c6f4e266dc4" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="e97205b0-a890-42ea-a210-82f29123517f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0fab8a3b-1e49-4037-bbf0-537efea3ad90">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7679,8 +7679,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="234250ad-faa8-4b07-8875-18831c8986d8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d66ebd1e-23b0-4ef4-9ecc-88c78b981c6b">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7689,8 +7689,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="b8950589-963e-4dd9-a862-c6dca36766ae">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c7042382-8892-486a-858b-2f0d1e50569b">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7700,10 +7700,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5445c29f-a8b8-4dbd-a64a-660bbdb1b689" control-id="sc-7.3">
+    <implemented-requirement uuid="bd054bfa-4fc7-4624-91e4-6bf2052ee2da" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="56a87190-cefb-4042-b0cf-0d0ea619cb15">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="96aa914a-145b-48fa-9355-28e48266133d">
+      <statement statement-id="sc-7.3_stmt" uuid="bd50dd22-917d-43af-be8e-58c4da6d8e02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="755d6cf9-a601-470e-95e6-6a9d439390c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -7718,42 +7718,42 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97d49a61-b552-4509-a78f-23d96e35ddf0" control-id="sc-7.4">
+    <implemented-requirement uuid="d7c75c63-231c-4096-b614-fb94a7e697bc" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="4b7afbfc-766b-47ec-9d30-df250785ce96">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="03b53566-797d-4c1c-b6c0-e89e1cb008c3">
+      <statement statement-id="sc-7.4_stmt.a" uuid="32e6ca84-d7c2-43a0-bbb5-1eace8e1ad07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="02828fe1-67f3-496f-82d0-bd0b2ddac8c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d1fdbf11-5774-4d53-9896-6e67818666d8">
+      <statement statement-id="sc-7.4_stmt.b" uuid="bcd5c039-1219-4ec3-b329-e45d99c4d340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="64ac3e4c-fa21-49e8-ab02-d768cc66bac2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b5eccbc4-5844-479f-9967-08ed9f0e5ea8">
+      <statement statement-id="sc-7.4_stmt.c" uuid="069d86ca-da6a-4077-854c-868ee5e9ecc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="0ff5e6cc-a65e-4dd5-8ce3-c924d2d96aff">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="579c5eb5-d77b-48ca-958a-137c6b4bdffe">
+      <statement statement-id="sc-7.4_stmt.d" uuid="8f227e9c-9dfe-4054-b121-4d8a1d4695cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="bd7d9c42-4ee4-4714-a07f-19ef531feaf4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="95ea0b15-5bce-40ba-80b3-3734a16f4bc5">
+      <statement statement-id="sc-7.4_stmt.e" uuid="a3fb9713-8f46-4fbe-9950-20c1f82b14d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7761,10 +7761,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7f4a525-af59-4d86-aefc-77fde6dd50f3" control-id="sc-7.5">
+    <implemented-requirement uuid="6352f83a-1990-4f77-b7d4-20477ea193fc" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="f4da6e0f-242b-4fdc-ab17-5830d3074232">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8869058a-5a54-47cd-bf51-7ffcd89546f8">
+      <statement statement-id="sc-7.5_stmt" uuid="77c7eed5-e937-431d-9ecf-06142441cead">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017bbc7a-e859-49ef-99f5-32b45c249480">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -7778,10 +7778,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48fe10ff-87ff-48e5-8414-3a9e801eab0b" control-id="sc-7.7">
+    <implemented-requirement uuid="9ce1fd85-8385-434c-9f52-5f83ca6b94f8" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="897c0820-e5a4-43d7-b0f0-01f96be329ca">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="645d39e6-ff71-4f90-bb64-6cc68bab8c3b">
+      <statement statement-id="sc-7.7_stmt" uuid="8fe6423b-55dd-492f-98bc-ea63fe10afbc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8058ef3c-62cb-49af-8163-2a203fc25a6f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure Red Hat Virtualization Manager (RHVM) nodes do not act as proxy or relay servers between
@@ -7790,10 +7790,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0c536d57-f611-44a9-8657-2fcc1fa5bdad" control-id="sc-7.8">
+    <implemented-requirement uuid="c27f649c-058c-46d1-af09-2651e9668239" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="22cce17c-c20c-456f-ab0f-6a2d65284209">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4607368c-b0f6-4746-ae54-e3d6371b151d">
+      <statement statement-id="sc-7.8_stmt" uuid="d2cb6062-09d9-4314-9a79-1a3b3bb55fc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7803,10 +7803,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1954f249-a2c4-4eed-9039-24eaa50d00a6" control-id="sc-7.10">
+    <implemented-requirement uuid="cc49fbe8-b64c-46f0-80de-948244ebae7b" control-id="sc-7.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.10_stmt" uuid="24de4b05-8d59-47f8-9674-37e62f7dd590">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f4102dc3-1062-4e46-a85b-2afba6f50073">
+      <statement statement-id="sc-7.10_stmt" uuid="0d61d3ad-5c62-4c7b-a099-298a65951f81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7816,10 +7816,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="58128a8e-aa79-40f2-b813-b986b3f412cf" control-id="sc-7.12">
+    <implemented-requirement uuid="88cc2cd2-e8b8-474c-a3f7-e1da1d36e3c6" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="828d521a-59d9-414f-8d59-b04a6fb30e18">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9b6c5899-afc3-4713-bd4a-5a7f63cd4769">
+      <statement statement-id="sc-7.12_stmt" uuid="47ea0ad6-5d46-4f24-a661-403095ebf876">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c52e724-9ba0-4f88-bf6d-10dc91dee8d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -7833,10 +7833,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="009b7b18-a3f3-4a3f-a5f1-a0e6ff308176" control-id="sc-7.13">
+    <implemented-requirement uuid="87adc99e-fff5-4af4-ba83-1b6b82b0ee89" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="325e103c-7fac-4005-aa32-ca79ce24cc21">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2801d09f-6606-4c9b-a14d-cea4a1c18cdf">
+      <statement statement-id="sc-7.13_stmt" uuid="999496f6-49b0-434a-a22f-8718c88aba4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d58896a-07f9-449a-837d-c1bef5a36c8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that Red Hat Virtualization Manager (RHVM) is
 isolated from other internal information system components by
@@ -7853,10 +7853,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6daa5a5a-66b9-4590-8d30-b0e7c30330e0" control-id="sc-7.18">
+    <implemented-requirement uuid="005ffd60-e29b-4bb5-a964-7ef65783f3d6" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="82cf9b51-49c5-496d-a474-3108efecb2b8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f4f37cca-c479-42d7-8bb3-1410fb5d1ae9">
+      <statement statement-id="sc-7.18_stmt" uuid="00c478bf-252c-4c48-91df-18734f3c248d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7866,10 +7866,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d8a319b0-191f-4e85-9d4a-9793d908a1b6" control-id="sc-7.20">
+    <implemented-requirement uuid="ab95877c-c35d-48ec-a63b-31a1b89de7eb" control-id="sc-7.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.20_stmt" uuid="2499dd53-92cc-4f0a-b317-b64c4b807864">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="db521806-f8e2-448b-bc55-cc3cb1231e80">
+      <statement statement-id="sc-7.20_stmt" uuid="9f463691-e195-4fee-8c41-146ba28f45d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7879,10 +7879,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5364347-7486-4105-b56b-1fad5997ea2f" control-id="sc-7.21">
+    <implemented-requirement uuid="e5a85d54-73dd-4ad9-979f-2fb93f020afd" control-id="sc-7.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.21_stmt" uuid="bd7228b6-c282-46a0-8c4a-d4e123c20aac">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bd869582-191f-40c9-af38-d9c28aa2f92c">
+      <statement statement-id="sc-7.21_stmt" uuid="bbc96d1c-a56c-4a65-8746-c50a71054aeb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7892,10 +7892,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ed8ba88-50c6-4152-bc48-6533ffd88d85" control-id="sc-8">
+    <implemented-requirement uuid="6ebf81ff-2d9d-48c9-bc42-2cf9637471d8" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="0d2b7729-a398-4c59-bf4f-2759e3c26211">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5a6fd052-313e-471a-8c8c-168705997faa">
+      <statement statement-id="sc-8_stmt" uuid="49e34fad-76b9-4853-9a6a-5d5de9b11158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7905,10 +7905,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="790dbb7d-8366-4d66-a9a6-0d9b0da812df" control-id="sc-8.1">
+    <implemented-requirement uuid="1263ce60-fead-4fe3-91c1-2c246a05e045" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="f8b6fdc4-503d-4590-9b1a-11ceb22290ca">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ac35cbee-4a20-4c20-a45b-0de00b44309a">
+      <statement statement-id="sc-8.1_stmt" uuid="e8d6016b-24d2-4229-94ae-3de7956621a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7918,10 +7918,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb8b7a68-46e5-4f52-91e3-8795e84e378b" control-id="sc-10">
+    <implemented-requirement uuid="e5a2c493-ec0e-491d-86e3-7b162bdb4ef3" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="e46c58b9-b738-4569-9d52-21b69ab533f9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4aa5e82d-4639-4b43-8606-4a3d8f966cd0">
+      <statement statement-id="sc-10_stmt" uuid="ee7681ec-31ee-4c11-8ab4-7777139adc68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc326e1e-9b29-46ee-8e79-35af828fc76e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -7936,10 +7936,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e404b467-1797-4768-a8cd-dde1a4124044" control-id="sc-12">
+    <implemented-requirement uuid="a6c2e22d-2e4c-4524-a9b4-40e7699e2590" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="4ec205ff-3d6d-480e-9d1d-a3e931996881">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="99d9bb02-9360-4164-aff4-38e48682a2f9">
+      <statement statement-id="sc-12_stmt" uuid="146275cc-6a6b-41fa-adbd-aa394c6964da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c1a45b-7ea9-4b3c-ac60-2c0e6a977cf1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -7958,10 +7958,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4f9a552-61df-40a3-a754-ccf653cd24f5" control-id="sc-12.1">
+    <implemented-requirement uuid="1934a050-8156-4c6e-9bec-31f5dc1a0187" control-id="sc-12.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.1_stmt" uuid="d17b802f-9571-455f-b5dc-311f7f0d7cbc">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="935eedb4-5d43-42c5-918c-47ad23f40ea0">
+      <statement statement-id="sc-12.1_stmt" uuid="9aa0ac2c-47d8-4e8a-a0f1-45e7200dfa28">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7971,10 +7971,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3579addd-9f15-40d6-adeb-26d473968888" control-id="sc-12.2">
+    <implemented-requirement uuid="4d4f5d27-f723-4222-939b-a20a7b8f0b43" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="dd21038e-e850-4197-8202-1a8f8fb4ce4c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8a8f1c50-439b-4d2a-89a6-439f005db3fb">
+      <statement statement-id="sc-12.2_stmt" uuid="a5a12b62-f938-4920-bb4a-79a0fe345369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7984,10 +7984,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9adb7e64-79c5-4efd-a288-14b1ea2a9d3d" control-id="sc-12.3">
+    <implemented-requirement uuid="08160e29-14fc-4dd7-b5b6-fba597db4b6e" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="f85ccfa7-7b44-4976-aa88-e21e3c76783b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0f54bae9-cc62-4bbd-926d-f53aa2d3975c">
+      <statement statement-id="sc-12.3_stmt" uuid="84f2cc66-d583-4e4f-abea-1ec72a4c573b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7997,10 +7997,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e42326ed-38b8-44d6-b5bd-8b9b767aad97" control-id="sc-13">
+    <implemented-requirement uuid="17cc2bbf-50a8-46dc-b8cc-81ec9436957e" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="83ef1831-77f5-4d45-a6e1-88fd9a60ed35">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bc0389ff-cbf9-46af-ba36-710c64fd1dde">
+      <statement statement-id="sc-13_stmt" uuid="c9215f59-79d7-4038-850b-46d60f6d2416">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95afdfd4-0996-40f2-9c0c-f68fbadbe2cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -8015,10 +8015,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3ccc198-7d75-49e5-a100-647cd1b40fd5" control-id="sc-15">
+    <implemented-requirement uuid="20f5a259-b494-4a5d-890d-10bf65c16c05" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="d841298d-ed8c-40cf-aa4d-c472faa20af7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eaf4cf7f-4eef-4cb8-a452-a84092d14338">
+      <statement statement-id="sc-15_stmt.a" uuid="45e9cdd5-9166-40b2-bb0c-31a61d7c90c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8027,8 +8027,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="5c2b45fe-93ab-418f-a9c4-545b83409db4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eea8fd3c-64d3-42fb-a22a-9418f74d58da">
+      <statement statement-id="sc-15_stmt.b" uuid="60a11b00-60e7-4cb4-af05-3f2e19e96459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -8038,10 +8038,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ed023bf-6b40-48a2-919f-0ebc91539307" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="7aa2bd9d-4064-49c5-b574-5293f2226eb9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5dfeea52-4bbd-4a93-a6ae-c6ad2fe890a4">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8051,18 +8051,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f96a4ac-839c-40d5-8343-b6979bf83c10" control-id="sc-18">
+    <implemented-requirement uuid="5d3f05bc-c7c8-470c-914d-ec87c04ee392" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="abf96492-f35e-4ece-80b7-a3574829e50d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6d39b3ae-c363-46c7-89f0-c53c5e4a3953">
+      <statement statement-id="sc-18_stmt.a" uuid="288c4934-cfa1-43b0-80b6-2c17d0c59fb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9bbcb63-8565-4eae-b386-70f3337b4970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining acceptable and
 unacceptable mobile code and mobile code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="4d93af7b-40af-4a1e-bd58-10102857c330">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="17ad7628-838c-42fc-af12-0d3a2e7c7b92">
+      <statement statement-id="sc-18_stmt.b" uuid="f2075982-e716-4d6f-b59f-fb353c22add2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="300a4a3e-4553-45b6-9fa6-64fb56470ffa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for establishing usage restrictions
 and implementation guidance for acceptable mobile code and mobile
@@ -8070,8 +8070,8 @@ code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="89a46afd-24e2-4b9e-b61f-91008b9a6ec8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="333c25e3-05b9-466a-a9a9-6a30fe91f0ff">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -8080,18 +8080,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93856361-8b82-4473-aecf-0f4659ca2693" control-id="sc-19">
+    <implemented-requirement uuid="f72216e1-b23a-4af4-b730-3073eac610e3" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="1505a156-59a7-4797-9be6-b12c0b9d62e4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="36f28e13-4853-4edd-8ecc-a3c2140044b1">
+      <statement statement-id="sc-19_stmt.a" uuid="7ee93e00-bbb1-4e9e-b761-a49b76fce2ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="0a174498-c087-490e-8599-f46b44dc7798">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b8714392-7e69-4724-80b6-44e0856037b5">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -8100,10 +8100,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bac4a640-1d66-46c4-91de-16b5123f3dd9" control-id="sc-20">
+    <implemented-requirement uuid="aac327f7-334f-4136-ba0d-a69495a4228f" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="3421ffdb-d64a-4aae-bf32-c77c2ae529b1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="433e2bed-baee-4de7-aa6b-c673a01a87fa">
+      <statement statement-id="sc-20_stmt.a" uuid="67b81ea6-2bf3-46bc-9722-e0dff2d50c87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="934926ee-05e0-47e6-8f1e-13a8858e54f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -8118,8 +8118,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="bb51b5f5-ec8d-416c-bdb6-993b9985897a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8d46afbe-19a8-410c-8bd8-c2444a09c285">
+      <statement statement-id="sc-20_stmt.b" uuid="a871ad06-8c3e-4f76-b4c5-a7de3dd9040a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5279d66f-e6dc-4f01-a4f8-207873b40bd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -8135,10 +8135,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c791096-7bca-4fea-9d8f-f1aa6e4269cb" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="229abe00-229c-4813-976c-28bae25bfe2a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e5c3e787-656e-4fda-a3a2-415145674b71">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -8153,10 +8153,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="247ebbda-4ceb-4fba-86de-8e296575c6c2" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="f38ddc8a-7313-4b2c-b5fc-675e903c5fc9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f7d0b802-cc71-4be6-8376-b1d8cf84e232">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -8165,10 +8165,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5056d74-cacf-4bb8-a7ed-d07919877e48" control-id="sc-23">
+    <implemented-requirement uuid="8d358d47-5981-4e35-b156-3f59ebcb9375" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="627c5049-9978-4426-afc6-983158babca9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ce499694-96f4-41c2-87ad-05cf4db92de3">
+      <statement statement-id="sc-23_stmt" uuid="af621af7-8e88-404f-8733-4ec9d3319a92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e411f9a4-503d-41df-8bb6-75236999ea40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -8188,10 +8188,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="476dd224-890f-445f-b41d-0673cbae1d8d" control-id="sc-23.1">
+    <implemented-requirement uuid="d753123d-8a30-4a29-8b2c-5d85ba63d24b" control-id="sc-23.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23.1_stmt" uuid="2f21b518-ed6b-4812-9540-584b92169d89">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="04b2f7fb-61be-4ec4-8410-90b4d40570e1">
+      <statement statement-id="sc-23.1_stmt" uuid="871e60d8-2d43-4a32-883e-840e6c3e4340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8201,10 +8201,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ec0022e6-a23a-4412-b0fd-39cca06b05ac" control-id="sc-24">
+    <implemented-requirement uuid="a630d193-a419-452b-86b2-b8bdccbc8b42" control-id="sc-24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-24_stmt" uuid="38ffa6cb-6947-46a1-8a41-6be38c49ebc9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eb1d5e6f-b5b9-4eb0-a7a2-e3215aef884d">
+      <statement statement-id="sc-24_stmt" uuid="8fcd865f-3154-43ca-baf3-7f1acfc40b84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8214,10 +8214,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50125b88-7658-4c00-babe-7187f1b5235e" control-id="sc-28">
+    <implemented-requirement uuid="5369e7e4-4f63-47a4-a269-858e0d726ed2" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="5a4c0adc-e5a0-40c6-8e91-16c2d32593ae">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="0e4e920a-75d6-4e04-bd18-2741d6d1b052">
+      <statement statement-id="sc-28_stmt" uuid="3c623361-fd52-46c2-b652-86f40cfbf05c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8227,10 +8227,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d9d4b37-b4b4-4bd5-b2ad-961c89dafbfd" control-id="sc-28.1">
+    <implemented-requirement uuid="ead5d9b7-8685-4ec5-98e3-be95239a7ac1" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="2382b003-e9e8-4efd-b83c-24888cda0de3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6901d0c0-c665-4476-95bb-02a26ce03071">
+      <statement statement-id="sc-28.1_stmt" uuid="85579a64-91f8-4875-ba31-3a301c7c2da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ff1eb1f-b2c6-42e0-a5a3-df44f4885a46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -8251,10 +8251,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9e8ceb8-d30e-4578-9d2d-0a21dfaae87b" control-id="sc-39">
+    <implemented-requirement uuid="18492d24-fcdb-4b37-bca3-45866ef75858" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="4e0617ea-e0dc-4c0e-b3ce-bdd8f9c83b61">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d17f2885-2908-4895-98f8-b0c7874afcd7">
+      <statement statement-id="sc-39_stmt" uuid="3d537e80-1058-4a08-90ba-7914b55b29b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -8264,50 +8264,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5023f96-7d61-45de-8ab9-9359f84264ab" control-id="si-1">
+    <implemented-requirement uuid="69d4323a-60d7-433f-8def-834118e54ec3" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="7344a814-0b85-4d42-8680-7fcf78c09311">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="20a7521b-29e7-4d02-8cbf-37675bda882a">
+      <statement statement-id="si-1_stmt.a" uuid="94b8cd57-db6c-45cb-9083-c68f55d824ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="b4d13951-8bec-4980-9e7b-51032806812c">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c104b606-4b10-4023-a2ba-95b7477ca0e8">
+      <statement statement-id="si-1_stmt.a.1" uuid="5445db05-a229-4dc8-8db5-aac44c81e11b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="3fbf6645-99b2-4b15-837f-0894fa398016">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="21dcd042-32a7-4e00-98c2-66e0f2c54c88">
+      <statement statement-id="si-1_stmt.a.2" uuid="f701cd56-8a46-46f9-a67b-f933907d3366">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="c308cb1d-46fd-4fb4-9ef2-f78ce21bfa26">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3bba70e1-a53c-49cc-a83d-f8bddbfa16ee">
+      <statement statement-id="si-1_stmt.b" uuid="43752a7d-deb8-4a5b-95e6-24d6559073a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="10a12a1f-8ac5-4c22-bfb3-595f53c63ab1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="eee9fa4c-3994-40c0-a346-003f96be77c3">
+      <statement statement-id="si-1_stmt.b.1" uuid="f51c8e38-661f-4dc2-8b95-d9a6a581256c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="573f3344-5152-4e3d-a38b-46a1ffd370ad">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b91339f9-fd21-467c-829b-5d334e687d24">
+      <statement statement-id="si-1_stmt.b.2" uuid="8a613969-37bd-44a4-b52f-347ed9730db4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8315,10 +8315,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e8c1760-3c78-422a-b985-acab1e70cd16" control-id="si-2">
+    <implemented-requirement uuid="7cedbd5c-1b1d-4006-8b67-4a7737372576" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="c419ff08-5df8-45d1-93b7-62ff57d2c98b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2dd384a9-45df-44be-91f1-64cc26e25e20">
+      <statement statement-id="si-2_stmt.a" uuid="96489f3b-4bf5-4c8f-861d-51c61891be1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ed4991a-e585-4e65-8fcd-7dc03286246b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Manager (RHVM) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -8328,8 +8328,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="c3ea0954-e703-482c-847b-c58a7d77598a">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="726e6f35-a576-473d-bf7c-6fceba2e399b">
+      <statement statement-id="si-2_stmt.b" uuid="086eebad-1e6b-4123-baff-e5d987e41741">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29cfb255-66c1-40de-b090-cf3d790e6c1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Manager (RHVM) updates
 related to flaw remediation prior to installation. A successful
@@ -8339,16 +8339,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="1c9a3349-0994-4ea5-ba6b-7150c1f9e74f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5576e683-2b63-4542-844a-1200ad279802">
+      <statement statement-id="si-2_stmt.c" uuid="0a0349f9-7247-4d4f-9252-6510fb5c3964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="323ac9d6-a8f8-44f2-a498-57ab35d77541">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de305e00-f448-475a-a9c5-34428f4890aa">
+      <statement statement-id="si-2_stmt.d" uuid="40f6fe99-bbfa-4675-9b65-946ed3fcddf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8356,10 +8356,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="aad0965a-be8a-4078-bacc-fb3b4ac4d053" control-id="si-2.1">
+    <implemented-requirement uuid="cb386662-eee1-4a0e-9f60-6934573e24b2" control-id="si-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.1_stmt" uuid="9f269dfa-cfef-4c7a-9220-6d22fa7a37f2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="75fa9df7-c79e-49b0-8ccc-a78c737b5d75">
+      <statement statement-id="si-2.1_stmt" uuid="c845d583-2a7c-4904-ae6f-90ba2996a2c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad4dfd7d-62cf-4f50-8d54-5acff9614b55">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-2(1) is planned. Engineering progress can be
 tracked via:
@@ -8369,10 +8369,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="997094bc-7b24-4f4b-8327-627ff3d04d03" control-id="si-2.2">
+    <implemented-requirement uuid="f39f62f5-798d-48f5-8703-27d537979525" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="1712ed6f-9706-4e25-a4c1-04084e3c1c15">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c1d1a215-d82c-4591-a862-70cc83284223">
+      <statement statement-id="si-2.2_stmt" uuid="2fcbc796-5a33-4953-b75d-ed3bbf6cd579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d37014f-dd7c-410f-8ccd-f0873ee726fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -8390,10 +8390,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="93e701ba-1641-4914-842e-f2ee01bdeb73" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="1067bd97-6553-41aa-a94e-4b15ae174efe">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="5e5af01e-0c61-4968-bb67-54cde75cf7e7">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -8404,8 +8404,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="8fbf888d-f4f3-463a-8770-af89e846f2fe">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="430eafc3-864c-482a-b2ab-d988a6bc46b8">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -8417,10 +8417,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="33666e2e-d54a-46dd-b8ee-08de4e63283b" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="e8e387d2-d361-4057-93ab-5c88edf20fbf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="837181b7-68d2-47d7-8e6a-5b82fbea84f7">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -8436,8 +8436,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="9b35b2c0-ef45-413b-afdd-da4dc3f5c9ce">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7a0fd142-d583-4857-b2a4-5c403ffc2f99">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -8446,8 +8446,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="385299f2-c995-44ef-be9b-c8dd5133a126">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7f541b76-04d6-4ad9-b714-a84afa7fec55">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -8456,8 +8456,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="fc4b1d3b-d45f-4121-854c-fcceb48ee61f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7c3038cb-490d-4ffe-a07d-c7dbe856e8d2">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -8466,8 +8466,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="d0f3e8d9-5044-4b98-b17c-d5e266f3610f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e2b76f2b-0e17-488a-8ee8-5683aaa2b1d8">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -8476,8 +8476,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="8ed0ffce-b839-4b9e-8d2e-2a2389c977f6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="bed56015-4633-453a-aa9d-837cf56a633e">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -8487,10 +8487,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="468e5e32-3575-4cd6-8d6f-da055d25eaea" control-id="si-3.1">
+    <implemented-requirement uuid="3ebea031-233c-464a-998d-c0c3d922b851" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="aa5f727f-e591-4eef-98b4-621884655adf">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ef9f3c35-fab2-4606-aca4-54f7ce2a3725">
+      <statement statement-id="si-3.1_stmt" uuid="9e989886-07e9-4d4a-98ed-be98fb1368ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c58ac54f-22ef-4855-adb1-33eee390792b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -8506,10 +8506,10 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="980f157f-8811-4322-9a50-e8c04f9efd73" control-id="si-3.2">
+    <implemented-requirement uuid="67609e78-72bc-40fd-b9f8-0728765cfc5a" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="830ba041-57c5-4bf6-8ba1-2e6f01170107">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3eb0797d-f220-474e-8613-7900621eedb7">
+      <statement statement-id="si-3.2_stmt" uuid="b0ad1bcb-2da0-409a-bce2-8c8dce7b4539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071bdb1c-8691-40b5-b1e8-17d54c02caa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -8525,10 +8525,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="06de05ab-069e-404c-8b99-1ace7582db14" control-id="si-3.7">
+    <implemented-requirement uuid="e0f1ca33-2212-4e02-bea8-2b2961431e00" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="2173de5a-b311-4e28-ab82-160863815c66">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fc24f6fb-6adc-4258-ad7b-41712973899a">
+      <statement statement-id="si-3.7_stmt" uuid="c197c739-ab67-4d4a-89bd-78bc67721465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98787694-bec5-4c19-a079-27ca4960a28c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -8543,90 +8543,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb25376e-8563-43c7-aaaa-8de48a44cd9f" control-id="si-4">
+    <implemented-requirement uuid="42da28da-22d3-48d2-9596-ee182934124c" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="9d5dfdce-c2e6-4ae1-a993-50c3ce80beb1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fa750e2e-8341-4227-9bb6-6f52033ab093">
+      <statement statement-id="si-4_stmt.a" uuid="ad5f1c2c-5d90-4441-a995-674a523c202c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="4a46b356-f088-445e-9d2c-0b5470caaa4b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fe028c7b-bc50-47de-8f15-c27831cce860">
+      <statement statement-id="si-4_stmt.a.1" uuid="f607b60e-d90e-4e43-98dc-3a7a9636fc7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="9ea03041-ae6f-4bf7-b847-bec4924bf522">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="54ddea37-34a1-4b4a-8711-cd48c7801a6f">
+      <statement statement-id="si-4_stmt.a.2" uuid="a10661b3-77ee-4238-a310-7a54cfbbe381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="915a0536-3ce7-48d5-bcd8-3ad62b008065">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="dc3c6e64-3c83-4225-8882-1628cd66b089">
+      <statement statement-id="si-4_stmt.b" uuid="93b8c509-885e-418d-a16d-2e774aeafb13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="fabc48df-b38e-497d-9656-012adc26a009">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d66cfd5d-b6e2-44a1-9289-36b34c6b4dda">
+      <statement statement-id="si-4_stmt.c" uuid="c35fb893-5523-4f34-925d-1434f16a0e91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="805e8e1a-8381-4f04-9465-6e8c7a7ecd35">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="016e9a5f-ad27-45d5-b305-043cb9c27070">
+      <statement statement-id="si-4_stmt.c.1" uuid="5551c8bd-d3f0-48a4-89fd-fcff3254c583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="c819a583-b53c-4d3a-8abd-c9a084d53d13">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c26dba06-534d-4356-80fc-b4006cce9a11">
+      <statement statement-id="si-4_stmt.c.2" uuid="d541badd-ea98-4830-b51f-44e2b827e474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="87e9eebf-67de-4ed3-9594-194ad77b8a8d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a1c2d39c-f6e7-4590-820d-73c4e9e9de8e">
+      <statement statement-id="si-4_stmt.d" uuid="eab74f27-bef7-4c94-9448-5664bc339713">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="24fa5f22-1cbd-492f-afe4-e333a69ae465">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f66bb663-c171-42ec-8565-2579df311c71">
+      <statement statement-id="si-4_stmt.e" uuid="c67c8bcb-a07d-4eb1-8ecc-033bc9a800aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="6461b472-fb94-4e68-9d15-4ce45bbecfe9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ef4cd426-47b7-49d5-be4c-787a7ef57d1c">
+      <statement statement-id="si-4_stmt.f" uuid="97dc93ed-5f81-4453-b322-45bdea8dd72f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="dbdfd7e9-1bf3-4979-b399-2580e5398613">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b27257a7-55c0-40d2-a68a-8d3b2dbf651e">
+      <statement statement-id="si-4_stmt.g" uuid="83c23958-58eb-45ae-b5d9-57211186fd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8634,10 +8634,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0dc8061-b874-49b0-a5c3-1662feb3afc0" control-id="si-4.1">
+    <implemented-requirement uuid="9fb8d001-a07c-48bc-a75f-a742ff6757b0" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="14644b71-365c-4ccb-8646-4e008d793d24">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="de8b0d42-50a3-4b38-a6e7-173744f60e58">
+      <statement statement-id="si-4.1_stmt" uuid="1f43e40b-e9c7-43d4-a4f5-7521084f3bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a0cc4d0-2529-46e1-8af9-82ad56c02239">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the Red Hat Virtualization Manager (RHVM) environment, and documenting how this
@@ -8654,10 +8654,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="046740ef-2113-4818-8976-8717daa82e41" control-id="si-4.2">
+    <implemented-requirement uuid="283ad864-6082-4571-848c-9fd3accadf1c" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="b6c822d2-37a1-4b6b-9093-54a13004c5c8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="9a6c3612-ed72-4727-b8a8-032653ee8a06">
+      <statement statement-id="si-4.2_stmt" uuid="80a356fd-653d-432a-bfa8-eaaca3b3cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bf351-1106-49a6-9dda-1dda289ea4db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -8676,10 +8676,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2cd4f438-2ebf-45a0-ad96-e083dc93da1c" control-id="si-4.4">
+    <implemented-requirement uuid="16783170-544f-41c7-9a13-99abdbbd9c36" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="e7522fdd-1aa5-46cb-b87d-0c4a52c34107">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a87f119e-35ec-41bd-83a0-67c9a2024227">
+      <statement statement-id="si-4.4_stmt" uuid="c2cf100d-6819-43c6-be66-ea9fb2012e61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d2ca56b-bd9b-411b-bb38-3e205fc8d841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored.
@@ -8692,10 +8692,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f60d1ac-5248-4e4e-9b09-9a65cc1fc05e" control-id="si-4.5">
+    <implemented-requirement uuid="5396bcbd-5df3-468b-a6fc-70f008a8c1b5" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="3aa918e4-ad27-4fe8-b809-8b1f3440a4dd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b81fe709-ea11-4eff-b3cc-f50edf37964d">
+      <statement statement-id="si-4.5_stmt" uuid="7d4e1aa3-8989-4b97-8cb1-1b607440335b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c63bf7-e4b8-499d-8db7-bf313c017b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -8712,10 +8712,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b448838-c1c6-4c69-9305-31a806a2fc8a" control-id="si-4.11">
+    <implemented-requirement uuid="39d4c16d-ea53-449e-8d66-798730a79f88" control-id="si-4.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.11_stmt" uuid="e2be43da-e7fe-40ec-bacc-c5a7bd377795">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="08ae28f2-4732-48a1-a8c2-36ab8b644e0d">
+      <statement statement-id="si-4.11_stmt" uuid="33feb9bc-ce38-4179-8a57-68ca527223c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8723,20 +8723,20 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28e22b75-bc78-4ee3-b6a1-913ef8edad3e" control-id="si-4.14">
+    <implemented-requirement uuid="7fddf4bf-1684-4e2d-8d95-0e8ca745a37d" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="7c33b441-155b-48e7-948d-e085ee7a6af7">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="c5d7e204-285a-4e60-946d-b01596f47061">
+      <statement statement-id="si-4.14_stmt" uuid="b41ffecc-9d23-4e18-a5ae-e37101e9f3a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6e4f3a9-00ac-48a1-a8be-7f607b8f5761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An Red Hat Virtualization Manager (RHVM) infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b65c7cf-3c0e-4929-9999-d2743010588d" control-id="si-4.16">
+    <implemented-requirement uuid="253bf33a-ac68-4dd3-b870-7700ee285f87" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="a887c069-f2a9-49cf-9e8f-24b620b900d3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="90d41893-14e7-4445-ae9c-8f81a153f7e9">
+      <statement statement-id="si-4.16_stmt" uuid="a152da88-93f8-4db0-81c4-cb866db6b80a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7452c87a-d7b0-43c2-8a16-d7f459271774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -8751,10 +8751,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d7d83f83-b6ca-4ed7-bcf7-8ccf3c10b27e" control-id="si-4.18">
+    <implemented-requirement uuid="9f8f854e-6037-49cc-9ab3-441435676162" control-id="si-4.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.18_stmt" uuid="4a8e0545-eeca-4cc0-9d4b-04e0a66f68b8">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="d8d93abb-1d22-4c25-80d3-7987b8c1d589">
+      <statement statement-id="si-4.18_stmt" uuid="0df2b7f5-1a6a-42c9-b6f9-f55a2106f62f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="01c57c4c-9c00-4662-b6ab-6e175282e464">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(18) is planned. Engineering progress can be
 tracked via:
@@ -8764,10 +8764,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41784a37-9055-4dbd-99ab-588a3912dcd8" control-id="si-4.19">
+    <implemented-requirement uuid="57deefc9-5f72-4ab8-ae86-27166cfe98b0" control-id="si-4.19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.19_stmt" uuid="65d329ac-fd59-4c33-912b-3f3b72165c3d">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="fd3717d8-787c-4e6a-b864-78788b424d6b">
+      <statement statement-id="si-4.19_stmt" uuid="151c2c54-9341-4c7b-a08d-965791d2e78f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8775,10 +8775,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05f731a7-10ce-4790-81e1-5cfcb4682224" control-id="si-4.20">
+    <implemented-requirement uuid="3d18cce4-09bb-4987-bcbf-d730f6c7031c" control-id="si-4.20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.20_stmt" uuid="26d574af-33be-4f81-b54b-98ef4e180186">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7556b594-95ce-427b-a676-fd25575af0d0">
+      <statement statement-id="si-4.20_stmt" uuid="c1b02903-76ab-4989-8c57-5c76212a01dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8788,10 +8788,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="44dfe8ab-bbe2-4645-8ead-f6ae852e1e8c" control-id="si-4.22">
+    <implemented-requirement uuid="b22622d3-10fb-4d8d-90d9-a004ed3acfb8" control-id="si-4.22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.22_stmt" uuid="7f42d1a9-e4fd-4997-853b-495c0bfec47e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f42ecf8c-0385-40fd-a664-22d7131c34a0">
+      <statement statement-id="si-4.22_stmt" uuid="a0422862-aa8f-4e3d-b4de-a719eb7309cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8801,10 +8801,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="467237d1-e2d9-44de-b896-1221e843d446" control-id="si-4.23">
+    <implemented-requirement uuid="017b99af-4904-448c-9750-472ca8910e0c" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="d859ae15-4133-4517-bc03-a2b38c177d1e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a57a052e-7b46-4e13-9e07-b44d44908a70">
+      <statement statement-id="si-4.23_stmt" uuid="41aff24c-6253-4372-adda-a2c33d49d2cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c33bcf-6d25-4521-ad34-a59873c6219c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -8818,10 +8818,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09d43e1a-989d-4d82-bf86-ef9a9981811e" control-id="si-4.24">
+    <implemented-requirement uuid="0e6a813d-3704-470e-8ebc-16eea18b800a" control-id="si-4.24">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.24_stmt" uuid="ae9dc067-e4e1-4082-8855-d3a54c73977b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="213ba28d-4e43-4cba-aabc-742e5e3dc307">
+      <statement statement-id="si-4.24_stmt" uuid="2657beee-c87a-43a5-8de3-cadbf4589cce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859d1122-b59c-4a51-bb05-9b5919099f8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-4(20) is planned. Engineering progress can be
 tracked via:
@@ -8831,10 +8831,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59c29ea3-eb46-4b35-a2a8-3882d1e5cf89" control-id="si-5">
+    <implemented-requirement uuid="e294f724-c931-45f0-be8e-18f53f1e1de1" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="1fa62dc1-4b61-4b86-a725-2072e14d4e37">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e509fef2-8ea6-4084-8a7d-bab111c84fc9">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -8843,16 +8843,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="f86a29b3-a25e-42cd-9956-aa107bdbf3a0">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="33841b9c-0e56-48e3-9cd7-98c4968abee7">
+      <statement statement-id="si-5_stmt.b" uuid="cb7122e4-08c8-438d-ba3d-66beb38366d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="296294d9-e6d7-4636-ba32-e2a6b6fa2b01">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="648d8229-6af5-4c68-94d0-3e9bb5c1ad64">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -8861,8 +8861,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="daa690ce-4217-4582-a703-cc44bb510105">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="6cc36cda-4831-42ab-ac7b-4dbe08bb2797">
+      <statement statement-id="si-5_stmt.d" uuid="cd44fe4d-fa2d-40d4-8f5b-e52b09880005">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8870,10 +8870,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b1a1df09-21a7-4bf8-8eb4-43e8f8331ea1" control-id="si-5.1">
+    <implemented-requirement uuid="4559dcb9-9f2f-4c0e-9eda-df9037f90a20" control-id="si-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5.1_stmt" uuid="6358ed2c-1c26-45eb-8ec8-fd21dfb2c4cd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3b993b41-ec7e-499b-aef0-a889b31ef2c0">
+      <statement statement-id="si-5.1_stmt" uuid="f133c092-a1f8-4b7e-a99c-cc1f2d9d210d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -8881,10 +8881,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7e928e7d-5596-481b-a016-6a9e24daf8af" control-id="si-6">
+    <implemented-requirement uuid="38b01b39-5943-49c8-b108-044a6e4bacd8" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="e7781f3a-a1ae-47a9-ae34-8aecd0d8c87b">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2a1b409f-521d-4c42-abda-eafaacc2a6c6">
+      <statement statement-id="si-6_stmt.a" uuid="d64f2de2-7f02-4e63-aaff-02696686cb5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a447dc-056f-47a6-933c-b570d8213b54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -8899,8 +8899,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="20dde81e-b8bf-40a8-9d41-270f2f2eb4f9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="2db95715-523e-476f-87d7-0d3d36cd9431">
+      <statement statement-id="si-6_stmt.b" uuid="d22f4f0c-240f-4b13-bdc9-47cce702cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8909,8 +8909,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="9a84e3d4-00eb-4af8-a2a9-be94a09da0cd">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="deea3af9-c264-4ddd-9031-030249ac614b">
+      <statement statement-id="si-6_stmt.c" uuid="4bb561ed-8a3d-4fe3-9ca6-00b7213dc2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8919,8 +8919,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="542750ce-0107-4ca8-a97b-2212d0a83ae1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="b149e299-f718-4b90-bf50-897005fcb47f">
+      <statement statement-id="si-6_stmt.d" uuid="2d6bd4eb-8197-41d5-9e13-023435276675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -8930,10 +8930,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b988578-e76b-4736-b68a-95e2fe45cd32" control-id="si-7">
+    <implemented-requirement uuid="fd45ca54-ac27-4043-9523-cb122d75ef7b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="46aa5859-f43f-414d-a90b-254e9df4a790">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="a586aaec-b379-47d1-a3b4-7b27ecdfbc98">
+      <statement statement-id="si-7_stmt" uuid="2d2570a5-feaf-4efa-9783-099aa818c505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff0de457-49b4-4344-8372-7c7e6a4164cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -8948,10 +8948,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="119ad0da-9f88-43f4-a432-c20e59cef01f" control-id="si-7.1">
+    <implemented-requirement uuid="3c62e9a0-e77d-4915-b5bd-d8e7c7cebf56" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="7509219d-b014-4604-b99a-f0b1f96b260f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="f84ba503-d6b0-4460-ac5e-c974136b1455">
+      <statement statement-id="si-7.1_stmt" uuid="a3e8de9b-0300-45f9-a7b7-2d965e7a83ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db598211-5d2e-4a86-b372-f2d6a2f5c9de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -8967,10 +8967,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="07c44e85-7364-48c3-b829-0e3b8bf65587" control-id="si-7.2">
+    <implemented-requirement uuid="65843773-a426-4fe8-902f-a514ab7330e2" control-id="si-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.2_stmt" uuid="28e859e2-a6f8-4da9-9952-ab2ba79a6885">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="695c36fd-ad83-498d-8cad-76de616ce674">
+      <statement statement-id="si-7.2_stmt" uuid="c260d1a1-0aa0-412b-8446-c2a617a6e53f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="201b77cb-ae40-4171-a48d-0f9f2852d959">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(2) is planned. Engineering progress can be
 tracked via:
@@ -8980,10 +8980,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cebf7e59-2944-4857-8f71-20420a3391de" control-id="si-7.5">
+    <implemented-requirement uuid="cc7ba65d-f990-4d6a-b594-d9bba5dcbae1" control-id="si-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.5_stmt" uuid="63adb0ec-26d7-4918-ab4f-f0563558a5a4">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="90c85485-d22d-430e-bfcd-fcb01f839e70">
+      <statement statement-id="si-7.5_stmt" uuid="6271f138-4a0a-4833-952b-531be65bdcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13f44617-703b-41be-b9c1-61eca6e44852">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-7(5) is planned. Engineering progress can be
 tracked via:
@@ -8993,10 +8993,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8488cab1-34e2-4be5-8343-68bbf5df7131" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="c1de1a42-7647-4b3e-bcc4-fbf0d29a8b1f">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="26144e73-2b8c-43f0-86e9-120a885d1b46">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -9008,18 +9008,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a1563842-4742-4928-ab70-0f5066d6949f" control-id="si-7.14">
+    <implemented-requirement uuid="06f5077c-296a-4e00-a144-f59753a6993d" control-id="si-7.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.14_stmt.a" uuid="9d962416-6344-4b1d-be2e-2c317d8fde52">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="43e06da7-b645-49a6-818a-705886c2b5ca">
+      <statement statement-id="si-7.14_stmt.a" uuid="1f699f60-0e59-492a-9126-2d4a90a18166">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-7.14_stmt.b" uuid="112195f1-6a44-4cff-a229-5cac5cc373c3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ffd09597-c954-4a62-925c-d43d873a71d7">
+      <statement statement-id="si-7.14_stmt.b" uuid="fc68ffae-5a39-4ffa-8860-a27c6ed12185">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -9027,18 +9027,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c140c52b-83c9-4845-9cab-48318ad5ec49" control-id="si-8">
+    <implemented-requirement uuid="c22c0270-72c1-4c9d-a808-23c4af992f0f" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="f491c97b-17bd-4a42-ac81-1cd440b979a9">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="08ef1acb-7465-49dd-8fee-8d338624e841">
+      <statement statement-id="si-8_stmt.a" uuid="03fe5bcf-c4c4-4996-970f-516793b29758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="b04756c9-c56e-4a0b-9ee0-888d018284e1">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="e693e493-b8b4-4bc9-8d88-43ba88e9ffb9">
+      <statement statement-id="si-8_stmt.b" uuid="2de94f56-26bb-4b4c-b442-0ba0071ed8b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -9046,10 +9046,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef57e2a5-07e4-4e7a-ade6-51d7533cb1a2" control-id="si-8.1">
+    <implemented-requirement uuid="c970cc21-906f-4f2c-968e-501975d83dd6" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="6a4ae231-f180-44a9-a408-6e515dd5d2e6">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="4a64c4d9-dbb9-4e4b-b891-57ea5d5f3db8">
+      <statement statement-id="si-8.1_stmt" uuid="2d1fea47-0b97-470c-b2a4-0129938f179a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -9057,10 +9057,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a45b87e-da98-4f8c-9a9a-1d9e70925850" control-id="si-8.2">
+    <implemented-requirement uuid="fcba003b-aee3-4093-a092-c2a3dbc5bf7d" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="f70f19f8-1bb3-445e-9c78-68071233e439">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="8f2c2e21-de18-41f9-942b-52074f8f1cd3">
+      <statement statement-id="si-8.2_stmt" uuid="aa0c719b-2499-486f-aa1f-aeadd9b07cc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -9068,10 +9068,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59128908-8162-4f7d-80df-f2eb72b1e480" control-id="si-10">
+    <implemented-requirement uuid="a692ad57-9df9-46f8-9f6b-9cfdc5eb8331" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="6f6919ab-3b5f-4bee-b1db-116e00c55fe2">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="1746ae85-f49c-4842-b6df-fc8830a1c811">
+      <statement statement-id="si-10_stmt" uuid="5653a342-a850-4ce4-86c7-ee90659a39b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f5633d-efbc-49d5-9e55-9124a516abe3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -9088,10 +9088,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6867e7b6-60af-493c-9a11-c9a25ea579f8" control-id="si-11">
+    <implemented-requirement uuid="b3a5c29e-0faa-469d-b445-999334811b7d" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="18ba9341-444d-4440-9b8a-4a465a6c85ec">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="3ad57816-b1cc-4e48-8ad7-99c486787b9d">
+      <statement statement-id="si-11_stmt.a" uuid="96e25551-2aaf-4632-aede-caced5280e5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="336b8f57-a23a-47a8-b9d6-99b085addd75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -9107,8 +9107,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="98f89771-7fd7-4d6f-920c-9babbb102588">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="7a020bf3-157f-4efb-a987-11b1779e24c5">
+      <statement statement-id="si-11_stmt.b" uuid="865efc56-48e7-464c-9d66-8d1fd50b47ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad9a4e66-e871-4618-ba62-7d464c99668d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -9123,10 +9123,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="08ae93dd-767b-409e-a724-aac0864a7318" control-id="si-12">
+    <implemented-requirement uuid="073e59b6-334f-4554-8dcb-e8adb4bfa03a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="123c0b6a-57e1-48de-9b1d-18b26eb7ddd3">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="407aeb92-d758-4613-b934-3f2d7a98f743">
+      <statement statement-id="si-12_stmt" uuid="c54da56a-94d6-48d2-a137-0577ddfb83e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071845fd-4fb7-4382-9736-531d35f08a6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Manager (RHVM) in
@@ -9140,10 +9140,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee13989f-d1d1-48fa-bb5c-a3ba86b71ea7" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="8e08165c-b653-4c5a-aa80-68c214c3077e">
-        <by-component component-uuid="766bea88-c1ff-46f6-9cc7-e04eeee733a1" uuid="ce83fd09-ad8f-4a51-8ee9-00deb4b0e50e">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/virtualization-manager-fedramp-Low.xml
+++ b/xml/virtualization-manager-fedramp-Low.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="306792a6-7d73-4a6e-b33a-c0d7b9e93c8c">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="ed5ac79e-c5db-46a4-9499-c2b432145d10">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.92+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:21.17+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="83ac6791-cb07-47e5-9879-0c14c0aa998c">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,117 +484,117 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="54b242d1-3834-4f68-974a-53d0fde178a3" control-id="ac-1">
+    <implemented-requirement uuid="935fc585-8c0d-4e23-8c2b-8d1a82bc6de5" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="185e983c-fef1-4854-bcda-e43a4d82722d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ca229959-e6a6-4330-a352-ce4574b62b37">
+      <statement statement-id="ac-1_stmt.a" uuid="cc53016a-7b4b-43c2-a7be-d7e3881ffc09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bc7848e-1ff5-456d-bb50-4c66da19c7ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="ee38fbb7-a51f-4ae6-8ed3-26834461b3f7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4ab5ffbf-2ef7-44cc-851a-73bf01a42715">
+      <statement statement-id="ac-1_stmt.b" uuid="14971f3c-d3c7-4586-ab6c-e96a64f00105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192a21b9-f20e-40b3-be11-4658c5b10f4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b90a56e-3725-4a3c-9704-20feba36ae1b" control-id="ac-2">
+    <implemented-requirement uuid="f67d4ab2-d0ea-4ba7-9451-88e518020d4f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="315af169-d400-405b-bb81-c369cd712bb4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8899bf7e-41dc-4da1-b726-65be6775a1a7">
+      <statement statement-id="ac-2_stmt.a" uuid="9fbdf8ad-2b9c-4abe-a179-df8a0cf999ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0948d8a3-d0de-4772-8129-51d7044bc708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="ecd52018-9e06-4502-a493-94a9af9330b0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d883bcd8-a6f5-4121-b6f6-3143e998154b">
+      <statement statement-id="ac-2_stmt.b" uuid="37679c35-79a9-440a-b0ba-70bf1adf0843">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e397b49e-743d-42f7-9b6e-c27d903220d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="9984ac7e-0349-46df-922f-8a889680c4b2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="76c0c9c3-714a-422a-823f-1e39803770ac">
+      <statement statement-id="ac-2_stmt.c" uuid="57796f3c-04d2-48e7-b548-9f7cc23dfe1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5372385-2e96-4f5c-b3c9-dedd9fa4768b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="3cd8fd97-8868-4174-89d5-16833449b879">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f1f88a88-6e33-4fa9-9042-2a238e2b2e2e">
+      <statement statement-id="ac-2_stmt.d" uuid="16e7b8f5-72fc-463f-bcf9-dff9f1a98444">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192c3c92-4449-46db-bd35-3b3baa1a8e6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="ad296969-6581-47ef-a4cb-9aa624969f59">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c2d90179-9d1c-4bb1-ab6d-b7964c5b3c11">
+      <statement statement-id="ac-2_stmt.e" uuid="85035d84-9393-43dd-8d99-c4e3338892e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="354d4cb1-65e7-4f33-a3b7-3659e7d47759">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="2ff183c8-a438-4bd2-aeae-9807b3a0169c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c5de9cd2-f594-44ef-87c3-0ac673f4189c">
+      <statement statement-id="ac-2_stmt.f" uuid="8b9e97ff-b352-4097-a6b1-73095aaef138">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cb7701-547c-4964-a739-069548f34e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="a793db8a-6c1d-4816-aa82-f2aa21f745d7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f189f7a7-7424-4406-a4d9-d9442857f841">
+      <statement statement-id="ac-2_stmt.g" uuid="4f167f93-f6cf-48a2-9cd8-eff8812dd65f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5025090f-c1f8-4dba-bcf6-04b6e53d5135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="08f53061-ab6a-4ad3-a9fe-93155978b8a8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="59d9eb80-4975-4e8c-82f2-6ac6dd570f05">
+      <statement statement-id="ac-2_stmt.h" uuid="140deaea-5b89-406d-b8cf-e0067c52c4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f73dfb7-a97f-4283-b843-3c45bba5d201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="f16c96cc-b0da-45fb-8e05-bd719b4688dd">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ea40451f-2e95-45b8-bd42-13e864078709">
+      <statement statement-id="ac-2_stmt.i" uuid="96e1e1b0-69f0-447a-b451-0c237009cf21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a143884-7ff3-4077-ab98-a8e3ec37f214">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="ccd2c6f2-c5ba-4da1-b456-2055da7d949b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="39d71e8c-f160-4b68-8068-49ec937f3ce8">
+      <statement statement-id="ac-2_stmt.j" uuid="218ada72-ea7e-4142-ace7-16852053482b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9688aeda-4137-4df5-842d-43e0a620fc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="77341811-23fb-4048-97a2-7ed949cacfe4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f552afb3-6752-4d86-b5e8-50de8b8e00b3">
+      <statement statement-id="ac-2_stmt.k" uuid="be123a77-9ada-4c78-834b-1d8f12977e36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723be80f-78e5-47fc-b9b5-123a1ab7c7b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a88e9b06-f64d-42b3-a8e4-5bd4d78c17dd" control-id="ac-3">
+    <implemented-requirement uuid="28464255-c97b-4c55-9e87-f9276306d86c" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="2d1c6329-c099-4ade-852d-e0feb5e7d16d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="15ba2d07-cdd2-4f94-9b97-09f90b900fb6">
+      <statement statement-id="ac-3_stmt" uuid="826d29a9-48d8-40b2-b9f7-10cd9b1d5b1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75430695-3c06-4a3d-b50f-5da476b1efa6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Manager (RHVM) enforces logical separation through
 role-based access control (RBAC) and VM pools.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="67fa8c11-8595-4cd1-9d47-09b71b80b2f9" control-id="ac-7">
+    <implemented-requirement uuid="761f627f-cf3b-42d8-b82b-6a1c4723948e" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="e8c734b6-f91c-40b0-9d04-1b556b9b7213">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2afba1e0-5f45-4edf-8708-60e979362fa5">
+      <statement statement-id="ac-7_stmt.a" uuid="2a696c96-a01f-4a4a-9223-54b944accd33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -602,8 +602,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="6c10a588-0375-416f-98a9-c90bcf40e7f5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1711bf32-4469-4e76-a020-88f31bf4d83e">
+      <statement statement-id="ac-7_stmt.b" uuid="843983ad-bd02-4b99-9e32-735a65349fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -612,10 +612,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c87dbdd-8933-4aee-9b28-be98ee29521e" control-id="ac-8">
+    <implemented-requirement uuid="44a4224c-e76f-463f-b5ad-5b9e20d17871" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="187b1543-93ce-4de6-86dc-7690b410cec6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="144ad1d8-15b2-4e38-993d-949a4eb4434b">
+      <statement statement-id="ac-8_stmt.a" uuid="3483450d-de7e-43d1-bad5-66d9e0a227ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -624,8 +624,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="d1c3ea9f-d212-4e32-b33c-89c288602fca">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f9c3f474-98e0-4f19-a862-0f675ea9f62f">
+      <statement statement-id="ac-8_stmt.a.1" uuid="c713ced8-a4c3-441c-aef0-773b700b4013">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -634,8 +634,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="41f8bce4-670d-4cc7-a710-b9ebce105399">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f5db0aab-7ca8-4899-bdbe-fcf6069ce0f8">
+      <statement statement-id="ac-8_stmt.a.2" uuid="65992988-917c-4f28-9826-1504e479c581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -644,8 +644,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="14900367-8de9-4c57-b422-0d5d53ff2322">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3e5118e9-479a-4174-9d51-86956fd20682">
+      <statement statement-id="ac-8_stmt.a.3" uuid="15178095-1d4c-43e9-bf09-f914bcab2f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -654,8 +654,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="7c7d8529-bd1d-4539-8ca6-c7cc7540477e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="721e2f1f-e168-40bc-88f7-d6194bd0efb0">
+      <statement statement-id="ac-8_stmt.a.4" uuid="c5b5cd5e-6256-4bfe-893c-20f356c6b541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -664,8 +664,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="44a10d72-658a-4bf8-930c-a91d3895273b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="82c00c67-fe14-48be-9555-145834b9510e">
+      <statement statement-id="ac-8_stmt.b" uuid="cb1fec5b-ae91-4800-96b8-f438c632bc87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -674,8 +674,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="cb723b0f-c6f0-4d98-9751-53eef8daa14b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b3b58983-9a09-4e66-98f3-ef0ddcfc653d">
+      <statement statement-id="ac-8_stmt.c" uuid="894aa761-37c6-4c0c-8089-4d2b1deb8edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -684,8 +684,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="764ed59b-50b0-43cd-a6ab-9e81d467c8d3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a8c52587-e291-4606-8fee-a5cb40426f2a">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -697,8 +697,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="0573cd73-ec09-406b-98fd-bca271d5ee10">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="53b38336-a162-41cd-9fc9-478d38f173be">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -711,8 +711,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="0ac8669f-7fa7-4e98-ac17-5df8526f07f1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a5e2570c-73e3-4a62-aa30-3538dba1631d">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -728,10 +728,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf9c1838-dcbe-43cc-ae0f-d8fe25c37a44" control-id="ac-14">
+    <implemented-requirement uuid="e51e582e-b200-4523-ae86-adb9167bc5b8" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="8b3d527e-8206-48e9-8534-79d9b16a8b36">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ebafa21d-d5df-442a-855c-88a926040080">
+      <statement statement-id="ac-14_stmt" uuid="28d9020c-55d3-44bc-ad3f-27406a65c4fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a16e91f-5966-4db6-9ed1-47240cc81350">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Manager (RHVM) without identification
@@ -741,10 +741,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1f34bd03-3d4a-4520-8e02-2a81d3208d1d" control-id="ac-17">
+    <implemented-requirement uuid="4a111d5b-6ac1-4941-9c0a-c24eef46e2ba" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="5580505b-9e81-4ab6-9e01-5d95e87ea371">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f437258d-351d-43f1-98b1-a481ce7f9f6a">
+      <statement statement-id="ac-17_stmt.a" uuid="c8a02a7d-08f1-4192-a892-9159f8a19ba7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d722ad06-ab06-45d4-a05e-04c143007431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -753,26 +753,26 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="9e9253aa-3ce4-4bc9-af04-939e22cccda4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="06eae533-d4e1-45e7-8d2d-54148e58507f">
+      <statement statement-id="ac-17_stmt.b" uuid="66024b1b-269f-49d4-a238-a1bc5b390733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="833ec1af-cf7a-477d-a49a-54545a6a6f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe8ec1a-8dcb-451f-9354-e6693826a922" control-id="ac-18">
+    <implemented-requirement uuid="c1873412-3837-49db-b8ae-069923f0727b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="5f908bee-62b2-4e9a-9841-b7557663eca4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="418bab83-c973-424f-88c3-e813dbaab41c">
+      <statement statement-id="ac-18_stmt.a" uuid="f1d58d58-5159-4102-8696-b8a0440484f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb3356fa-980e-40d8-8f64-dfca6267031b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="6fd584e9-bb68-4ccd-890a-d76025b8b821">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fbe7a69f-7c03-4739-bf0b-9f0a801da452">
+      <statement statement-id="ac-18_stmt.b" uuid="39a8576c-b896-4866-b189-21aa6b8d48e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597ce99d-7e33-42d0-b1ee-44a03b15cb19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -780,18 +780,18 @@ system are outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="48a8b30b-3003-464d-927a-5a14b3ef40f0" control-id="ac-19">
+    <implemented-requirement uuid="fb790932-cf12-4fb9-8968-1871d9a4b396" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="d1189818-2ed1-47d4-8063-5a0fda53c257">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c735a579-2e6b-4f5e-b4d5-0f2228a0d70b">
+      <statement statement-id="ac-19_stmt.a" uuid="241910b9-cef8-43e3-8c5f-85fabe70defa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d8234d-bb8b-41c8-92ac-7e8d4691ba62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="b94cd7a4-e0db-42bb-8106-186eba9b2743">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="69640a5c-c076-4642-80b6-996cd66f0d77">
+      <statement statement-id="ac-19_stmt.b" uuid="a46fae67-24c3-4f6e-991d-1486d06e1a7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8863c77c-6449-4252-b60d-21f8c96bcbdb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Manager (RHVM)
 configuration.
@@ -799,10 +799,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bc20a91e-66ba-4ad3-817a-7cc1b6566322" control-id="ac-20">
+    <implemented-requirement uuid="c34ea5da-47da-42b6-85b5-fca636c9b75a" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="b188cc93-6e76-47b0-97bf-0aa556b44334">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e44574f3-df9b-46f0-8892-29c75a1001ad">
+      <statement statement-id="ac-20_stmt.a" uuid="6d0c7514-1991-476c-bc2c-3d8611a9e19e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f2fc23a-e940-43ab-b1b6-1fcb8f008b05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -810,8 +810,8 @@ systems is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="540c40fd-3aa3-4274-803b-e7e26e49e331">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b27709b4-7c7c-4434-af82-294efc6768ec">
+      <statement statement-id="ac-20_stmt.b" uuid="a46036f8-a251-41dc-b2a3-bf7906b3dd39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b4bf9b-c190-45df-8e19-d02c1fb0f8d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -821,10 +821,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2574a1bd-6577-4d81-83a3-006851ad841b" control-id="ac-22">
+    <implemented-requirement uuid="ca09818d-ee7b-4091-a831-6da3befbd076" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="db44e534-4784-4fae-b8f4-68ea0180cf3c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="60e77a90-48f3-47b6-950b-f66bdeba6f6b">
+      <statement statement-id="ac-22_stmt.a" uuid="2ac78e26-4472-42d3-a251-887f1d03237b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44a457bb-3906-4ed6-b02a-cc696670129e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -832,8 +832,8 @@ system is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="1a212b1d-9a57-4f1c-a684-de6eb89cbf3f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7f4618ab-21c1-4b7a-9599-5f81c1a938b6">
+      <statement statement-id="ac-22_stmt.b" uuid="8b2c06aa-d7a5-44c7-860f-ea27cc42545f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d29cdd-993b-47d6-8f28-b8716cc70fa4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -841,8 +841,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="724ae019-6cd7-40f8-b0b6-b68522e90ad6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="437428fc-7113-460c-88c5-efd543f0389f">
+      <statement statement-id="ac-22_stmt.c" uuid="07007492-71f3-436f-a4f3-5933c095645a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a0e4b22-0898-44e2-8097-fedc799a5436">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -851,8 +851,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="c8a390bb-223c-4865-bb10-cb1282f193fa">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="224d31db-0a64-418b-a613-ba62a780be47">
+      <statement statement-id="ac-22_stmt.d" uuid="eefd0fea-5edd-4f8f-9873-d094ad7bdae9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4539a35-9259-4cbe-86ca-a4c2cece9e62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -862,18 +862,18 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba9e9106-2d06-4591-b27a-977f2a0ea4d9" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="b6434bd5-d594-40e6-a171-d5231c9bb15f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c1d3a700-e687-4cb5-89b4-24d695265732">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="2d9067e0-ce00-4de0-8663-854cd458cda4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6352ea53-e609-4e21-8c09-5e7e8a69695e">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -881,26 +881,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebb64a3c-f906-4cc5-8ecc-04b2c0caf71f" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="f24f2ae6-a256-4ee1-8b49-be58573e8a87">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5455287d-dcb3-4566-88ee-fe1956647176">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="c6b8c210-c396-4a42-b851-bba18aa2c776">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a7712052-5b4e-463b-88ad-e4de846e5496">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="4dddabb3-ed39-4e4e-be9c-1761ccfb11f2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d2564edc-6545-4311-acdf-be3c55cd68d0">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -908,26 +908,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="05a661d5-0228-41b1-a252-d1d6841a19db" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="f6e60a1b-43df-40dc-a6b3-57ce9955840e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b50066e8-91d8-4f3f-9673-a65780112907">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="24be7996-8e11-4040-b0fa-2ff4d8322756">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="de3eebcd-7e7a-4022-bfb0-591947ab7be9">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="53b7a5d8-6a67-4ad8-9f6d-11de7a28fdca">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8921f702-4b37-4321-8031-d8b0a6a5beee">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -935,18 +935,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e5e83f7c-0ff9-41be-b4e9-dd3fe6a9f0ba" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="94b5e6f8-d248-4d3c-badc-958f20a2127a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3c83153c-cd93-4606-9649-2033c9499940">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="78b2a0e8-8143-471f-8205-71538698edb1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="95838628-bbf5-425a-80f9-48df7f475c65">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -954,18 +954,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="117e25c9-3d95-4d1c-8e99-dc382ba95c43" control-id="au-1">
+    <implemented-requirement uuid="e9cabea3-f6c5-4b2d-9b6e-608ecb5a2d60" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="45b51e0c-211c-469d-9a40-bd641d7ae83d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="462d2988-ba8e-431e-b519-e2b4f35bd858">
+      <statement statement-id="au-1_stmt.a" uuid="b4704272-5e35-4d61-a3e7-4c41b2c3e331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecad1585-1c8a-4c21-b344-710da9629818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="71546b8c-3004-43f2-9032-825c776e99ae">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="590faca9-c230-4e45-96ea-6980455d7829">
+      <statement statement-id="au-1_stmt.b" uuid="b5bab3ed-bf6d-401d-b248-9cf9f4385e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b81de348-a2de-48f2-95d5-0e9c52b81473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -974,10 +974,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6c5840f1-4494-45a0-bf52-03a4cf766c99" control-id="au-2">
+    <implemented-requirement uuid="f37536df-2d1d-45bc-9bc5-955338dd25ae" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="2410e007-4bfc-41c3-aeee-7961257572c0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="51db885e-6a37-4dc7-8a0e-a5ef80b74ac5">
+      <statement statement-id="au-2_stmt.a" uuid="a9a07f46-29b2-4398-b64d-3f2baa5a4866">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90dfd323-b412-4ed5-b8ce-f8a55d91887b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1009,8 +1009,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="e44fa11f-49ff-45ac-b1ee-f0a28d9344d1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="92b7c92c-5290-4129-b87a-c079cb7ad55c">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1018,8 +1018,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="6aa13657-51ed-42ab-aeff-1fd58a1aca12">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4eccc6a5-a6c2-40b1-8b38-f66c09dbaaf2">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1028,8 +1028,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="142cdb10-4e0b-4a46-9708-d9feb3df0e81">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="375466f0-847f-4a9c-a007-b0e67a82730f">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1041,10 +1041,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a250c86f-4ec7-46d9-b785-b48d9b3fb181" control-id="au-3">
+    <implemented-requirement uuid="613f15a9-4b0a-4484-9d9c-35c37b801eb3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="260d6337-238d-4b2b-b311-89c0ae5f3afd">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4b8c8293-8cd2-47af-9fb1-77190fc029e5">
+      <statement statement-id="au-3_stmt" uuid="abff9881-4373-417c-88b8-9b9dccc3b074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce2d9ba-344e-4481-9e1b-e2d83e094b5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) audit records contain
 the required information and cannot be configured to be out of
@@ -1052,10 +1052,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5539cbfe-bc68-49e2-9a86-c8e343c602cb" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="d5e5f93a-e539-42ed-a889-1200dfef128e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b58eed76-371c-4ae0-bf32-350f1751b476">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1063,10 +1063,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d36006ce-a793-4dc5-95c3-c572941d46c5" control-id="au-5">
+    <implemented-requirement uuid="1fd1013d-f125-4909-bccf-7bded096a777" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="0bf7a669-8e06-46dd-85fe-910bda54c61b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2fb4726c-855d-40dc-bcf1-3b19a212fd50">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -1077,8 +1077,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="f6a547ea-ea02-4793-8301-e4370fabad93">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1dea34b2-5ef4-403d-868f-1913fb3cc85d">
+      <statement statement-id="au-5_stmt.b" uuid="cab92b87-4307-4c56-8c92-3babc223a754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d394fda-b268-4b77-b11d-8a9b88b52eba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1086,10 +1086,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d24f579d-90a2-4314-bbdd-e0c15fbb6f7c" control-id="au-6">
+    <implemented-requirement uuid="51fe15b0-044c-4985-afb6-baad7f178a5c" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="acbbddde-34c6-41a8-824d-a17f6f1c8a38">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9e553be7-fa29-4f19-b0e0-790934fd5d20">
+      <statement statement-id="au-6_stmt.a" uuid="7b1dcbde-95d0-42b1-b013-a780f0e83bf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8acf550-693e-4f5b-b155-0273ae0eb7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1098,8 +1098,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="262c8f16-3b88-46cb-978d-eadcdf4651da">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="87f9e948-f6a6-4b48-8657-1052aa8a0a3b">
+      <statement statement-id="au-6_stmt.b" uuid="e7b9cdd6-1b82-4291-9758-47f8dc6fa43f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e1c7703-df09-4498-8d8c-89b24eead496">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1108,18 +1108,18 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54152ce9-cffa-4a36-a880-7b4a858e09e3" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="55cc125b-701f-4119-b09f-acc09f66d9c1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2f5171df-0278-407d-9f3c-0e2cd5790874">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="4ed37a6c-52bb-40b1-9fc4-df8a7b5437f6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="af51c75c-8eee-45bd-b391-44a13cb244fa">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -1133,10 +1133,10 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="38032280-f508-46d6-8c07-bc7641cacae2" control-id="au-9">
+    <implemented-requirement uuid="89bcf6ba-66d0-4a48-91b8-c67eee441ddb" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="858e8186-a31e-4882-a3e9-5e490332cc6c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1d43053b-e4e4-4acc-9103-c503142867c0">
+      <statement statement-id="au-9_stmt" uuid="b46b4b6d-f09a-456b-bf91-242c0686255e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bd61434-c1de-4925-96ff-0e211dceea2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1144,10 +1144,10 @@ https://projects.engineering.redhat.com/browse/RHV-</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e850251-bb45-4bc5-b910-534ebb3be3f8" control-id="au-11">
+    <implemented-requirement uuid="edbeb994-318a-4120-b241-1bc4aded0391" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="fabf7619-bf03-4a40-a35d-2d140c1643ed">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="99bb9082-33ae-4768-8652-694db601b605">
+      <statement statement-id="au-11_stmt" uuid="26eb54dc-8093-46aa-909c-020a5e1db4e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f08406ee-76f8-4183-b6e3-1607ae2ced7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1164,10 +1164,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27c0565c-92f3-49f6-ad39-fbe13a396400" control-id="au-12">
+    <implemented-requirement uuid="38d49d2a-f4d9-42d8-a3fa-b31d7132e244" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="8c048a8b-3601-42cc-8649-36e9f8aaafdc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="382c9c4f-82d2-4058-aae1-bb94be9ee631">
+      <statement statement-id="au-12_stmt.a" uuid="225fa91c-7d1b-4e58-aae6-3e6281bd76d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1175,8 +1175,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="c1b95f22-8fea-43f0-b448-33231892c674">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e036a23d-e2db-4554-ac3a-7b64f109dc27">
+      <statement statement-id="au-12_stmt.b" uuid="a6084a76-0615-4445-900b-1ecf686ac4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1184,8 +1184,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="f9226977-857a-4d9d-9608-e5151753ca18">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="39f127b0-c29a-4ec6-9932-0142c11cff54">
+      <statement statement-id="au-12_stmt.c" uuid="2d8026db-7a9c-4bc6-988e-3154a0654906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1194,10 +1194,10 @@ https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27beab9d-9159-4392-a9c4-ece792c9a04b" control-id="ca-1">
+    <implemented-requirement uuid="8cbbc6cf-9345-4f6e-b104-c8db9d8f9d89" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="a54784a3-6485-4360-bbe8-1c99c2f45321">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c0e141dc-7541-43e8-91f3-e75992b882d1">
+      <statement statement-id="ca-1_stmt.a" uuid="a0253951-4a7e-4254-bb33-1b97d9a24513">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1205,8 +1205,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="a2f1f099-85f5-437f-b806-f03624f39e84">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="79a766bc-67dd-4d36-b0ad-286cebcb03e5">
+      <statement statement-id="ca-1_stmt.b" uuid="6469ba5f-5046-4d1d-85a9-677b23d18a19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1215,34 +1215,34 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fdc0fcc0-6382-44c1-808f-45427551d122" control-id="ca-2">
+    <implemented-requirement uuid="8c763ab6-9d10-4826-8b45-3effbdfbe4d9" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="42e5755b-6ec1-41fd-ab99-165892238ad7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="eb723fa3-b4e0-4d20-9bfc-394490dfe6b7">
+      <statement statement-id="ca-2_stmt.a" uuid="626ecdc7-b47b-4fb6-9459-bfd2fa8ffcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="3a6953d3-a8dd-4f2d-be20-d66bd3ea62d1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8245df56-ed75-499b-b3a9-dd4029561f0d">
+      <statement statement-id="ca-2_stmt.b" uuid="925f0019-139e-4452-a753-b210216ba834">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="c0691836-b1db-42cd-ba6a-599109b2b263">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="349fb067-c764-4965-9529-673f27ff5998">
+      <statement statement-id="ca-2_stmt.c" uuid="0f171c67-efaf-47b2-8078-b9903c8ae8b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="cea3ce73-ebf3-4db0-be75-8a2224cc2c31">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7d253fe1-53a3-4754-8826-8e63f0c8448d">
+      <statement statement-id="ca-2_stmt.d" uuid="8d798b0b-6546-480c-95ba-3fc01fe6c200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1250,10 +1250,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98bf23d7-54f2-4299-9f05-0ed46a69334b" control-id="ca-2.1">
+    <implemented-requirement uuid="76b67f0e-9f42-4293-8c48-b7a65c41c682" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="29d12eba-012e-4649-9f45-adec49fd6b96">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dfdebbd4-d2ae-4030-ab1f-f16864fa3480">
+      <statement statement-id="ca-2.1_stmt" uuid="09078d4c-092e-40cf-a917-e92667347b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="834a2feb-b1b6-4d62-a47e-0c3ae4349529">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1261,10 +1261,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e5a695-87f9-442c-9650-025b0f241bc6" control-id="ca-3">
+    <implemented-requirement uuid="f5960985-7eb0-49cf-9b7f-376a4d3d1ac0" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="469e5de2-f721-404b-b0bc-531d280e1552">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="55742fd5-aaff-49ca-b09e-4ba52c682d8c">
+      <statement statement-id="ca-3_stmt.a" uuid="f93c7647-10cc-4268-84ca-8f629b37ac10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -1272,8 +1272,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="1e08e2fe-1b62-45b4-8213-f770be0511f3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0e9c08f1-e506-4094-b162-e58a2983a06c">
+      <statement statement-id="ca-3_stmt.b" uuid="568429c3-01ef-4b4a-9190-79d0d39b3583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a002fb44-9bc4-4d24-b1c6-19e9dd0048cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -1291,8 +1291,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="38306d48-c690-49a0-b79e-dfb528e14170">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7b7ad149-b598-4262-b669-aef927065fd9">
+      <statement statement-id="ca-3_stmt.c" uuid="5cdab430-5333-47e5-a48c-27c3c6b8c64c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -1301,10 +1301,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a7168fe-04dc-4585-a340-4ad4a01c8cfa" control-id="ca-5">
+    <implemented-requirement uuid="916a5a45-7e51-49b7-892e-440ba9d04f38" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="9167dd9e-b02d-455f-ada4-fe145714919c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8e461d9a-c8b6-44de-a4d4-39b1873c02d0">
+      <statement statement-id="ca-5_stmt.a" uuid="42fea6ee-b53f-4c1f-aa5d-474ee3dddb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7874121-b842-41ab-9612-07bb4b21d6b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -1312,8 +1312,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="423d35a2-9810-4457-b197-9ecd2af2b0f0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="52c08156-9e0f-43ce-be98-5ed69efc5a78">
+      <statement statement-id="ca-5_stmt.b" uuid="b4827a86-e5eb-4620-9e4b-919ef5614254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8061e04f-b49b-4260-a7e4-1a24bb30d0ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -1322,26 +1322,26 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration proc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53af5837-a468-490e-98c9-af780d776e61" control-id="ca-6">
+    <implemented-requirement uuid="e77dc7d2-9b46-4183-8c94-e99507c06928" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="5e560669-95bd-4901-9a2d-0866a857103a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6e33d1c2-169f-46a7-8325-e5de7579878b">
+      <statement statement-id="ca-6_stmt.a" uuid="f60bab46-13ed-43e1-9850-62104b44dae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="92f2a3ce-ee7a-4dfe-9e92-94c0204530a8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a815fc5f-49e9-4792-bc90-5fb78e5f4c9c">
+      <statement statement-id="ca-6_stmt.b" uuid="6575c90e-d09d-4ce5-84a5-9d899f39067a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="13732ce1-956f-4342-8ad0-97fac57d1d26">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="47459c75-9d1c-4af4-a5df-75c3aeca30a2">
+      <statement statement-id="ca-6_stmt.c" uuid="be0641aa-a2f1-43e0-add3-d3e0d11d710e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1349,10 +1349,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8d0e5f9-d7ba-472e-aefe-c4765575b646" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="024457c4-3288-4c49-84f1-7d0f9f336dba">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6cd1fa46-7383-48aa-95ac-95aefbf63292">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1360,8 +1360,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="9bd76300-aca6-4f91-9ccf-ff78e151ce6b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1a65a11e-1837-4617-8762-941077f51703">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1369,8 +1369,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="77896891-d3d2-4c79-ad7b-12c9c33524f6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b82ab48e-e257-492f-93e7-aef26f552d2d">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1378,8 +1378,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="2bbe3fcf-2b63-406c-bc46-fe856e449748">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7eecb82a-3081-400c-99cd-a8ac296d6596">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1387,8 +1387,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="b6fb4839-439c-4ed9-b225-7a0ac060dba6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0a17afbf-4388-4562-8f39-1034cc426412">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1396,8 +1396,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="fcb82934-b015-42b6-b17e-c17cbab4ddfe">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="15c67877-f1c6-4ac1-b8ae-65a50d73cfe2">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1405,8 +1405,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="3b210a93-331e-4d35-8616-9a23c084eaf0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0d98b7bf-2bf2-4f89-aa3c-a44262109fbb">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -1415,10 +1415,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="32c5f688-1dfe-460c-b279-79430e9d083f" control-id="ca-9">
+    <implemented-requirement uuid="45ea858f-bfa7-4ae7-8719-983784957410" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="2fe1e792-6744-4a68-8d68-a1a3eb87a48c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="be50cbd8-1e2d-4f07-b998-feffb16e0d44">
+      <statement statement-id="ca-9_stmt.a" uuid="631e344c-a84b-4f5e-94a3-07f5e67a31c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a3ee2b7-20d7-4ad2-ae09-7b3f216bc65b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -1436,8 +1436,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="a4603f74-146b-4772-98ad-2b711d1f64a9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6be49274-2208-412f-b653-6d00ec4f4a3a">
+      <statement statement-id="ca-9_stmt.b" uuid="a8a307a1-8a60-4450-8dc6-f1ddfae3fda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fc22de-738a-495d-b232-35a18545f791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -1457,18 +1457,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9bbbba7f-1ff2-4d3e-bfd7-d29633eb51ab" control-id="cm-1">
+    <implemented-requirement uuid="1c8b54fb-4325-41c9-a1ca-37c68f28d3fd" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="4ce75d51-ed91-4641-b1dc-22dee62a35c0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c76a8416-b835-4cab-944a-ad5fbec283ed">
+      <statement statement-id="cm-1_stmt.a" uuid="174b8ba1-a971-465b-8641-9e998f2439c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102ce2d9-1875-4b4b-9293-c9f1a3980e18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="1ff3c570-8397-42a1-8867-7bd919f8e833">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cb718d95-87c6-4c72-b692-3da188bd0db4">
+      <statement statement-id="cm-1_stmt.b" uuid="928f676b-41ef-425d-be9e-5bd02f0ef36a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60c97a59-a5bf-4503-800b-e4e898136392">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1476,10 +1476,10 @@ management policy is outside the scope of Red Hat Virtualization Manager (RHVM) 
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="928e4148-2750-4f06-bde7-4a932fd4005e" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="5b22c234-74bd-415b-a91c-69bbc8daeb37">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="900542cf-0a7c-4538-a51b-5851d0937644">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1489,10 +1489,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2d3f462-1112-4501-8081-e6f6f0d98198" control-id="cm-4">
+    <implemented-requirement uuid="63d595c7-8d11-4911-8177-e162e11285a9" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="919a89df-6a66-452c-b7b8-7d9e3817f3be">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1ca21eac-2c36-4e70-a75c-87780eec9481">
+      <statement statement-id="cm-4_stmt" uuid="482a2d9e-5114-44a8-9d6c-27ba0e1e0394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b824338-6e70-4964-904b-130716a616e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -1501,10 +1501,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e1f7493-f209-4a56-9581-4e46c2368085" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="fdba2d7b-c5ca-47d1-9b10-967e73edfa4b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5818651d-0029-4cb7-8d5d-10ee34750712">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -1518,8 +1518,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="08e23bda-0c35-4570-8015-9be27b5f0351">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a68a2004-7698-4384-8ea1-e7d95e9b7e24">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -1533,8 +1533,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="5f42d81e-48a7-495f-ac37-877017ecc9c8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b7c2b433-e21e-4aaa-a0e6-9d030c5862b5">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -1543,8 +1543,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="f4fab13e-4ea2-424f-add3-d6237dbd707e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="03404b9b-ad8c-4bec-a371-6f19cde468d4">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -1561,10 +1561,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2bd758f-0024-448e-9151-87e33b7f8f1f" control-id="cm-7">
+    <implemented-requirement uuid="561ea0a2-91db-42a2-b53d-eb884dec4f5e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="2bf2626e-a7f7-410b-99d6-88d6d49c8ac8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8bca5ef5-25a7-4106-94c4-7825bd06b764">
+      <statement statement-id="cm-7_stmt.a" uuid="a4606d24-0ffb-4ffa-916c-3d1cbb7bcbd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee69df66-379d-4c22-85b7-764d5297fd9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -1575,8 +1575,8 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="465230cc-372c-4b27-ba09-5155223da45c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="25f668ba-f85c-4872-8fb6-4268b3419b68">
+      <statement statement-id="cm-7_stmt.b" uuid="f69cf7cc-8bb2-4015-83e6-84507b776058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102260a9-4802-4b23-91dc-0a6863b8747d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -1587,10 +1587,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="20709f60-28c8-4ccb-b0b8-00a943fd19ec" control-id="cm-8">
+    <implemented-requirement uuid="79c169b4-bf05-497c-a8b1-dcef13806a00" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="3e484f85-a6a9-45d7-9a1c-f7291a980bb5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a9435660-2942-4ef9-9354-083a6f428527">
+      <statement statement-id="cm-8_stmt.a" uuid="3c5ff47e-7ec6-44b7-bd5e-78045d54ec5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1602,8 +1602,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="78ba34c7-e505-4af3-a9dc-a3121292e6d6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7a71c95f-e695-492d-a162-2a90dbd71d09">
+      <statement statement-id="cm-8_stmt.b" uuid="82d686fe-390f-44e1-909d-20019a30cd8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1616,10 +1616,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e24c6362-307c-4c52-973d-f8129f3f7f3c" control-id="cm-10">
+    <implemented-requirement uuid="212372d7-17b0-4c31-97d7-1852edcf0ff3" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="7c333aa0-9275-43c5-ab85-074d80329219">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="282c012b-c69e-4c67-a666-e2440a3f682a">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1628,8 +1628,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="59a2ba28-3fab-4ce2-81c9-f01f8344efa0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6d101cc8-032a-4a58-82ec-12c6d27401a1">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -1638,8 +1638,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="cdb85d91-29f6-4eab-b7be-0054e3e20148">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7c383398-cd17-40ce-95e6-0364906c6649">
+      <statement statement-id="cm-10_stmt.c" uuid="c7e6da74-487f-4a2e-9eea-a88e1c27503b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1647,10 +1647,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f230703-8045-4517-a3b4-ab99581876d8" control-id="cm-11">
+    <implemented-requirement uuid="a9f52025-43c4-4f61-93d2-a98b2c60d563" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="90a9259f-37c0-47f7-b153-1c5ae51581e3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b3758c6a-70c4-4584-82b8-e44ffc44a567">
+      <statement statement-id="cm-11_stmt.a" uuid="1cab1caa-5580-4ed2-8424-6cfe2b65ff97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5783ab5-0535-43ae-bc60-fade80694031">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Manager (RHVM) nodes. The following are suggested
@@ -1669,8 +1669,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="9bb9f4e6-6d19-4a8e-9802-a78838b778bc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="27756e3e-94eb-4365-94a9-e60aaf7768c7">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -1687,8 +1687,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="ffc03eff-4c27-402b-8a03-89aa7c83c37a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ab79de72-8476-4e83-b1d3-2b051fa0e78b">
+      <statement statement-id="cm-11_stmt.c" uuid="726caa7d-38cd-4199-9e94-f4e4739123c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1696,18 +1696,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5cfd08e6-1f75-4387-936f-f5c6b890d5ae" control-id="cp-1">
+    <implemented-requirement uuid="94fd9d87-eef1-4ee9-a6b4-2513764aa623" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="58e2f0e9-1b97-460c-80d6-504086f5fc9b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9f0b752f-9440-43f8-b7ed-c81b9fd4977e">
+      <statement statement-id="cp-1_stmt.a" uuid="4606f193-8cfd-4aba-bfcd-a2c14fe88b17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="19c2797f-652c-4526-b402-8ead153df078">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a72fede5-e7d6-4908-b546-4d2eec0a3129">
+      <statement statement-id="cp-1_stmt.b" uuid="bbd89b79-7bca-4cb5-b926-c67d1cb70a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df78838f-634d-4325-838c-4b8f271f8b34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1715,34 +1715,34 @@ policy is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3e5376cb-6d18-4e5b-9ea6-591f2cab859f" control-id="cp-2">
+    <implemented-requirement uuid="5be63def-f217-4ff2-8546-9e1a25a88095" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="ae2a3ab3-0ec3-406e-aa5c-c5af3f55e83b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="31e2eec1-87d8-4261-ad6d-3a172da7af2e">
+      <statement statement-id="cp-2_stmt.a" uuid="51fece35-394b-427c-9acf-2f7a56ef7aa4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="be6ce1f4-661a-40e4-8165-735ee5a7fd74">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="416c3e73-081e-457e-af85-44e7dc3b17d7">
+      <statement statement-id="cp-2_stmt.b" uuid="e1ea39b3-9ade-47ea-8a1a-aa597e92509c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed5f1a2-a796-4faf-bf82-bbdb8c32a470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="ac25ee00-6813-49e9-be7a-d32af0778c75">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3485811d-6339-4790-81a6-2621e2cd7fbb">
+      <statement statement-id="cp-2_stmt.c" uuid="e4ba12f5-6b75-43a3-8183-75933ffbc39e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4de58bb-0b92-4d0d-9c6f-8ae9063a8cb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="b131106e-25d2-402a-893d-fccb771f5a24">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b461cf63-dda2-4444-99ea-af5414121045">
+      <statement statement-id="cp-2_stmt.d" uuid="58bc51ec-35cd-430d-b9f8-6154022256a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cc6ee67-b8d2-4122-9e62-c26bd331e237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -1750,24 +1750,24 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="ac710b54-8e84-484d-9d81-12475f2376db">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7f0b98fa-8f85-4cfd-b0fa-3f6d577419ce">
+      <statement statement-id="cp-2_stmt.e" uuid="68831a9b-b5d0-4c23-aaf2-a7bcbd78b0ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="125155a3-5e64-49e7-a25d-fe1a5411a01d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="ca51a198-7a04-43fd-ac8b-2e34ea4f6ad5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6cdc4939-c171-41b8-8f68-d0ab3a5ea444">
+      <statement statement-id="cp-2_stmt.f" uuid="d268656f-9f1e-41e3-8038-788c94b5d7db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87062d43-0fd7-4631-914e-0816520851d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="c32e68a5-d6a5-4c6b-a6f7-5ad3d1ca2519">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="74a76836-9d0c-4f94-b78d-57d129a51dd9">
+      <statement statement-id="cp-2_stmt.g" uuid="126666e0-1012-48eb-bb3f-86f4dc04349c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="940539c3-1e0b-4ee4-bbe6-76f6a4434309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1775,10 +1775,10 @@ modification is outside the scope of Red Hat Virtualization Manager (RHVM) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="04331590-4f5e-4e88-97d6-eb46a2d66acd" control-id="cp-3">
+    <implemented-requirement uuid="77fd7c71-2983-49c2-87b0-d365a779d34f" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="60b35812-9d49-4751-b5ad-c27a81a40da9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2deef4b6-6df4-4b38-8624-224935e4945e">
+      <statement statement-id="cp-3_stmt.a" uuid="5d12514d-8d69-4301-b10c-c7a450bad0c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="180e2f38-0c8a-4a5c-9f2d-bc493074566d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -1787,8 +1787,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="04c9a211-2cf8-40c7-b72f-31fc3f436e23">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="aec1d37b-cb1e-40ff-85db-b6c76899bffe">
+      <statement statement-id="cp-3_stmt.b" uuid="6354df03-8e96-4446-b298-736abebc922c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d206f41b-3100-4686-bc8c-4bef56754e65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -1796,8 +1796,8 @@ system changes is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="05d4b206-2bea-4771-9db8-51201b084a1c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9e85786a-ce57-489d-8f48-3246659c124e">
+      <statement statement-id="cp-3_stmt.c" uuid="9c8ec9b8-186d-47d0-b6ea-1237205b8548">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="682e9951-3a64-421f-b29c-dfb1abc45d23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -1806,10 +1806,10 @@ frequency is outside the scope of Red Hat Virtualization Manager (RHVM) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ef4aff8-4809-4b6f-a466-adc2d3859021" control-id="cp-4">
+    <implemented-requirement uuid="6d1d21ea-64b9-4cfa-8db5-2647bd354b53" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="c48eeef9-8a55-4036-8e8f-5c675f26936a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2b679a5f-07b8-4e40-8597-17e954b990d6">
+      <statement statement-id="cp-4_stmt.a" uuid="2b26ec0b-3a47-439b-8af5-a354417d354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e14a882a-1808-437e-b859-5d650dfcfc80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -1819,16 +1819,16 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="67f316dd-f6e8-43fc-9b4b-8f6a45ce3b05">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9e05f333-297c-4dcd-b848-a9f5c92e7aea">
+      <statement statement-id="cp-4_stmt.b" uuid="11dc66c7-9ead-407f-aff8-e01e30ea36bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7712450-e25f-472a-b052-42ddc560b339">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="72002d90-a615-4e5c-8a2f-0cf79fc371c2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bccf8c14-aa65-44bc-b5cc-8864cdb8859f">
+      <statement statement-id="cp-4_stmt.c" uuid="8354574c-c5e0-48bd-8496-2e47579499d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37a66071-7cb9-4803-8e60-77c475929537">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1836,10 +1836,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d480ce8e-c608-4e15-9235-877881e0b5de" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="4aa3e4a8-f316-4fd1-86c4-150baf692915">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="aa70cd55-f228-454f-baa8-44cd8b3d0e3a">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -1857,8 +1857,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="c43c3a88-9c11-43ce-9c02-503e46c8fa61">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2f7689f8-6dd0-497d-b393-b5aafeda6a54">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -1876,8 +1876,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="86dac95c-a492-4681-8674-bd11171ee2a7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="05965e40-9cfc-4925-a183-2326552eae05">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -1895,8 +1895,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="6fe686b3-4ecb-40e3-ac23-865d0d32abe5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cca33a98-b39d-4c79-95af-63e4ea7fe57d">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -1914,10 +1914,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e39159a1-85a9-44fe-9d43-75350508b256" control-id="cp-10">
+    <implemented-requirement uuid="8de00722-2d4f-47ee-a9b8-9c752caecd5b" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="afc1b335-f25c-4dd9-9804-4aa8a5ad9679">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9d0be172-6929-4eb1-9fc0-ad17de42ec92">
+      <statement statement-id="cp-10_stmt" uuid="05fbd0da-7a83-4c99-8b87-de3cee556d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="891ee6cd-8cd3-401b-8521-4719de6de859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Manager (RHVM) environment. A successful control response will detail
@@ -1931,18 +1931,18 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="344a4471-876d-4761-b923-f57fecca483b" control-id="ia-1">
+    <implemented-requirement uuid="2f3b1020-66be-47d7-a27b-868ac082de53" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="5f92aba5-3e9f-46a2-a666-9d4a1c1a5e17">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="81099fe7-966b-43b9-8f51-2eddc132f4f7">
+      <statement statement-id="ia-1_stmt.a" uuid="f29dbb7a-a552-44b4-b173-b9cec76a4e2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3af05d0-0b99-40f0-a835-c48cd64e7d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="89471d85-a134-49cc-b993-9073d88d9c6b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a9e84375-ea98-4525-9c47-89aaacb44a67">
+      <statement statement-id="ia-1_stmt.b" uuid="0fff2124-8eb8-4f7d-afa8-846a004019f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="261111a2-f9a5-481b-a7c2-c287c360b653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1950,10 +1950,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Manager (R
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f124227d-72de-4087-a025-8f80751a1513" control-id="ia-2">
+    <implemented-requirement uuid="f55156c3-dbd3-4e17-b67a-635142694cac" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="54fcc513-5ed2-4ff0-8026-2bdd934f177d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6f86006e-8e12-484f-bde7-7e310993dc07">
+      <statement statement-id="ia-2_stmt" uuid="f76099a9-754d-4fa1-8311-118e38567e0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ebf37cf8-ce97-4664-9ee9-53dc8ff8490c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -1962,10 +1962,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f50e8e31-f20a-4b3a-af90-c0356dc45b02" control-id="ia-2.1">
+    <implemented-requirement uuid="7ba01777-86d4-48e5-b3fd-7bedbc360dd9" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="6125b370-b8a6-4f65-ae93-aab5dd94ea0c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="39d742a1-0eb3-46eb-9787-c1dfc6ffac79">
+      <statement statement-id="ia-2.1_stmt" uuid="652e20a2-8b06-4be3-b875-0332f361d163">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f005b4-3ce5-44f8-94b0-73508ababd84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -1974,10 +1974,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2e3bc92-7108-4ce8-83b0-df0a6f18ec9f" control-id="ia-2.12">
+    <implemented-requirement uuid="4a97d0f3-d836-47e5-a3a6-4b7aad438a32" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="bb425fb3-437f-4ed8-8b39-a8e444a6d75a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d4d0f98c-45c1-4a3e-9093-a300d7a25d98">
+      <statement statement-id="ia-2.12_stmt" uuid="099f7acd-ad66-488c-971d-8e035fe74120">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d18528b9-1a11-4602-a574-dd3eaa7c4125">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -1986,34 +1986,34 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac89ef89-52d4-4c22-9524-538a5ea24eab" control-id="ia-4">
+    <implemented-requirement uuid="f22c4227-9a59-474f-a12e-f819931abe4d" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="4a0d50b0-0a0e-4deb-b333-7c4915bfe8f7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bc038983-333f-4ea5-a3ea-a0e579c59cc5">
+      <statement statement-id="ia-4_stmt.a" uuid="c167bcfd-1c81-48f9-8253-738b08b79d70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="63fd8c21-e472-4f37-8d3f-f3026ee764bc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dbd5e2ed-9d19-481c-ac12-e535cbacad9c">
+      <statement statement-id="ia-4_stmt.b" uuid="049da705-362b-41a8-b560-518ca8365ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="0c21be8c-b64e-40ba-8e34-638ef8ca7c40">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="205f0279-5ef2-40bc-b0b4-2863067b1cdd">
+      <statement statement-id="ia-4_stmt.c" uuid="392c1e50-a521-4659-a51b-9777980657ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="2217ff02-0a6f-4400-9f4d-6e70bf0a6efe">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0b1cc492-b4cf-4b7c-9315-eff41fe5126f">
+      <statement statement-id="ia-4_stmt.d" uuid="e96f4007-63aa-4366-b552-17cf998650fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fcb766d-2f87-4259-b20e-980df6842530">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -2023,8 +2023,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="ba92f28c-8dcc-4225-9b6e-ef0c2d3e901d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="25a20c79-1c1e-4aa9-9f18-4552f02cfd9d">
+      <statement statement-id="ia-4_stmt.e" uuid="c12dd478-a4bd-4ae0-afe9-803f7fe47e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1290e859-497c-4528-9276-c533a1beac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -2039,18 +2039,18 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a7e75498-45b5-4cd3-8060-1e01769efaa4" control-id="ia-5">
+    <implemented-requirement uuid="3dbd5d5f-c89f-4286-ae21-2099b279f150" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="25cec5c3-2831-4156-8ed5-4f91f691f479">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6772fc62-b893-4b2a-8e7c-40a3a079ea4f">
+      <statement statement-id="ia-5_stmt.a" uuid="7b0a503b-79cf-4f86-8477-64651d2c6e78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="99f754e9-3de3-4ca5-884e-5c3252e5de3b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="61168502-7b65-4d12-8a85-8fc9e5c761f5">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2058,8 +2058,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="fbba8bd7-4df0-4c2b-9e9f-ffeeabc10ee9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b299e21d-3323-4cdd-8c3e-fc804b4b5a3b">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2067,16 +2067,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="6bad7b95-2a07-42d4-8058-8e6d51c10592">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="79c6bdea-5f3b-468f-94f8-dc86bc27b660">
+      <statement statement-id="ia-5_stmt.d" uuid="5c386be2-b297-4853-9a7e-9307940b9f1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="e6b931e1-f422-4e9b-961a-da494d7a3a5b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e7802dbc-a367-406e-807b-0988723c8836">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2084,8 +2084,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="c83bf735-7fcf-419a-b617-b4e6b25a8381">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c086d9fc-d7b2-4d4d-847c-94384520ce30">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2093,8 +2093,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="26f5c80e-d4db-428c-89b4-ad6236c394c3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8cd03df1-b1c5-447a-975b-91fcbb5e70d4">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2102,8 +2102,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="25205676-5986-4b56-9afa-1dd861ca52a9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3af2aadb-f099-446b-912b-a459b5489844">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2111,16 +2111,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="2ed3e9b9-ea8b-4fbc-bc1c-327d1bc50732">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="478ece15-1c26-4b95-ab50-51ace41ea029">
+      <statement statement-id="ia-5_stmt.i" uuid="8cd40f58-98ac-43cd-99fe-c51dbfa5e016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="a5c0f836-e19a-4aff-9ad5-59201084da1e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="96a83d54-403a-426e-9a9f-c46ad78e9d66">
+      <statement statement-id="ia-5_stmt.j" uuid="160b8f2b-8776-4a5e-af26-1df569e42d5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2128,10 +2128,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0d1cd0c5-e33a-48b5-9b88-92cd23d23c4a" control-id="ia-5.1">
+    <implemented-requirement uuid="9a10ca43-6f11-4a52-8567-4bcbd544ab73" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="df0c2cb9-edd7-464d-b3d7-da85b6002265">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3d57c560-5b96-45fd-80e4-7828746eec46">
+      <statement statement-id="ia-5.1_stmt.a" uuid="2eb87715-5e65-4cac-a28a-4a5ab19266c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2139,8 +2139,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="9f5c637e-4a03-4d09-8278-4d1ad42d564b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="68abde1e-e502-4c57-a02b-b0f98cac034a">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c88ff946-4f4e-48f3-abc5-f8b8a5d5f370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2148,8 +2148,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="18cec49f-0f4e-41eb-948a-3ba801bbdd73">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f92953f8-3262-4e6e-9693-bfb7b99c4816">
+      <statement statement-id="ia-5.1_stmt.c" uuid="2f0ca946-a3ab-48e1-afc2-3feaefbb1ebc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2157,8 +2157,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="034a8d5e-b6ab-4992-b979-c179e062f36c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="056565e5-f79e-485d-b259-3524a63e8374">
+      <statement statement-id="ia-5.1_stmt.d" uuid="2fe55d3b-2ca5-4fd1-8132-fbd0b6367481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2166,8 +2166,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="31fe8bfd-38fe-4455-9190-3d134c117e8a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bcbe0f5a-86a7-4430-8241-3d32c2600268">
+      <statement statement-id="ia-5.1_stmt.e" uuid="b4d6cce9-c6ff-4f4e-902e-0cbee43a557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2175,8 +2175,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="5d712f69-b25d-45e4-9338-c2e39708f891">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e8faea2c-52d8-4cbe-bdf1-95f640524133">
+      <statement statement-id="ia-5.1_stmt.f" uuid="48c96ae6-37ae-422d-9ff0-4290751a74dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2185,10 +2185,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0878201-fc68-4983-9204-6c198da95491" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="737c638a-a740-4f3c-af1d-cddaf333a023">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e978dea2-9a89-4189-bd74-b96ef769a0eb">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2197,10 +2197,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f5f034c-dbea-41d0-94e5-b850de6849f3" control-id="ia-6">
+    <implemented-requirement uuid="022887aa-4532-4de0-9f39-837ff9bb0039" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="5c7f9c22-38a3-4c0d-b05e-114d83ebbfe1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="673dd271-822a-401c-9be4-874cd34a9b3f">
+      <statement statement-id="ia-6_stmt" uuid="c69f5a79-fc8c-42d1-9d9e-3dcbf71d7fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5702a69f-2325-4eb2-b49a-28fc0805096f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) automatically obscures
 feedback of authentication information and cannot be configured
@@ -2213,10 +2213,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b42f19a3-5b6b-41e8-84ff-7e8cdfa31717" control-id="ia-7">
+    <implemented-requirement uuid="83da2df7-d021-4c45-96df-f2724a8346bc" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="71b077ba-8eec-4362-9bd9-64b170131f11">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2060fce6-ac43-4196-9309-81dd72ac25eb">
+      <statement statement-id="ia-7_stmt" uuid="9fbba9ca-a1f5-438f-85a7-93516e6ce37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="718d669c-6b16-4974-b480-636316eefd8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2225,10 +2225,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4355163c-b27b-4d5e-8f4d-0edc3bb5bfe7" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="0be52cd5-c1f7-4cd5-a53e-1cbf3bdf129c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a5ce6eb2-475d-4c8a-ad67-2581c2513b0c">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -2238,10 +2238,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1c1cd9a0-58ff-46f6-89aa-eda514b68729" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="1dd79780-b8b8-495f-b17a-802ea6e949f7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="83c60e84-8d34-4bd1-aa71-b6ec7b210642">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2250,10 +2250,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7539749f-7c87-4963-ba77-e96ed7a7e072" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="b4341c58-e785-4b86-944e-0411714ac8f0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9dc4ad58-962e-4a08-9e03-374d8deab402">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2262,10 +2262,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a81d55bf-af68-4015-a539-ecffca8e5007" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="455ac6c4-df0a-4b5b-a579-d1b9407ff3f2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="45cea4bf-bd8c-4986-b61f-a1c1e745fb45">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2274,10 +2274,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40e54ecd-5eef-4aed-b3d9-7e020389d082" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="2a71ce8d-c187-4e52-aa85-5d4f89bfae65">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="abd480f7-41c6-40bc-8e8b-c4674053ce9d">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -2286,50 +2286,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="35976f37-cf30-4fbd-855b-1dd271170c9c" control-id="ir-1">
+    <implemented-requirement uuid="3240daee-30be-4876-ba10-7269c896711d" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="56b08816-a32b-4c13-89ab-9f5972179729">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bb505c23-63e2-4617-9b43-99377d1e2c51">
+      <statement statement-id="ir-1_stmt.a" uuid="7a9bac04-55a7-4332-8bb1-661acbf6603a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="364204a1-fd22-437a-8092-19a19eecbc28">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ce1083fb-adab-4f40-9e54-0e0ecfd12f45">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a0f17d3d-926f-4d88-948c-47ddbd989dcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="eead640e-3382-4d2c-9b9e-d4593fce0e46">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5081e2c0-4d30-4076-ad91-5ae499cff396">
+      <statement statement-id="ir-1_stmt.a.2" uuid="11e3a4a5-07b5-437b-91e6-47d3d4459389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="d8caff77-b0fe-43ce-bdf1-bea3a88db1ed">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="949069e1-c499-4c6d-b53b-b02c4face51d">
+      <statement statement-id="ir-1_stmt.b" uuid="001fcc6d-73c7-4c36-8212-ea870c51eb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="76061bf7-0339-4bba-ab76-753c4b4b1f08">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5d9a908c-6f5b-4ddd-ad82-f89b8b5afce5">
+      <statement statement-id="ir-1_stmt.b.1" uuid="e77b8f95-f72d-49a7-9be9-cb6a9548fa03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="7d86f89d-27f8-4737-9f65-01137270c3f0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="22397cbe-8a3f-4dd7-8cc5-a73f7e18d6d2">
+      <statement statement-id="ir-1_stmt.b.2" uuid="1ab303e1-20cf-491c-b402-28f04e190fd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2337,26 +2337,26 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6205a717-8ed0-4060-9536-6b4f873e8c3f" control-id="ir-2">
+    <implemented-requirement uuid="6dab2fe3-8e32-4952-b163-f79148aa1035" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="7d0b436f-1ba8-480c-abab-0d7b1f377104">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cb8e8027-99c7-48ad-9fd6-ddb057066506">
+      <statement statement-id="ir-2_stmt.a" uuid="dd62a057-8077-49c7-ac5f-1fb9656a0e69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="6133b5de-7f59-473e-bf74-8669fc6af4c6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="67475712-0183-45df-96c5-c12466be09ad">
+      <statement statement-id="ir-2_stmt.b" uuid="050ee893-949a-49a4-b8a0-3288b4aebe74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="8cc0afa3-fde2-493a-9570-e23e68f932e6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b471f7b4-969e-422b-a854-f5e65b249731">
+      <statement statement-id="ir-2_stmt.c" uuid="90e22189-04f6-4dc2-a3ff-482921aee142">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2364,26 +2364,26 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d40cf255-538d-4e45-8cff-d7bc9171a0e4" control-id="ir-4">
+    <implemented-requirement uuid="1155072e-5be7-426f-8051-6ad707df4adf" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="4b87d44a-cb90-4efa-b54f-2bb06c07da13">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="995b78bc-1397-4ac8-9ced-fee6d913e334">
+      <statement statement-id="ir-4_stmt.a" uuid="d7396185-ef72-414c-9685-a82b7865b70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="bd0941fb-0ac8-46c3-9594-0cb7a846ac33">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9149ba07-dd3b-40f7-8e63-c877176d53ea">
+      <statement statement-id="ir-4_stmt.b" uuid="3f4818ef-7b32-46ae-822e-9ecbbbd81883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="d784781c-2b02-4e2e-a8bc-af091551c878">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7055c271-4e44-4c91-aa4a-02adedd291a2">
+      <statement statement-id="ir-4_stmt.c" uuid="2f72cf07-e50e-421b-8661-3845a296db7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2391,10 +2391,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5fe54788-eced-46a3-94ec-c776e1614f54" control-id="ir-5">
+    <implemented-requirement uuid="1e48707f-48f7-4759-9469-03b2c024f350" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="5d884585-be03-481e-aeae-ec13caf5a52b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bba473ef-7bec-4350-8ef8-378a1a10f132">
+      <statement statement-id="ir-5_stmt" uuid="80d2a2ec-8bc0-4799-8052-9cecbdea4e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2402,18 +2402,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="444b634e-40a8-49a2-b758-ad94912ffc6b" control-id="ir-6">
+    <implemented-requirement uuid="2d2e105e-5a5f-4c63-a0d9-8fdee571c5cf" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="8e966041-c90d-4cd8-8c40-0818cad8b8e9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="82588a62-c610-490d-a1b0-009ee6480166">
+      <statement statement-id="ir-6_stmt.a" uuid="b83624b2-4873-4a2f-9824-5dc52eb52a13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="42b04b77-a102-4cb9-bd10-6f34f2163f73">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="003d702e-1a04-44bc-91d0-883d8d4b952a">
+      <statement statement-id="ir-6_stmt.b" uuid="054880bc-4ed1-4ef9-bcf7-be11417fb024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2421,10 +2421,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebc67be1-8a00-46a9-b087-82b1de476036" control-id="ir-7">
+    <implemented-requirement uuid="3f425480-b8e7-4177-b13a-33ba3b91d721" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="1eb17ef9-a344-4419-a9ca-aebe604b3da2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4e614ffc-b105-4d54-8ca3-26e51d0c387c">
+      <statement statement-id="ir-7_stmt" uuid="d9cdcde0-b75d-4101-9cda-8d35144e7488">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2432,114 +2432,114 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c7afbdcc-c1cb-4c8b-92d9-f23f8d927270" control-id="ir-8">
+    <implemented-requirement uuid="967e97cb-b9b3-464f-afaf-eb257e79a9d8" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="4246937a-dccd-4b94-aa7a-d0d4b2ff3452">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1017e456-ef01-4051-b950-afb71d4501a3">
+      <statement statement-id="ir-8_stmt.a" uuid="cc8f2bb6-6e14-4297-bc04-25d74cf2d795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="ad321171-caa7-479f-978f-ed7df1604cf0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="89a1c675-7411-45bb-8bd8-99cdb9c4dde3">
+      <statement statement-id="ir-8_stmt.a.1" uuid="9b5a26d8-abfe-484a-a7a4-518decf26f32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="9aa1f7a3-236f-4e8e-9ced-7aa0c5390ce6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5c253de3-4113-4be1-b4bc-e764acb92f9d">
+      <statement statement-id="ir-8_stmt.a.2" uuid="2e063b17-fee1-46a5-9aaa-f976e6829ae8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="9ace9987-efa5-4a9e-bf90-a104ee74fb55">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="52efacdf-96b1-4814-9136-9e68c40e92bc">
+      <statement statement-id="ir-8_stmt.a.3" uuid="e17ca486-9878-4f4f-862d-35cf728f9dab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="d3fb01eb-761b-4e60-ae92-063d699010fa">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f00c3029-8eae-43af-a749-536d46144e66">
+      <statement statement-id="ir-8_stmt.a.4" uuid="f409d770-51db-4a9e-aacc-f444c7334037">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="140f7594-5334-4e4c-b19f-24a1610ec9b0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9e52bdda-adc2-4ee3-a262-e109595ef6ff">
+      <statement statement-id="ir-8_stmt.a.5" uuid="9ecdfeee-c454-45da-9772-8819ac9eb51a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="b8024ed3-1d22-4922-b733-4a8ab1af5f29">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="037a425f-3797-4870-9ac2-d3921b84675a">
+      <statement statement-id="ir-8_stmt.a.6" uuid="d36a19fc-8360-42d5-bae0-dc72f837945e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="6b7fb1fc-4e08-4ee6-8f77-5fde1c318722">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="92971df2-5938-4686-95c9-5db5f6501739">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d5ff6c68-b16b-4143-96a5-cd6511d31b7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="2ed4ded9-aebd-4fbf-a600-18c43d0e9222">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cb5a07c3-362f-4990-bda8-b3771d530b77">
+      <statement statement-id="ir-8_stmt.a.8" uuid="5b4f8897-2628-46dd-b058-283e27888b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="677ad991-6c81-4c36-8012-5288b718f0c1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8c8bb31b-98ad-4b16-963b-8578de6ab498">
+      <statement statement-id="ir-8_stmt.b" uuid="2c2a5c3f-56b8-4129-857d-eec9c7cd0e0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="6769b274-4716-46b1-adc2-28e9adc5ce2f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="be968257-9fa8-4b88-90ed-df2cde52d3eb">
+      <statement statement-id="ir-8_stmt.c" uuid="5462a597-ce52-4d20-a027-2350d4f05779">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="ded4205d-d553-43a1-98d4-548b91504f7e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="064c6a29-8e1e-4c08-851b-0a86317f9ef5">
+      <statement statement-id="ir-8_stmt.d" uuid="5ad0a837-3c8b-45be-9cd9-b7260d3ce617">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="a912425d-da75-484e-b82a-c9eecc14d753">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d9b3d8ea-d250-485a-b59c-b9d42613913f">
+      <statement statement-id="ir-8_stmt.e" uuid="8c8f9a0f-5052-45a7-9f20-0096cec25c09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="b877bed0-2e34-4a45-a63c-2f1a4115aa7b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2b2029d8-0763-4599-8cca-687ebe873c05">
+      <statement statement-id="ir-8_stmt.f" uuid="b94c4a7d-f35e-4cd5-9db8-cee39d2ed822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2547,18 +2547,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f1afb5c-21b3-4cf6-b6d3-779f3c01fc80" control-id="ma-1">
+    <implemented-requirement uuid="79bbe60d-fb10-4957-8236-c6012202d83a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="ad11387a-f7ab-4529-9700-a96202b8628e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1a32204a-608b-4c0b-bacb-3dcc8f066b65">
+      <statement statement-id="ma-1_stmt.a" uuid="9330d002-55ee-428a-b026-9534632ae9bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="fa5397b4-fb1e-4c1b-b888-b23cac776d8e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b1d17ef6-bc25-4dbe-ad7a-23319d32afa2">
+      <statement statement-id="ma-1_stmt.b" uuid="01d928ae-fba4-4073-bed0-d2b7b996e31c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2566,50 +2566,50 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56d2bb24-7c12-4dee-8173-d5db589a2bd5" control-id="ma-2">
+    <implemented-requirement uuid="2c7f66ff-b53e-4cf1-a882-4224dfd66064" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="82c419ea-cda3-46b7-8b24-9d499bf91ab9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2ef3973d-efe7-40a0-87b9-105d922ceccd">
+      <statement statement-id="ma-2_stmt.a" uuid="4effddb8-e41b-4761-b7f3-1e725cd04b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="9d9f681e-1e60-4b93-a983-44de93c5756f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f13c3668-5549-46f6-9680-bcd2357612d1">
+      <statement statement-id="ma-2_stmt.b" uuid="b62298fa-b158-4c85-88ac-04e00acc41de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="a7d2c48a-30fe-491e-97df-0c7ad9f381a3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e991e3a2-92b0-44dc-8898-b975b7960a21">
+      <statement statement-id="ma-2_stmt.c" uuid="a077c965-9ef7-43eb-a00e-0eecd8465d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="01f80827-85d6-481e-b3ce-e2a6c011bb4c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b3352fc5-43be-4174-8713-9330ee398776">
+      <statement statement-id="ma-2_stmt.d" uuid="71605f10-203f-4d37-8a73-60acf1a19490">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="98585ad1-ffb9-44ef-92b9-879578191485">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="65400daf-3a25-45b2-98fe-73f9a0a50476">
+      <statement statement-id="ma-2_stmt.e" uuid="8059b9a5-9327-4fdb-9fb4-1817ef4b8282">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="a2e79150-30b0-45a5-9777-03b27199759a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0b83efdc-8b6b-4018-a1ae-b6535303fc71">
+      <statement statement-id="ma-2_stmt.f" uuid="c07f9d07-d835-4f83-ac78-1b754f3787c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2617,10 +2617,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f53b4294-7ce9-4884-a770-84d23895f798" control-id="ma-4">
+    <implemented-requirement uuid="712c9223-7d41-4954-abfc-9ddcc8bd2a96" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="4b0f92f9-0ed5-434a-b6e9-58de8bd17c00">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e2342bff-03c9-40c9-82ff-1b5699007971">
+      <statement statement-id="ma-4_stmt.a" uuid="2bf356a4-b2a4-4067-929b-74401aef9739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1256c0a7-6fc1-4515-82e3-6c020b38bbff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), all
 maintenance and diagnostic activities are monitored regardless
@@ -2629,16 +2629,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="37b2afd3-92a4-47ad-9389-4a574d7bc03b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0d588e6e-9680-40fb-9c4e-5a31d938dae8">
+      <statement statement-id="ma-4_stmt.b" uuid="33c06d7b-42ca-43a2-bf2d-b9452b3aa380">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="74fd1476-e5c3-4da0-ab54-ef73b371569c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dec2b84f-e9ad-4520-8528-57f649b88ea3">
+      <statement statement-id="ma-4_stmt.c" uuid="4072929c-605c-4829-ae5c-1c42f91a53e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ce23348-7b55-4f0d-9945-d882f911512c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -2650,8 +2650,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="a9e01edb-4a8d-402e-a86e-1627494be72f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4b38b4b8-15b4-4691-b1f6-f9ec4e5d371f">
+      <statement statement-id="ma-4_stmt.d" uuid="6219f076-9f22-4aad-947e-62fb9fe64cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66a7388b-468d-427f-a923-6ab2d04bc6ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -2663,8 +2663,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="222b5708-12cb-4440-8f0d-f7c2a6de8822">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3ea421db-c83c-4c64-91ab-ee2ae05eb0b6">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -2673,10 +2673,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="927ffc07-b3ad-4a2b-89ec-5a23a6c40fdb" control-id="ma-5">
+    <implemented-requirement uuid="c6f2454f-6039-4a5c-b3b2-3a12d261e62e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="8912ad36-a52a-48f1-9b71-ef1765f418ef">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f6596e0e-8754-481c-9f3a-3a82352c33c5">
+      <statement statement-id="ma-5_stmt.a" uuid="0d5aa9e5-9153-4af3-a61f-86b82fefe5cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37184d7c-fae7-4679-a963-845c88234b15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -2684,8 +2684,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="9c8773ff-10c9-4666-8a80-935f1cea29d0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d2c71fb8-9087-412b-9c18-867bb1eb71b9">
+      <statement statement-id="ma-5_stmt.b" uuid="13062598-98ec-4b3d-b796-e16c64663d7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c08b5ecc-06df-45aa-925d-de541e2bb933">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -2693,8 +2693,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="ff2d1e3f-8994-41cb-a731-c23dbad69dff">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c0834936-6e38-4f6f-85e0-024c20d3c9e2">
+      <statement statement-id="ma-5_stmt.c" uuid="287bd11d-ca0a-4758-9af5-1063bcf335fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6551219-a954-46c0-bceb-0316c766710b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -2705,18 +2705,18 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb043b20-d1fc-4672-9222-4dc6e3d67f78" control-id="mp-1">
+    <implemented-requirement uuid="21e2fece-6fb6-4dc4-a165-885ee0319bb6" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="208f16e4-b8cc-463f-ba7a-e6412d2af687">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="876a9dea-447f-4b9b-8521-4fb2f9e0b7a5">
+      <statement statement-id="mp-1_stmt.a" uuid="54245217-533b-4796-9349-d7b78db1cb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="e3dff750-f2ca-4e85-a260-d5b582580f9f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4b08807e-1811-4d47-80ef-d3c35ae853dd">
+      <statement statement-id="mp-1_stmt.b" uuid="1fa9aa7d-9754-40d5-b9bf-7b514bc8bba5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2724,10 +2724,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9c5ab627-b08f-4dc8-a795-12ae79c6b397" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="d6663bf9-2e87-4187-a1ef-a387c23bd89e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3c16fdda-4cd4-458d-998b-0ee5a1da4434">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -2736,18 +2736,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fba16a0-f81b-4e9c-961c-491d2a9af0cf" control-id="mp-6">
+    <implemented-requirement uuid="206115a1-32bb-45fe-b7bd-958b681716ef" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="338d021c-b8cc-40d5-9137-cdfde5a86aca">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7f86aadc-d286-4f86-a479-5685e5ac2733">
+      <statement statement-id="mp-6_stmt.a" uuid="11e0e048-562f-4a5a-8100-1d226ba054b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="6f7246a2-523e-4291-8720-576d56634e3f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2a7670d2-eefb-430b-872e-6b190a87bf66">
+      <statement statement-id="mp-6_stmt.b" uuid="bfe2ce74-209a-475f-8f81-b20fcb291d83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2755,10 +2755,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fdac20b-32fa-4c73-b65a-277e41bc70fb" control-id="mp-7">
+    <implemented-requirement uuid="beb2bb67-563e-4523-964e-e3f3311f8298" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="074945ed-0baa-4c93-91fd-dc6c8fa4bfbe">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="63a65d32-91ed-4ce7-b224-e1cb56a96b07">
+      <statement statement-id="mp-7_stmt" uuid="c569f073-ff56-4283-85df-edd9ea04a4bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ef5e981-f45c-4e6c-afee-b8b076d7f993">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Manager (RHVM) nodes, the following configuration check must be enabled:
@@ -2779,10 +2779,10 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d09d2221-427a-4b38-9a70-3dcaca80c595" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="fc323d0a-18a0-4126-938c-3252f01fba8f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b30ff25c-dc64-492a-99fe-730b1e12d37c">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -2791,8 +2791,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="002d468d-6cd7-4b5e-ba32-fbe88e77035e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e398eec0-c6cd-4189-8935-a8b21b539fdb">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -2802,10 +2802,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31adb0a5-e620-4551-9ebc-20be70febb38" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="883dcd36-1aff-4885-8412-97c6b104df8e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fe3abd75-f48b-4743-8d0c-0bf3fe8d528e">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -2815,8 +2815,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="525f69d9-4367-4f61-8ab6-86951128d57d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="db6d9b90-da0b-476e-a649-e3d7807941ce">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -2824,8 +2824,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="cd8f8f23-05e3-4994-a9e7-b50be66867ec">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="907d3e12-3e01-48f1-b27b-e2fd15d30b1a">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -2834,8 +2834,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="642125e7-9ac6-47e7-852a-b69f925a9567">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="891359ab-065f-4fb7-ab81-78ba1a236a8a">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -2844,10 +2844,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb7963fb-8fc2-4830-ab05-88090a280332" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="62667207-e67c-491b-98fb-73838e5ed4de">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3338dcfe-35ab-4079-a272-0bc50da0f212">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -2856,8 +2856,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="c765ecea-86be-4b47-a532-57d8a2650204">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dce0f8c2-cc47-4c9f-bcc2-33d1b2953d04">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -2865,8 +2865,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="d32e8bda-40f6-4250-a2db-f322a15ef4c1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2089ce91-3fff-4610-9af3-580910699ffe">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -2875,8 +2875,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="1481db24-43e8-4de4-8d12-a1c2c467b3a0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9d068ee3-2cbc-4da0-9efe-8a3668d83708">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -2885,8 +2885,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="0963a66e-5cbf-4ba1-8b33-ac79a2dad4a8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="518e1658-00c2-4d34-b6b7-58886c236576">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -2894,8 +2894,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="1f9a406d-b26f-4018-81d5-da22ecd3446e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6da87fe3-76a6-4c7b-9567-1950cf6963de">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -2904,8 +2904,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="5bd677f7-ecdf-42fb-a7ee-2c00461ff274">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0c630790-2526-4b8a-b685-8d83df64b4f6">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -2915,10 +2915,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cf9ad0c8-8901-4976-839e-8026c11d3ad1" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="e156ae62-b2a5-41a1-ae0c-5959afa1e972">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ca76a72c-3720-4c59-a8db-1c634632aa59">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -2927,8 +2927,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="6843af82-d8ce-4c3d-9168-d1da3d68f2b1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="301c8f9e-5aa8-47ca-9474-030000e03c60">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -2938,8 +2938,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="7bf2be45-fd26-4de1-8fb5-188217bae531">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8d29190e-e3e5-4715-942a-7fa914c97c45">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -2949,84 +2949,84 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f71f34ec-75a1-4434-91c8-5b09707757f8" control-id="pe-8">
+    <implemented-requirement uuid="8320c2c9-7961-4f3c-a38e-e9264bf352e0" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="472dbbc9-15d4-4411-88b7-ae986aeb2376">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3459a302-2053-49d3-a526-b4694c85b7dc">
+      <statement statement-id="pe-8_stmt.a" uuid="a118fbde-88f3-42fe-98bb-1251e82a149f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="19d1edd2-e5ad-4aaf-93a1-ae938d10fb1f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6b96036d-9a71-4032-9db4-6274d271d1bf">
+      <statement statement-id="pe-8_stmt.b" uuid="3ac78417-d2a1-4a9b-b566-644a13808b22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="acedca40-64be-4b9d-9ee6-fd5b601a5166" control-id="pe-12">
+    <implemented-requirement uuid="6838a18a-fb90-4c6e-a008-a476bb0c63a5" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="3985ffbe-db63-46ec-8ac3-e2fea60069dd">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4bbd381f-c601-4e26-bd73-48884b745c8f">
+      <statement statement-id="pe-12_stmt" uuid="e6a116ec-fda4-49a6-ad02-e5fe48020d81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="419744bd-b95c-44c4-8f23-9a244142a056" control-id="pe-13">
+    <implemented-requirement uuid="a6a6cfed-f002-4a29-861e-3dec20ca9722" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="d2686af2-cb08-4b1b-8129-55678a5480ab">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ab88323d-3090-49bd-8a5d-1f874c0e9fa8">
+      <statement statement-id="pe-13_stmt" uuid="46ea2a14-ef47-42d4-a128-07e8622f9a69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9865836d-5521-43e4-860c-1b25e285c876" control-id="pe-14">
+    <implemented-requirement uuid="9b806d64-c3c8-45ed-aea1-dbccae65b275" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="d3d1f4b6-6cac-49a9-ac73-ea9bede14fe2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cb8c43f8-e9c0-4538-8b16-5abbdc4525ee">
+      <statement statement-id="pe-14_stmt.a" uuid="51e93fff-5147-4e45-a169-fed84fd1f4a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="3bcd26e4-00a0-47d2-9c78-d2ff05dd160f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9f2ffa3e-bdf2-45f1-9dd7-7b4050ba86f5">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="8d267bc3-c1d2-434e-9f28-6660c53eb59d" control-id="pe-15">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="31c7f065-7317-414f-b82f-9f29d1102ab7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d3cae6c8-a11b-45e7-905f-a32abb05742e">
+      <statement statement-id="pe-14_stmt.b" uuid="9492c294-a053-476d-83b7-481034179948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8533df18-435e-467e-8ba7-92b3fad13b3e" control-id="pe-16">
+    <implemented-requirement uuid="2bff9725-cc40-4d0d-8a46-3e0ff4392ca3" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="2f589e45-9a17-46c7-80a7-af36fb55521a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c1fadced-8ed7-4e52-be73-de0e22f2ebb8">
+      <statement statement-id="pe-15_stmt" uuid="2fedfbd9-eb4d-4b1d-a5a5-956dc3113cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1215601-ce16-491b-83e0-fe187a870a11" control-id="pl-1">
+    <implemented-requirement uuid="e595f42c-de11-4e82-9d18-fabb75f17145" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="c996bbf9-8caa-474e-8654-1d94cd9a4975">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="5427fde3-42c1-407b-838c-2db4d9ba0a7b">
+      <statement statement-id="pe-16_stmt" uuid="7f5a2ee2-6937-4a86-aef6-151e852bee1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3034,10 +3034,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7cd8bee7-0c13-4606-bc59-0c59f3e72b6f" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="3153183e-fe31-4d2e-86eb-c1a56e6dd216">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f2257dc2-4532-4e9a-97e0-dc80b224bd76">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3045,10 +3045,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a01abee0-fbee-4149-9701-164f8c780f33" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="2b8e1748-9118-473b-9f70-3fe5431eaf23">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="264233ed-4a1b-4b6e-b8c0-2fa62ffe4619">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -3056,10 +3056,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="51cc3960-dfab-4f3f-8363-69de8eb02a90" control-id="ps-1">
+    <implemented-requirement uuid="93d1e507-8951-45a8-96c5-57a2597e1852" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="cb1def82-ceba-4765-b744-1616a41c0fc6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b1b3dbd7-e9d6-42e1-98c8-b7d5acc1581e">
+      <statement statement-id="ps-1_stmt.a" uuid="9a1d5fe5-b6b6-436a-bdc2-97245e2cf2af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3067,8 +3067,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="1e463388-9709-4c6b-820f-5e78edffdc66">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d67b5961-5172-435e-8b8c-0a30464c39af">
+      <statement statement-id="ps-1_stmt.a.1" uuid="8bd33eb5-670c-4421-810e-3788087e21ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3076,8 +3076,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="dad01ddc-5bb3-4294-b0cc-3d88b7990c99">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="173ffe73-037e-4600-813e-c01847c21aed">
+      <statement statement-id="ps-1_stmt.a.2" uuid="b381e8bc-dd72-4f30-9c01-80de40b9fd09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3085,8 +3085,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="58ba76a8-4a6e-4fb1-b166-b431ae1d74f8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dfa9d9ab-3136-4d91-949b-1bea03c232e3">
+      <statement statement-id="ps-1_stmt.b" uuid="d5793809-eac8-4e6a-85e9-846e5c09d8a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c65f605a-8f0f-4eb4-8633-fc65d9734d42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -3094,8 +3094,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="fc0d38ca-f513-40dd-a27c-ac6ba393111d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4ec8a16a-154a-4b69-809c-ff9816a5a1f4">
+      <statement statement-id="ps-1_stmt.b.1" uuid="6ec7797b-8ba2-4407-95da-bde11a63c8be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3103,8 +3103,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="42b91f0c-98be-411c-9e13-75852bce5682">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ac9b7515-c431-49d6-9aa4-c956c9bb08a8">
+      <statement statement-id="ps-1_stmt.b.2" uuid="fa7b6a20-02e8-461a-9d2a-45340c6a5448">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -3113,18 +3113,18 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="958764ca-2087-4e84-bbef-935cdd3c2bf6" control-id="ps-2">
+    <implemented-requirement uuid="02a20a00-7ff3-4211-b43b-c104cc3b6a9d" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="66d6fd04-7379-48c8-8cbf-a1cbd630857e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0dee06fa-85d3-44d7-b89d-9a9982516bde">
+      <statement statement-id="ps-2_stmt.a" uuid="6cfc9b43-511f-465c-9044-654e5fe87f77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad506da8-c0ec-48ba-97b5-16f6fef72a89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="2feafefe-4245-4570-8807-be985b042a04">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="57016f76-5bd5-4e3b-ad81-21e80627044f">
+      <statement statement-id="ps-2_stmt.b" uuid="4ccf8cb8-eeb1-4eb3-8d98-043269082fa5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a604cd65-e085-46ae-9208-9ab9455e1b97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3132,8 +3132,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="130443fe-16ba-4278-aa39-9a4f450e5fc6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="12e99d48-b2fe-4c05-a342-9f5cc37a4bbc">
+      <statement statement-id="ps-2_stmt.c" uuid="49f819b8-0769-467f-a8c1-148162cf7870">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09fcf4c-ceb0-4c42-8b6b-a2d20ecf7aee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -3142,10 +3142,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="effe7160-578d-407c-a832-8de3e7b97ca7" control-id="ps-3">
+    <implemented-requirement uuid="97381a61-dfe9-4a8f-a784-2a54978b29df" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="e78ab445-43a3-4fd6-b46d-9fe6ed8734b0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9ae7c0ae-a882-41c1-8c79-1d0b73c861d2">
+      <statement statement-id="ps-3_stmt.a" uuid="729af710-a601-4b8d-9073-286a85ec0661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1de7d3-05c5-4397-a184-9cef0d215851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3153,8 +3153,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="7de311dd-36eb-4a28-bda2-62baea0bcc39">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ade50226-03b4-4a69-945a-231c825c69d9">
+      <statement statement-id="ps-3_stmt.b" uuid="e81d4485-4e21-47af-bd94-3c3d8b7cdd40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78b3be79-a4bd-4282-8372-aad211307d45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -3165,10 +3165,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5124c80-2c3d-41be-b777-4c6504ab0ea0" control-id="ps-4">
+    <implemented-requirement uuid="0e6a90ed-195c-4088-8519-f26013c7405c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="564c4cce-2521-4795-a884-ca168533618d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="526f21a8-7ca6-414f-8bd9-3183be9ceffc">
+      <statement statement-id="ps-4_stmt.a" uuid="a8023110-58db-44db-91fe-d97f1798ef8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1404eeb-e2cc-4490-99b2-c19e8deca439">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -3177,8 +3177,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="ac26f2d9-1264-4bed-a5a9-c57c90d9ec59">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c08483a6-fc28-430b-97e1-fbb2396a1fb3">
+      <statement statement-id="ps-4_stmt.b" uuid="565c4b29-d531-4981-88a0-45547dc4e097">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28910026-6a47-467a-af9b-6f0ec47e6374">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -3187,8 +3187,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="37e55abf-e8ac-4087-93cd-c4997bf63c47">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6ad3e9f7-5bfe-42ef-868d-f5a316f782c5">
+      <statement statement-id="ps-4_stmt.c" uuid="72aec3d3-80d8-45f6-8d03-cf9b201fa8a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b37e5a2e-159b-40f2-af13-28248cc0aa75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -3197,8 +3197,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="3f9fdb4e-14fa-406a-bdd8-81205a7cfc2e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="81cd9ce7-af10-4c4a-a68a-cd42342a8d91">
+      <statement statement-id="ps-4_stmt.d" uuid="8088243a-2a94-4ee1-800f-3369881614b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a79f6048-6ca4-4ec7-8f9d-e64fdbaac1f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -3207,8 +3207,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="ca5a4279-a8c3-455e-90e0-8e4b61cc6bdc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="40ec4db4-1c75-4b40-aac1-ac0e85da895b">
+      <statement statement-id="ps-4_stmt.e" uuid="f544df03-7464-47ed-9841-2e9062150d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59ecd01-7b04-44c2-a2ac-707c570e59f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -3217,8 +3217,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="24e5b4c8-25ca-4250-8562-a60017ee15ad">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c3fffd95-f292-4dc0-88bc-54d58c2e6f59">
+      <statement statement-id="ps-4_stmt.f" uuid="ac32121f-0381-469c-9caf-d4460bd7ced8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbbf7554-60f3-4b0f-8315-63a9bd26c505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -3228,10 +3228,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9658e6ed-6006-4ab5-8065-5521fb9d528c" control-id="ps-5">
+    <implemented-requirement uuid="cd598627-3439-41df-b571-4a11593cc881" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="ac86eac5-99b2-4f5d-93ca-0eb639893297">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fb321251-2e01-4b40-bc54-852ad190984f">
+      <statement statement-id="ps-5_stmt.a" uuid="18d71eb9-934a-44af-895c-c2297d4f5a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7de8444-be5d-489a-bfa9-65b247e63be7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -3241,8 +3241,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="122657bd-c7c0-4dcf-81ba-8cd58bc9d4ed">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="936d45ab-b237-414d-b892-b603cc46408c">
+      <statement statement-id="ps-5_stmt.b" uuid="a0511f2d-f25a-423b-9de3-f72ddc023dd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d979dc27-c785-4757-a867-f69edf4c49e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -3251,8 +3251,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="71b5156d-f81f-4b32-94bc-95dc0c0156f5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="606217d3-fd2d-4bf0-af8c-f6c8c1142da9">
+      <statement statement-id="ps-5_stmt.c" uuid="79299773-1e94-45ca-818a-6b44ff49f8c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7f89e6b-7ad4-479e-bf98-8d2ccd964ce3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -3260,8 +3260,8 @@ or transfer are outside the scope of Red Hat Virtualization Manager (RHVM) confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="13e398d7-3fc1-4b2a-a8a1-9e965caab6d3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="00143281-37dd-4458-9820-1fd93613579c">
+      <statement statement-id="ps-5_stmt.d" uuid="a7ed6648-787e-4ab7-ae5b-93de192eac06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cbb3c05-982e-466e-9515-d9abb34b357b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -3270,10 +3270,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="999f5a51-5b57-445f-901c-7198dbb1fcbf" control-id="ps-6">
+    <implemented-requirement uuid="d90e7ad8-3c29-46e4-bb5b-bef781918e51" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="dc2d3c98-807b-46e6-bd6b-297a9e505f2b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bbbb5be1-777c-4341-8cfc-4c16b2dde13c">
+      <statement statement-id="ps-6_stmt.a" uuid="2d8b2dcb-5489-4e51-a83a-db6a26f5a4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7347cdf-4d1f-40c1-8cb5-bd6ef4a60ffb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -3281,8 +3281,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="0a90db73-a28c-454c-9789-be596a3e6360">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6614caa9-5b0d-4467-87b1-189242e2d32c">
+      <statement statement-id="ps-6_stmt.b" uuid="f6f7ae39-b871-40b9-8d44-5a5bcf51350d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09056f23-47fc-43c4-a899-244bf39ca814">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -3290,8 +3290,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="a71483ad-7ecc-4e0d-8d92-fedff4889465">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4fd8346c-d41f-4a6b-8551-da2dd38870af">
+      <statement statement-id="ps-6_stmt.c" uuid="6e392695-59f0-4dc5-a9c0-80e340eb569d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3299,8 +3299,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="3f08691a-cf66-4fe7-9004-432aaa738a96">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cc1c5283-90f6-4137-ba4e-28b02b9913ea">
+      <statement statement-id="ps-6_stmt.c.1" uuid="2ad016a9-cfec-47f5-bcf4-9f54605827bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3308,8 +3308,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="94d25018-6d91-4f3b-8f60-c23b8dd02f7f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a1106dc2-b1e6-4680-a24e-f22922343019">
+      <statement statement-id="ps-6_stmt.c.2" uuid="2c0af91a-c347-43e4-bd2f-7ff47b39258e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -3318,10 +3318,10 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="baacb0a7-c9c6-4283-8b5d-279fa27d5b8b" control-id="ps-7">
+    <implemented-requirement uuid="e90d5213-ee27-4a47-9929-4f4851a4c13e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="63d3489d-457a-48d1-8c56-4be4bf242c28">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4c7a714b-1994-40bf-b50e-44bee1956de0">
+      <statement statement-id="ps-7_stmt.a" uuid="6b876f4c-4d44-499a-91d0-6d66ad5d851d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13710e7a-11a5-49df-9cf1-5620861dea20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -3329,8 +3329,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="fb149f5d-2e61-4b22-b025-8451cb1896e7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ed200dc1-ab63-456c-9181-18701a890363">
+      <statement statement-id="ps-7_stmt.b" uuid="95bda73f-2c03-4b3f-ac60-bf47f0a89426">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11f7bf5f-4f0a-4273-bdc9-b664d512d429">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -3338,16 +3338,16 @@ the organization are outside the scope of Red Hat Virtualization Manager (RHVM) 
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="02f9689c-cd61-4d89-9373-55b7d23da8f6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="cdf1ab43-a7a2-41ca-b4b4-04457de7d150">
+      <statement statement-id="ps-7_stmt.c" uuid="10765576-a41a-4bd1-9ec6-f62f07947d54">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef7d9a4d-5ee3-414b-bfe3-7287c70cde54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="c38ba180-1a43-479c-9ce0-8b5b461a6abc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ccca7bb0-a1ab-4642-956c-0d39a472247f">
+      <statement statement-id="ps-7_stmt.d" uuid="ee923c84-ceb4-4fcc-b017-9575e996ef24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="278ad774-501b-42d7-8c90-3af58cc2c049">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -3358,8 +3358,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="c0b0e8d6-83fa-4638-9e8f-7a830830ec4b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9315fa5b-0e62-4410-8f32-5a0d86a280c6">
+      <statement statement-id="ps-7_stmt.e" uuid="100e63ef-5092-48be-84d9-4c1d180176dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b90694c-5c80-4865-acbe-b25f0a92c0dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3367,10 +3367,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="202cd78c-b4cd-421a-9da2-47debd8fb4ef" control-id="ps-8">
+    <implemented-requirement uuid="9000ddd2-1f58-451e-ac22-112f1e24834a" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="c7ce9120-7cb4-496c-b302-ff217cf6a316">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f79ad0ac-ad03-4dc9-8707-ab774c62ad10">
+      <statement statement-id="ps-8_stmt.a" uuid="a2da16b7-9efb-4ba7-adcb-660fab49c818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4380d5a-0e4d-4519-9ff7-d45b76504135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -3378,8 +3378,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="c269e245-84c5-414d-a670-18e3871b8a8b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="131792e6-2766-48f8-a9d6-591166cd0ca3">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -3389,10 +3389,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="39994c31-f191-45dc-a156-d23370c95da7" control-id="ra-1">
+    <implemented-requirement uuid="44d5151b-7cd9-4df7-9782-2f19636ef16f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="6d9bb8e7-c798-48bd-b83f-3184101d0d05">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="83d10b05-c24b-463b-a110-4c8efcd1ac7b">
+      <statement statement-id="ra-1_stmt.a" uuid="611a8157-0211-45cb-9cb5-3a41191b55cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3400,8 +3400,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="0bef7987-b7fc-40d6-bf9a-0ef3a2ca4570">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="00d45f40-e005-4b0e-b132-65ba217284df">
+      <statement statement-id="ra-1_stmt.a.1" uuid="c2c644cf-bf5f-45f7-9426-8ffd1e58bd2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3409,8 +3409,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="76aaf1dd-389e-4e0e-9a41-2058880ed37d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="46a5c7c3-76cf-4753-a488-50b56b439548">
+      <statement statement-id="ra-1_stmt.a.2" uuid="43048ae8-d506-42f9-8e29-c262f83261a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -3418,8 +3418,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="7318872f-918f-49b9-a1ed-81681b1f19d4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="531be5c2-20f9-4201-9645-3e5865dcdd6a">
+      <statement statement-id="ra-1_stmt.b" uuid="e9b70516-72ab-4477-8bd6-bcd12e4051a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3427,8 +3427,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="2bd522fe-a951-4b68-b09c-ec34b1731da7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="004781ce-4f1f-459b-bece-1e2c4b4a4bfa">
+      <statement statement-id="ra-1_stmt.b.1" uuid="2a36cb87-f7c0-43be-8aed-76456ce1a6b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3436,8 +3436,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="8fc1c3b7-d0bb-4d2b-aa46-3f892b75cfee">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="40f76268-0233-4829-889c-d8ea589e0f2a">
+      <statement statement-id="ra-1_stmt.b.2" uuid="b15c9576-2e76-4357-8d59-32758d67061d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -3446,10 +3446,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f9d37978-5af8-4d26-bc1a-9bcac71badce" control-id="ra-2">
+    <implemented-requirement uuid="0ab6a230-1abd-4c7b-a7ce-4d231dea47e8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="f72674b9-6d29-47d1-a4fe-8203267126a1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b9f5b911-f613-4970-89cf-4c0ab7e7e33e">
+      <statement statement-id="ra-2_stmt.a" uuid="f4541f8c-b79c-4ef9-ae8a-0d030bd01480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca47edfd-09f3-49c4-8365-53ec0d9f9e7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -3458,8 +3458,8 @@ guidance, are outside the scope of Red Hat Virtualization Manager (RHVM) configu
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="a190887a-b452-45b4-8727-61b1f05f3804">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9e2f7e92-b61c-4e04-a680-1b9a941ae2aa">
+      <statement statement-id="ra-2_stmt.b" uuid="b7676df9-5836-4d3b-a0cd-a2db0e8c37fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae86df2b-e64b-45ad-9165-1168e2f87afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -3468,8 +3468,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="575ce362-506a-4822-9109-3f6118faff0a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="855dc27b-a2de-44c2-a9f7-b174c588ab64">
+      <statement statement-id="ra-2_stmt.c" uuid="65212924-f089-4cc7-b8af-53fd6a111ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91dd3cf9-5a59-4a54-b6fa-67ffc7f6e780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -3479,10 +3479,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="50e3e0ce-dd8c-4cd9-b59b-0944e40d5e7d" control-id="ra-3">
+    <implemented-requirement uuid="15f5dd33-0cdd-4e59-a1cd-3c84dad5b12e" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="39e24392-2891-47c7-b3ae-3b3c3b19195f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bf11f2a5-7cba-49c0-8332-11afea0e365b">
+      <statement statement-id="ra-3_stmt.a" uuid="7f26caeb-eb87-4f26-950f-6a4b133440d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="825effd2-1fd5-4147-bca9-7282d6fbc19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -3492,8 +3492,8 @@ transmits, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="19eb2971-fe8f-48f7-9cc1-b42ea2cf0dad">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ca917dfd-bc59-4a6d-8a13-706e077b2882">
+      <statement statement-id="ra-3_stmt.b" uuid="f79083ff-317a-449e-97f4-310242546dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0692007f-e7a4-467f-ae1d-64c3e2d8cb40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -3501,8 +3501,8 @@ documents, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="4d870820-7553-4f98-9351-0528bb9baa47">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="394b8dd4-e3a0-4160-96a5-d765bba44f7d">
+      <statement statement-id="ra-3_stmt.c" uuid="0dcd2f27-33d9-42aa-9329-472f8fa07cd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de13535d-336a-4db5-8cfb-af7e369f09a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -3510,8 +3510,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="7d792578-b188-443f-82e0-4ef267958673">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="7f673bd9-ccae-48e1-b11a-27ba1d3d75fc">
+      <statement statement-id="ra-3_stmt.d" uuid="4c6ea21f-9eaf-470e-a2fc-4d4dfb06a46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3cf43908-7074-438a-89e7-2f60335176cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -3519,8 +3519,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="d47781fa-8c91-4e2b-a42c-9f7ece5a4fa8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="551e6296-b365-4949-aa2b-ebfe04cba18d">
+      <statement statement-id="ra-3_stmt.e" uuid="5b44cac1-93ec-418c-b42b-b7f26bb0794c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1d934df-406d-4e87-8e96-3d48fcac2aff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -3532,10 +3532,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bbe43ce7-42cf-4c4d-93b2-2bbad1e0964d" control-id="ra-5">
+    <implemented-requirement uuid="796d19ec-7ee2-48f7-8a58-46c76a50db80" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="f65ec898-8662-4825-a08a-5c67e0c8eb50">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ac11acbc-d3b6-48bd-86e2-10a7143386ec">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3543,8 +3543,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="db2dd27c-b42d-4e0e-8c89-e2ffc5d018a1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="61de1c94-931c-4f44-8097-394bf371aad7">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3552,16 +3552,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="ecded803-d1e5-4434-9cc1-fbd150cb5119">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b58dd362-0881-4a9c-8bcd-a13e27795695">
+      <statement statement-id="ra-5_stmt.c" uuid="2b015f3a-d332-481f-87df-0362eb31b0ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="4128c5a1-57b1-4100-a312-8a0faabafa6b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2ed79b13-aa7f-4119-88ec-e7b5e0195480">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -3569,8 +3569,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="3fae6c89-44ff-4312-ab34-9957273363b1">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6ab0cfac-d97e-4be6-ba6a-bf7cbd5ddbe6">
+      <statement statement-id="ra-5_stmt.e" uuid="431ed74f-8371-44cb-8d48-682acd1bfe3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c1cf1b-136f-4647-86a3-b6055003ca11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -3582,10 +3582,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4d49a11-55de-41ec-aa59-9b09e5bec2da" control-id="sa-1">
+    <implemented-requirement uuid="a172707c-e357-4978-be84-30e20d476ab0" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="fd69707b-d82a-40d7-b8d0-aafdf94b9d3b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ec27cb53-4fea-4e63-80a3-080a515d4aa4">
+      <statement statement-id="sa-1_stmt.a" uuid="a571b48a-fca2-459a-916a-d6a6f24deb5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3594,8 +3594,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="81a91e01-88d5-47af-b810-ef0502ac49e4">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1d1450a5-6f16-4ffe-80ad-976f46e5069f">
+      <statement statement-id="sa-1_stmt.a.1" uuid="c7e3108a-d39a-4501-9232-187d48111480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3604,8 +3604,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="b6b14b75-cb00-4e8f-99d4-a53ceb5dca3d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4f761bb3-50a2-4152-97e2-59d5940154a9">
+      <statement statement-id="sa-1_stmt.a.2" uuid="13f8840c-c38c-4e70-8635-8cb5419abf98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -3614,8 +3614,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="b646203e-133e-4dba-8fcb-83dd8187e10f">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d28be48d-7126-4626-9502-f51c6da9f906">
+      <statement statement-id="sa-1_stmt.b" uuid="f2bf354e-951d-4b99-8101-871827b86f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3623,8 +3623,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="a5926629-c5fe-4531-a03c-bb7f499ab9ed">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a64dfa49-bf44-4a96-9cc0-22909bfad764">
+      <statement statement-id="sa-1_stmt.b.1" uuid="d3bed5b6-3a90-43a6-a31c-2110bb93ae49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3632,8 +3632,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="0e0bdaf7-cc94-45e6-8e29-16be2605e0b3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="45533d06-5c67-4934-b716-b17985de2b55">
+      <statement statement-id="sa-1_stmt.b.2" uuid="cb76ce98-b4b7-443b-b678-5d3295c84fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -3642,10 +3642,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3fc398d9-fc2b-4b40-8609-450a0c3c75f0" control-id="sa-2">
+    <implemented-requirement uuid="050a21c8-b6c1-4fb9-9500-c8fe7e4e80cb" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="a5e31b03-1fc3-4f9c-8b73-ea6b2b8db873">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="35a386fa-6a88-4ba8-ae9d-0bc29005ce10">
+      <statement statement-id="sa-2_stmt.a" uuid="9a617d20-93f0-4558-9782-16e8b1cf2fb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68d0d4b0-c0d2-4acd-b8d5-b7737dd46b7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -3654,8 +3654,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="cb76ff27-06f9-413e-8b8e-b24cacd14a0e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="caeb6b9a-3f29-4c7d-971a-186f5b037f6f">
+      <statement statement-id="sa-2_stmt.b" uuid="4e0e53ca-f38d-4c22-8cad-26bfa4c4dbd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae257788-6a44-42b5-9e86-ce24b5d7dfb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -3665,8 +3665,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="9c6957f5-86d6-47e2-80cd-da25c8c8d96b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9f82a59f-c6d6-47e7-b4de-291a15dea24c">
+      <statement statement-id="sa-2_stmt.c" uuid="483cd77e-9463-42bb-b620-df78fa0c5603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33619df-53cf-4942-b14b-df386101333b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -3675,10 +3675,10 @@ documentation are outside the scope of Red Hat Virtualization Manager (RHVM) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="117b3d24-eb47-4549-b3fb-6209454e0164" control-id="sa-3">
+    <implemented-requirement uuid="2defe23d-c379-4286-8dd2-f9cc601d209d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="36f2a393-f39c-4115-be11-02f484799673">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="748582c0-5a06-4e6b-ac86-ecc5b5e44df2">
+      <statement statement-id="sa-3_stmt.a" uuid="b107e4ab-86ec-4e37-a993-1653c35c3d46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f73b71c4-22a7-4d0d-b09e-1ed07d64c174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -3687,8 +3687,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="296737bf-64ae-4704-9873-41c60db534ed">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a5b602ae-f953-4faa-afae-4fcdb4b0884b">
+      <statement statement-id="sa-3_stmt.b" uuid="5ed40cbc-20ea-4b20-8fa8-cbcfe6f4f38a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70f49197-05e3-4b11-ae79-720d5aaa677b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -3696,8 +3696,8 @@ life cycle are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="b5bd2628-97b0-4231-97e2-244cb8d08efb">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fdeb238f-4fba-4dea-801e-34ff8f7563b6">
+      <statement statement-id="sa-3_stmt.c" uuid="607967a3-21b9-458f-b9eb-f5785b8974b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017043aa-c72c-4e96-9ed2-6ec39b5742ef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -3705,8 +3705,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="c3e4bf6a-e1a6-4a14-90ce-f8d90fe19672">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b056042a-e26f-4e17-b831-1535d4107345">
+      <statement statement-id="sa-3_stmt.d" uuid="928cbd83-6d80-4906-9edf-bbf9d55d98ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="426bc4b6-9812-4098-9cc3-b5dbf7d359d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -3715,10 +3715,10 @@ activities are outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="88e5c3ae-af84-473d-a4a1-44894ad782e4" control-id="sa-4">
+    <implemented-requirement uuid="bf3098f0-03d4-40c7-9745-d2235ee228c0" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="9bd7c037-15d3-4e42-9cb9-ba54336237f3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="d0c93432-41e4-4af6-95b9-564bf45e784b">
+      <statement statement-id="sa-4_stmt.a" uuid="d8407af8-acd4-4428-840c-efefa414e336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1552cce1-10a9-4a28-acff-0819cd1d5552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3726,8 +3726,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="d8ea8407-ebc8-4f33-af10-7226d7fefbbf">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="863ba8dc-07e8-4cf8-8333-6ebfdc5be126">
+      <statement statement-id="sa-4_stmt.b" uuid="516ec171-7079-4c0c-b931-01cfa87d9f39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54666440-ddf1-495a-b24b-de93c187adfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3735,8 +3735,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="9b492cbd-ac08-4095-b6b3-14f8f5532658">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="15ed93ac-0fe5-4a06-af64-7b70462f555d">
+      <statement statement-id="sa-4_stmt.c" uuid="19367cff-d60e-42dc-aff7-5a3263f206c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a4549b6-b8fd-4d3b-a303-c815c6b65618">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -3744,8 +3744,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="22e353d7-5097-4859-bfe5-550866aa1f78">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c72efad8-e096-4945-847a-96f25b46ad68">
+      <statement statement-id="sa-4_stmt.d" uuid="9e656b9a-3b82-47e1-82ad-85a95b2f3224">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4fdfc14-17e4-4910-82d8-60ad518cffb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -3753,8 +3753,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="356c27fc-fbe2-43ed-b33d-b0b387b7cfa2">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a3ef56c6-2aab-40f9-a738-4d2fdc75ba28">
+      <statement statement-id="sa-4_stmt.e" uuid="ba757458-3c0c-4974-8eb6-04500d23ccc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="661ec3a0-e738-42f9-a92f-02d313d8e900">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -3762,8 +3762,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="ba44ef30-0faa-41df-bcfa-e9b2577067ce">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="de275830-779e-491c-a96f-6cdf0251a90d">
+      <statement statement-id="sa-4_stmt.f" uuid="04fa1d51-9152-46b4-b4ae-dc50924ba75e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45200b4a-85fd-4567-9c82-613516999bd1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -3772,8 +3772,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="e7770004-81ab-439c-a197-a003ebb6e0db">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b5e9f8d9-1102-47c2-a105-3085472a0a8b">
+      <statement statement-id="sa-4_stmt.g" uuid="965605ae-2f59-4939-b51f-99c648774e29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd3b9e75-24f0-4011-8062-0dd44081dbe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3782,117 +3782,90 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="745d7006-54b1-48c8-b440-5993cfc17444" control-id="sa-5">
+    <implemented-requirement uuid="c927e6eb-cd03-4cfc-8370-e65bc1d08e8b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="a110d7b5-3bea-4d28-a027-764ce4e68177">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c7852fc4-b9d3-42e5-97db-6a60083d08c0">
+      <statement statement-id="sa-5_stmt.a" uuid="4faea3e4-73a8-43e7-80fd-d83650013818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="535b1056-75e3-4188-9182-4526a85640ae">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2640dbe2-a30d-4a78-adb0-1878bc83fc2c">
+      <statement statement-id="sa-5_stmt.a.1" uuid="ae559028-e1e5-4605-8783-025c00f9a8a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="6149a692-f5d1-483a-8b13-d4f96d602101">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="932def0a-bee9-4cab-b782-6c9f3213fa60">
+      <statement statement-id="sa-5_stmt.a.2" uuid="397a73bf-b7a0-4aaa-bf9d-ede4ecf3685f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="8ab673a6-35fa-4ed0-be08-ca543bfb5991">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="74b3aa47-60be-4c17-92e7-a510f09c738c">
+      <statement statement-id="sa-5_stmt.a.3" uuid="c9ced858-df8e-469c-afbe-1e88080e4ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="ef43928b-43b9-40e0-b619-45727d5f0893">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="019ab157-195d-4dfb-8221-38e7221b7282">
+      <statement statement-id="sa-5_stmt.b" uuid="c1639c11-0075-422e-a3bd-a02e115d7a80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="594704c9-d489-40c9-aaab-bcd676c96efe">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="0f4492d1-08e9-42f9-aee3-bde9bfc21aaa">
+      <statement statement-id="sa-5_stmt.b.1" uuid="a9909ce0-0b06-4bf4-83df-c013a2fdd5c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="9315bbfe-8f41-4133-86eb-dff0eefab141">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fce464b5-5bd3-4442-aa50-a2b95a263e4c">
+      <statement statement-id="sa-5_stmt.b.2" uuid="10ef634b-6c51-40fe-a25c-4ad6ebba34d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="671d7188-5a3f-4a9b-b0e1-d7eae43ddfd0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9c65a083-1309-4219-97e2-c01548a36e20">
+      <statement statement-id="sa-5_stmt.b.3" uuid="da0b3f67-4def-4323-b907-0a8237c874c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="8cd0de04-8eab-4b36-947d-035c81b26a68">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3ebcbf42-faf7-413a-87e5-fd1671d66c06">
+      <statement statement-id="sa-5_stmt.c" uuid="7517ad19-1345-4b26-9f37-c21dc9721b39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="46ae25d4-9660-4df9-b03e-3a42cc6a0f7a">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="e3680479-5454-4538-b80f-57def9e31be3">
+      <statement statement-id="sa-5_stmt.d" uuid="44d3949f-6897-4950-ad77-aec1c2b4daa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="d7d2dce8-0ad0-4073-83e4-0637847b77f3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="3eeee1ab-b621-4905-bd99-1c580626b70d">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Manager (RHVM) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-    </implemented-requirement>
-    <implemented-requirement uuid="46bc9f43-7d6e-478d-9bf0-e5354a6cd5cb" control-id="sa-9">
-      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="72614caa-ebe2-4615-818d-865c2b3fcce3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c2cb6190-6cef-4fdf-b864-aaf3ac22c939">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Manager (RHVM) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="8a8b2c38-1263-48a0-b0e2-8cbbe0e67556">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bfc5aa36-ee40-4cb4-93a2-f98fbd35fdb0">
-          <description><p>Describe how is the software component satisfying the control.</p></description>
-          <remarks><p>This control reflects organizational procedure/policy and is not
-applicable to Red Hat Virtualization Manager (RHVM) configuration.
-</p></remarks>
-        </by-component>
-      </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="0177ecc7-567d-4451-86f2-b2d839e971b8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f61cdb88-0f9a-4e05-82ad-ebe9a3d2c6f3">
+      <statement statement-id="sa-5_stmt.e" uuid="38a8ddba-5efc-4f18-91bb-a8fec5728d35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -3900,18 +3873,45 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="590bbe5e-d600-4833-b164-d7ad8a0d0cc4" control-id="sc-1">
+    <implemented-requirement uuid="0e348750-2071-4c59-a38c-68082ef7a9fd" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="6fe9510b-cee3-4af6-9845-ff42e0914413">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8e608a37-5aa3-4380-abc5-995a189d4940">
+      <statement statement-id="sa-9_stmt.a" uuid="26cf006d-8120-4aa3-b93e-2c88997ab89e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Manager (RHVM) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.b" uuid="2830bcbf-b8eb-409c-b878-25d755268c11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Manager (RHVM) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+      <statement statement-id="sa-9_stmt.c" uuid="c356c752-c622-4e5e-ab13-8f1b11206e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
+          <description><p>Describe how is the software component satisfying the control.</p></description>
+          <remarks><p>This control reflects organizational procedure/policy and is not
+applicable to Red Hat Virtualization Manager (RHVM) configuration.
+</p></remarks>
+        </by-component>
+      </statement>
+    </implemented-requirement>
+    <implemented-requirement uuid="b86cee4d-ce61-45cd-9e34-afdbef6abb73" control-id="sc-1">
+      <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
+      <statement statement-id="sc-1_stmt.a" uuid="c470702a-260b-496d-9061-de3685081609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="c2bd3b72-ff7c-4508-8c5a-4cf03b8a7ce3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="2aaa9d1b-7ff0-48c0-a9b6-4b7aa1989acf">
+      <statement statement-id="sc-1_stmt.b" uuid="ee59ae69-664f-40fa-b0ec-b0c276e6781e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3919,10 +3919,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef5aad54-6e35-491c-bfb5-877dd6a3c96d" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="273b7f0e-851f-4244-b45e-da3febf893f0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f8d28c0f-bd5e-49af-a67c-525299fcc5b2">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3932,10 +3932,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="170d6f08-436c-433d-bb09-c498b22f7ea7" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="222ea2cd-bd38-4281-b0bc-924ac72484e7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="40cb3f9a-3b50-4e54-ba14-ae66b57e637a">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3944,8 +3944,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="2816ac3e-2331-487f-976f-0e2aff75aacc">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="46778790-9e2f-43da-983b-a4eaf01aa686">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3954,8 +3954,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="540f8ce6-406e-4b51-8492-5b0f185e7642">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="49a39bd5-dc15-4392-96c5-0a5345668a50">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -3965,10 +3965,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="10240112-9329-4879-a58a-b7cad178e876" control-id="sc-12">
+    <implemented-requirement uuid="a6c2e22d-2e4c-4524-a9b4-40e7699e2590" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="da5a6e62-ed06-48ec-9529-9c6e11cbe2ea">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c85ff7b4-0f07-436e-ac78-8cd8eec7dc59">
+      <statement statement-id="sc-12_stmt" uuid="146275cc-6a6b-41fa-adbd-aa394c6964da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c1a45b-7ea9-4b3c-ac60-2c0e6a977cf1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -3987,10 +3987,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d55a9df6-e2bb-4893-aca9-873e8b80c073" control-id="sc-13">
+    <implemented-requirement uuid="17cc2bbf-50a8-46dc-b8cc-81ec9436957e" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="accd1ebe-ebe6-49f6-abfc-8b8abdc12581">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1cf0fb0d-9e2f-4ddc-886d-536eb3568792">
+      <statement statement-id="sc-13_stmt" uuid="c9215f59-79d7-4038-850b-46d60f6d2416">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95afdfd4-0996-40f2-9c0c-f68fbadbe2cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -4005,10 +4005,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b449dee2-344f-4b5a-b072-1c4e5c462e07" control-id="sc-15">
+    <implemented-requirement uuid="20f5a259-b494-4a5d-890d-10bf65c16c05" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="8482b027-f543-4b6e-83f3-5af7f96fcdd9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="39027ba5-a80a-4ad6-bdd5-7be5ca3b26a8">
+      <statement statement-id="sc-15_stmt.a" uuid="45e9cdd5-9166-40b2-bb0c-31a61d7c90c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4017,8 +4017,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="f36ce0de-a0f3-492c-bc79-ee66d59cecfe">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1b501471-76d3-418e-9033-c7c00fbeb81c">
+      <statement statement-id="sc-15_stmt.b" uuid="60a11b00-60e7-4cb4-af05-3f2e19e96459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -4028,10 +4028,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c24041f3-ad91-4609-a347-06e50ed385a2" control-id="sc-20">
+    <implemented-requirement uuid="aac327f7-334f-4136-ba0d-a69495a4228f" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="6ddf4280-1304-47cb-aa61-142ddba5d17b">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="9b6dcbbe-db13-4b0e-a5a2-0e34ea929d44">
+      <statement statement-id="sc-20_stmt.a" uuid="67b81ea6-2bf3-46bc-9722-e0dff2d50c87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="934926ee-05e0-47e6-8f1e-13a8858e54f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -4046,8 +4046,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="3cbcf043-c54f-4b93-b799-c3ef1d504458">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1afd0cca-05c5-4542-bbfe-50cc6d51ef89">
+      <statement statement-id="sc-20_stmt.b" uuid="a871ad06-8c3e-4f76-b4c5-a7de3dd9040a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5279d66f-e6dc-4f01-a4f8-207873b40bd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -4063,10 +4063,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2e411366-c39b-44d9-bf2c-fcb8f41cfcd5" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="68bbf704-a314-4591-a9d5-b4d5d4c81027">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="602024b2-778c-49ae-a9e9-d4a650417650">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -4081,10 +4081,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6431f63a-af0d-4d1c-88cd-67ce819b6cfd" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="86d6ce67-590c-452f-aa49-9cef4463a2c7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6427b49b-f34c-4302-867f-0feacad113d5">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -4093,10 +4093,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8258f4cf-5c9a-473e-b0af-200f3d3a7c25" control-id="sc-39">
+    <implemented-requirement uuid="18492d24-fcdb-4b37-bca3-45866ef75858" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="6fb227ce-5c4c-4e5d-8668-22d6e29d3eab">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="bab75cae-8554-4bc4-ac39-4f13878089dd">
+      <statement statement-id="sc-39_stmt" uuid="3d537e80-1058-4a08-90ba-7914b55b29b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -4106,50 +4106,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f373f85e-63b2-4d9b-aceb-91652898eccf" control-id="si-1">
+    <implemented-requirement uuid="69d4323a-60d7-433f-8def-834118e54ec3" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="82a5844d-5fc1-4b73-a21f-7cc284011537">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="f0c5db27-0579-4f4c-b842-65954cd7bc2d">
+      <statement statement-id="si-1_stmt.a" uuid="94b8cd57-db6c-45cb-9083-c68f55d824ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="181afb6a-1e72-4ce9-bbec-2c0205ad2c83">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="480614f4-a395-4444-869a-3b230ac18a46">
+      <statement statement-id="si-1_stmt.a.1" uuid="5445db05-a229-4dc8-8db5-aac44c81e11b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="a7840b9c-b0a9-43d3-a818-5e2392ef3d84">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="89fc2885-964b-4957-9938-1c2834a6cc97">
+      <statement statement-id="si-1_stmt.a.2" uuid="f701cd56-8a46-46f9-a67b-f933907d3366">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="d413d150-4093-42ef-ac2b-0992ad87bef0">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4ce89302-7fc7-4d41-9d4d-d98275cc6eff">
+      <statement statement-id="si-1_stmt.b" uuid="43752a7d-deb8-4a5b-95e6-24d6559073a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="529071aa-2a52-4fd5-beb8-6f3a4bfde2d7">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="a2190bf1-8b16-470a-9293-8d32f6b48e83">
+      <statement statement-id="si-1_stmt.b.1" uuid="f51c8e38-661f-4dc2-8b95-d9a6a581256c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="e43c6068-a65c-4794-9c37-7a00c887fef8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1071dea4-7063-4ac1-9c61-a5c7527d3ca5">
+      <statement statement-id="si-1_stmt.b.2" uuid="8a613969-37bd-44a4-b52f-347ed9730db4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4157,10 +4157,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="72261c49-0127-4f56-9bc9-c50b74e36ee7" control-id="si-2">
+    <implemented-requirement uuid="7cedbd5c-1b1d-4006-8b67-4a7737372576" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="c46a564e-40ef-4fc5-ade3-46ff218256ad">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fe7c7f02-e3e8-41de-b4b0-fbc995e35a0e">
+      <statement statement-id="si-2_stmt.a" uuid="96489f3b-4bf5-4c8f-861d-51c61891be1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ed4991a-e585-4e65-8fcd-7dc03286246b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Manager (RHVM) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -4170,8 +4170,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="edb68959-f129-4874-bc16-38fe6aba463e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dce9f406-d505-46aa-8d1a-03aa8734cd14">
+      <statement statement-id="si-2_stmt.b" uuid="086eebad-1e6b-4123-baff-e5d987e41741">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29cfb255-66c1-40de-b090-cf3d790e6c1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Manager (RHVM) updates
 related to flaw remediation prior to installation. A successful
@@ -4181,16 +4181,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="426cac3e-6492-48c7-89ce-2a86e4485bf5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="b4d03666-b8a1-4db2-aade-0a743affc7ba">
+      <statement statement-id="si-2_stmt.c" uuid="0a0349f9-7247-4d4f-9252-6510fb5c3964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="6ce6fa15-a043-45f0-99e6-c54102a4c0e5">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="6724b57a-1d8d-4cea-b1a8-43b9a296b14c">
+      <statement statement-id="si-2_stmt.d" uuid="40f6fe99-bbfa-4675-9b65-946ed3fcddf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4198,10 +4198,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fe5ddcb-9347-4d65-b58f-c878bcc0c5fe" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="a20fc79d-ec20-4160-ab6b-966fcf35df59">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c1b20460-4696-4f2f-88a6-427bc6e7f401">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -4217,8 +4217,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="d4b84aa1-e02f-4c68-a7a2-f8a5cc990c3e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c1823294-0e7c-4db1-ad45-d954d99924ed">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4227,8 +4227,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="5651dd82-131e-45de-9f1c-5720a116d98e">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="10c1b569-c524-4131-b055-c73f107d745c">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4237,8 +4237,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="71dfd40d-180e-4fc1-afc4-de1c782492f9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="18bd240d-8cfa-42e0-a201-3a468a8f100a">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4247,8 +4247,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="11cf6056-6199-42b7-b65b-0dff9b5175ab">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="05797736-05cc-4168-8019-a68614c925fa">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4257,8 +4257,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="dbbd3bad-3018-4afe-bc8c-73eb268a80f9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="fe105b96-86b0-4233-9c18-6b61d6de506d">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -4268,90 +4268,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="55a2a673-92eb-4a3f-9ca4-2ed9c0700aa7" control-id="si-4">
+    <implemented-requirement uuid="42da28da-22d3-48d2-9596-ee182934124c" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="bbc6816f-d4ee-44b9-9961-69f4fe956134">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1f627e46-90ff-4789-9dd0-736f8e23794a">
+      <statement statement-id="si-4_stmt.a" uuid="ad5f1c2c-5d90-4441-a995-674a523c202c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="2707ccb8-88b0-44e7-b81e-e5ee1476a430">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ea189863-cf34-4fbd-9a88-7c1c80c6c2a0">
+      <statement statement-id="si-4_stmt.a.1" uuid="f607b60e-d90e-4e43-98dc-3a7a9636fc7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="ca59f0a6-e5c1-4369-8786-2f31c7065a2d">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="54aa33b2-6ac8-47d5-a7ee-9a56ec4fbf08">
+      <statement statement-id="si-4_stmt.a.2" uuid="a10661b3-77ee-4238-a310-7a54cfbbe381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="a681f8ea-fed5-42e3-86b8-be365afff5b8">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="07884dc3-fce4-4870-bc42-5426687b30f7">
+      <statement statement-id="si-4_stmt.b" uuid="93b8c509-885e-418d-a16d-2e774aeafb13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="9ceae90c-8796-46b3-abab-b2bd2d887ad3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="dd633642-5422-4fd3-9b64-af489e9b17d4">
+      <statement statement-id="si-4_stmt.c" uuid="c35fb893-5523-4f34-925d-1434f16a0e91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="0e75cd2d-2621-4afa-b8aa-b47dd98984d3">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="11b28f00-36b9-42a9-bd42-70d702aca61b">
+      <statement statement-id="si-4_stmt.c.1" uuid="5551c8bd-d3f0-48a4-89fd-fcff3254c583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="5f923d47-67ed-446b-a0cd-1c54603c2187">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4dca03c2-044c-48fc-9696-6674da228974">
+      <statement statement-id="si-4_stmt.c.2" uuid="d541badd-ea98-4830-b51f-44e2b827e474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="0eee0af1-77c7-47e5-b3d7-6646405f5b5c">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="4905a1ed-fba3-4a52-b7c4-a5674c65c509">
+      <statement statement-id="si-4_stmt.d" uuid="eab74f27-bef7-4c94-9448-5664bc339713">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="a12d90f5-68e4-485e-b74c-58661198d5b6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="8691faf9-3a58-4d31-8436-8b49c622a5a1">
+      <statement statement-id="si-4_stmt.e" uuid="c67c8bcb-a07d-4eb1-8ecc-033bc9a800aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="0da77a3a-bd87-4e7d-984f-6f5c5c8d0cb9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c2464c02-02d0-4f07-bab1-74feee02d799">
+      <statement statement-id="si-4_stmt.f" uuid="97dc93ed-5f81-4453-b322-45bdea8dd72f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="3e29634e-d055-4434-894a-c91934efd521">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="525111de-3919-406f-826f-53abd56b7b2f">
+      <statement statement-id="si-4_stmt.g" uuid="83c23958-58eb-45ae-b5d9-57211186fd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4359,10 +4359,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e8fb6890-6caf-47ac-b387-12f7cf9d2694" control-id="si-5">
+    <implemented-requirement uuid="e294f724-c931-45f0-be8e-18f53f1e1de1" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="7c78f65a-b6f4-4111-b992-7aa3898ba9a6">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="31d266b9-5369-47b8-a81b-6f36d2db8f33">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -4371,16 +4371,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="ee6bc7d6-997f-48f8-8acf-4ecb77079a61">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1d00cc92-70b0-4e8f-9e86-c58842224326">
+      <statement statement-id="si-5_stmt.b" uuid="cb7122e4-08c8-438d-ba3d-66beb38366d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="fa449a1e-b82b-451d-bad6-14e824b16bd9">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="915346eb-febc-497d-a5e1-81bd07dcbeae">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -4389,8 +4389,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="48d434d4-3812-47a8-ba35-08d06b3dc594">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="1e193d1d-8e65-4d29-9bcd-fe9db7e2348f">
+      <statement statement-id="si-5_stmt.d" uuid="cd44fe4d-fa2d-40d4-8f5b-e52b09880005">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4398,10 +4398,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e91b172e-d245-486c-ae8b-cf8bc5f19529" control-id="si-12">
+    <implemented-requirement uuid="073e59b6-334f-4554-8dcb-e8adb4bfa03a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="6c7b7edf-f41f-4993-a5ed-9e99b2d05019">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="ee4a86a5-a593-4445-a3b6-7e343babf638">
+      <statement statement-id="si-12_stmt" uuid="c54da56a-94d6-48d2-a137-0577ddfb83e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071845fd-4fb7-4382-9736-531d35f08a6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Manager (RHVM) in
@@ -4415,10 +4415,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb30f02d-437d-42c5-9a0d-eddade6bc0b3" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="786a0e7b-c77f-428f-8986-f0ad336d46be">
-        <by-component component-uuid="75e8b746-4efb-4e5b-9aa8-0dd156eddba0" uuid="c49bd6af-26a8-4177-b8d4-23c852398f77">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:

--- a/xml/virtualization-manager-fedramp-Moderate.xml
+++ b/xml/virtualization-manager-fedramp-Moderate.xml
@@ -1,8 +1,8 @@
-<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="36dff4e6-d9f7-4e96-9f8c-924a4bbed474">
+<system-security-plan xmlns="http://csrc.nist.gov/ns/oscal/1.0" uuid="59c284f9-9b1d-442d-b5c4-d4d5f4b171c1">
   <metadata>
     <title></title>
     <published>2020-07-01T00:00:00.00-04:00</published>
-    <last-modified>2020-11-22T00:32:02.96+00:00</last-modified>
+    <last-modified>2020-11-30T13:03:21.25+00:00</last-modified>
     <version>0.0.1</version>
     <oscal-version>1.0.0-milestone3</oscal-version>
     <revision-history>
@@ -473,10 +473,10 @@
     </authorization-boundary>
   </system-characteristics>
   <system-implementation>
-    <user uuid="d2fc58c2-11ab-468a-b971-9c5895bf3867">
+    <user uuid="ebddf85a-2c8b-493f-89af-2e03c5ede486">
       <role-id>generator</role-id>
     </user>
-    <component uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" component-type="system">
+    <component uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" component-type="system">
       <title>This system</title>
       <description><p>The entire system as depicted in the system authorization boundary</p></description>
       <status state="under-development"></status>
@@ -484,107 +484,107 @@
   </system-implementation>
   <control-implementation>
     <description><p>FedRAMP SSP Template Section 13</p></description>
-    <implemented-requirement uuid="09e450ed-259c-4940-843b-bc210515c00e" control-id="ac-1">
+    <implemented-requirement uuid="935fc585-8c0d-4e23-8c2b-8d1a82bc6de5" control-id="ac-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-1_stmt.a" uuid="e5d0cd9a-5324-4d45-889e-835f89a4f32f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2a0e504d-779d-4fff-aa95-4c0a8e6db0c7">
+      <statement statement-id="ac-1_stmt.a" uuid="cc53016a-7b4b-43c2-a7be-d7e3881ffc09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9bc7848e-1ff5-456d-bb50-4c66da19c7ad">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-1_stmt.b" uuid="e64628a8-28cb-4eed-87fe-b00613d13c02">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="98438bda-630c-4091-9810-df5ba8616e7d">
+      <statement statement-id="ac-1_stmt.b" uuid="14971f3c-d3c7-4586-ab6c-e96a64f00105">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192a21b9-f20e-40b3-be11-4658c5b10f4f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-1(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc125f96-182d-4eb4-8793-bca369aee42a" control-id="ac-2">
+    <implemented-requirement uuid="f67d4ab2-d0ea-4ba7-9451-88e518020d4f" control-id="ac-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2_stmt.a" uuid="f7320421-0380-4c96-8efa-0f132bc6f9ba">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2e7559e0-3cb8-4e5b-825a-39f37d1b3d6c">
+      <statement statement-id="ac-2_stmt.a" uuid="9fbdf8ad-2b9c-4abe-a179-df8a0cf999ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0948d8a3-d0de-4772-8129-51d7044bc708">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(a) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.b" uuid="30276e02-132f-4269-afb3-6ae0e3abbeb6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1424c299-05ea-4d31-8fc0-ba4b8856780e">
+      <statement statement-id="ac-2_stmt.b" uuid="37679c35-79a9-440a-b0ba-70bf1adf0843">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e397b49e-743d-42f7-9b6e-c27d903220d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(b) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.c" uuid="1c429fda-a41d-4134-b158-bce71c8fef3d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3bc06d48-a51d-4663-a7d2-c7b8effb13cc">
+      <statement statement-id="ac-2_stmt.c" uuid="57796f3c-04d2-48e7-b548-9f7cc23dfe1f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b5372385-2e96-4f5c-b3c9-dedd9fa4768b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(c) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.d" uuid="65b76afc-ba03-4a3e-8d66-2d736be630d2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0784a98e-8a09-468e-af24-53d696be190a">
+      <statement statement-id="ac-2_stmt.d" uuid="16e7b8f5-72fc-463f-bcf9-dff9f1a98444">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="192c3c92-4449-46db-bd35-3b3baa1a8e6b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(d) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.e" uuid="d87921e4-6239-4f47-a73d-bf432c694ed3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4927a30c-2753-4124-9849-1a9ce13d2577">
+      <statement statement-id="ac-2_stmt.e" uuid="85035d84-9393-43dd-8d99-c4e3338892e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="354d4cb1-65e7-4f33-a3b7-3659e7d47759">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(e) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.f" uuid="fe4b3209-233d-4d7c-8d5a-6154806f81cf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="50be1186-7539-4ddd-b450-b62cf9e91dc3">
+      <statement statement-id="ac-2_stmt.f" uuid="8b9e97ff-b352-4097-a6b1-73095aaef138">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17cb7701-547c-4964-a739-069548f34e1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(f) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.g" uuid="2277ab9f-2ac7-4e8b-9217-430e697c87d1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7aa11aba-ef9f-4d6f-838a-e2ec6e1c2b3c">
+      <statement statement-id="ac-2_stmt.g" uuid="4f167f93-f6cf-48a2-9cd8-eff8812dd65f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5025090f-c1f8-4dba-bcf6-04b6e53d5135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(g) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.h" uuid="320def91-34bb-4753-9c0d-9f6f5a1616a3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="51ed03a1-e8dd-4dbd-97cf-6c9724fadac0">
+      <statement statement-id="ac-2_stmt.h" uuid="140deaea-5b89-406d-b8cf-e0067c52c4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2f73dfb7-a97f-4283-b843-3c45bba5d201">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(h) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.i" uuid="19cf9837-eba6-4dc4-a091-252a5350cbf3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1c9ff013-f6d8-4eba-b01b-6a9273e2e6bf">
+      <statement statement-id="ac-2_stmt.i" uuid="96e1e1b0-69f0-447a-b451-0c237009cf21">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5a143884-7ff3-4077-ab98-a8e3ec37f214">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(i) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.j" uuid="d73e4096-3cdf-429a-87f3-f8bee9e05397">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1e7b41ba-c379-473a-8319-342d8b20549c">
+      <statement statement-id="ac-2_stmt.j" uuid="218ada72-ea7e-4142-ace7-16852053482b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9688aeda-4137-4df5-842d-43e0a620fc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(j) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2_stmt.k" uuid="32ad4757-5ae7-4d31-ad3b-94a256ab4bcc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2b2b879a-fa48-4849-a24c-573bb07548e0">
+      <statement statement-id="ac-2_stmt.k" uuid="be123a77-9ada-4c78-834b-1d8f12977e36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="723be80f-78e5-47fc-b9b5-123a1ab7c7b0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>AC-2(k) is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d67ee51-d2d6-4a14-8200-8074a3ebc56f" control-id="ac-2.1">
+    <implemented-requirement uuid="9715651b-80fa-4d22-8bee-37a82e36f37f" control-id="ac-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.1_stmt" uuid="182374e4-8547-4abf-9a57-605a3353eb88">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1421f70b-74e5-4132-8478-4082148ae87b">
+      <statement statement-id="ac-2.1_stmt" uuid="0b81d118-447c-418a-ba20-583f601c82ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34148e4a-d2f0-445b-a912-24cbb554682f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) components of the system support automated
 management through monitoring of accounts and system
@@ -604,10 +604,10 @@ https://projects.engineering.redhat.com/browse/RHV-19937</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40d5856c-64c5-407b-a7f2-fce374258fbe" control-id="ac-2.2">
+    <implemented-requirement uuid="29407e38-674e-4b6c-ba4a-71366b8bf0ca" control-id="ac-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.2_stmt" uuid="3241fa24-11ad-4b28-a60a-6cd67d3b0bbb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e120882b-3d1f-41d6-bbd6-c8f96cf6c0a4">
+      <statement statement-id="ac-2.2_stmt" uuid="bae8eb29-5a04-4606-94fe-1f7d26ad0114">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cb7a3500-065e-48d1-a512-7ab26eb568c5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) does not have the capability to automatically
 delete guest/anonymous accounts or temporary accounts. Any
@@ -617,10 +617,10 @@ identity service (e.g. Active Directory, LDAP, etc.)</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b6e1a2bc-04e1-484d-a368-6ade71addbfa" control-id="ac-2.3">
+    <implemented-requirement uuid="704d6fd5-d8b8-4452-9429-bcdc9d2d31e5" control-id="ac-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.3_stmt" uuid="1132e0f2-aa78-4165-9ce8-41af2cecb246">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3924cceb-67e9-450d-b3ad-7f812a15aaeb">
+      <statement statement-id="ac-2.3_stmt" uuid="2793ab65-312d-41bd-9540-f3525fc62391">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="381e0da0-8465-4ad2-ad7c-29ec45d6079f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -629,10 +629,10 @@ https://projects.engineering.redhat.com/browse/RHV-19938</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="278f82c8-0b69-491d-a012-4d15fc197992" control-id="ac-2.4">
+    <implemented-requirement uuid="27d8f87a-5fc4-47af-8466-b3411e509250" control-id="ac-2.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.4_stmt" uuid="3613964b-31e8-46e8-a933-fa8233602354">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="004465c2-899a-4b6a-aee9-286788222318">
+      <statement statement-id="ac-2.4_stmt" uuid="eaebd66e-070e-4cd7-a27f-a1f698b92a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="beb2350c-a692-4a5a-8336-d126cb5462a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -641,10 +641,10 @@ https://projects.engineering.redhat.com/browse/RHV-19939</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2142a1a-4125-43e6-b7df-e4ad72e703f9" control-id="ac-2.5">
+    <implemented-requirement uuid="dd5e5105-d2cd-4733-9fd5-fd3020397f4e" control-id="ac-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.5_stmt" uuid="194aa038-c164-473d-b280-4f09fb47117b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="637b0576-af23-4844-aa88-973f6dd26fe0">
+      <statement statement-id="ac-2.5_stmt" uuid="3c6eb3c7-fc42-4181-a8ec-da4f7e3b6b9f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2645dafa-cbbb-4d6a-84f0-4d1ce85741c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -653,10 +653,10 @@ https://projects.engineering.redhat.com/browse/RHV-19941</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="417257f1-de2f-42d7-928f-1fd637f3afd6" control-id="ac-2.7">
+    <implemented-requirement uuid="9268ed20-31b0-4df0-bd0a-80416e29ddd1" control-id="ac-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.7_stmt.a" uuid="5100cdd0-e2a2-4d11-b67a-fa9d943d01c3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="926158ba-46a5-4db2-88f0-5a82625222ac">
+      <statement statement-id="ac-2.7_stmt.a" uuid="f19cdaaf-9b1e-48e4-9b3d-2b356087abe0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e056b0fb-5e60-4904-90b7-a7a6f3936b64">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -664,25 +664,25 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-19943</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.b" uuid="e20ab207-2c20-47f3-9c3d-f9d613807325">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b1f1d6c5-9284-47d3-8f67-2c7e74cb290d">
+      <statement statement-id="ac-2.7_stmt.b" uuid="ed3ffabb-c47b-4c81-8730-7b4e3f9dcef0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4496e10-886b-4309-97cf-44271743c943">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Manager (RHVM).</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.7_stmt.c" uuid="1aeab50f-3f2e-4e0b-839b-60968139d4f8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="61dbd57c-afda-4869-82f6-5192f3cbca85">
+      <statement statement-id="ac-2.7_stmt.c" uuid="bce80856-3d60-40c2-99b7-ad08cf5df799">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4496e10-886b-4309-97cf-44271743c943">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control and not applicable to the configuration
 of Red Hat Virtualization Manager (RHVM).</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17e952c2-3dde-44e2-be4a-08de0ffe353a" control-id="ac-2.9">
+    <implemented-requirement uuid="8e61c5f7-a4e4-4704-b012-0aecab349f9c" control-id="ac-2.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.9_stmt" uuid="30c76bc6-5a98-40a9-8319-39aa8d766dce">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="546ed7fa-786e-4a66-886e-49e90956a279">
+      <statement statement-id="ac-2.9_stmt" uuid="5df1697b-7fe7-4fdc-a5e6-44eb181ea9c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e160bbd-eb3d-498c-b364-71ec5c51130c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -691,10 +691,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="96d3f93d-bb37-42c5-a826-6dcc3092a8ec" control-id="ac-2.10">
+    <implemented-requirement uuid="bccf9c5e-a4d7-4085-93b6-d3744f75f95e" control-id="ac-2.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-2.10_stmt" uuid="0e6a2783-d536-4000-ba0d-4fd1c2bfa606">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fca90697-9d84-420e-b8e9-59637ad30682">
+      <statement statement-id="ac-2.10_stmt" uuid="e4022c08-bf1a-48b3-9b1e-de84af44a65a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9e160bbd-eb3d-498c-b364-71ec5c51130c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to the identity service provider
 and outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -703,10 +703,10 @@ of configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3343bb6f-8047-4b13-8581-dd70ee846e11" control-id="ac-2.12">
+    <implemented-requirement uuid="f87599d6-cdda-44c8-a492-0a03ce2512da" control-id="ac-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-2.12_stmt.a" uuid="bcccf1e9-25b8-4908-ba08-9f34c6329b08">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="faf46146-ac34-4f6d-b4ab-e28125546b2a">
+      <statement statement-id="ac-2.12_stmt.a" uuid="3e81fc69-33f7-479e-bfd3-ea0347fe65ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6081c351-b18f-4343-8345-f7972bf41f8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(a) is planned. Engineering
 progress can be tracked via:
@@ -714,8 +714,8 @@ progress can be tracked via:
 https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-2.12_stmt.b" uuid="e39912db-1847-4cdc-bc97-5524a32f1998">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="67f7d5c3-5707-4a7d-a3db-a9083d04c9d3">
+      <statement statement-id="ac-2.12_stmt.b" uuid="bded1b14-61c2-475a-b9a5-925cfdb9c421">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc5978cb-1d46-4568-8533-5ad7f0b52d7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for AC-2(12)(b) is planned. Engineering
 progress can be tracked via:
@@ -724,20 +724,20 @@ https://issues.redhat.com/browse/CMP-259</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="056e1397-4919-4454-a8a5-8d73d27b6c56" control-id="ac-3">
+    <implemented-requirement uuid="28464255-c97b-4c55-9e87-f9276306d86c" control-id="ac-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-3_stmt" uuid="2c49e79f-a64b-4e5b-8c46-f7194481feb8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dc97301f-e048-43c5-bfb4-a1f321ca4390">
+      <statement statement-id="ac-3_stmt" uuid="826d29a9-48d8-40b2-b9f7-10cd9b1d5b1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="75430695-3c06-4a3d-b50f-5da476b1efa6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Manager (RHVM) enforces logical separation through
 role-based access control (RBAC) and VM pools.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="970ac4d9-8f55-404e-a8bc-3cf7e6d11496" control-id="ac-4">
+    <implemented-requirement uuid="fb206e6b-1e3e-463a-9813-1054cf5eb413" control-id="ac-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4_stmt" uuid="fcfdebe0-561a-4bdb-b26e-1f9d36907ad7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8ea96542-20f8-4b9e-82be-a8887a1777fc">
+      <statement statement-id="ac-4_stmt" uuid="431a8b3f-25c1-44d5-b6bf-f6e13d08bf46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d03a35b-2b3c-46a6-934b-24d7d32561c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -746,10 +746,10 @@ https://projects.engineering.redhat.com/browse/RHV-19975</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c2f9d888-67fd-43df-a244-857a2c03b69e" control-id="ac-4.21">
+    <implemented-requirement uuid="552e2d31-d520-4e5f-bdf2-fa21f7df835e" control-id="ac-4.21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-4.21_stmt" uuid="cbbfc8ef-ed00-4d90-ade9-2eadc85ef57d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="02d297ea-68b3-4f89-842c-8747f68a30ac">
+      <statement statement-id="ac-4.21_stmt" uuid="a45d1455-852a-47aa-a2d0-c063b9663faf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="314eeab2-b5af-48d9-a8d6-b30a00f379e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for separating information flows
 within the customer application. A successful control response will
@@ -764,10 +764,10 @@ https://projects.engineering.redhat.com/browse/RHV-20102</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb9a13f6-6925-4ca9-81d3-29e43f540f67" control-id="ac-5">
+    <implemented-requirement uuid="f9218ad6-810c-4b3e-9276-46079139b6c1" control-id="ac-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-5_stmt.a" uuid="7ac64ed5-0e32-4f74-9388-677d972c28ba">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f69dbcaf-89d8-4688-b0be-44164e535d65">
+      <statement statement-id="ac-5_stmt.a" uuid="519ead93-eaaf-4e22-90b7-177f13f4bacb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7721745d-042f-42e9-989b-9de0c2d07e5d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Separation of duties is an organizational process outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -778,8 +778,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.b" uuid="0531879f-d831-446e-b444-2c454ce0b55f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="256c9a0e-abaa-46f9-9efc-04bda7432f9e">
+      <statement statement-id="ac-5_stmt.b" uuid="4a08086b-3d21-4e41-b6c2-469ac14be0f6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8f7c1c6d-f12c-4f6e-af99-ecf352cfffc8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation of the separation of duties of individuals
 is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -791,8 +791,8 @@ user is allowed to perform a given action.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-5_stmt.c" uuid="a963f513-918f-491d-a470-8f0376aee1b0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dc023dde-43ba-4396-bbb8-cc4fb3258f9b">
+      <statement statement-id="ac-5_stmt.c" uuid="bba22151-a82c-40cf-a8df-8765cc27156c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="40ce6ba4-739a-40b4-a1ca-1482bd036c2c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes which define information system access
 authorizations to support separation of duties is outside
@@ -805,10 +805,10 @@ user is allowed to perform a given action.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79775098-7a74-44b2-8566-5e7bc3ba7db7" control-id="ac-6">
+    <implemented-requirement uuid="cd068943-85d8-4507-bfc6-c1b5ac06fed1" control-id="ac-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6_stmt" uuid="85c9d507-d0bf-4314-a28f-48ca6a8406d3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2ba925ca-599a-4165-98a7-1dfb11ad7c8a">
+      <statement statement-id="ac-6_stmt" uuid="395124ff-7909-468c-8c26-9c019a94a445">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12714d47-155a-4a25-8adf-0c9fa759d3d2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -818,10 +818,10 @@ https://projects.engineering.redhat.com/browse/RHV-20104
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a1f917d-66c6-44fc-9f81-95698dbe8712" control-id="ac-6.1">
+    <implemented-requirement uuid="79009ec5-feda-41fd-9466-3d1170902932" control-id="ac-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.1_stmt" uuid="edc3f781-6b52-4a9a-935c-08b3e4fb6464">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="82521c7b-9192-4a9a-8a33-c84c6bbb05af">
+      <statement statement-id="ac-6.1_stmt" uuid="bbedf025-0a76-4145-a3a8-e0772c011e7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e72751f-1477-4bd5-9b86-4079f8d1c129">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -831,10 +831,10 @@ https://projects.engineering.redhat.com/browse/RHV-20105
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6fb23537-3741-420c-a1bd-f790897ae35b" control-id="ac-6.2">
+    <implemented-requirement uuid="7c835bf6-c66d-473a-a4dd-6b7a1266c57a" control-id="ac-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.2_stmt" uuid="04d645a8-c453-4af5-ba1f-4f5375eb281b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dd9eb7d7-76c4-40e2-93e2-a2487c9577ee">
+      <statement statement-id="ac-6.2_stmt" uuid="ddaa3277-0e5f-4c48-9b7e-83c783c6a950">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa9ec760-7bbc-4979-adeb-6d1e777a7c51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -854,10 +854,10 @@ https://projects.engineering.redhat.com/browse/RHV-20126
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60b730e2-290b-4125-831a-bf3e4461b84a" control-id="ac-6.5">
+    <implemented-requirement uuid="d7189002-409d-4c4b-9b90-56b0e74688ec" control-id="ac-6.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-6.5_stmt" uuid="e7304ce3-86d2-43f6-aff1-ed3fe5ead21c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c6b8793f-9241-4e22-bcd9-ce4272abb901">
+      <statement statement-id="ac-6.5_stmt" uuid="9d630a05-593e-4d15-aabd-319f21f5f23c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017c4528-e1ae-4187-a8e6-fab33c96d350">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational/procedural control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -872,10 +872,10 @@ and login with an account that has received appropriate RBAC rights.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="90b90ae4-0f19-46fa-bc3e-f0b509b9fe26" control-id="ac-6.9">
+    <implemented-requirement uuid="435c04e1-8c27-49fa-8e5a-112bf8ed04af" control-id="ac-6.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.9_stmt" uuid="9ddab116-d9c2-43c0-9b03-4792b0d5a0b0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d915f0e2-699a-44e9-bebb-555e29fe89b7">
+      <statement statement-id="ac-6.9_stmt" uuid="4dec473d-de52-4b32-b0d1-cad9f73f8cfd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023ccb0e-4287-4b46-baf4-be96cd66a27f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for auditing the execution of
 privileged functions. A successful control response will need
@@ -890,10 +890,10 @@ https://projects.engineering.redhat.com/browse/RHV-20149
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0373b09a-651b-48a4-80cb-99802d6e6599" control-id="ac-6.10">
+    <implemented-requirement uuid="7949fd53-0e80-4c80-bb4b-9a7c96bf9e66" control-id="ac-6.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-6.10_stmt" uuid="15c7f055-0848-4e03-afa5-3eda6cdcf206">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="84d37897-1072-46bc-b41c-db705c394513">
+      <statement statement-id="ac-6.10_stmt" uuid="f4f90226-de6b-4803-b91e-66e2e0913185">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d898ce-e363-48cc-87b7-0b6b804c10c8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that non-privileged
 users cannot execute privileged functions. A successful control
@@ -909,10 +909,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a17812d1-078c-4465-81c6-f73e5fbac571" control-id="ac-7">
+    <implemented-requirement uuid="761f627f-cf3b-42d8-b82b-6a1c4723948e" control-id="ac-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ac-7_stmt.a" uuid="604557b2-4f66-4724-a9fa-2fe979702b91">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="459053af-2fa1-4749-8c52-368ab1e878a4">
+      <statement statement-id="ac-7_stmt.a" uuid="2a696c96-a01f-4a4a-9223-54b944accd33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -920,8 +920,8 @@ progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-7_stmt.b" uuid="66230181-c4bf-4bdd-b3d8-a85432c9dabd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="33ba530c-7771-403b-a0a1-879ec620407d">
+      <statement statement-id="ac-7_stmt.b" uuid="843983ad-bd02-4b99-9e32-735a65349fe6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1da28c43-84df-40d3-9aee-964c802196ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -930,10 +930,10 @@ https://projects.engineering.redhat.com/browse/RHV-20201</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fad45b2b-f67b-4a2c-95cd-47aefa9dc7fc" control-id="ac-8">
+    <implemented-requirement uuid="44a4224c-e76f-463f-b5ad-5b9e20d17871" control-id="ac-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-8_stmt.a" uuid="2bf1d1b7-f148-40df-937b-d842d78b9bb1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2d46652e-2a75-40db-9543-7481facf6d84">
+      <statement statement-id="ac-8_stmt.a" uuid="3483450d-de7e-43d1-bad5-66d9e0a227ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -942,8 +942,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.1" uuid="61466a6c-25d2-4628-93cb-0e0df332c426">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7834b5d6-a2f4-4ed3-b830-a84f8260ccdc">
+      <statement statement-id="ac-8_stmt.a.1" uuid="c713ced8-a4c3-441c-aef0-773b700b4013">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -952,8 +952,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.2" uuid="911e36d3-c374-4ce5-8210-1cfb1db72a1e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c8dfe476-00f2-4237-97b4-a2e29aab5661">
+      <statement statement-id="ac-8_stmt.a.2" uuid="65992988-917c-4f28-9826-1504e479c581">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -962,8 +962,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.3" uuid="d806b2b5-4c32-4dbe-900c-8833cb363ba9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8721b35a-6bab-42c9-9f8b-d8895eb7737f">
+      <statement statement-id="ac-8_stmt.a.3" uuid="15178095-1d4c-43e9-bf09-f914bcab2f4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -972,8 +972,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.a.4" uuid="adab9bf3-50e8-48fe-9f54-41aba7dfb362">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c74a41df-e02b-4127-a7a9-3037045ba2a7">
+      <statement statement-id="ac-8_stmt.a.4" uuid="c5b5cd5e-6256-4bfe-893c-20f356c6b541">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -982,8 +982,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.b" uuid="29c5e66e-ece9-4361-83d3-5c3518aed8db">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f6664abc-accc-43f0-8d81-20f54fba47ed">
+      <statement statement-id="ac-8_stmt.b" uuid="cb1fec5b-ae91-4800-96b8-f438c632bc87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -992,8 +992,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c" uuid="c71d4ad0-e97c-48ef-8469-e7e2d9b83044">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="01c7011a-612e-4ab3-9739-b8a552482e89">
+      <statement statement-id="ac-8_stmt.c" uuid="894aa761-37c6-4c0c-8089-4d2b1deb8edd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a4cef1d2-9650-498a-b1e8-68a842da4deb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1002,8 +1002,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.1" uuid="444e41c7-6d09-474c-bfd2-7fb31405e50a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0d202e0b-47be-4d33-88f7-1ebbae8c921a">
+      <statement statement-id="ac-8_stmt.c.1" uuid="a544ca8b-3d84-4cc7-9b32-ba5beb4c1d9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="99c5a1d4-ba79-4244-ae02-e671903f4e1e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for determining the conditions
 under which the system use notification will be displayed.
@@ -1015,8 +1015,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.2" uuid="c23668d7-1ca3-4df9-b01c-017fc702b21d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="75274971-1fd7-49b7-87eb-6175f41b287f">
+      <statement statement-id="ac-8_stmt.c.2" uuid="c1a9a1e9-1718-418f-9c72-adfd9c033413">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b61b3cb0-0974-4af9-85f9-d444be034a2d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for how the system use notification
 will be verified and how often it should be re-displayed and
@@ -1029,8 +1029,8 @@ https://projects.engineering.redhat.com/browse/RHV-20204
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-8_stmt.c.3" uuid="8e60c9dd-939c-4c8a-b2b3-01320646739d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1adef382-6286-4f7c-a1b2-ade16a60f133">
+      <statement statement-id="ac-8_stmt.c.3" uuid="35374bba-898d-408f-a718-545e0facfb66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93dc765e-9f31-430f-9426-0680b9d956c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying that the system use
 notification is being displayed as required, either through a
@@ -1046,10 +1046,10 @@ https://projects.engineering.redhat.com/browse/RHV-20204
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="af106c7c-9be0-4771-aaff-ee1c639833a0" control-id="ac-10">
+    <implemented-requirement uuid="658dfd46-01b0-44b2-9e87-8b8c43b810fb" control-id="ac-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-10_stmt" uuid="583ac0eb-93d7-4315-89c8-f3ca7ebe4922">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="170f3208-4742-4e2b-99a7-2a94d89de686">
+      <statement statement-id="ac-10_stmt" uuid="77d6b558-3a40-4f35-b6ed-4d29c010404a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="24c2c079-5b6d-4e1e-a549-72a4a6046ebf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for limiting the number of
 concurrent sessions to the customer application as required.
@@ -1064,10 +1064,10 @@ https://projects.engineering.redhat.com/browse/RHV-20220
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ab7a16b-bd58-4b0f-a266-f6fe2bff2569" control-id="ac-11">
+    <implemented-requirement uuid="de47af6d-3ab2-4ccf-be56-0e9d1b328c6c" control-id="ac-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11_stmt.a" uuid="f2bbad89-d800-4d14-9544-ce8f2e8684c2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f334ee12-618d-4c87-a01d-3137b41d95b7">
+      <statement statement-id="ac-11_stmt.a" uuid="4322b9cb-3cc1-4b1c-aa75-ee0f7d42d6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1076,8 +1076,8 @@ https://projects.engineering.redhat.com/browse/RHV-20311
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-11_stmt.b" uuid="e34c73bf-7af0-4414-8d3e-7b4c47185f0a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="64955a28-aabb-4da0-a5f9-83f70b0b96f0">
+      <statement statement-id="ac-11_stmt.b" uuid="afe463cd-920f-447c-8ef4-0c01bc1d59db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eb73e9f3-45da-40d5-b9ed-bab3154b3d88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1087,10 +1087,10 @@ https://projects.engineering.redhat.com/browse/RHV-20311
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3d478fc9-1afb-42ad-825b-4c5f0876a8e9" control-id="ac-11.1">
+    <implemented-requirement uuid="9186ba2c-900a-4af7-b19f-bb180f5b2a76" control-id="ac-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-11.1_stmt" uuid="e45fc376-287f-46f5-a97c-fd2e9c4ac796">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0d860d62-8161-4e32-9a68-ba84da773aab">
+      <statement statement-id="ac-11.1_stmt" uuid="9f71193c-566a-40c0-b07e-a386d1989365">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="33f20195-3d93-43ed-9b21-63e4c9107fd4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1100,10 +1100,10 @@ https://projects.engineering.redhat.com/browse/RHV-20312
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="add0626f-657a-4856-9cfb-f9d66954a857" control-id="ac-12">
+    <implemented-requirement uuid="e31814b1-e9f1-4f64-803c-4d8a3773aeed" control-id="ac-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-12_stmt" uuid="e4e858b5-611c-4762-b54f-6f567e8c6801">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b5cc90b1-7516-4822-9af1-21073d52bec4">
+      <statement statement-id="ac-12_stmt" uuid="90b59e85-2cd3-45ff-b096-a35056dd4d53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4b753ca6-6101-42a2-98ce-14b9560c501b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining events or conditions
 requiring disconnection (for example, user requesting logout), and for
@@ -1119,10 +1119,10 @@ https://projects.engineering.redhat.com/browse/RHV-20313
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5427088c-54e5-40c1-a1fd-bed23c0aa465" control-id="ac-14">
+    <implemented-requirement uuid="e51e582e-b200-4523-ae86-adb9167bc5b8" control-id="ac-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-14_stmt" uuid="86f926ea-31f3-4e44-8274-bfe6feadb2a3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="50ab1737-b488-48b4-b43d-b5e6d1d12759">
+      <statement statement-id="ac-14_stmt" uuid="28d9020c-55d3-44bc-ad3f-27406a65c4fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a16e91f-5966-4db6-9ed1-47240cc81350">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>There are no user actions that can be performed on
 Red Hat Virtualization Manager (RHVM) without identification
@@ -1132,10 +1132,10 @@ behavior.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ccafd8d0-8e94-4b73-ba7b-56b31ba4d15e" control-id="ac-17">
+    <implemented-requirement uuid="4a111d5b-6ac1-4941-9c0a-c24eef46e2ba" control-id="ac-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17_stmt.a" uuid="da99b25a-ae57-4ffe-a8cd-2e342d4f9a65">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="83be1368-3d89-4fdf-9594-0beeeb1f0756">
+      <statement statement-id="ac-17_stmt.a" uuid="c8a02a7d-08f1-4192-a892-9159f8a19ba7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d722ad06-ab06-45d4-a05e-04c143007431">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1144,18 +1144,18 @@ https://projects.engineering.redhat.com/browse/RHV-20372
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17_stmt.b" uuid="f123d778-8610-4b3d-b588-6321d726c7b6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a3028a12-8404-43b4-a08b-9f7f23038fd1">
+      <statement statement-id="ac-17_stmt.b" uuid="66024b1b-269f-49d4-a238-a1bc5b390733">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="833ec1af-cf7a-477d-a49a-54545a6a6f0e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b9dc13c7-4a80-4cf6-917c-0760d6e3b8bc" control-id="ac-17.1">
+    <implemented-requirement uuid="2c168041-4ca0-48cd-9b1d-43827a6bfb6b" control-id="ac-17.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.1_stmt" uuid="f0d4d14c-1409-407c-8980-6cffc14d43d1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8bebd734-f263-455b-bd9d-32921f70cdf2">
+      <statement statement-id="ac-17.1_stmt" uuid="779cdd50-e242-4ef3-8fca-6512a0d0b012">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70e205b6-1bc3-463b-bc62-fe2f320ba8ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1165,10 +1165,10 @@ https://projects.engineering.redhat.com/browse/RHV-20373
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8874b661-85e5-4c8b-a9cf-1502979306d3" control-id="ac-17.2">
+    <implemented-requirement uuid="4ca77273-9117-40b2-983a-4dd5040356ce" control-id="ac-17.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.2_stmt" uuid="ba00cab1-571b-42cd-8556-86460fc52ba3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="95ec4d28-7efa-401e-937d-f15a1233092c">
+      <statement statement-id="ac-17.2_stmt" uuid="1ce07c9f-0df5-4991-b8fb-98fbac3b4bf4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dce36b4a-1920-441f-80d1-3e68abe7fff2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1178,10 +1178,10 @@ https://projects.engineering.redhat.com/browse/RHV-20374
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6084c3bb-236a-4d80-805b-f08aeffa18e7" control-id="ac-17.3">
+    <implemented-requirement uuid="bc44a17a-d305-40bd-aa49-f123590cef90" control-id="ac-17.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.3_stmt" uuid="b9aa61f6-7727-41d0-ade3-16c716f9b89d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="45c8f192-03b5-4a62-ba70-04e64a50c877">
+      <statement statement-id="ac-17.3_stmt" uuid="42eb896e-2e27-499e-a0f0-578bb7b8ce33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d263384-2276-4a13-9725-cc474255f41e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for requiring remote access
 connections to the customer application to be routed through
@@ -1198,10 +1198,10 @@ https://projects.engineering.redhat.com/browse/RHV-20375
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc5a9ed3-e836-402d-bf2f-a4e87d75b62e" control-id="ac-17.4">
+    <implemented-requirement uuid="601d7507-7916-4d74-9366-bce72369763c" control-id="ac-17.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ac-17.4_stmt.a" uuid="7f6ce833-7dab-4df7-8d89-00223fea42f1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1048f68a-b15b-4588-afed-afbf17660d42">
+      <statement statement-id="ac-17.4_stmt.a" uuid="e376c343-772b-42ff-9c33-17681b5bc45e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1210,8 +1210,8 @@ https://projects.engineering.redhat.com/browse/RHV-20376
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-17.4_stmt.b" uuid="95221832-a4dc-42e1-a276-70841e3e83c6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="757053bb-2f82-46ce-aad1-00513472e898">
+      <statement statement-id="ac-17.4_stmt.b" uuid="4b4c9a85-6a8b-44e1-adca-dd63c6562b7b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ad6fa91-9398-4901-b397-74aa5965622d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -1221,10 +1221,10 @@ https://projects.engineering.redhat.com/browse/RHV-20376
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7bfa1794-f68b-4873-979f-d65196e17a24" control-id="ac-17.9">
+    <implemented-requirement uuid="66dd437d-56d7-4764-8ece-c0b14f740b76" control-id="ac-17.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ac-17.9_stmt" uuid="58c1dc86-7f30-4bfa-9c1a-a5c42d9ca0ef">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dd792436-21e3-4173-ac2b-fca9d604e0b4">
+      <statement statement-id="ac-17.9_stmt" uuid="2d36a737-6c55-4cb7-9857-d4a7f80f0721">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc46be39-19af-49c0-9d51-fc3c706dadc2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) utilizes the firewall technology named firewalld
 that allows a system administrator to configure host-based rules which take effect
@@ -1239,18 +1239,18 @@ https://projects.engineering.redhat.com/browse/RHV-20377
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="41e26985-cae3-46bb-9e95-7c2c879ac8cb" control-id="ac-18">
+    <implemented-requirement uuid="c1873412-3837-49db-b8ae-069923f0727b" control-id="ac-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18_stmt.a" uuid="c6f66df8-47a7-48cc-bcfc-ed7001d3100a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ac767e07-13bc-437d-9834-d13788814f32">
+      <statement statement-id="ac-18_stmt.a" uuid="f1d58d58-5159-4102-8696-b8a0440484f7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fb3356fa-980e-40d8-8f64-dfca6267031b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the establishment of wireless
 access usage restrictions are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-18_stmt.b" uuid="b5dc95b4-503b-4cbd-8645-173d977780ad">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4ab0c419-4e69-43f7-8dfb-3231bc75d540">
+      <statement statement-id="ac-18_stmt.b" uuid="39a8576c-b896-4866-b189-21aa6b8d48e0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="597ce99d-7e33-42d0-b1ee-44a03b15cb19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding wireless access to the information
 system are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1258,10 +1258,10 @@ system are outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="82f30319-932b-4df8-bce4-04d80fcbb125" control-id="ac-18.1">
+    <implemented-requirement uuid="738b24a2-ebe0-4d52-8c93-1b0dbf2d5561" control-id="ac-18.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-18.1_stmt" uuid="28289b46-e993-4636-b3af-eb7e8d30d326">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d975ff7b-4552-4b01-9f38-1a777c2d5e5c">
+      <statement statement-id="ac-18.1_stmt" uuid="04f38577-1377-4db0-aab9-a097ee829f7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0080bfe5-159f-4980-bb1b-225d86076927">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Configuration of wireless networking is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration.
@@ -1269,18 +1269,18 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="483595b6-4a72-405c-bd04-c26f9feab820" control-id="ac-19">
+    <implemented-requirement uuid="fb790932-cf12-4fb9-8968-1871d9a4b396" control-id="ac-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19_stmt.a" uuid="6cf9cb95-978b-477c-9657-239196794f66">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2b50635e-518f-4502-a110-6261f42e15b7">
+      <statement statement-id="ac-19_stmt.a" uuid="241910b9-cef8-43e3-8c5f-85fabe70defa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0d8234d-bb8b-41c8-92ac-7e8d4691ba62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational usage restrictions for mobile devices is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-19_stmt.b" uuid="36b5f319-f5c2-4bfb-a97c-c4427e8ad52e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6f125613-6f2e-4ff0-8605-c4f6fd3c6b05">
+      <statement statement-id="ac-19_stmt.b" uuid="a46fae67-24c3-4f6e-991d-1486d06e1a7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8863c77c-6449-4252-b60d-21f8c96bcbdb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Authorization of mobile devices is outside the scope of Red Hat Virtualization Manager (RHVM)
 configuration.
@@ -1288,10 +1288,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="803fc867-844d-44d5-a421-1e539e418f22" control-id="ac-19.5">
+    <implemented-requirement uuid="d8a39712-92a1-4fca-a7f6-c5e85de27fd2" control-id="ac-19.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-19.5_stmt" uuid="e085059d-0f0f-44af-8407-7f7445d64b1e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3b14e182-4657-4f7c-ab20-0dbfafe90d97">
+      <statement statement-id="ac-19.5_stmt" uuid="7f224c08-cf70-48f0-b76a-d566b556b8fe">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6b2365f1-eede-41d3-8949-26df982ee48b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Encryption strategies for mobile devices is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1299,10 +1299,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="11415836-2f79-48f3-9841-808f12cd301d" control-id="ac-20">
+    <implemented-requirement uuid="c34ea5da-47da-42b6-85b5-fca636c9b75a" control-id="ac-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20_stmt.a" uuid="9e2dc344-685b-487e-bfc6-0098cabb1348">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d0542c95-6f6a-4bb3-a49c-e6c12d127922">
+      <statement statement-id="ac-20_stmt.a" uuid="6d0c7514-1991-476c-bc2c-3d8611a9e19e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f2fc23a-e940-43ab-b1b6-1fcb8f008b05">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for accessing the information system from external information
@@ -1310,8 +1310,8 @@ systems is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20_stmt.b" uuid="3d8bc545-d040-4308-8c09-4f209537e5e1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="52e9fce9-ed8c-4670-a981-3795f505aac7">
+      <statement statement-id="ac-20_stmt.b" uuid="a46036f8-a251-41dc-b2a3-bf7906b3dd39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="52b4bf9b-c190-45df-8e19-d02c1fb0f8d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes for establishing terms and conditions
 for the processing, storage, or transmission of organization-controlled
@@ -1321,18 +1321,18 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="826495cc-db41-4460-8da0-adbca59ce094" control-id="ac-20.1">
+    <implemented-requirement uuid="d320e0a4-eb93-450a-848f-89cc28a05301" control-id="ac-20.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.1_stmt.a" uuid="962f0a3e-ce23-4369-a517-638b50bcb581">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8b4017b8-a766-43b5-a0c3-3fcd41c00757">
+      <statement statement-id="ac-20.1_stmt.a" uuid="8346f2b2-b1d4-4afe-ad6f-68cf1272fe66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81b4bb58-9128-41b5-800e-6457785f93ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Verification of security control implementation on external systems
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-20.1_stmt.b" uuid="7bfa7994-c20f-4c28-bb08-d069767cc987">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dbc55b05-68c5-4bdc-957e-c8ba6516c955">
+      <statement statement-id="ac-20.1_stmt.b" uuid="cb91fee2-6858-431b-af3e-b8c41b1d90e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a776194-2066-4f00-bd4b-a0e4ecdc8aae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Retention of approved information system connection or processing
 agreements with organizational entities hosting the external
@@ -1341,10 +1341,10 @@ information system is outside the scope of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8275f337-026b-4e7e-a0fd-77ece1a4da05" control-id="ac-20.2">
+    <implemented-requirement uuid="0931dbac-0a01-4f99-ae5e-23f499876459" control-id="ac-20.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-20.2_stmt" uuid="4c6190d9-5bb9-4b87-8980-b760d0455bd4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7e96bdad-06fc-4d97-9e88-7bcc93c215f7">
+      <statement statement-id="ac-20.2_stmt" uuid="6ea83c05-9fef-40c1-8340-eee8c04b4874">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ffbfa92c-648c-48d4-8d9b-2c6197aefe51">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the restriction or
 prohibiting of the use of organization-controlled portable
@@ -1354,18 +1354,18 @@ systems is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c1e01e23-6cbe-4ec2-9a09-88c29cc606a6" control-id="ac-21">
+    <implemented-requirement uuid="cc0dd4e9-d0cb-4ce6-97a8-d7dd7f340645" control-id="ac-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-21_stmt.a" uuid="8d93def7-053b-43d1-a5d0-20d9bbd75632">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5cccbab3-870d-4547-b4eb-e13a3032f1ae">
+      <statement statement-id="ac-21_stmt.a" uuid="fac6665a-63cb-4d7f-a4cd-60826603a24a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="abb1d154-fdff-4675-a2c3-67358bdba6a2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Facilitation of information sharing is outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-21_stmt.b" uuid="613aedca-9994-455a-9548-c75d29848719">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1c9b9411-36e1-44da-b2ed-73e44cb53475">
+      <statement statement-id="ac-21_stmt.b" uuid="559726f2-d3f1-4290-97a3-b6fc25d03563">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89973b8e-f1c4-4db4-96f9-56b06603f5a7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of technology or processes to assist users in making
 information sharing/collaboration decisions is outside
@@ -1374,10 +1374,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="265b17cf-1d47-40fe-807b-c055423c77fd" control-id="ac-22">
+    <implemented-requirement uuid="ca09818d-ee7b-4091-a831-6da3befbd076" control-id="ac-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ac-22_stmt.a" uuid="9a4fc51b-d902-4bf8-8a3c-a884c60cbf30">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="272403c7-4132-4fc3-93ee-8726297b9cb7">
+      <statement statement-id="ac-22_stmt.a" uuid="2ac78e26-4472-42d3-a251-887f1d03237b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44a457bb-3906-4ed6-b02a-cc696670129e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes regarding the designation of individuals
 authorized to post information onto a publicly accessible information
@@ -1385,8 +1385,8 @@ system is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.b" uuid="665ad023-3ca1-4ff5-9700-e8fe127bf7df">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1d32e28e-c899-431a-90e7-c0aaca1cd64b">
+      <statement statement-id="ac-22_stmt.b" uuid="8b2c06aa-d7a5-44c7-860f-ea27cc42545f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66d29cdd-993b-47d6-8f28-b8716cc70fa4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Training authorized individuals to ensure that publicly accessible
 information does not contain nonpublic information is outside the
@@ -1394,8 +1394,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.c" uuid="6b626e17-f4c0-48ea-8cd4-aa4609927a5f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0358209c-fe9f-4c23-a805-82133fa34b95">
+      <statement statement-id="ac-22_stmt.c" uuid="07007492-71f3-436f-a4f3-5933c095645a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a0e4b22-0898-44e2-8097-fedc799a5436">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the proposed content of information prior to posting onto
 the publicly accessible information system to ensure that nonpublic
@@ -1404,8 +1404,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ac-22_stmt.d" uuid="c0f3e5de-e120-4402-9e9a-aa535620bb79">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a1f55663-6926-431a-8423-bef96fca96d4">
+      <statement statement-id="ac-22_stmt.d" uuid="eefd0fea-5edd-4f8f-9873-d094ad7bdae9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d4539a35-9259-4cbe-86ca-a4c2cece9e62">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing content on the publicly accessible information system
 for nonpublic information at an organization-defined frequency and
@@ -1415,18 +1415,18 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="01ee2a7c-9e50-4f4e-9503-2dd361a3940f" control-id="at-1">
+    <implemented-requirement uuid="a5f7c261-b143-4932-bafe-56a203d2974f" control-id="at-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-1_stmt.a" uuid="f6121221-ecc6-44ac-b4fb-377eca0efb97">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fc534cee-cede-4649-9d3d-6716c1140465">
+      <statement statement-id="at-1_stmt.a" uuid="4fb55f92-8f7a-4b68-9edf-48625ce3a62a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-1_stmt.b" uuid="dc2b8caa-2012-4f5a-9b6c-4de271390584">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c218f5b2-4faa-409a-a396-fe3681809d7e">
+      <statement statement-id="at-1_stmt.b" uuid="faf43c77-46a3-41ed-8d55-a238c5c3c300">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1434,26 +1434,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb495377-b6d3-4124-b2d0-edfeb4f90e7a" control-id="at-2">
+    <implemented-requirement uuid="187bbf86-112c-43bb-a6b1-0370ac67b459" control-id="at-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2_stmt.a" uuid="b6d95a9f-00b9-45dc-9598-305b9faf67df">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="959633ea-f1d6-41a8-a301-d5ac28c3bc05">
+      <statement statement-id="at-2_stmt.a" uuid="11e87d5e-a558-4352-8418-864f48a3fa5a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.b" uuid="d20099b0-58e6-4f4d-8aa1-496772b80d3c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fdc9f4a7-05dd-4421-be5f-e1f191143446">
+      <statement statement-id="at-2_stmt.b" uuid="6b809c4b-ae3b-448a-b599-1cc724f41ce5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-2_stmt.c" uuid="bbe0bef4-e2ef-44dd-820b-80855e14fd3d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6bc64544-6aa9-474d-a0bc-364e3ff5e97d">
+      <statement statement-id="at-2_stmt.c" uuid="326f3d80-8c5a-4a2a-ab26-8a3a290f2d01">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1461,10 +1461,10 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5333d4c7-7332-4657-9d70-018f5517ab4a" control-id="at-2.2">
+    <implemented-requirement uuid="85423d56-ffaa-47b7-91de-4b3716fdc1e9" control-id="at-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-2.2_stmt" uuid="efe1636b-ef7d-40f7-b0ef-f3fbda1680fd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1cee3580-2f31-41d4-8676-2bc3b0872bff">
+      <statement statement-id="at-2.2_stmt" uuid="df48593e-8383-492b-bf47-79f3bf4bc514">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1472,26 +1472,26 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f155f074-cdb9-48d5-ae4e-9e52b2144b32" control-id="at-3">
+    <implemented-requirement uuid="6b128074-d806-4839-b3ec-d1afd70507f0" control-id="at-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-3_stmt.a" uuid="81bce96b-69e4-4446-9a0a-69a663084faa">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="573716e6-c36a-49f0-b67a-8553309e7e93">
+      <statement statement-id="at-3_stmt.a" uuid="9fd8bcd9-0953-4643-8659-30a875b9bf4e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.b" uuid="b4124800-1faa-4677-8f0f-3e7dce4966cb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ee6f56cf-459f-4950-9d1d-441c9429f5b3">
+      <statement statement-id="at-3_stmt.b" uuid="c069e62b-112d-4576-aa88-f8728db3cd66">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-3_stmt.c" uuid="4805ed1a-e6ef-4550-944f-0a979bf5c53c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8f89ad01-6953-4593-a815-7dff66df916c">
+      <statement statement-id="at-3_stmt.c" uuid="e21d0bf9-7aac-4595-be92-736aeec4ec3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1499,18 +1499,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e940c192-a7fa-45e0-b216-052531d0e0f1" control-id="at-4">
+    <implemented-requirement uuid="2ff212e3-ac02-4eba-8546-8fa25721828c" control-id="at-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="at-4_stmt.a" uuid="97c2dfb4-d43e-4099-bce7-5ed7a97931f9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="31406b6e-2d95-4b8f-8d1b-85f730dc1af3">
+      <statement statement-id="at-4_stmt.a" uuid="07d09c72-058c-4b7e-be8b-044b9a8f8236">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="at-4_stmt.b" uuid="77dc30c2-de39-413e-9036-55dbe7fa8fb8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cae84855-cd40-4ce5-abb0-8fc0332bf118">
+      <statement statement-id="at-4_stmt.b" uuid="2ffa39fb-db05-43b4-83ff-65762cef8c30">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fec21d0a-8f0b-4ec3-935b-62a5310fc014">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.
@@ -1518,18 +1518,18 @@ applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a02da4c8-9d89-46e5-97e1-e4d799954c2b" control-id="au-1">
+    <implemented-requirement uuid="e9cabea3-f6c5-4b2d-9b6e-608ecb5a2d60" control-id="au-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-1_stmt.a" uuid="f0a87bd4-0035-4447-b428-b510d99d09b7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d6039774-9495-451c-803d-9b1acb4ffc7e">
+      <statement statement-id="au-1_stmt.a" uuid="b4704272-5e35-4d61-a3e7-4c41b2c3e331">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecad1585-1c8a-4c21-b344-710da9629818">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level audit and accountability
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-1_stmt.b" uuid="082f5b8a-c0af-4713-88ad-20335fdc8a7f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4957a1e8-9966-47dc-a616-06ec5d9dc1b9">
+      <statement statement-id="au-1_stmt.b" uuid="b5bab3ed-bf6d-401d-b248-9cf9f4385e53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b81de348-a2de-48f2-95d5-0e9c52b81473">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level audit and
 accountability policy is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -1538,10 +1538,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2a0f6cdd-6e1c-4761-8c74-79d1a4a2929e" control-id="au-2">
+    <implemented-requirement uuid="f37536df-2d1d-45bc-9bc5-955338dd25ae" control-id="au-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="au-2_stmt.a" uuid="11071875-90fb-4a9e-9ab5-5e49428170f7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b0324f7f-16a9-4cf9-a1cd-5ccb18a3885c">
+      <statement statement-id="au-2_stmt.a" uuid="a9a07f46-29b2-4398-b64d-3f2baa5a4866">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="90dfd323-b412-4ed5-b8ce-f8a55d91887b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The selection of organization-defined auditable events is not applicable
 to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1573,8 +1573,8 @@ suggested to be audited:
     - System Reboot, Restart &amp; Shutdown (Success/Failure)</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.b" uuid="9bbbca6d-2416-4b50-aef9-3c716ed3af54">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="eef231f5-067a-433d-9865-542660498219">
+      <statement statement-id="au-2_stmt.b" uuid="6ddc33b4-cc7e-4bd2-9457-d7d9fb9004d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="67377e19-ce57-493f-afbb-94b5aeef99cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating the security audit function with other
 organizational entities is outside the scope of
@@ -1582,8 +1582,8 @@ system configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.c" uuid="b2ddccbe-ed50-481e-af2b-945c0b18ba67">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4e2bce56-a3d2-4b31-b6f2-805541d99d65">
+      <statement statement-id="au-2_stmt.c" uuid="42087765-e3cd-4949-9dd3-81ec7c375538">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f152a6a4-2281-40a1-b8a3-36d556dd583e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>For rationale regarding why the auditable events are deemed to be
 adequate to support after-the-fact investigations of security incidents,
@@ -1592,8 +1592,8 @@ https://www.commoncriteriaportal.org/ccra/members/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-2_stmt.d" uuid="f9feef3f-ace8-4ef0-b643-8edb1dfd49fd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a1813a4b-5f3a-4ed5-bbfc-d97549021b0a">
+      <statement statement-id="au-2_stmt.d" uuid="7bf74b46-610c-4b46-a4e3-e529faf01f73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1f82f79d-8cc9-45e8-b46b-fd38eeaee845">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The frequency (or situation requiring) the audit of events identified
 in AU-2(a) is not applicable to the configuration of Red Hat
@@ -1605,10 +1605,10 @@ failure, in realtime, of events identified in AU-2(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0e3c4e3-9641-40ab-89ed-90ee68b0ea13" control-id="au-2.3">
+    <implemented-requirement uuid="66779f5a-6540-4359-b6bd-2177bc68b5a2" control-id="au-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-2.3_stmt" uuid="eec84c10-e98d-49b6-8bf9-92521a6fb86d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="67039f78-b934-42f3-bab7-110e6bd9c5b2">
+      <statement statement-id="au-2.3_stmt" uuid="a5296cf2-5ea8-4b11-9cb8-425f430601a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="772c7da5-2040-4c26-ae48-d5d0f25dcc6e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the audited events are
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1616,10 +1616,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="de65a1e9-5fa4-4ae8-9faa-7c2d6c6da475" control-id="au-3">
+    <implemented-requirement uuid="613f15a9-4b0a-4484-9d9c-35c37b801eb3" control-id="au-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-3_stmt" uuid="b338c69a-f802-41eb-b39c-98ae3254c41f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1b5ad56b-5be5-4395-a2b1-dfbe54ce97bf">
+      <statement statement-id="au-3_stmt" uuid="abff9881-4373-417c-88b8-9b9dccc3b074">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cce2d9ba-344e-4481-9e1b-e2d83e094b5c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) audit records contain
 the required information and cannot be configured to be out of
@@ -1627,10 +1627,10 @@ compliance with this control.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="334777df-7b28-4f76-87ba-287897c4b8b0" control-id="au-3.1">
+    <implemented-requirement uuid="be77b6c8-342f-4bc5-b488-a40884a0f1eb" control-id="au-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-3.1_stmt" uuid="5adeacb1-708e-47d8-a9d3-fb9cc47f5783">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3b944db7-518f-4ffb-98cd-f1417c10ac63">
+      <statement statement-id="au-3.1_stmt" uuid="f04ec7dd-9f1c-45e1-a32a-eb05a6a66d48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1639,10 +1639,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6cd07a7a-bbe6-4604-b067-63423585cc59" control-id="au-4">
+    <implemented-requirement uuid="39393e8e-594f-4b89-a537-2ae2a1e9d91a" control-id="au-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-4_stmt" uuid="6aea9c0c-a278-4bd1-9c34-398e199c99f6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0c6f51bf-efa5-4061-8393-b402913d7274">
+      <statement statement-id="au-4_stmt" uuid="b07f6205-70fb-49a9-a294-8bade5380856">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="81e77ff7-df26-4510-8970-b1c17d5b162f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1650,10 +1650,10 @@ https://projects.engineering.redhat.com/browse/RHV-20419</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f962ceb9-f51a-4ce8-9405-ff5e8d35cff4" control-id="au-5">
+    <implemented-requirement uuid="1fd1013d-f125-4909-bccf-7bded096a777" control-id="au-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-5_stmt.a" uuid="37b8c3a4-70a1-45bb-8fe5-69721aeddaa3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="48ac0f19-8abf-469a-94f8-dcae8414bd2b">
+      <statement statement-id="au-5_stmt.a" uuid="83fc2b72-61d9-45d1-8298-785e86ee8682">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="832e3598-de52-4a8a-bbb6-d63bea0bb903">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem was designed to uniquely identify multiple causes
 of audit processing failures. Configuring the audit subsystem to alert,
@@ -1664,8 +1664,8 @@ A control response is planned. Engineering progress can be tracked via:
 https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-5_stmt.b" uuid="c0826153-bf86-43ac-ba20-825befa09672">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e504a768-0844-49b6-80a9-669ceb84260e">
+      <statement statement-id="au-5_stmt.b" uuid="cab92b87-4307-4c56-8c92-3babc223a754">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d394fda-b268-4b77-b11d-8a9b88b52eba">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1673,10 +1673,10 @@ https://projects.engineering.redhat.com/browse/RHV-20421</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9d8ae030-63be-43b2-945f-1cbe9c178c8f" control-id="au-6">
+    <implemented-requirement uuid="51fe15b0-044c-4985-afb6-baad7f178a5c" control-id="au-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6_stmt.a" uuid="fc34df34-1a57-4d33-a90e-16a69a671583">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="62c89209-48d2-45e4-a283-793bd6add2c5">
+      <statement statement-id="au-6_stmt.a" uuid="7b1dcbde-95d0-42b1-b013-a780f0e83bf7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b8acf550-693e-4f5b-b155-0273ae0eb7a3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and analysis of information system
 audit records for indications of organization-defined
@@ -1685,8 +1685,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-6_stmt.b" uuid="ddea4cac-e14b-4c0d-b3d0-2fee3bd76305">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1a05d1f7-c250-48e7-9f3c-f1c423a914e1">
+      <statement statement-id="au-6_stmt.b" uuid="e7b9cdd6-1b82-4291-9758-47f8dc6fa43f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e1c7703-df09-4498-8d8c-89b24eead496">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reporting findings of organization-defined inappropriate or
 unusual activity to organization-defined personnel or roles is
@@ -1695,10 +1695,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ccf3502-bd1a-45ac-9bab-1b3bcff0a3c9" control-id="au-6.1">
+    <implemented-requirement uuid="5a24e207-00e7-42be-ba1e-74832d3813c8" control-id="au-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.1_stmt" uuid="9b76329b-a3cc-43b6-879d-d0fee2c572fd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d8919c5a-a5a8-4989-ab75-214d4314c853">
+      <statement statement-id="au-6.1_stmt" uuid="7e1c0b9d-8939-42ef-8cc1-dc58203888eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32e41f4c-71cc-4f96-abcf-1a199a4c0ae9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational use of automated mechanisms to integrate audit review,
 analysis, and reporting processes to support organizational processes for
@@ -1708,10 +1708,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5babbf41-b36f-4591-b89d-f464a5442b8b" control-id="au-6.3">
+    <implemented-requirement uuid="7540e26e-108b-4cfd-91d6-1335e152fd90" control-id="au-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-6.3_stmt" uuid="318261ae-15a1-4717-b13c-6e94b777a8d2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c5fa5850-724d-434e-985f-25d6b673d719">
+      <statement statement-id="au-6.3_stmt" uuid="62b889e6-f75d-4da3-bee0-415b87f3ef8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a57151a-70a0-4008-8a9f-1f2cb0d2fc90">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis and correlation of audit records across
 different repositories to gain organization-wide
@@ -1728,10 +1728,10 @@ system-wide correlation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b7e9fe2-6a52-405e-a2b9-a67189360109" control-id="au-7">
+    <implemented-requirement uuid="9d404010-fdda-4aaf-883b-c36e2876d5c8" control-id="au-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7_stmt.a" uuid="01d333d5-fa34-4f3b-8260-ced5bd034c72">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a2474791-e840-4abe-b6c6-8a625e3c8aa0">
+      <statement statement-id="au-7_stmt.a" uuid="32c2238f-fc50-4cf0-8789-85635ac69e09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1739,8 +1739,8 @@ https://projects.engineering.redhat.com/browse/RHV-20424
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-7_stmt.b" uuid="de7de7f0-b1c2-441e-ab0e-bf931bac7d80">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="31dc5f8b-e005-4c97-bcc6-39046667ac53">
+      <statement statement-id="au-7_stmt.b" uuid="460204fa-d554-49cc-8aee-1e7b603104a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab5257e-78fb-4a42-8220-ef7980f51174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1749,10 +1749,10 @@ https://projects.engineering.redhat.com/browse/RHV-20424
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="833be3b1-6e51-4f6c-8ac9-c35376be647f" control-id="au-7.1">
+    <implemented-requirement uuid="b714e1ac-5385-47db-b004-f4538318cbd4" control-id="au-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-7.1_stmt" uuid="cf7adbfc-c9e5-4113-94bf-f8e931d4dab1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="69bf24fd-fd22-4bb3-8c5d-4c1cc0699f20">
+      <statement statement-id="au-7.1_stmt" uuid="6b9632dd-07c3-406b-a28f-0dfdaf45a47b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34dc1b8b-6c3a-404f-aa23-7106d0a34670">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1761,18 +1761,18 @@ https://projects.engineering.redhat.com/browse/RHV-20425
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fedff25-9cde-49aa-abe9-4c3e2bacdaa4" control-id="au-8">
+    <implemented-requirement uuid="fa5cb008-2586-4f3f-868a-8e2e5dd385ad" control-id="au-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-8_stmt.a" uuid="ebe64a8f-3063-4364-8d34-e4449a6ff998">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f6512a86-0433-4588-ae7f-482f948b8baf">
+      <statement statement-id="au-8_stmt.a" uuid="4bbb394d-c64a-44d6-82a8-5efb6a4aeda8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6d82178f-b77d-491a-ba96-d6d94eee8ebd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default the audit subsystem utilizes the system clock and cannot be
 configured to be out of compliance with this control.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8_stmt.b" uuid="c4f6965c-007d-474e-be04-ddd93b05c97a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="23c801e0-d5a0-4a3f-ad32-5f4cb81dd204">
+      <statement statement-id="au-8_stmt.b" uuid="22e57f47-bd12-4ef3-b57c-7b2c466fd329">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="553db694-b15a-4ae3-8692-bbd5278ec2cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The audit subsystem is hard coded to only accept internationally recognized
 timezone settings. This ensures audit log timestamps can be mapped to
@@ -1786,18 +1786,18 @@ configuration is detailed in AU-8(1).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cd8da177-7aca-4f34-be1c-e61fd1e931b7" control-id="au-8.1">
+    <implemented-requirement uuid="0e971d45-90fa-43f7-8bab-c986504dc178" control-id="au-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-8.1_stmt.a" uuid="f57ed074-4c8a-41b8-be9b-86884d6930ab">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="84692577-4db8-4c71-8d1a-ea02d9a7b9ff">
+      <statement statement-id="au-8.1_stmt.a" uuid="2d7cdc2c-3501-4a42-a939-7d8ece4fe973">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bd61434-c1de-4925-96ff-0e211dceea2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
 https://projects.engineering.redhat.com/browse/RHV-</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-8.1_stmt.b" uuid="00ed8199-9834-4af5-aece-f934725ca696">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e0f90f22-a276-4aab-b837-c1857a2dbbd0">
+      <statement statement-id="au-8.1_stmt.b" uuid="3fd7490c-5aca-4e1a-89a6-51b03cc5e487">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b245e2b0-b1c2-48f0-902d-382bb162eb8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1806,10 +1806,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c6b28b78-101e-46f3-985f-6a5e6ad60efa" control-id="au-9">
+    <implemented-requirement uuid="89bcf6ba-66d0-4a48-91b8-c67eee441ddb" control-id="au-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9_stmt" uuid="0dabba8d-af81-4102-924d-d796005f6547">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0ca0f4c7-2218-4381-9390-48d81c52b6c4">
+      <statement statement-id="au-9_stmt" uuid="b46b4b6d-f09a-456b-bf91-242c0686255e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0bd61434-c1de-4925-96ff-0e211dceea2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -1817,10 +1817,10 @@ https://projects.engineering.redhat.com/browse/RHV-</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3f57f3cb-58f9-411d-84a5-ca012c49d4de" control-id="au-9.2">
+    <implemented-requirement uuid="77852b60-b78c-4db8-8ce4-a0dcca222199" control-id="au-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="au-9.2_stmt" uuid="e5b3750a-7ded-4408-a36e-446ad88555b1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bcbebfb8-3311-4753-a87e-80d81c9d325a">
+      <statement statement-id="au-9.2_stmt" uuid="5fd279ce-ed77-4061-a510-ac5232ed1258">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bce79094-0534-4af1-b1a0-332c5f43b2be">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Backup of audit records onto a physically different system or
 system component than the component being audited is the
@@ -1831,10 +1831,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ccd1edb-a931-44a2-b3fb-830dede605c2" control-id="au-9.4">
+    <implemented-requirement uuid="a265c8f6-0497-4ffd-baa0-bd923d1b9308" control-id="au-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="au-9.4_stmt" uuid="9962b3d3-b25c-47d4-b69b-94e1722de2f0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="98534003-a715-4d7a-a50b-e51cecd5ba42">
+      <statement statement-id="au-9.4_stmt" uuid="9be4ed66-62d1-4775-aa28-bb2096f5649d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20adb15-f43b-4008-bf7e-2fc6ac84b3f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1844,10 +1844,10 @@ https://projects.engineering.redhat.com/browse/RHV-20506
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d5e660b0-426b-4f9b-93a5-9f31ee0b9efe" control-id="au-11">
+    <implemented-requirement uuid="edbeb994-318a-4120-b241-1bc4aded0391" control-id="au-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-11_stmt" uuid="7d2cba43-35bb-4ff4-8fa8-411d89977882">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5ff45df8-f838-456c-85f3-959106370e6c">
+      <statement statement-id="au-11_stmt" uuid="26eb54dc-8093-46aa-909c-020a5e1db4e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f08406ee-76f8-4183-b6e3-1607ae2ced7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -1864,10 +1864,10 @@ https://projects.engineering.redhat.com/browse/RHV-20509</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8a4c2afc-58ba-4858-8bfa-3ea1e8d930ed" control-id="au-12">
+    <implemented-requirement uuid="38d49d2a-f4d9-42d8-a3fa-b31d7132e244" control-id="au-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="au-12_stmt.a" uuid="006a427d-2330-46fa-bdda-e111d99f734d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1abc9d59-829a-49be-963e-0adc08d55e65">
+      <statement statement-id="au-12_stmt.a" uuid="225fa91c-7d1b-4e58-aae6-3e6281bd76d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1875,8 +1875,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.b" uuid="1294a302-40d4-485a-bf6d-f2e872660bfa">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5e304219-7fa7-44b9-9fa8-de5b63f9521a">
+      <statement statement-id="au-12_stmt.b" uuid="a6084a76-0615-4445-900b-1ecf686ac4cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1884,8 +1884,8 @@ via:
 https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="au-12_stmt.c" uuid="cb73c092-f312-45cb-90f6-0116fc499d4e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4ff89af7-10e0-41ec-808e-1d0a1537072b">
+      <statement statement-id="au-12_stmt.c" uuid="2d8026db-7a9c-4bc6-988e-3154a0654906">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f9aa938c-fb81-49d4-993d-19924ddac710">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked
 via:
@@ -1894,10 +1894,10 @@ https://projects.engineering.redhat.com/browse/RHV-20513</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a977887f-ce8f-49fc-bd51-f5366c6327fa" control-id="ca-1">
+    <implemented-requirement uuid="8cbbc6cf-9345-4f6e-b104-c8db9d8f9d89" control-id="ca-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-1_stmt.a" uuid="111d2d65-09e4-4de1-967c-9c0327e066e9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0097c411-5465-4848-94a5-a62ea5f226b1">
+      <statement statement-id="ca-1_stmt.a" uuid="a0253951-4a7e-4254-bb33-1b97d9a24513">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1905,8 +1905,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-1_stmt.b" uuid="b81a683e-2c13-4909-ba45-2f5b0e1c675d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="07e5040e-d15d-462e-80f1-0211287f5a9f">
+      <statement statement-id="ca-1_stmt.b" uuid="6469ba5f-5046-4d1d-85a9-677b23d18a19">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0b46cece-4f60-4968-b1fc-6d0e1ea4b3ea">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing organizational security assessment and
 authorization policy and procedures is outside
@@ -1915,34 +1915,34 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0b9d8a48-04e8-4fa5-803a-540b0da3b170" control-id="ca-2">
+    <implemented-requirement uuid="8c763ab6-9d10-4826-8b45-3effbdfbe4d9" control-id="ca-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2_stmt.a" uuid="0044f0e2-87f6-4195-9cb2-9ba503f37e8a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5c7a1878-746e-40e7-bb38-1fe55e9d7d4c">
+      <statement statement-id="ca-2_stmt.a" uuid="626ecdc7-b47b-4fb6-9459-bfd2fa8ffcaa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.b" uuid="b1364eb0-350c-4c0e-bfbc-fa27fd10ce9e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cf3366c4-33fc-49d0-8c6a-3e31ee9d1cc6">
+      <statement statement-id="ca-2_stmt.b" uuid="925f0019-139e-4452-a753-b210216ba834">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.c" uuid="1ca9663a-5dcf-474a-933b-b9793c7017f7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2285200c-808a-47dd-bd6c-1ec45b84b5c7">
+      <statement statement-id="ca-2_stmt.c" uuid="0f171c67-efaf-47b2-8078-b9903c8ae8b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-2_stmt.d" uuid="421f62ca-26d3-4257-85c7-c6e7717895bd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="65bae04e-bcf0-44c7-9b13-c9fd05c1dffc">
+      <statement statement-id="ca-2_stmt.d" uuid="8d798b0b-6546-480c-95ba-3fc01fe6c200">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b3f96dfa-981f-469d-800c-c9492abbe5e9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of an organizational security assessment plan
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1950,10 +1950,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c0cbb4e3-ac8f-42fe-8c71-aa5cbb5c98a7" control-id="ca-2.1">
+    <implemented-requirement uuid="76b67f0e-9f42-4293-8c48-b7a65c41c682" control-id="ca-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.1_stmt" uuid="732ac840-cb8a-4413-8781-ccc95a30d036">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f9b8b016-4289-4400-99de-a34ee2876095">
+      <statement statement-id="ca-2.1_stmt" uuid="09078d4c-092e-40cf-a917-e92667347b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="834a2feb-b1b6-4d62-a47e-0c3ae4349529">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent assessors or assessment teams
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1961,10 +1961,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration guid
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="25d04090-403f-4802-acc7-c39cd723b2c6" control-id="ca-2.2">
+    <implemented-requirement uuid="db49b140-100e-45e5-aba4-ad89745dfc1a" control-id="ca-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.2_stmt" uuid="b5d9046b-78e0-41a3-b373-78604aa17198">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f8c0d18c-38a9-49e8-abc4-66b0f668197d">
+      <statement statement-id="ca-2.2_stmt" uuid="26df812a-16fd-4b18-bed2-60483bbeaeca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c871d43-f32b-4649-8a62-b9d1d6ecf0b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Specialized security assessments are outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -1972,10 +1972,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87f974b0-3ad3-4b5f-b768-f180b2e4a8e7" control-id="ca-2.3">
+    <implemented-requirement uuid="a97a0ced-d7be-4471-b78e-c63ee591b721" control-id="ca-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-2.3_stmt" uuid="5f7df5bc-0b28-4401-a9e1-42eafea73d5f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a6a38c3f-721a-4b84-9966-95a01f0ee423">
+      <statement statement-id="ca-2.3_stmt" uuid="508e8310-ecaa-406d-a74f-852950564c4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eddf5da7-9406-451a-81f5-e133c3078bdd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational acceptance of the results of an assessment
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -1983,10 +1983,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="755393aa-bac4-46a6-b7ce-b6bed94472d3" control-id="ca-3">
+    <implemented-requirement uuid="f5960985-7eb0-49cf-9b7f-376a4d3d1ac0" control-id="ca-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3_stmt.a" uuid="ffe7410e-59f9-4f1b-97f5-aa561fcb3288">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="79b44904-7d92-454c-9428-957e2987c008">
+      <statement statement-id="ca-3_stmt.a" uuid="f93c7647-10cc-4268-84ca-8f629b37ac10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -1994,8 +1994,8 @@ guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.b" uuid="6932691a-ff6c-4314-be99-098d7134c646">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9253b6b6-6b98-4c21-88ed-3ec8c2ef73dc">
+      <statement statement-id="ca-3_stmt.b" uuid="568429c3-01ef-4b4a-9190-79d0d39b3583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a002fb44-9bc4-4d24-b1c6-19e9dd0048cd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -2013,8 +2013,8 @@ https://access.redhat.com/documentation/en-us/red_hat_virtualization/
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-3_stmt.c" uuid="c3f7b0d6-c3d6-4453-8013-d933383bf909">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cc6443b7-2083-4fcb-b4c3-852758bdd603">
+      <statement statement-id="ca-3_stmt.c" uuid="5cdab430-5333-47e5-a48c-27c3c6b8c64c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a7743fe5-bcb4-4756-9ec4-a273d37b5060">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational system interconnection
 agreements is outside the scope of Red Hat Virtualization Manager (RHVM) configuration
@@ -2023,10 +2023,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2fc79700-9ddd-4caf-a5a9-63e960adf53a" control-id="ca-3.3">
+    <implemented-requirement uuid="a15d4db1-5953-45de-b527-11993db07cc2" control-id="ca-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-3.3_stmt" uuid="3ef92590-8e85-4c18-b808-9757379d0736">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="53c721b8-457b-4a58-858f-7ced3602ef7d">
+      <statement statement-id="ca-3.3_stmt" uuid="4f45bb7b-51fe-4d1c-b827-8f5b87c18aaf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="974bb17d-4ccd-4c35-ad6b-706eb2ea17a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2034,10 +2034,10 @@ Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="59d0d874-7919-4922-af39-d8268334780c" control-id="ca-3.5">
+    <implemented-requirement uuid="4aeaec96-0a8f-4f73-87cc-c339578c7fa8" control-id="ca-3.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-3.5_stmt" uuid="fcf878bf-f253-45d6-9e11-cbcb727f27de">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="72a4b75a-5da5-4ca6-a0b2-fb8662758a57">
+      <statement statement-id="ca-3.5_stmt" uuid="a1e3cb3e-ce49-443f-aef9-b438272829d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2ff8ea56-f1e8-4fd9-92bf-ad0a693de964">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is applicable to Red Hat Virtualization Manager (RHVM) and applicable
 through host-level firewall rules.
@@ -2049,10 +2049,10 @@ https://projects.engineering.redhat.com/browse/RHV-20516
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3945dc10-a149-41ac-a20a-ecbcb5238c67" control-id="ca-5">
+    <implemented-requirement uuid="916a5a45-7e51-49b7-892e-440ba9d04f38" control-id="ca-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-5_stmt.a" uuid="7b695797-f2d8-4c80-9c3e-440973d99813">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d14bf6e4-3f1e-4a7e-ae30-6bb77900ef5a">
+      <statement statement-id="ca-5_stmt.a" uuid="42fea6ee-b53f-4c1f-aa5d-474ee3dddb6e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b7874121-b842-41ab-9612-07bb4b21d6b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Creating an information system-level Plan of Action
 and Milestones (POA&amp;M) is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -2060,8 +2060,8 @@ configuration processes.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-5_stmt.b" uuid="87b4510a-4ad7-4496-a521-2ed43d5571db">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e5810db9-6c74-4d4e-839d-0104fdf8b4c9">
+      <statement statement-id="ca-5_stmt.b" uuid="b4827a86-e5eb-4620-9e4b-919ef5614254">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8061e04f-b49b-4260-a7e4-1a24bb30d0ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes relating to updating and the maintenance
 of an information system-level Plan of Action and Milestones (POA&amp;M)
@@ -2070,26 +2070,26 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration proc
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e57f5589-ef45-47e0-a89a-df335e60e5e8" control-id="ca-6">
+    <implemented-requirement uuid="e77dc7d2-9b46-4183-8c94-e99507c06928" control-id="ca-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-6_stmt.a" uuid="0cec9d3c-5af9-40ad-aa85-d009fea573d2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="01902ce5-a996-4b5f-8323-bc7ac346d9ac">
+      <statement statement-id="ca-6_stmt.a" uuid="f60bab46-13ed-43e1-9850-62104b44dae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.b" uuid="efcced7e-2ece-420c-9faa-2b1b42e25d17">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="934bcf0a-6e76-44e9-9d3e-d46f4ad71b73">
+      <statement statement-id="ca-6_stmt.b" uuid="6575c90e-d09d-4ce5-84a5-9d899f39067a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-6_stmt.c" uuid="5d8eba4b-c16a-4133-a766-78028157ab51">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="40378bb1-ef72-4d59-b70b-521c126e744d">
+      <statement statement-id="ca-6_stmt.c" uuid="be0641aa-a2f1-43e0-add3-d3e0d11d710e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2097,10 +2097,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="846baae4-bd75-407c-bf0b-762fda4beed5" control-id="ca-7">
+    <implemented-requirement uuid="fb72bd48-03ef-478c-b1b7-be0403c1fa3a" control-id="ca-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-7_stmt.a" uuid="c55b98f2-901f-49dc-a3f0-e706c5e8188b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0adc0cf6-5dce-4a10-b074-2cfab0aed1de">
+      <statement statement-id="ca-7_stmt.a" uuid="5d5b85ea-2852-43e0-b2a8-8ee5d9bc7639">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2108,8 +2108,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.b" uuid="cd9dc39b-0a91-4171-9a2d-7617a25a8d35">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b433cc65-d32b-407f-be28-395a5dda5a82">
+      <statement statement-id="ca-7_stmt.b" uuid="915c1b94-a86e-4146-8aa9-3a0e75245c62">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2117,8 +2117,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.c" uuid="dd616bf9-5655-4b06-a78d-bd5b67aa6e5d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="46bd3f01-0c0c-48b3-8cab-afd7caaf9426">
+      <statement statement-id="ca-7_stmt.c" uuid="896fd0cb-0917-41c3-9f4d-e1093f19a495">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2126,8 +2126,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.d" uuid="031aa691-e1f2-4241-b1ca-e6a65d71319a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3f65a4a2-a8e3-4398-8b2c-1c01f93e9812">
+      <statement statement-id="ca-7_stmt.d" uuid="0f25a0ad-e73b-4ff4-bea7-d5fc07227a58">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2135,8 +2135,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.e" uuid="cb24aea6-10b3-4aaf-9531-db38ded7ffdf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="90c29373-bbc7-448c-99a7-6860a4c3b8e1">
+      <statement statement-id="ca-7_stmt.e" uuid="4d312bad-2457-4405-963f-f0804b5102d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2144,8 +2144,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.f" uuid="3a993ce0-15a4-45f9-bcc9-3dd514c11f7f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6287a8a2-0452-4002-b979-bfc8448e1c6f">
+      <statement statement-id="ca-7_stmt.f" uuid="bac4ec7e-f555-4460-baa6-fbc8266d2101">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2153,8 +2153,8 @@ https://projects.engineering.redhat.com/browse/RHV-20517
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-7_stmt.g" uuid="5427b6a4-0853-4507-a200-43ef96484bf8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f1b4bccb-8aff-4df6-9990-c22d4bb2593b">
+      <statement statement-id="ca-7_stmt.g" uuid="70fc1f04-9047-402d-a4d9-d99f75776661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b43dee45-9aca-4f1b-b7c5-1f48e1038544">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Engineering progress can be tracked at:
 
@@ -2163,10 +2163,10 @@ https://projects.engineering.redhat.com/browse/RHV-20517
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8c5832b7-c921-477c-8a14-7962d88ee2f4" control-id="ca-7.1">
+    <implemented-requirement uuid="e17499b0-5110-43e9-ba2e-f6d5079b846f" control-id="ca-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-7.1_stmt" uuid="570f79dc-f7bd-4bbf-b414-316a7d7f8f83">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5817c893-a069-470b-8917-6308615d0af4">
+      <statement statement-id="ca-7.1_stmt" uuid="bda2872a-093f-49d5-8fbb-3c3fad811419">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0281eacc-f30b-41e5-88f5-30515ef38569">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of assessors or assessment teams is outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2174,10 +2174,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7a68daa9-9814-4a7b-99e0-b2959b907a5c" control-id="ca-8">
+    <implemented-requirement uuid="6a1d4558-5f7e-47c1-a9ae-09fda4e1ee90" control-id="ca-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8_stmt" uuid="7c21e108-b787-4cb1-98f3-f00d3b6de1ff">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d4b7b9c3-13ee-49be-b375-c9a65c1befb7">
+      <statement statement-id="ca-8_stmt" uuid="58038235-64b4-4903-bd13-53886ee0c53b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d75cb0b4-d1be-496a-89ea-616e3cf323d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Penetration testing is outside the scope of
 Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2185,10 +2185,10 @@ Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="080072c9-4636-4352-b2c0-000ec931f06f" control-id="ca-8.1">
+    <implemented-requirement uuid="24b00d0a-dad5-47c8-932b-f2c24d341160" control-id="ca-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ca-8.1_stmt" uuid="f6bd18b8-c109-4a04-9b13-01d8edf95bfc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8324c948-d7a6-405e-9cb9-9e5da02c5976">
+      <statement statement-id="ca-8.1_stmt" uuid="50eb7175-9c37-4f43-b0dc-cbd36d0a5cb1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8e8a0ee7-e840-45ed-bf6d-fcebb96b502b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Employment of independent penetration testers
 is out of scope for Red Hat Virtualization Manager (RHVM) configuration
@@ -2197,10 +2197,10 @@ guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ad46653-8ddd-4c33-9e70-9544cf1e0de4" control-id="ca-9">
+    <implemented-requirement uuid="45ea858f-bfa7-4ae7-8719-983784957410" control-id="ca-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ca-9_stmt.a" uuid="053ac8be-988d-4141-8b15-acf5361762b8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b4c6dbe8-5e3a-46a0-bc46-2eeefe7133e5">
+      <statement statement-id="ca-9_stmt.a" uuid="631e344c-a84b-4f5e-94a3-07f5e67a31c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0a3ee2b7-20d7-4ad2-ae09-7b3f216bc65b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -2218,8 +2218,8 @@ Engineering progress can be tracked at:
 https://projects.engineering.redhat.com/browse/RHV-20518</p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ca-9_stmt.b" uuid="915358e5-1c98-4ab4-8de3-56fbea388a7a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9c3e7f6f-bd4d-4782-8d6b-788f755272a6">
+      <statement statement-id="ca-9_stmt.b" uuid="a8a307a1-8a60-4450-8dc6-f1ddfae3fda2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7fc22de-738a-495d-b232-35a18545f791">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) requires
 a number of ports to be opened to allow network traffic through
@@ -2239,18 +2239,18 @@ https://projects.engineering.redhat.com/browse/RHV-20518
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="626ac8d3-7cdb-4fc6-9a52-ae2f1187a9d8" control-id="cm-1">
+    <implemented-requirement uuid="1c8b54fb-4325-41c9-a1ca-37c68f28d3fd" control-id="cm-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-1_stmt.a" uuid="4cffe9d8-992b-4e04-ac49-0d546c711631">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f602c2ba-de00-42d8-87d0-c87607869f6a">
+      <statement statement-id="cm-1_stmt.a" uuid="174b8ba1-a971-465b-8641-9e998f2439c0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102ce2d9-1875-4b4b-9293-c9f1a3980e18">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing, documenting, and disseminating an organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-1_stmt.b" uuid="9043f923-6a29-4d96-a1f5-cf17937f7505">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b15c9a9b-867e-4023-ae1d-d4e5bdb7bb2d">
+      <statement statement-id="cm-1_stmt.b" uuid="928f676b-41ef-425d-be9e-5bd02f0ef36a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="60c97a59-a5bf-4503-800b-e4e898136392">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and update procedures to the organizational configuration
 management policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2258,10 +2258,10 @@ management policy is outside the scope of Red Hat Virtualization Manager (RHVM) 
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f6ef08e-e148-4e00-adea-f1119e0c68a2" control-id="cm-2">
+    <implemented-requirement uuid="a2836a68-44b1-4fd9-977c-c7e7f7860e76" control-id="cm-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2_stmt" uuid="dd3d34d5-30eb-4383-81cf-73717429df66">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a889b111-9523-47f6-a729-b3a9a6801b4e">
+      <statement statement-id="cm-2_stmt" uuid="f8591c5e-e129-4243-9e44-6cac9921b05b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4e4c8613-d4e2-4be1-8ff1-6182ad21c2a5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2271,10 +2271,10 @@ https://projects.engineering.redhat.com/browse/RHV-20519
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2775f384-5e70-445c-bbc1-7ac965d20853" control-id="cm-2.1">
+    <implemented-requirement uuid="1175aab2-b8fe-4b48-a82a-54c02ce8b030" control-id="cm-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.1_stmt.a" uuid="89b2dfcc-ef2a-4fb7-915b-65f87b438813">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="78f63c12-a3bd-45e2-8344-fe048cba36ad">
+      <statement statement-id="cm-2.1_stmt.a" uuid="c70cb871-7647-4a19-9e18-25d13e0c8134">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2283,8 +2283,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.b" uuid="1d21aba7-6f52-401c-8b62-7fc202a84edf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="870f8c56-033c-45c7-9093-389fe96cd141">
+      <statement statement-id="cm-2.1_stmt.b" uuid="02f6ac89-58fc-4803-9ca7-d8ba052bdb7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2293,8 +2293,8 @@ https://projects.engineering.redhat.com/browse/RHV-20520
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.1_stmt.c" uuid="e6935ef1-b8e6-4d12-b52c-7412d45bb70e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="92f22b9e-218b-4de7-a8ee-6fee0a5b80a2">
+      <statement statement-id="cm-2.1_stmt.c" uuid="5c60f968-1ec3-4d42-a3d5-6506b6229de3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0aeb445-fc96-4445-a900-8570102ecc29">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2304,10 +2304,10 @@ https://projects.engineering.redhat.com/browse/RHV-20520
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d86286b5-5da1-4a0d-9406-0f0ff6bda889" control-id="cm-2.2">
+    <implemented-requirement uuid="70c0fb30-fa81-406d-9884-90eda4617fae" control-id="cm-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.2_stmt" uuid="090a1c0b-89b8-4538-a6ec-58d969cf132d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1decaa46-008c-403b-b453-32a8bc8dad13">
+      <statement statement-id="cm-2.2_stmt" uuid="ad22cfd3-c298-49b0-abc1-f14139cb228d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4c82280c-9d27-4e3c-bfcd-2cf177e34ba4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2317,10 +2317,10 @@ https://projects.engineering.redhat.com/browse/RHV-20521
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0bf931eb-c55b-413e-accd-be2bd033f8ce" control-id="cm-2.3">
+    <implemented-requirement uuid="25e98aef-d677-4c77-9d54-2973e72f1750" control-id="cm-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-2.3_stmt" uuid="ae38adec-3dcf-45c9-9453-a9c6cab5a257">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3782953f-1e6e-4f90-ba83-7a838fc1313b">
+      <statement statement-id="cm-2.3_stmt" uuid="9120376e-fb5f-4f88-84f4-5bd32d647c33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d33969d0-128b-432f-b439-dc4f470e4466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2330,10 +2330,10 @@ https://projects.engineering.redhat.com/browse/RHV-20522
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="57cde64f-2f57-418e-99dc-ff5ca8a45ac9" control-id="cm-2.7">
+    <implemented-requirement uuid="5af15dba-e95f-4efd-8fff-6c9f14020489" control-id="cm-2.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-2.7_stmt.a" uuid="f8f79a34-1d2b-45fd-a2ab-a41b45f0409b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c334a7d5-838e-46a5-bff2-28385badfb55">
+      <statement statement-id="cm-2.7_stmt.a" uuid="35f3ac0a-3c3a-42ec-8a4f-546ed6c4496b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="46038ae2-5727-4c4b-b676-e473645059c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational issuance of organization-defined information
 systems, system components, or devices with organizational-defined
@@ -2343,8 +2343,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-2.7_stmt.b" uuid="d258b306-516f-43db-87f5-f29b0d1cacf9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cf5b3aa2-38ec-4599-b3be-7d07f8274946">
+      <statement statement-id="cm-2.7_stmt.b" uuid="b31ccc86-2005-402d-a5b4-58e1572a3f3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0596ea37-1b58-4d6b-bc15-aa3d156641d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to apply organization-defined security
 safeguards to the devices when the individuals return is
@@ -2353,10 +2353,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="eb6abf31-8302-4f19-bdb1-02d757df52ad" control-id="cm-3">
+    <implemented-requirement uuid="22352fe7-ba54-4934-8dd4-9e42cd2b5021" control-id="cm-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-3_stmt.a" uuid="0d59ca11-179f-46bb-8733-3e5195bad9e7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="72461a63-2518-4761-8f80-f7aa4103612a">
+      <statement statement-id="cm-3_stmt.a" uuid="42365f59-42dc-47f7-8da3-2d45e8a13a76">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2365,8 +2365,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.b" uuid="d05c4e3a-0a7d-4b20-be72-eb2be6f37928">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="10dd687c-39f8-4701-bae3-643dfa876209">
+      <statement statement-id="cm-3_stmt.b" uuid="1b035e1c-2536-48b3-b14f-f55f3da4cae4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2375,8 +2375,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.c" uuid="4da9415f-7810-44e5-9e0e-1595cc9db6cb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a3baaf4c-a387-42d8-9d9e-006a2a990cb7">
+      <statement statement-id="cm-3_stmt.c" uuid="8236707a-18a5-4ca4-8be3-7c39745b62a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2385,8 +2385,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.d" uuid="9ef4878a-7e93-4b3c-9ea5-3481fc820afe">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0dfa5432-ead1-418d-925f-a7855b8e0fe0">
+      <statement statement-id="cm-3_stmt.d" uuid="637f76df-2369-481c-bd48-6a7e18bdbecd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2395,8 +2395,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.e" uuid="3e2bd339-d6a9-4b56-aa25-cba5457466e4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="addd76cf-853e-494e-a035-c0294b7c808b">
+      <statement statement-id="cm-3_stmt.e" uuid="3cd7556c-0293-4c0b-8c95-66a14873b29c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2405,8 +2405,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.f" uuid="c1ef7ba0-e6a2-4d12-a89a-8992a2ad760e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="384f6d73-9932-4e70-8eda-1357b8830662">
+      <statement statement-id="cm-3_stmt.f" uuid="eba81077-99e6-499e-a7a3-f7e96ce35b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2415,8 +2415,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-3_stmt.g" uuid="c3b5f73e-07b3-4de6-a2d3-1595f53865b1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1c79f767-76eb-4844-8790-7b2fa6608899">
+      <statement statement-id="cm-3_stmt.g" uuid="73a7cff6-a632-4769-b7c4-359fdd83e4e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2424,10 +2424,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e201cdc7-bede-429c-b28d-2cfa53c0be5e" control-id="cm-4">
+    <implemented-requirement uuid="63d595c7-8d11-4911-8177-e162e11285a9" control-id="cm-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-4_stmt" uuid="7c441b27-a167-46d3-8c25-4fb8868dfe37">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3beb74c4-8281-499f-9660-1d17d9d8418b">
+      <statement statement-id="cm-4_stmt" uuid="482a2d9e-5114-44a8-9d6c-27ba0e1e0394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2b824338-6e70-4964-904b-130716a616e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational analysis of changes to the information system to
 determine potential security impacts prior to change implementation
@@ -2436,10 +2436,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7779283-3e92-455f-a84c-cbed3d7b5bd0" control-id="cm-5">
+    <implemented-requirement uuid="9f708a89-8399-4d08-b0f1-daeb58dae350" control-id="cm-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5_stmt" uuid="3c1ff70a-2445-441b-b7ce-ec74d1e074fa">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c2c4e404-2e99-4d25-bcca-cbcac66cc630">
+      <statement statement-id="cm-5_stmt" uuid="d4061f56-cb87-4aae-903c-636462701d2b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2447,10 +2447,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54cafb70-de1e-4615-b811-fc87a17f1bb9" control-id="cm-5.1">
+    <implemented-requirement uuid="6a0f4778-ac03-4417-bb0d-6454f165ebc5" control-id="cm-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="cm-5.1_stmt" uuid="61a0eb63-7a0b-42f3-9d7c-e786cb5599ef">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="697dbe35-8f8a-4d1d-a4eb-b77180e33489">
+      <statement statement-id="cm-5.1_stmt" uuid="8495d5df-5f1f-40d8-bb5e-57adf0bb341e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28aea2d2-60b4-47de-8206-03d1cc256146">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2460,10 +2460,10 @@ https://github.com/ComplianceAsCode/redhat/issues/897
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="020881a3-d9fa-49d9-bc4f-1892743d3afa" control-id="cm-5.3">
+    <implemented-requirement uuid="8bd4800b-4d23-4722-b068-f53f04d79298" control-id="cm-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-5.3_stmt" uuid="f8e38ec7-96a8-41ab-821c-ffd8f9adb9bf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7b80eae9-582a-4635-ab84-3113881acf33">
+      <statement statement-id="cm-5.3_stmt" uuid="1a42a7ca-52dd-4fc7-a4c6-db20e4737bd7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="020466c9-c44d-46eb-a233-a4b3e05d72ca">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2473,10 +2473,10 @@ https://projects.engineering.redhat.com/browse/RHV-20591
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="98d86342-0d9e-4f01-af56-afdfcc9bea56" control-id="cm-5.5">
+    <implemented-requirement uuid="a9fdce8c-4397-4ef8-9831-f28efb08595d" control-id="cm-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-5.5_stmt.a" uuid="7424e817-2948-4cb6-9808-3e377f98505b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="45b01263-84c8-4d2e-9d7d-29efd1d1db13">
+      <statement statement-id="cm-5.5_stmt.a" uuid="dd60c188-efab-41b2-b837-9dd1fc6e0744">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1444903b-5a53-4300-bf9a-f0c65262db2e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2485,8 +2485,8 @@ https://projects.engineering.redhat.com/browse/RHV-22703
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-5.5_stmt.b" uuid="0d2e0c13-fe64-4ce0-91b1-e3e6d4e0d48f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="568b130b-85b6-4c3c-8d6e-87e1e8d19f00">
+      <statement statement-id="cm-5.5_stmt.b" uuid="ac1d1b81-21e6-49e9-a4cd-018202635442">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2494,10 +2494,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="656a3523-9514-4930-ad30-e1667b6334c5" control-id="cm-6">
+    <implemented-requirement uuid="6558ac8f-3d19-463e-b2ac-16b46802e2b9" control-id="cm-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-6_stmt.a" uuid="e686d9c5-104a-42bb-bfc0-b89e64542d3d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f17388cb-6850-4932-85a5-16d5c1c0b041">
+      <statement statement-id="cm-6_stmt.a" uuid="95abafe0-9595-40a1-9057-98b2e71fab7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d326c628-53f3-4c5f-8dd7-b4409811cc75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational control outside the scope of configuring
 this system component. Use of the NIST National Checklist
@@ -2511,8 +2511,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.b" uuid="2de6f31c-3cf5-40f5-9b2a-ffb98547eeca">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fcd1f229-9665-452b-9cbf-b2293cdbeb44">
+      <statement statement-id="cm-6_stmt.b" uuid="ef6066b8-a88a-46b1-aa20-2d7b578600cc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="47e35b23-06bb-4e98-b0eb-dd8d208042b4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing configuration
 settings as defined in CM-6(a). A successful control response will
@@ -2526,8 +2526,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.c" uuid="b5d43214-af6f-40b3-9982-83cc1bbab518">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0753680a-3605-4ce9-a853-408cde622107">
+      <statement statement-id="cm-6_stmt.c" uuid="6ea890e4-9092-4b37-bec3-1f3d04389389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cc466aa-9f81-41d7-8aa1-2797d99135f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2536,8 +2536,8 @@ https://projects.engineering.redhat.com/browse/RHV-20523
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-6_stmt.d" uuid="3a03d71d-ed3e-4e5e-80a9-e7b870316ab2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="921a8829-6e4f-4723-8b32-710b65ffb58f">
+      <statement statement-id="cm-6_stmt.d" uuid="e8a406c7-c005-4b3e-a989-33e1f0bcd025">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7c7a2193-cd4d-4d5e-af1c-0cb9f4792591">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for monitoring and controlling
 changes to the configuration settings in accordance with organization
@@ -2554,10 +2554,10 @@ https://projects.engineering.redhat.com/browse/RHV-20523
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="051dedd9-3f03-48e3-9a4e-d33440be7d8e" control-id="cm-6.1">
+    <implemented-requirement uuid="856967aa-a9a0-488d-8182-c49747d9d848" control-id="cm-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-6.1_stmt" uuid="88ad25dc-d345-4da7-9bb7-5dc15b41b5a5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0ba6805c-5574-4f11-a8af-e9146c411dc3">
+      <statement statement-id="cm-6.1_stmt" uuid="413e2e1c-43d7-45ab-8c9b-c76ed699a071">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="44ea72c2-dc7d-4422-8f76-6ff1f5ad4e68">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2567,10 +2567,10 @@ https://projects.engineering.redhat.com/browse/RHV-20524
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53aada59-0b7f-4e63-9224-7154a4c947eb" control-id="cm-7">
+    <implemented-requirement uuid="561ea0a2-91db-42a2-b53d-eb884dec4f5e" control-id="cm-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-7_stmt.a" uuid="0b5418f1-1aed-4cfd-a68c-04cc46800645">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ec508c55-2127-4d3b-a98b-6b991eee16c7">
+      <statement statement-id="cm-7_stmt.a" uuid="a4606d24-0ffb-4ffa-916c-3d1cbb7bcbd6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee69df66-379d-4c22-85b7-764d5297fd9f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is a purpose-built operating
 system baseline which only provides minimal/required functionality.
@@ -2581,8 +2581,8 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7_stmt.b" uuid="3e781283-8900-45e5-9bf0-de1304b2344b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2f90c220-76f0-415a-bd43-ba0852488c71">
+      <statement statement-id="cm-7_stmt.b" uuid="f69cf7cc-8bb2-4015-83e6-84507b776058">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="102260a9-4802-4b23-91dc-0a6863b8747d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The default firewall configuration is a deny-all allow-by-exception
 policy. No additional configuration is required for this control.
@@ -2593,10 +2593,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb5a5222-1862-42a0-9420-bbcd38c3a697" control-id="cm-7.1">
+    <implemented-requirement uuid="9df378ad-07af-4f16-8970-7121beb0b4c0" control-id="cm-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.1_stmt.a" uuid="ada78aac-622d-46bb-a26d-653576ef9c3a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="98a6f45b-a056-4ac0-9ef4-1fe949cf8139">
+      <statement statement-id="cm-7.1_stmt.a" uuid="4990b97e-55cb-437d-b94b-c67fbdd00243">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2605,8 +2605,8 @@ https://projects.engineering.redhat.com/browse/RHV-20525
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.1_stmt.b" uuid="2af2bc23-6b10-4e2c-8c31-3624adb6f60e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9928274e-bfb3-4988-ac20-e7a32822d676">
+      <statement statement-id="cm-7.1_stmt.b" uuid="bdf67c38-65b8-4222-a28e-94cde8b3f1d9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="57215e3b-36cd-44cb-9ef6-541231e69ecc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2616,10 +2616,10 @@ https://projects.engineering.redhat.com/browse/RHV-20525
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="330c0df1-f35a-4f34-b0a4-320bb617290f" control-id="cm-7.2">
+    <implemented-requirement uuid="d7ae7ecb-9b0e-4166-9b23-6a5583c845c4" control-id="cm-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.2_stmt" uuid="9d62622d-7392-4642-aedf-13dbccbe80eb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="60085541-2845-4ca1-8c4b-c74e05a23f7c">
+      <statement statement-id="cm-7.2_stmt" uuid="713b03e4-4959-4cd0-830e-ea99848a6d84">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce0022ee-1dff-44a4-903f-ec64de590727">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2629,10 +2629,10 @@ https://projects.engineering.redhat.com/browse/RHV-20592
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f4fe2d9-28c3-4eb2-b5c6-6cb410d8ca34" control-id="cm-7.5">
+    <implemented-requirement uuid="606826ac-a5f3-412f-9951-0b9330d1c7d0" control-id="cm-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-7.5_stmt.a" uuid="16defaf7-c891-4329-b852-eedc45a5a3a5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d7de197c-2450-465b-b267-49a56fc1a344">
+      <statement statement-id="cm-7.5_stmt.a" uuid="0c69d796-a67f-4a62-a30f-59a3998fa9e8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2641,8 +2641,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.b" uuid="6dca879e-9dc9-474d-b20f-d844c07be426">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="69151852-9d49-4f80-a1f2-60807c50898d">
+      <statement statement-id="cm-7.5_stmt.b" uuid="a04d7c8d-a185-4c75-b689-e74cf9229520">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="308ee977-a3c7-4ee2-9b10-5a909c89d929">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2651,8 +2651,8 @@ https://projects.engineering.redhat.com/browse/RHV-20594
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-7.5_stmt.c" uuid="f323b396-a6e4-47eb-a475-0e20e8e683c7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="19d947f8-7093-4573-a532-a5a17410a7af">
+      <statement statement-id="cm-7.5_stmt.c" uuid="0f2c54d2-4592-4240-8750-55533c426bc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2660,10 +2660,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="09993c88-c8d5-49ca-9194-46fe2ecaafa4" control-id="cm-8">
+    <implemented-requirement uuid="79c169b4-bf05-497c-a8b1-dcef13806a00" control-id="cm-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8_stmt.a" uuid="73e11da5-7c69-4c10-9f9a-09590ed37620">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6e659717-00e2-4296-a7cc-f58fecc40ff1">
+      <statement statement-id="cm-8_stmt.a" uuid="3c5ff47e-7ec6-44b7-bd5e-78045d54ec5f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2675,8 +2675,8 @@ https://projects.engineering.redhat.com/browse/RHV-20779
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8_stmt.b" uuid="f3d76326-852f-493e-a0de-5f1c1a5bf379">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0a9f5c3d-fb79-4593-80eb-6ba2eb1ae185">
+      <statement statement-id="cm-8_stmt.b" uuid="82d686fe-390f-44e1-909d-20019a30cd8c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5aed2db-18e7-4916-b6ff-69026987ba21">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2689,10 +2689,10 @@ https://projects.engineering.redhat.com/browse/RHV-20779
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ebc1280f-cfff-44a4-90fc-e784b5b48a4b" control-id="cm-8.1">
+    <implemented-requirement uuid="d918bbaa-fa67-4981-a6cf-c1fb58598ed0" control-id="cm-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.1_stmt" uuid="364c7394-8b40-4f67-95ba-11064fd1a735">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a02d1249-3263-4a2d-b922-90cde311047c">
+      <statement statement-id="cm-8.1_stmt" uuid="98c82f1a-8fba-48c6-a2f3-50b707fa6cea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f086a431-fb22-4d02-86b9-ec0947418fe6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2702,10 +2702,10 @@ https://projects.engineering.redhat.com/browse/RHV-20780
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e71cf90f-accc-451c-ac64-8b247cfc1194" control-id="cm-8.3">
+    <implemented-requirement uuid="f2b54bf3-daf5-44c2-859c-d06bf379b306" control-id="cm-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-8.3_stmt.a" uuid="3aa93f30-41d0-4bc8-af49-d4adb7a8ae66">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="36e6cf3f-958c-4193-b991-3f80d034c6e1">
+      <statement statement-id="cm-8.3_stmt.a" uuid="66d965d3-4618-43ea-9ea0-c9790410ba10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2714,8 +2714,8 @@ https://projects.engineering.redhat.com/browse/RHV-20595
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-8.3_stmt.b" uuid="16af24c2-47e8-4db2-a8bf-2a5f973698c3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="85d2d53a-38ff-45e8-b57e-07a2914d7968">
+      <statement statement-id="cm-8.3_stmt.b" uuid="f4777728-b259-4f4b-aa37-d73575034a7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="aa0def49-d3ed-45d3-b7e8-ac921034e749">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -2725,10 +2725,10 @@ https://projects.engineering.redhat.com/browse/RHV-20595
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3bc1841c-259d-4f78-b4e0-41980a607cc7" control-id="cm-8.5">
+    <implemented-requirement uuid="7d60c73b-ad5e-4c32-a838-721ff73d347f" control-id="cm-8.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-8.5_stmt" uuid="494b9052-c6d7-4e68-8763-f938ab6d15d1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2e46528a-f405-4ceb-babe-e9797be3fdb9">
+      <statement statement-id="cm-8.5_stmt" uuid="2030fafe-0bb2-449f-a487-21f4bac6906e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="641262c8-fe04-4638-ab7d-f103028868f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational verification that all components within the
 authorization boundary of the information system are not
@@ -2738,34 +2738,34 @@ inventories is outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9cd5417-269a-46d9-92ed-ade2b23b83ee" control-id="cm-9">
+    <implemented-requirement uuid="ce16263b-74f6-4858-a655-9c8f3262e36e" control-id="cm-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-9_stmt.a" uuid="b03a238e-6f86-41da-88c4-24ecc40809c6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="aa77a34c-e1bc-4761-96d7-b05aa1fcfa31">
+      <statement statement-id="cm-9_stmt.a" uuid="75c3aa3c-b803-45f1-8d84-818539eda6a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.b" uuid="56b33a67-1afd-4904-a0c3-40a06d3d0cb6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6d0bb9c4-d61b-4d6d-96ed-8107d84ae6e2">
+      <statement statement-id="cm-9_stmt.b" uuid="611c14ab-733a-4eee-a2d4-2f97fd5e89fa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.c" uuid="34786085-945a-485f-81af-be99856ebe0e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ef9bd5d3-0bcb-4e09-b9d0-c93e6ef1dcd6">
+      <statement statement-id="cm-9_stmt.c" uuid="e0477be6-92bc-4086-b6f2-33083b6b236d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-9_stmt.d" uuid="43230e01-6d20-447b-bbdc-384616874cbd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5cc177c7-8814-4cdf-bc26-89324c1fc8b4">
+      <statement statement-id="cm-9_stmt.d" uuid="79287362-1802-4c81-a479-db771b47b5a5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2afc1560-ad32-4e79-be87-f5f5daa9c391">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational processes outside the scope
 of Red Hat Virtualization Manager (RHVM) configuration guidance.
@@ -2773,10 +2773,10 @@ of Red Hat Virtualization Manager (RHVM) configuration guidance.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d7cb3f1-058f-4af6-b132-52994081d086" control-id="cm-10">
+    <implemented-requirement uuid="212372d7-17b0-4c31-97d7-1852edcf0ff3" control-id="cm-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="cm-10_stmt.a" uuid="c56de09d-353c-4a04-892e-58e6d90238ed">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bd97b55a-9be9-45fe-9cf3-16f3953f0c5e">
+      <statement statement-id="cm-10_stmt.a" uuid="73dd88bc-9671-4d80-bc72-761c6c9241ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2785,8 +2785,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.b" uuid="0bb45854-ca4f-4ca2-8b4e-8d43cb0192fc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="da2b9ca8-2c38-4376-af58-84dd3fbdf62d">
+      <statement statement-id="cm-10_stmt.b" uuid="916484a3-df1b-408f-9160-2aee5490dc0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1e5625d3-23d4-4837-adce-7d22834ff8a6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Progress can be
 tracked via:
@@ -2795,8 +2795,8 @@ https://projects.engineering.redhat.com/browse/RHV-20596
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-10_stmt.c" uuid="9400c0e5-a2a4-4969-ba47-5bebe330f7cf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b003e3a5-dbe6-4b2e-b362-5d590d2056d4">
+      <statement statement-id="cm-10_stmt.c" uuid="c7e6da74-487f-4a2e-9eea-a88e1c27503b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2804,10 +2804,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e0202c45-e963-458a-815f-5ea4a3ce7b55" control-id="cm-10.1">
+    <implemented-requirement uuid="865e730f-a041-4c58-b656-d8a1de79a4a0" control-id="cm-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cm-10.1_stmt" uuid="f38e666f-9b1a-46b3-b889-472653c00758">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6908e3f0-9182-4a51-9994-f57f926bca91">
+      <statement statement-id="cm-10.1_stmt" uuid="baeb0478-1cd1-463b-a6c0-ae5b4e184049">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f14d1188-97fc-41de-b6cf-14640585a522">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of organizational restrictions on open source software
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2815,10 +2815,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5d644023-260d-4a7f-969e-3a000bfbda69" control-id="cm-11">
+    <implemented-requirement uuid="a9f52025-43c4-4f61-93d2-a98b2c60d563" control-id="cm-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="cm-11_stmt.a" uuid="9a32cb43-42eb-4257-9692-8dcf10ffb157">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="684b6628-a02d-402e-8f0d-a0e61bc950b5">
+      <statement statement-id="cm-11_stmt.a" uuid="1cab1caa-5580-4ed2-8424-6cfe2b65ff97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d5783ab5-0535-43ae-bc60-fade80694031">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>It is highly uncommon to deploy additional software on Red Hat
 Virtualization Manager (RHVM) nodes. The following are suggested
@@ -2837,8 +2837,8 @@ versions have been installed.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.b" uuid="8315a8ec-7a6e-45e1-8024-74b4d2e1aac8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="31e07034-daf7-45ec-b418-50c2fb20dac3">
+      <statement statement-id="cm-11_stmt.b" uuid="d9e649d7-bf97-4f78-baad-e7e423544b42">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6027da29-6566-490b-9641-861f6f851ed5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The following configuration checks enforce the policies identified
 in CM-11(a):
@@ -2855,8 +2855,8 @@ in CM-11(a):
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cm-11_stmt.c" uuid="a6370bbb-593c-47a3-9b4f-9414ad35b46c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b87f8e3c-3f8a-4b4e-97c2-e84d4c4ae351">
+      <statement statement-id="cm-11_stmt.c" uuid="726caa7d-38cd-4199-9e94-f4e4739123c3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2864,18 +2864,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6b1a5163-1dc3-4117-8a38-a3d5bc02067c" control-id="cp-1">
+    <implemented-requirement uuid="94fd9d87-eef1-4ee9-a6b4-2513764aa623" control-id="cp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-1_stmt.a" uuid="f64aa280-e5ee-45b9-8cba-ce03ebf221c9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="195d5c97-909e-4759-b8b9-924268eaad56">
+      <statement statement-id="cp-1_stmt.a" uuid="4606f193-8cfd-4aba-bfcd-a2c14fe88b17">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-1_stmt.b" uuid="a9f64ab3-955d-4cf7-b841-40a1130d507a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ff7d11a0-1ab0-4e20-bac1-5706be4ecf01">
+      <statement statement-id="cp-1_stmt.b" uuid="bbd89b79-7bca-4cb5-b926-c67d1cb70a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="df78838f-634d-4325-838c-4b8f271f8b34">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2883,34 +2883,34 @@ policy is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8b8136b7-efe4-4825-bf7d-260488ce35ac" control-id="cp-2">
+    <implemented-requirement uuid="5be63def-f217-4ff2-8546-9e1a25a88095" control-id="cp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2_stmt.a" uuid="2efab243-f564-4761-be6e-0f2e20808608">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f2d0f3a1-a293-468f-a5a4-63d03b6652dd">
+      <statement statement-id="cp-2_stmt.a" uuid="51fece35-394b-427c-9acf-2f7a56ef7aa4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80ad9000-4646-4758-b132-e5554bef4d48">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing an organization-level contingency planning policy is
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.b" uuid="e8f62d1f-184b-4783-845f-ca20630048dd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c8e0e1c1-464b-4992-86b9-008133531394">
+      <statement statement-id="cp-2_stmt.b" uuid="e1ea39b3-9ade-47ea-8a1a-aa597e92509c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed5f1a2-a796-4faf-bf82-bbdb8c32a470">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Distribution of an organizational-level contingency planning
 policy is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.c" uuid="2e0dbf11-2cf3-490b-b163-e8416e03f31a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="88a44cf2-1374-44ce-8300-9d5c838d21d6">
+      <statement statement-id="cp-2_stmt.c" uuid="e4ba12f5-6b75-43a3-8183-75933ffbc39e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4de58bb-0b92-4d0d-9c6f-8ae9063a8cb8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency planning activities with incident handling
 activities is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.d" uuid="2bfb9b42-d722-4eac-8e7d-1b593dfba987">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="84a1ff55-abb1-4685-8b04-664faef24bce">
+      <statement statement-id="cp-2_stmt.d" uuid="58bc51ec-35cd-430d-b9f8-6154022256a4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4cc6ee67-b8d2-4122-9e62-c26bd331e237">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing organizational contingency plans for the information system
 at an organization-defined frequency is outside the scope of
@@ -2918,24 +2918,24 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.e" uuid="5c005920-fc3b-4903-8789-c377a98241d0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="06cb7ea0-bfb0-4221-9015-e790be4a0790">
+      <statement statement-id="cp-2_stmt.e" uuid="68831a9b-b5d0-4c23-aaf2-a7bcbd78b0ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="125155a3-5e64-49e7-a25d-fe1a5411a01d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the contingency plan are outside the
 scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.f" uuid="e181075b-d46b-48dc-bb67-3cc0ce476670">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d79d764b-aaff-487a-89d3-815925b37f96">
+      <statement statement-id="cp-2_stmt.f" uuid="d268656f-9f1e-41e3-8038-788c94b5d7db">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="87062d43-0fd7-4631-914e-0816520851d1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational communication plans regarding the contingency plan are outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-2_stmt.g" uuid="85595b9e-fe1d-4cff-98c5-7425b0f30f68">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e539611d-3b15-4ce0-a87b-097e728322c6">
+      <statement statement-id="cp-2_stmt.g" uuid="126666e0-1012-48eb-bb3f-86f4dc04349c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="940539c3-1e0b-4ee4-bbe6-76f6a4434309">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Protection of the contingency plan from unauthorized disclosure and
 modification is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -2943,10 +2943,10 @@ modification is outside the scope of Red Hat Virtualization Manager (RHVM) confi
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e66912a8-c51c-4ba4-ab6a-7596c8519f8b" control-id="cp-2.1">
+    <implemented-requirement uuid="ebbb14e7-21ad-4cf3-86b2-04bf457a59a7" control-id="cp-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.1_stmt" uuid="a92a7692-2c20-4157-b876-f989f358165f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7c9a4e30-83d0-4e44-a948-384b9b1514c3">
+      <statement statement-id="cp-2.1_stmt" uuid="0cebb033-0531-48ae-8448-e574e89b1051">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a6c4f02-70ac-4bdb-8b2d-b775e5a17cf5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan development with organizational elements
 responsible for related plans is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -2955,10 +2955,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c855b21e-6d43-4c15-8ab1-61e1914ce0b7" control-id="cp-2.2">
+    <implemented-requirement uuid="f63bb2e5-2786-4d3f-8124-e09a15847cc4" control-id="cp-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.2_stmt" uuid="d457c0f3-6a26-496c-bdcd-1f7017ae00c8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="17026600-dbac-4363-bf55-e452fc69705c">
+      <statement statement-id="cp-2.2_stmt" uuid="d4b2afc4-dce2-41ce-9731-4c54f6f0d25c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20eab3e7-d9a7-43c8-b847-14de3ee49657">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -2968,10 +2968,10 @@ https://projects.engineering.redhat.com/browse/RHV-20781
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e9c2778a-055f-4aac-91c5-4590388d2b1b" control-id="cp-2.3">
+    <implemented-requirement uuid="2de3b427-45f4-4242-a2e9-de014d7bbe2e" control-id="cp-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.3_stmt" uuid="9d788092-b0fb-4b81-932d-d73f152e26cb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9dd6e18b-76fe-438a-a032-8e623c1bc133">
+      <statement statement-id="cp-2.3_stmt" uuid="a480c9a9-877d-4d4b-ab52-f2f14fd2bf6c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="839fcd1f-a824-42d7-84b0-4ee818e2ad76">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Planning for the resumption of essential missions and business
 functions within an organization-defined time period of contingency
@@ -2980,10 +2980,10 @@ plan activation is outside the scope of Red Hat Virtualization Manager (RHVM) co
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="506acaf1-d186-488f-88ea-130e4c195b88" control-id="cp-2.8">
+    <implemented-requirement uuid="fa0252c8-7d41-4727-a891-5dce072696c1" control-id="cp-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-2.8_stmt" uuid="aa545231-830e-4580-ba23-fb5bafa92afd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="361f6c7a-4fdd-4fc0-b055-bea66d553df6">
+      <statement statement-id="cp-2.8_stmt" uuid="1cf24495-43de-41fe-bf88-2b4aa7b565ff">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -2991,10 +2991,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0755a6c1-7c91-4bcc-8687-eddae8ec5d04" control-id="cp-3">
+    <implemented-requirement uuid="77fd7c71-2983-49c2-87b0-d365a779d34f" control-id="cp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-3_stmt.a" uuid="d2065479-5043-4d7d-8ab4-7077f5ae4061">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d399028f-8303-4a29-b026-389320c7ca7d">
+      <statement statement-id="cp-3_stmt.a" uuid="5d12514d-8d69-4301-b10c-c7a450bad0c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="180e2f38-0c8a-4a5c-9f2d-bc493074566d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities within an organization-defined
@@ -3003,8 +3003,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.b" uuid="e99aecae-e89f-4749-a046-7a3245b3e4c2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4ba4c41a-2ef0-4c61-865f-9745040631c1">
+      <statement statement-id="cp-3_stmt.b" uuid="6354df03-8e96-4446-b298-736abebc922c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d206f41b-3100-4686-bc8c-4bef56754e65">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities when required by information
@@ -3012,8 +3012,8 @@ system changes is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-3_stmt.c" uuid="0e7574b6-03e0-4c11-9282-c0c12c1d10e4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7303cc49-0956-4996-bb08-36b5fd8b7825">
+      <statement statement-id="cp-3_stmt.c" uuid="9c8ec9b8-186d-47d0-b6ea-1237205b8548">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="682e9951-3a64-421f-b29c-dfb1abc45d23">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing contingency training to information system users consistent
 with assigned roles and responsibilities at an organization-defined
@@ -3022,10 +3022,10 @@ frequency is outside the scope of Red Hat Virtualization Manager (RHVM) configur
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ba06af9e-f699-46e7-b6c2-b8b6436b86c3" control-id="cp-4">
+    <implemented-requirement uuid="6d1d21ea-64b9-4cfa-8db5-2647bd354b53" control-id="cp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4_stmt.a" uuid="8b701f3b-848b-4281-9e5a-fe5f240bdbf0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4981f1e6-d292-45da-a6eb-5ea947ae18cf">
+      <statement statement-id="cp-4_stmt.a" uuid="2b26ec0b-3a47-439b-8af5-a354417d354a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e14a882a-1808-437e-b859-5d650dfcfc80">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing the contingency plan for the information system at an
 organization-defined frequency using organization-defined tests
@@ -3035,16 +3035,16 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.b" uuid="e31081d5-84a6-4538-b471-3143bf37a1da">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="77857ac6-52e0-4579-96ee-60184a8606ef">
+      <statement statement-id="cp-4_stmt.b" uuid="11dc66c7-9ead-407f-aff8-e01e30ea36bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7712450-e25f-472a-b052-42ddc560b339">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews of the contingency plan test results is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-4_stmt.c" uuid="e0132bd3-b5d5-46f9-9de9-46a5396dffc2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e10fa54f-21d4-4756-a9c2-8fa2b025aef5">
+      <statement statement-id="cp-4_stmt.c" uuid="8354574c-c5e0-48bd-8496-2e47579499d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37a66071-7cb9-4803-8e60-77c475929537">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to initiate corrective actions, if needed,
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3052,10 +3052,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7cde505-1896-4c5c-ac84-27268f2bb917" control-id="cp-4.1">
+    <implemented-requirement uuid="21a9e92a-0e98-4b65-b3e1-d06ecc6177c4" control-id="cp-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-4.1_stmt" uuid="1fc71e42-719a-4dab-a2ed-54183014dce8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1c5d5b10-a592-404f-ab76-4df58e560b4a">
+      <statement statement-id="cp-4.1_stmt" uuid="23f04288-80ca-48dd-addc-f66a8c731a91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="786fa4f6-edb0-416c-8ea1-a7cc647abc7e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating contingency plan testing with organizational
 elements responsible for related plans is outside the scope
@@ -3064,10 +3064,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="95290bd8-27d6-4a36-99d1-44d8301133c6" control-id="cp-6">
+    <implemented-requirement uuid="aacc6393-23a3-497f-869d-329be8a7e192" control-id="cp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6_stmt.a" uuid="58408bf8-a213-4a8c-9849-916fa88c100e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="11379d50-2543-47ac-99dc-e3b1c562eaea">
+      <statement statement-id="cp-6_stmt.a" uuid="3629face-e3f3-4691-914f-16d42cfa027c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34700da0-3ff6-4235-b2e7-123ee7850c24">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of an alternative storage site including
 necessary agreements to permit the storage and retrieval
@@ -3076,8 +3076,8 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-6_stmt.b" uuid="8dfd6f62-4268-42d3-84db-af1961583f5e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5223c6b8-0441-48a4-b9e4-813b6b5bb48c">
+      <statement statement-id="cp-6_stmt.b" uuid="e765749c-a6da-4941-bc4a-54a30e367994">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a5d5ef1b-09ee-4d53-b768-a1e8d221b0c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that the alternative storage site provides information
 security safeguards equivalent to that of the primary site
@@ -3086,10 +3086,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ee5e992-db7d-4b1d-8898-f2cf6d89085b" control-id="cp-6.1">
+    <implemented-requirement uuid="52e1bf95-d65c-432d-af16-c76e82cb99c4" control-id="cp-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.1_stmt" uuid="a97a8be0-ad86-4b6b-b72d-98ae8ad5cd95">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="26ebcba7-8a5d-4d6d-bc6d-61973cc447cf">
+      <statement statement-id="cp-6.1_stmt" uuid="b65e666b-2708-4948-9f82-331ecd9686c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="544b36ed-7a77-4f89-bbee-907c5f2bd757">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate storage site that is
 separated from the primary storage site to reduce
@@ -3099,10 +3099,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="28d7522a-99f3-4282-a4b9-7e3db64e0f93" control-id="cp-6.3">
+    <implemented-requirement uuid="f11d9fee-fe1a-43d8-b242-e10422130239" control-id="cp-6.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-6.3_stmt" uuid="4254c787-8ce5-493c-8f78-8f5f8ee249e5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="68190365-62df-4304-ab60-5ad0e6601ef4">
+      <statement statement-id="cp-6.3_stmt" uuid="ff9e2a13-70bc-4635-a49a-3abb5499801f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="74389a35-dd1e-41cc-966b-0ddd28eab010">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the alternate
 storage site in an event of an area-wide disruption or disaster and
@@ -3112,18 +3112,18 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0e2b7b1-520f-4f9b-aad5-60942b7b64f5" control-id="cp-7">
+    <implemented-requirement uuid="38de22bd-b4d9-48e4-b2c7-38781b5b488c" control-id="cp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7_stmt.a" uuid="4061fb7a-c94a-4865-a2e1-62cbaa738e50">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8eff25d8-59f6-4ddf-b708-088b13b4132e">
+      <statement statement-id="cp-7_stmt.a" uuid="294005bd-b34a-488b-b84a-de0032311646">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.b" uuid="f6da7a98-47b3-4848-ae4e-cc2a03576848">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2e90a850-4470-4d1d-a320-3364bdf6a25e">
+      <statement statement-id="cp-7_stmt.b" uuid="a0f1dfbe-434f-4a8f-8f3f-802800025991">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9c9ac56e-812a-4721-baff-1bb201292bcc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To assist with this organizational control, documentation is being
 planned. Progress can be tracked via:
@@ -3132,8 +3132,8 @@ https://projects.engineering.redhat.com/browse/RHV-20598
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-7_stmt.c" uuid="4638b8d9-8309-4773-9e82-2c6fddbf603e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b06ab899-55a7-4931-a70c-720ff1205574">
+      <statement statement-id="cp-7_stmt.c" uuid="1102769d-5d32-48a6-b22f-95e2631de36f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3141,10 +3141,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="944a3934-9ebf-49fb-86fb-476e29bcfc2f" control-id="cp-7.1">
+    <implemented-requirement uuid="d040b58e-1c83-40f5-9f24-220e6f3249e8" control-id="cp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.1_stmt" uuid="636bb038-bba7-4073-871e-1b214a9b704c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7de4241d-1c53-4321-b694-25940c5ebc2c">
+      <statement statement-id="cp-7.1_stmt" uuid="7d8f6d99-1a7d-4d0d-b358-b542d5c50a48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2590d25d-e107-496c-b31c-0c3f86841913">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of an alternate processing site that is
 separated from the primary processing site to reduce
@@ -3154,10 +3154,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb79604a-aaa5-4632-a1f5-0cfbdb97dd79" control-id="cp-7.2">
+    <implemented-requirement uuid="d809046b-378d-441e-b083-1127bbf74ff6" control-id="cp-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.2_stmt" uuid="7391e653-fa95-4176-a4c0-8f593d030929">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="21dff22c-9bd6-4786-99e8-cfa015b7956d">
+      <statement statement-id="cp-7.2_stmt" uuid="d58d938e-10a5-44ad-95c6-de322f5d443d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2e750ec9-7062-4a41-8771-9d69a0785694">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Identification of potential accessibility problems to the
 alternate processing site in the event of an area-wide
@@ -3167,10 +3167,10 @@ actions is outside the scope of Red Hat Virtualization Manager (RHVM) configurat
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f04e062-0a79-451e-86b7-9ea5d0cdee03" control-id="cp-7.3">
+    <implemented-requirement uuid="1cc217ba-296f-4a50-9c87-96a6f8cd2264" control-id="cp-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-7.3_stmt" uuid="a8f381c6-5da0-4b72-aef6-85669a923b7d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7bf11b3d-a2a8-442b-b7fb-5176a264c4fb">
+      <statement statement-id="cp-7.3_stmt" uuid="d8c4fa74-6603-4d25-8708-fd581fe5f582">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d43239c9-8b54-4e2d-bfe8-2b38d9d90d84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of alternate processing site agreements that contain
 priority-of-service provisions in accordance with organizational
@@ -3180,10 +3180,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ae811114-0df0-4ac8-8744-a8aa8cfd4b98" control-id="cp-8">
+    <implemented-requirement uuid="f27082f0-8010-4d25-ac1a-5296a61474b5" control-id="cp-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8_stmt" uuid="c96093f9-be90-463e-8ae2-b43e61fe1935">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4e5804af-873e-454d-ae45-c6557c9894dd">
+      <statement statement-id="cp-8_stmt" uuid="17594190-820d-4302-85f6-84b8e99327b6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="010e3ecf-ffe5-4b48-910c-3bbec2af00b5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishment of alternate telecommunications services
 is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3191,10 +3191,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adc209cf-5b5f-4f24-9050-d3b882ebcbdd" control-id="cp-8.1">
+    <implemented-requirement uuid="a24372f5-3549-4b0b-9037-21e04d7d8103" control-id="cp-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.1_stmt.a" uuid="e0f779a5-0e6e-4c0d-b84c-0dce892d4d95">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c66be08f-c65c-437b-b539-e72f5d835de9">
+      <statement statement-id="cp-8.1_stmt.a" uuid="2ecb50cb-e56e-4df3-bbb2-801f4be0c688">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17e55bfd-487c-4aa3-a67c-1b67440da396">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development of primary and alternate telecommunications service
 agreements that contain priority-of-service provisions in accordance
@@ -3203,8 +3203,8 @@ time objectives) is outside the scope of Red Hat Virtualization Manager (RHVM) c
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-8.1_stmt.b" uuid="0c879503-94e2-4471-8899-49c734f29c04">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d7f85aa8-d8f2-48c6-ba94-089d6545b478">
+      <statement statement-id="cp-8.1_stmt.b" uuid="621f3641-6f33-4355-8781-14e62cc01439">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bb74ff0-7a2f-4de9-b88e-1ed1b3c0a410">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Requests for Telecommunications Service Priority for all
 telecommunucations services used for national security emergency
@@ -3215,10 +3215,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="939f9415-612e-49cc-873e-2812c0388f5b" control-id="cp-8.2">
+    <implemented-requirement uuid="6a5f96da-9e27-4ae1-9249-f0d4cbde244c" control-id="cp-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-8.2_stmt" uuid="77d4b7a9-98ab-4c4f-a063-560d80477a9e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="00cd54d4-680c-46d6-8be0-f9e26c0ca358">
+      <statement statement-id="cp-8.2_stmt" uuid="ab859b33-5a8a-4920-9b78-8b05c6b0d8f9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4076ac7a-37ea-46bb-b471-c30180085c38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Obtaining alternate telecommunications services to reduce
 the likelihood of sharing a single point of failure with
@@ -3228,10 +3228,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b10ff3e-8c6e-4a2f-b7d0-5f7e93025028" control-id="cp-9">
+    <implemented-requirement uuid="0b0125b6-af9c-4e49-9d5a-6cc083bb1275" control-id="cp-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9_stmt.a" uuid="ec980a93-c310-4802-b6f8-c53c41e5ee87">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ee808888-4826-41a3-9491-feadeba8b6df">
+      <statement statement-id="cp-9_stmt.a" uuid="2a99a229-8bec-4fc9-88ae-08c30ac68992">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6176fd89-6efe-49f0-a5df-682cbcddfe4c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of user-level information contained in the
@@ -3249,8 +3249,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.b" uuid="61374e45-3626-4a31-aaa9-f98218ae776b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4aa6f6bd-ad6e-41ee-9a06-26d2eecc2eb9">
+      <statement statement-id="cp-9_stmt.b" uuid="06b12f83-7383-4cfd-8198-0837928e9187">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ecc2b40c-2095-43b1-919f-07bcce9381d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of system-level information contained in the
@@ -3268,8 +3268,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.c" uuid="171a0959-ac61-4c09-b473-338a5318c51f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d57efe29-7784-4df2-b96d-03f649f24ff0">
+      <statement statement-id="cp-9_stmt.c" uuid="68ff9e4c-fa53-4c0c-a081-20fed0a5247a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f7c0e339-62a7-487b-8af5-f03e227e3377">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for conducting daily incremental and
 weekly full backups of information system documentation including
@@ -3287,8 +3287,8 @@ https://projects.engineering.redhat.com/browse/RHV-20600
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="cp-9_stmt.d" uuid="fc317997-faef-4d6d-b14d-9fbadfc70adf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="971ed142-8207-4ccb-872c-a2239af36158">
+      <statement statement-id="cp-9_stmt.d" uuid="ed80900b-b53a-49c3-a1f9-546ef1cd621a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80400d5c-92a5-44f0-aabf-71084d68ce1a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for protecting the confidentiality,
 integrity, and available of backup information at storage locations.
@@ -3306,10 +3306,10 @@ https://projects.engineering.redhat.com/browse/RHV-20600
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="99640bfa-4395-4be2-bb19-c2e961180d3f" control-id="cp-9.1">
+    <implemented-requirement uuid="f85b417a-a21c-4e46-b3b0-3ecd96cd3fae" control-id="cp-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.1_stmt" uuid="e3a43c18-2828-4acd-85e3-3c545e001398">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1934ce89-b6f7-4cb5-ae67-462ecda3ca96">
+      <statement statement-id="cp-9.1_stmt" uuid="d2d01e73-c3bc-4b90-9b32-0faca8c4040e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f2f2fbae-d6d0-4a49-9a77-a50d0057c301">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Testing backup information for reliability and information integrity
 is an organizational control outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -3318,10 +3318,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d091467-1646-4ed3-bbd6-84452b214b21" control-id="cp-9.3">
+    <implemented-requirement uuid="26e51a6a-29c2-47b7-aa79-3f180fcc991d" control-id="cp-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-9.3_stmt" uuid="61f7383b-3fbe-4898-ac44-cb14c36266e8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="93295c5c-9b7a-4fe2-b193-c67052da0e7d">
+      <statement statement-id="cp-9.3_stmt" uuid="05bb07ef-52b8-4bed-a618-477e48238237">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ec168c8-b0f2-482e-a012-f1b40286f743">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Storing backup copies of organization-defined critical information
 system software and other security-related information in a separate
@@ -3336,10 +3336,10 @@ https://projects.engineering.redhat.com/browse/RHV-20782
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3ee8d371-4ba6-455a-a6c8-2d1ccc0e2a87" control-id="cp-10">
+    <implemented-requirement uuid="8de00722-2d4f-47ee-a9b8-9c752caecd5b" control-id="cp-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10_stmt" uuid="c8292dea-e649-4a6f-9efc-234fc835b5ef">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fb03ac41-8e3f-4776-a6e5-6ebb3290f31b">
+      <statement statement-id="cp-10_stmt" uuid="05fbd0da-7a83-4c99-8b87-de3cee556d55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="891ee6cd-8cd3-401b-8521-4719de6de859">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for documenting how to reconstitute
 their Red Hat Virtualization Manager (RHVM) environment. A successful control response will detail
@@ -3353,10 +3353,10 @@ https://projects.engineering.redhat.com/browse/RHV-20601
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b20eaa8e-6dbe-4250-a267-cb6f948f2716" control-id="cp-10.2">
+    <implemented-requirement uuid="017891bf-c8b4-4f68-b52f-e0542ba52071" control-id="cp-10.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="cp-10.2_stmt" uuid="2c11ff09-656f-4cf8-900b-a7e55220db0f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f86c470a-08a2-4c76-ae93-a258076b733d">
+      <statement statement-id="cp-10.2_stmt" uuid="f11afd16-7d89-4edd-b7fa-c4f69dd2e646">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3364,18 +3364,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="83872e97-4118-4eab-9af4-b5aee5e746ef" control-id="ia-1">
+    <implemented-requirement uuid="2f3b1020-66be-47d7-a27b-868ac082de53" control-id="ia-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-1_stmt.a" uuid="56f9bbf5-7ce0-42ac-9148-9f5af67d02ff">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f950acdc-38c2-4206-a1eb-c011e10f7c6d">
+      <statement statement-id="ia-1_stmt.a" uuid="f29dbb7a-a552-44b4-b173-b9cec76a4e2a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c3af05d0-0b99-40f0-a835-c48cd64e7d28">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Developing organization-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-1_stmt.b" uuid="4079a8b2-e945-4deb-b98c-27cb1bf3416e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6d1dfb49-ac2b-47bb-a8ef-e9dd32cb40b6">
+      <statement statement-id="ia-1_stmt.b" uuid="0fff2124-8eb8-4f7d-afa8-846a004019f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="261111a2-f9a5-481b-a7c2-c287c360b653">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Review and updating an organizational-level identification and authentication
 policy and procedures are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3383,10 +3383,10 @@ policy and procedures are outside the scope of Red Hat Virtualization Manager (R
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b24cd2b1-3967-4ea8-8a81-ba84a0cb5e62" control-id="ia-2">
+    <implemented-requirement uuid="f55156c3-dbd3-4e17-b67a-635142694cac" control-id="ia-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2_stmt" uuid="99d693df-3c09-499c-aca2-2069277a2824">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="676d2f96-6c62-49d6-b521-6d33623d9235">
+      <statement statement-id="ia-2_stmt" uuid="f76099a9-754d-4fa1-8311-118e38567e0a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ebf37cf8-ce97-4664-9ee9-53dc8ff8490c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3395,10 +3395,10 @@ https://projects.engineering.redhat.com/browse/RHV-20602
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="56084d6c-0a8f-4dd8-8678-ca15ccc4c00f" control-id="ia-2.1">
+    <implemented-requirement uuid="7ba01777-86d4-48e5-b3fd-7bedbc360dd9" control-id="ia-2.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.1_stmt" uuid="3fddbaaf-5698-4d80-8472-305950e29ca5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5bfa560e-810c-4fd2-9e8c-cfff36b2457a">
+      <statement statement-id="ia-2.1_stmt" uuid="652e20a2-8b06-4be3-b875-0332f361d163">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98f005b4-3ce5-44f8-94b0-73508ababd84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3407,10 +3407,10 @@ https://projects.engineering.redhat.com/browse/RHV-20672
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="581e9611-5af2-4189-920f-7bdd7fb2014a" control-id="ia-2.2">
+    <implemented-requirement uuid="4d53d68d-2c6a-4a44-ac8e-b76051289b92" control-id="ia-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.2_stmt" uuid="8ad959a9-f282-4bc6-bf17-629eff470b98">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fc5eef9f-f014-4873-ba66-8e224025a081">
+      <statement statement-id="ia-2.2_stmt" uuid="bed222c9-6c1f-436f-8941-21b3fc8c8a1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c48dbeee-587a-42e2-ab32-91162f251ece">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3419,10 +3419,10 @@ https://projects.engineering.redhat.com/browse/RHV-20682
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf1ee33a-e2a4-43e7-9fa3-5dc0e73d4d3a" control-id="ia-2.3">
+    <implemented-requirement uuid="fa8b4f31-4204-401a-9799-bc98267d9a68" control-id="ia-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.3_stmt" uuid="8bc38044-001b-4bb2-8bc1-5b0d6ab677d8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b954ff3f-d78b-4d42-9750-c66967a489a8">
+      <statement statement-id="ia-2.3_stmt" uuid="90feaf4f-ad6b-4839-a0e6-f8b56c15b37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="321738ca-31a2-4b1d-b1b9-0b6c6f4197ae">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3431,20 +3431,20 @@ https://projects.engineering.redhat.com/browse/RHV-20683
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="501ba513-46e5-4d91-b7c8-eb0962fd5fdf" control-id="ia-2.5">
+    <implemented-requirement uuid="616cdfcb-1fbc-4491-91ab-4345b58ed394" control-id="ia-2.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-2.5_stmt" uuid="7dddb17b-39a4-4e47-882f-0f9397aa7535">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="723c3b62-354c-44e1-bb55-5f4583c7d77f">
+      <statement statement-id="ia-2.5_stmt" uuid="b75413d7-831c-4667-9d20-ef3a4fcb35bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1c3738e-386d-4537-89af-516d111565e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>By default, Red Hat Virtualization Manager (RHVM) does not support or allow group authentication.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbb760c9-b9b0-4483-808e-268296f57bc3" control-id="ia-2.8">
+    <implemented-requirement uuid="9324c09e-ebd4-4f86-8ccd-94c47ea733e2" control-id="ia-2.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.8_stmt" uuid="79a1a85c-7842-49a2-9e58-ab95e295f37d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b6ec3f2a-b45d-4189-b542-944b6bc0e8f8">
+      <statement statement-id="ia-2.8_stmt" uuid="19a4afe9-da23-41fc-986c-259ff51f0050">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="32f77256-ecf7-440f-ba84-714f7912e4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3453,10 +3453,10 @@ https://projects.engineering.redhat.com/browse/RHV-20685
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f60050ee-9993-42b6-8373-1225fa86cc4c" control-id="ia-2.11">
+    <implemented-requirement uuid="3b0bc4d2-9c8b-40b2-832b-47105fd850db" control-id="ia-2.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.11_stmt" uuid="afa9b13a-7b3c-4ea4-b14c-1374a64afed5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="94021441-2269-48be-b8af-e0135096a6d5">
+      <statement statement-id="ia-2.11_stmt" uuid="d5bdb471-f0d9-46bd-8b40-ba71fc204f36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fe551ed6-c765-4dea-98a6-4bf2b88d82c6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3465,10 +3465,10 @@ https://projects.engineering.redhat.com/browse/RHV-20687
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9a5ad3ba-baa7-401e-afa3-efcd1c01f6e6" control-id="ia-2.12">
+    <implemented-requirement uuid="4a97d0f3-d836-47e5-a3a6-4b7aad438a32" control-id="ia-2.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-2.12_stmt" uuid="2120a6e2-b8e3-4e3a-9753-cb33dd255d39">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2bfbab92-96ba-4d34-a6ca-246dd47da541">
+      <statement statement-id="ia-2.12_stmt" uuid="099f7acd-ad66-488c-971d-8e035fe74120">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d18528b9-1a11-4602-a574-dd3eaa7c4125">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3477,10 +3477,10 @@ https://projects.engineering.redhat.com/browse/RHV-20688
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e1760d34-7398-4836-af0a-98c3755d448f" control-id="ia-3">
+    <implemented-requirement uuid="813ba8a3-1cc8-4e5b-8c64-22a599c8634f" control-id="ia-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-3_stmt" uuid="ba9e8e18-3e17-48ec-8b5b-fe4eaea49819">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="be9a3c5e-2442-4901-9682-59c9401038df">
+      <statement statement-id="ia-3_stmt" uuid="fe4a9b85-3267-485e-a6b8-1c4190d9b864">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c0289593-6a95-4233-8e1a-780edff8a21d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3489,34 +3489,34 @@ https://projects.engineering.redhat.com/browse/RHV-20689
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a43366fe-c108-4a55-a052-567e2e43e4f5" control-id="ia-4">
+    <implemented-requirement uuid="f22c4227-9a59-474f-a12e-f819931abe4d" control-id="ia-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-4_stmt.a" uuid="f2f20d80-6983-4207-991d-74e92842424d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d1b49d24-37a6-4860-a7cf-92336e29f24c">
+      <statement statement-id="ia-4_stmt.a" uuid="c167bcfd-1c81-48f9-8253-738b08b79d70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.b" uuid="96a1d778-bff7-44fc-b6c6-b2d9f662d56d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="21d5102c-c8d2-4677-819e-fbdbc1eaa829">
+      <statement statement-id="ia-4_stmt.b" uuid="049da705-362b-41a8-b560-518ca8365ff4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.c" uuid="84d4aba9-f249-40e5-a512-d10222cdc2a4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="705fd0af-1266-41f1-87cd-4de31db7a3e2">
+      <statement statement-id="ia-4_stmt.c" uuid="392c1e50-a521-4659-a51b-9777980657ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.d" uuid="95cd6365-e59d-4551-afc2-f4eb71676403">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7274f085-bf65-4369-9c84-a5c93a496a8d">
+      <statement statement-id="ia-4_stmt.d" uuid="e96f4007-63aa-4366-b552-17cf998650fb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8fcb766d-2f87-4259-b20e-980df6842530">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) is not capable of preventing
 the reuse of identifiers for an organization-defined time period.
@@ -3526,8 +3526,8 @@ used (e.g. Red Hat Identity Management or Microsoft Active Directory).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-4_stmt.e" uuid="d54d02bc-0f46-45cd-857e-129a7af2674b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1e6e588c-a2f2-4d5e-98c8-76399f5ccc42">
+      <statement statement-id="ia-4_stmt.e" uuid="c12dd478-a4bd-4ae0-afe9-803f7fe47e55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1290e859-497c-4528-9276-c533a1beac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To disable identifiers after an organization-defined time period
 of inactivity, the following configuration checks must be enforced
@@ -3542,10 +3542,10 @@ it is the responsibility of the identity provider to satisfy this control.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a22098d7-6ff1-4813-ab57-71d61d70aaa8" control-id="ia-4.4">
+    <implemented-requirement uuid="2be69012-2d24-4210-99e6-998ca2328576" control-id="ia-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-4.4_stmt" uuid="75190f8c-d2ac-4785-9d5e-33f8aee43b87">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5302b02a-2f7b-4f25-98fe-5f45d613e9a9">
+      <statement statement-id="ia-4.4_stmt" uuid="39765129-14c3-4158-9aa0-88530f3040eb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3553,18 +3553,18 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="982c592b-e216-46e3-a4ed-6196b72767f6" control-id="ia-5">
+    <implemented-requirement uuid="3dbd5d5f-c89f-4286-ae21-2099b279f150" control-id="ia-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5_stmt.a" uuid="22216cc6-b35b-4a65-9c22-8b8e0a61a29d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fb765bea-9fb9-48bc-8972-588d59591942">
+      <statement statement-id="ia-5_stmt.a" uuid="7b0a503b-79cf-4f86-8477-64651d2c6e78">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.b" uuid="6c00f019-30f1-44db-9726-8b153900ac01">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="17e7ac30-6302-4e4f-93cb-67d83513b21f">
+      <statement statement-id="ia-5_stmt.b" uuid="612d6865-7d88-40d8-9671-19c662b1fb56">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3572,8 +3572,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.c" uuid="5e76749c-04f0-449d-9d02-5c52a96d2520">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a1e0dcb7-6ea4-4b44-b7e5-ac2e0ad68f11">
+      <statement statement-id="ia-5_stmt.c" uuid="6b8984b4-a29e-4ca3-918a-94a0858407ef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3581,16 +3581,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.d" uuid="5e10ae0b-3b28-491b-970f-8ddeed3ae743">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6a3077f1-4df3-4a36-b6f7-da8f9c33d2fb">
+      <statement statement-id="ia-5_stmt.d" uuid="5c386be2-b297-4853-9a7e-9307940b9f1c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.e" uuid="deab7f51-f511-4c23-b337-cba64566e08d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c0c80350-aa19-4a13-bb68-ee03f113bcc0">
+      <statement statement-id="ia-5_stmt.e" uuid="7a22d68e-3d38-44f2-911d-db076f24f98a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3598,8 +3598,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.f" uuid="38221650-4aa3-4aa7-879c-cc38c9defa25">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2df48acf-8021-4390-b5d6-d6b3df03314d">
+      <statement statement-id="ia-5_stmt.f" uuid="3e889e6d-3cab-4db1-b007-e3203f2a3872">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3607,8 +3607,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.g" uuid="8f2ab167-d9e0-44af-ac01-d0cb72d4ad28">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1cae562c-61eb-4720-b885-cef8d4f765fc">
+      <statement statement-id="ia-5_stmt.g" uuid="28d0ebb7-e542-4037-aed5-958a6f683a90">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3616,8 +3616,8 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.h" uuid="75b4c6d7-05e5-4d8a-851e-a6355c186169">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e6cd37f5-78ad-4b23-b3fa-69d32076d2a8">
+      <statement statement-id="ia-5_stmt.h" uuid="437d30a2-acce-4170-bc43-cd924439405b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="eecb583b-5879-4cc9-bebf-0eaa5415e78f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3625,16 +3625,16 @@ https://projects.engineering.redhat.com/browse/RHV-20783
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.i" uuid="c1239d7a-622d-4f67-9fe8-25940a1ce003">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7306afd5-27e8-4080-93d1-ba35005c3b33">
+      <statement statement-id="ia-5_stmt.i" uuid="8cd40f58-98ac-43cd-99fe-c51dbfa5e016">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5_stmt.j" uuid="da756c43-2f83-458a-970e-7f8d8fc143e0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6adc81c2-2ea9-4d8e-af93-b4cbf8d1156c">
+      <statement statement-id="ia-5_stmt.j" uuid="160b8f2b-8776-4a5e-af26-1df569e42d5d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3642,10 +3642,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4491c6ad-9027-4b68-aaa2-f66b325b8379" control-id="ia-5.1">
+    <implemented-requirement uuid="9a10ca43-6f11-4a52-8567-4bcbd544ab73" control-id="ia-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ia-5.1_stmt.a" uuid="c2ce7723-570a-4122-af09-1b724844c960">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b3411d39-d7dd-4316-8c67-958c430abaae">
+      <statement statement-id="ia-5.1_stmt.a" uuid="2eb87715-5e65-4cac-a28a-4a5ab19266c6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3653,8 +3653,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.b" uuid="49dad413-6a34-40c7-ab67-8936e2b2510d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b732956e-3ba5-4348-b184-670ac0ca73d2">
+      <statement statement-id="ia-5.1_stmt.b" uuid="c88ff946-4f4e-48f3-abc5-f8b8a5d5f370">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3662,8 +3662,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.c" uuid="b3dc6124-6de5-489b-9c20-cdd78de37861">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d338bdfd-75e8-4ab9-b162-00b3b1ae1755">
+      <statement statement-id="ia-5.1_stmt.c" uuid="2f0ca946-a3ab-48e1-afc2-3feaefbb1ebc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3671,8 +3671,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.d" uuid="f9772254-ad38-4e63-be5d-5a95252a0741">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="eaaf51ca-8c7f-413e-aa3d-3cde10f724dc">
+      <statement statement-id="ia-5.1_stmt.d" uuid="2fe55d3b-2ca5-4fd1-8132-fbd0b6367481">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3680,8 +3680,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.e" uuid="a4f71928-23e6-4c62-9341-022e3b548d59">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e7870d1a-deab-402b-a4e7-09b16ea22497">
+      <statement statement-id="ia-5.1_stmt.e" uuid="b4d6cce9-c6ff-4f4e-902e-0cbee43a557a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3689,8 +3689,8 @@ https://projects.engineering.redhat.com/browse/RHV-20784
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.1_stmt.f" uuid="3755c9b4-ec38-4404-b63f-f32643accc89">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5dfd8b82-dccd-4d8e-8cb2-677f479e34b1">
+      <statement statement-id="ia-5.1_stmt.f" uuid="48c96ae6-37ae-422d-9ff0-4290751a74dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6275c774-c27a-46ca-8b2f-9b298a309c8b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3699,10 +3699,10 @@ https://projects.engineering.redhat.com/browse/RHV-20784
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0040e898-12c9-4891-a53c-8c223e8a128b" control-id="ia-5.2">
+    <implemented-requirement uuid="a6b20dac-858f-4432-a9f8-454c24473d75" control-id="ia-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.2_stmt.a" uuid="aa505a71-e297-4596-b3a6-2ee606f8d41f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="25ef382e-f7dd-4614-b4ab-d3e11cd316a9">
+      <statement statement-id="ia-5.2_stmt.a" uuid="260426ad-e896-4c8c-bbbf-f9954d38e3bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3710,8 +3710,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.b" uuid="3f57a587-0fa6-4352-9777-e54f5c1a67b3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bca8bcf3-1b92-4fa9-8dd1-c1616d269db1">
+      <statement statement-id="ia-5.2_stmt.b" uuid="6a899cdf-1ff3-40d7-9f3e-d85b26f43e7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3719,8 +3719,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.c" uuid="cfdada26-aa14-4332-b986-58d61c350385">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="32151462-73b3-4a6c-b805-9f14dd7bbd52">
+      <statement statement-id="ia-5.2_stmt.c" uuid="5bb16a9b-a53d-486f-b097-939d1300eb80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3728,8 +3728,8 @@ https://projects.engineering.redhat.com/browse/RHV-21004
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ia-5.2_stmt.d" uuid="c9de3604-b9b6-46fb-8ccf-5fb2f917cef5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0c01d2a2-66c0-41d9-b253-79b9959588ac">
+      <statement statement-id="ia-5.2_stmt.d" uuid="5c943719-8bae-40cb-96a4-29de69026782">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3738,10 +3738,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c174f01b-2b65-4252-9ef5-dc7e16afa996" control-id="ia-5.3">
+    <implemented-requirement uuid="4006bb15-2593-43b1-a664-3bb5e3e8fed9" control-id="ia-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.3_stmt" uuid="53e1fcf1-cdee-45a0-b4da-cb768a5ed113">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0650ba8c-3402-44fa-81e6-b69bdef45cf9">
+      <statement statement-id="ia-5.3_stmt" uuid="30aec275-5150-4906-8e11-fb0a34d4f06b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bcadda7b-71db-424d-90d7-0c4f9774894c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational requirements that the registration process to
 receive organization-defined types of and/or specific authenticators
@@ -3753,10 +3753,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bf74cfb7-33a6-4a54-91c4-065984285db7" control-id="ia-5.4">
+    <implemented-requirement uuid="94607c21-260c-4efe-949e-59ccb3c94b40" control-id="ia-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.4_stmt" uuid="7acad3ad-32ea-42c2-b02c-e44056e1d4a0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a369b26b-7293-47a5-ad74-7b616cb62f26">
+      <statement statement-id="ia-5.4_stmt" uuid="516d6712-007c-4d1d-a6b6-825b46552ab6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fe18865-6a0d-4836-86b8-fcaa8ffeb7b6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3765,10 +3765,10 @@ https://projects.engineering.redhat.com/browse/RHV-21004
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="caea4320-360b-4039-a892-e5e25e9426bf" control-id="ia-5.6">
+    <implemented-requirement uuid="fd0192e7-e957-492e-966a-4e640178f91c" control-id="ia-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-5.6_stmt" uuid="37a2e3de-3f46-4500-b677-38c924205cb9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cc11a45b-9e61-4728-bf7f-537a430312b9">
+      <statement statement-id="ia-5.6_stmt" uuid="0d3c7248-39e9-4229-b6f8-d8885bbad9a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9fa5c10-ee2b-4567-91af-6520a1f4233e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This is an organizational procedural requirement
 outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -3776,10 +3776,10 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad1e0b37-8fbb-412a-8e9b-a5eb7121ed9c" control-id="ia-5.7">
+    <implemented-requirement uuid="19ebd989-8420-4755-ab4c-0bcec6997600" control-id="ia-5.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-5.7_stmt" uuid="1091e152-873e-449c-8705-84cedb839413">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cfe5d317-dbdb-4815-9dbf-ba8edaaf960c">
+      <statement statement-id="ia-5.7_stmt" uuid="7f6fb122-c12a-4362-8ec5-47258add160d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ba2705c9-0cbe-4254-9b40-b466ea9ffe38">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3788,10 +3788,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a17938fa-b02a-4de4-b96a-ca1ffd34546f" control-id="ia-5.11">
+    <implemented-requirement uuid="372ac3f8-b7d3-44d8-9392-213849caf270" control-id="ia-5.11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-5.11_stmt" uuid="53db7d5c-bab2-4255-8d2c-fa7f51b681e7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2f9cd261-6988-491a-bc4c-c5dd6ef9bcdb">
+      <statement statement-id="ia-5.11_stmt" uuid="6e356857-d10a-4023-8419-d5acfe9ba959">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a1db44d-bcb1-4104-b6c5-3ea25ba0b5c1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3800,10 +3800,10 @@ https://projects.engineering.redhat.com/browse/RHV-21005
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="00a6ccb7-7c12-4c33-b96b-674c91d98437" control-id="ia-6">
+    <implemented-requirement uuid="022887aa-4532-4de0-9f39-837ff9bb0039" control-id="ia-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-6_stmt" uuid="08f73ae5-4c68-4caf-bd1c-978bd7bb9d66">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b07079c1-6d49-43bf-8d79-7369be09d08f">
+      <statement statement-id="ia-6_stmt" uuid="c69f5a79-fc8c-42d1-9d9e-3dcbf71d7fe7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5702a69f-2325-4eb2-b49a-28fc0805096f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) automatically obscures
 feedback of authentication information and cannot be configured
@@ -3816,10 +3816,10 @@ https://projects.engineering.redhat.com/browse/RHV-21006
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6e965813-c0ed-463f-8839-5904e168f572" control-id="ia-7">
+    <implemented-requirement uuid="83da2df7-d021-4c45-96df-f2724a8346bc" control-id="ia-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ia-7_stmt" uuid="06739322-1cb1-437f-b29b-f6cf3313209a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8586e499-a60a-4589-968b-e9d52f499953">
+      <statement statement-id="ia-7_stmt" uuid="9fbba9ca-a1f5-438f-85a7-93516e6ce37b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="718d669c-6b16-4974-b480-636316eefd8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3828,10 +3828,10 @@ https://projects.engineering.redhat.com/browse/RHV-21008
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a314e6ed-fa8b-4acf-a697-28b2de588d78" control-id="ia-8">
+    <implemented-requirement uuid="fb0a4cf2-d3eb-4a45-a91f-cd200a41da4f" control-id="ia-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="ia-8_stmt" uuid="f6373e13-f634-41f2-82d0-f2d8f835391e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0c121271-f860-419a-85cd-fd1dac51424b">
+      <statement statement-id="ia-8_stmt" uuid="bb6466a4-c8b0-4604-9158-1e32ca184daa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="754bd778-fe3d-4269-82aa-6bd85e3a6765">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>All information system users, regardless of organizational
 or non-organizational, receive unique system identifiers. This is
@@ -3841,10 +3841,10 @@ user identifiers is audited through events defined in AU-2.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d6a73fb8-26e3-401d-8421-a24aef0987f9" control-id="ia-8.1">
+    <implemented-requirement uuid="65f521fa-59c3-4fe6-8eb9-2f0241a2058e" control-id="ia-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.1_stmt" uuid="2fdb8556-6666-423b-8673-4a4c5e937484">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d006d5dd-856f-4845-ae91-4c9e4baca724">
+      <statement statement-id="ia-8.1_stmt" uuid="bbcf75dd-c6bd-4a00-a418-2825314ca848">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="15bf5086-5807-4b3e-98d2-c48fb20b8ce8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3853,10 +3853,10 @@ https://projects.engineering.redhat.com/browse/RHV-21009
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5f49f9f7-d70c-4429-bb44-36b55f42c8b8" control-id="ia-8.2">
+    <implemented-requirement uuid="336c8e99-9688-4748-a4f6-6f52ee15bf62" control-id="ia-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.2_stmt" uuid="2fc605d9-f4c2-4eb1-968f-e7fda034643d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3a56be19-3f7c-4acf-ba12-4ca6a3bcc9c0">
+      <statement statement-id="ia-8.2_stmt" uuid="de4c1fa5-5b25-4148-bd2a-6251878dd168">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="21cf270f-52af-485e-966c-acbee2e6ac19">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3865,10 +3865,10 @@ https://projects.engineering.redhat.com/browse/RHV-21010
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="efb04580-f530-4ed6-8746-bceb34261a14" control-id="ia-8.3">
+    <implemented-requirement uuid="f7ad5650-6081-4c8e-bb81-29fa60d24c6f" control-id="ia-8.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.3_stmt" uuid="4849dbc7-05b9-4477-9755-da600e0b2093">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="28d0918e-b3b7-4da2-9e53-5ba3ef58005f">
+      <statement statement-id="ia-8.3_stmt" uuid="c35a8746-0b59-4815-860b-5b6bae7e4a24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1ab7d89d-ed19-494d-b5e5-10bfbfff6227">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3877,10 +3877,10 @@ https://projects.engineering.redhat.com/browse/RHV-21011
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1d5a311c-b0ad-4890-ab2b-24c43d0de998" control-id="ia-8.4">
+    <implemented-requirement uuid="ec3fefeb-0fb9-4f81-8fa7-1b01aa5da11a" control-id="ia-8.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ia-8.4_stmt" uuid="e096f014-54b0-4ca0-b334-35a974f2d32f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ebd19631-f0cf-46b9-9bff-e7b1f45240d0">
+      <statement statement-id="ia-8.4_stmt" uuid="5531915f-7a41-444c-8441-c97bb66c7b49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="660cd1a0-2e64-4948-bc62-e1b55b4c9662">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be tracked via:
 
@@ -3889,50 +3889,50 @@ https://projects.engineering.redhat.com/browse/RHV-21012
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c36fda0-aa46-459b-9964-b2584bdfe212" control-id="ir-1">
+    <implemented-requirement uuid="3240daee-30be-4876-ba10-7269c896711d" control-id="ir-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-1_stmt.a" uuid="f1c3f64a-c1b2-4ced-9d57-485d64d296e6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3ceba81e-f374-4f62-8e28-f97b58e20449">
+      <statement statement-id="ir-1_stmt.a" uuid="7a9bac04-55a7-4332-8bb1-661acbf6603a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.1" uuid="62a6a03b-6284-405c-995f-f0549f2747e3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="655461c5-abef-47f5-9792-b0c03b3e7d6d">
+      <statement statement-id="ir-1_stmt.a.1" uuid="a0f17d3d-926f-4d88-948c-47ddbd989dcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.a.2" uuid="0153d3d5-4608-403b-af65-7e851bbd230c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a7958f10-2f99-406b-9e88-0debcdaf3448">
+      <statement statement-id="ir-1_stmt.a.2" uuid="11e3a4a5-07b5-437b-91e6-47d3d4459389">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b" uuid="5328d1ef-79ff-4046-b9d0-6e44c896ff22">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6eaa8c04-8117-40af-bfc1-7e2138cd60e4">
+      <statement statement-id="ir-1_stmt.b" uuid="001fcc6d-73c7-4c36-8212-ea870c51eb18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.1" uuid="a3c15f49-9f51-4e62-b008-fc80a2c2e6cc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3c3187d6-79df-4b69-b543-5d65ab57464f">
+      <statement statement-id="ir-1_stmt.b.1" uuid="e77b8f95-f72d-49a7-9be9-cb6a9548fa03">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-1_stmt.b.2" uuid="4d8ad107-7dce-495b-83f6-eacc67d0c80c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="41bc2995-7457-498a-b6c5-3297cf31462a">
+      <statement statement-id="ir-1_stmt.b.2" uuid="1ab303e1-20cf-491c-b402-28f04e190fd3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3940,26 +3940,26 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adc04dcc-8e3f-4ff7-8b07-15f440de17f5" control-id="ir-2">
+    <implemented-requirement uuid="6dab2fe3-8e32-4952-b163-f79148aa1035" control-id="ir-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-2_stmt.a" uuid="5c322955-5365-4b3f-8229-d118cbccae38">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2c1300ac-b852-47c8-b82a-f80583efbdf5">
+      <statement statement-id="ir-2_stmt.a" uuid="dd62a057-8077-49c7-ac5f-1fb9656a0e69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.b" uuid="58c03ab3-cd92-4785-a7c9-484c0d49f5ce">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bef7a8ed-e05e-488c-91bd-eb2907809cd2">
+      <statement statement-id="ir-2_stmt.b" uuid="050ee893-949a-49a4-b8a0-3288b4aebe74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-2_stmt.c" uuid="0cec8efe-ced7-4282-abdf-e66cd4460beb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6e7e57c9-3607-4468-b832-ae1263f7ba83">
+      <statement statement-id="ir-2_stmt.c" uuid="90e22189-04f6-4dc2-a3ff-482921aee142">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -3967,10 +3967,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f38d0fd5-357e-4de0-8122-ee81d1328d74" control-id="ir-3">
+    <implemented-requirement uuid="b269290c-8e58-4628-8786-e2d1c130604f" control-id="ir-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3_stmt" uuid="2ad87206-516d-49ee-a074-d6f9cba3ee1d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bfe5ff56-e34b-4edd-aad8-414311e90a58">
+      <statement statement-id="ir-3_stmt" uuid="f892bc89-30b6-4fdd-ac2c-3146a3e30328">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -3978,10 +3978,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4b3b215a-bb70-4bda-870b-0eeeb7ec7004" control-id="ir-3.2">
+    <implemented-requirement uuid="3f2cdf17-d059-4d7e-ab78-4afbd737e92f" control-id="ir-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-3.2_stmt" uuid="161ab561-160a-4392-b31e-e704de86ad7b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="35e8932e-2bc7-4c78-a8f5-a2c8668ed735">
+      <statement statement-id="ir-3.2_stmt" uuid="f42e1a68-8813-48be-8af2-9569d928c6af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -3989,26 +3989,26 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ef6345e7-2e6b-48a1-8aed-958bae5a045d" control-id="ir-4">
+    <implemented-requirement uuid="1155072e-5be7-426f-8051-6ad707df4adf" control-id="ir-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4_stmt.a" uuid="cfd3a73a-c7e6-46d4-82de-1e930450d805">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6c788dfd-a684-4c1f-8921-e876b0838696">
+      <statement statement-id="ir-4_stmt.a" uuid="d7396185-ef72-414c-9685-a82b7865b70f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.b" uuid="efbc6a16-1a57-403a-a2e5-fc8dfd792457">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c68cf766-c77e-46cd-b85d-ebf3641b7950">
+      <statement statement-id="ir-4_stmt.b" uuid="3f4818ef-7b32-46ae-822e-9ecbbbd81883">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-4_stmt.c" uuid="52b7f82e-c635-4455-b7c0-169a760db521">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="27267a9d-3894-4dcd-ace3-d981d86571d5">
+      <statement statement-id="ir-4_stmt.c" uuid="2f72cf07-e50e-421b-8661-3845a296db7f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4016,10 +4016,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75204d98-d306-41de-9b9b-3898ffdfde6d" control-id="ir-4.1">
+    <implemented-requirement uuid="3d182f97-7b64-479a-bd57-23016ea6623a" control-id="ir-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-4.1_stmt" uuid="42ed3613-a266-44f5-b699-d534651412e4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="467a8d70-4609-4dce-b114-f0cda1109bb8">
+      <statement statement-id="ir-4.1_stmt" uuid="b1fb5ce8-22c3-45dc-ae46-99c68bb075c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4027,10 +4027,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="74717c16-a98c-4dd6-a3cf-60d888a1686a" control-id="ir-5">
+    <implemented-requirement uuid="1e48707f-48f7-4759-9469-03b2c024f350" control-id="ir-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-5_stmt" uuid="ca332165-5138-441b-bb6e-a7c7319e670d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a90b73f8-e6d7-46d5-8ed3-6b6620e95e1b">
+      <statement statement-id="ir-5_stmt" uuid="80d2a2ec-8bc0-4799-8052-9cecbdea4e70">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4038,18 +4038,18 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="81546987-a49c-43fe-9825-7d85f00f9b97" control-id="ir-6">
+    <implemented-requirement uuid="2d2e105e-5a5f-4c63-a0d9-8fdee571c5cf" control-id="ir-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6_stmt.a" uuid="d58ea868-a3c2-48ae-a523-2250d65e120a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8b2c0aeb-e6fd-4f59-88bb-6b7aaf59f7f5">
+      <statement statement-id="ir-6_stmt.a" uuid="b83624b2-4873-4a2f-9824-5dc52eb52a13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-6_stmt.b" uuid="f35604b9-4d58-4d1c-97f2-39220e021442">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d26d7d0c-2cd1-4c0d-bcb8-a1bed2030a6e">
+      <statement statement-id="ir-6_stmt.b" uuid="054880bc-4ed1-4ef9-bcf7-be11417fb024">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4057,10 +4057,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c8d6abdb-f697-4d1b-83a4-fce743a45f6a" control-id="ir-6.1">
+    <implemented-requirement uuid="5112de95-2735-413f-8b80-68e24f81e1ab" control-id="ir-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-6.1_stmt" uuid="0605487c-b90d-4133-a18c-1ecf88208eb7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c81664c9-2e8c-4da7-b4a9-505eb91cf247">
+      <statement statement-id="ir-6.1_stmt" uuid="b0ebd5fa-01ad-41be-8ad1-95e3fa47ba49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4068,10 +4068,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3186b9f8-4d9c-4d8f-9fb5-ef411a2d6f34" control-id="ir-7">
+    <implemented-requirement uuid="3f425480-b8e7-4177-b13a-33ba3b91d721" control-id="ir-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7_stmt" uuid="1c9317e8-0515-40b5-a974-971bd9475397">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9ed1960e-ed49-4f57-9e6b-9725dd3d6a36">
+      <statement statement-id="ir-7_stmt" uuid="d9cdcde0-b75d-4101-9cda-8d35144e7488">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4079,10 +4079,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="31f8d67c-fa73-4623-a896-747202362837" control-id="ir-7.1">
+    <implemented-requirement uuid="c1478f62-2c26-44d0-b938-a5e8cdee6537" control-id="ir-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.1_stmt" uuid="c0281f3f-6e76-4e13-84ad-c5e1da783b72">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="29c9fadc-674d-4a2a-9480-e45f7c53460e">
+      <statement statement-id="ir-7.1_stmt" uuid="47534123-7068-4d35-b381-bbf90556c0c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4090,18 +4090,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19150391-d9e6-4f2c-8e9b-8baca3781bb3" control-id="ir-7.2">
+    <implemented-requirement uuid="c33e7808-2fd5-4f78-8a24-f8ec8a166b06" control-id="ir-7.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-7.2_stmt.a" uuid="704eadcb-2cc4-4b8b-985b-60fc8525a5c4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="56d722bd-7339-4c93-a846-416e8c827e76">
+      <statement statement-id="ir-7.2_stmt.a" uuid="13c7c613-6d85-4bfe-a288-87ddfa035387">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-7.2_stmt.b" uuid="ac5013f8-9cf4-4cab-b1f5-be0ea3504fe9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ec77ccae-f710-4395-a919-a8c8c81aafd2">
+      <statement statement-id="ir-7.2_stmt.b" uuid="097701db-7c15-4855-b266-24a90fd7b49d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4109,114 +4109,114 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0e712513-1791-487c-90e5-6902f4419bb2" control-id="ir-8">
+    <implemented-requirement uuid="967e97cb-b9b3-464f-afaf-eb257e79a9d8" control-id="ir-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-8_stmt.a" uuid="5a59e7df-948a-4dfd-9c25-4c23aa7664a1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="defaefa3-11ec-4fe3-9be0-1935442531b7">
+      <statement statement-id="ir-8_stmt.a" uuid="cc8f2bb6-6e14-4297-bc04-25d74cf2d795">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.1" uuid="05ecf56a-ea50-48ef-bc18-8d7a3fa5c91c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e12e2f7d-cbfa-47ec-a1c9-8009e2ae5371">
+      <statement statement-id="ir-8_stmt.a.1" uuid="9b5a26d8-abfe-484a-a7a4-518decf26f32">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.2" uuid="4642ad8f-275a-4fa9-97f2-05bf4bdf6549">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5db51650-61d7-4320-8bd1-a107abffe96a">
+      <statement statement-id="ir-8_stmt.a.2" uuid="2e063b17-fee1-46a5-9aaa-f976e6829ae8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.3" uuid="8e7da0e5-5a26-4965-ae00-83d5c7e4ce2c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6b7be601-5f8d-49ba-8575-08f4c13edc03">
+      <statement statement-id="ir-8_stmt.a.3" uuid="e17ca486-9878-4f4f-862d-35cf728f9dab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.4" uuid="30296809-ae00-4999-916a-a37fc1a035d8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2cf096aa-ed10-4668-b4c1-80bf47da7ad2">
+      <statement statement-id="ir-8_stmt.a.4" uuid="f409d770-51db-4a9e-aacc-f444c7334037">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.5" uuid="2a962690-d207-48f5-8e3a-cff8af3a1c07">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5ee84eff-6aaa-4d82-bbe7-c917530cbb2b">
+      <statement statement-id="ir-8_stmt.a.5" uuid="9ecdfeee-c454-45da-9772-8819ac9eb51a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.6" uuid="6ea41bb6-987e-45d7-9546-bc0b986408d0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1062a68f-800a-46e7-97cf-995794e9ff35">
+      <statement statement-id="ir-8_stmt.a.6" uuid="d36a19fc-8360-42d5-bae0-dc72f837945e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.7" uuid="f0322b09-97d0-4873-aa8d-33cfe97bb1b2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9372b6fc-04d3-4018-8e33-e62d6524a5e7">
+      <statement statement-id="ir-8_stmt.a.7" uuid="d5ff6c68-b16b-4143-96a5-cd6511d31b7a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.a.8" uuid="05db1aba-0bd2-49b9-b22a-5c0d241e270e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fb2d1d2e-0a47-4b5f-be28-97dd21cfcccb">
+      <statement statement-id="ir-8_stmt.a.8" uuid="5b4f8897-2628-46dd-b058-283e27888b41">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.b" uuid="d2cc1032-b9c8-4631-bab9-5df19a73fc56">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="24eeb805-b954-408d-a624-98d3bdd72cb5">
+      <statement statement-id="ir-8_stmt.b" uuid="2c2a5c3f-56b8-4129-857d-eec9c7cd0e0f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.c" uuid="5409f751-28ab-4fd0-84d9-647635fdfb66">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="372aa05c-fc4c-4176-ad70-bc65394e0e61">
+      <statement statement-id="ir-8_stmt.c" uuid="5462a597-ce52-4d20-a027-2350d4f05779">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.d" uuid="2f0b5419-3e55-4283-999b-e509a3aa7588">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7df01cc4-f30a-4754-80b6-df87071dc6ca">
+      <statement statement-id="ir-8_stmt.d" uuid="5ad0a837-3c8b-45be-9cd9-b7260d3ce617">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.e" uuid="acb3ced4-9bd6-4ad3-82e4-d9120e6bc525">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6fb584ec-0748-4a19-bbe8-3c0220fa90d9">
+      <statement statement-id="ir-8_stmt.e" uuid="8c8f9a0f-5052-45a7-9f20-0096cec25c09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-8_stmt.f" uuid="66e3eb88-3d75-43d7-88cf-526799dd93a9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="15d8c8af-47f9-4966-a95f-530737b7db5b">
+      <statement statement-id="ir-8_stmt.f" uuid="b94c4a7d-f35e-4cd5-9db8-cee39d2ed822">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4224,50 +4224,50 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee282bab-3093-4755-9200-0aabf7075d9e" control-id="ir-9">
+    <implemented-requirement uuid="1c6b3117-4021-44ac-9245-603f7fa79bf2" control-id="ir-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9_stmt.a" uuid="ba274554-b229-477c-bca3-c54dd1a1fca2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2073169d-6c9c-47a1-bfae-99a958dc82f1">
+      <statement statement-id="ir-9_stmt.a" uuid="06bcdf67-876f-4b0a-a61b-691f4524a753">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.b" uuid="be9a106f-9eaa-4fe3-9fef-f7bbbe103367">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="15a67731-91ff-4b4a-8c74-95fca6241d07">
+      <statement statement-id="ir-9_stmt.b" uuid="32b03a4a-531f-4c74-9aec-2e15fd173dc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.c" uuid="f95623fb-75aa-4c57-8c22-c7a4457c8ac9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d692f9e0-be1c-401b-8645-38b68f7b775a">
+      <statement statement-id="ir-9_stmt.c" uuid="749a44a8-e6c9-4c73-85d6-382e1a18a478">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.d" uuid="d0ddabee-2996-4d29-9ec0-9e4519a5d042">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9617447b-09aa-4db0-9631-44a7c19e8af1">
+      <statement statement-id="ir-9_stmt.d" uuid="82a45b26-8d2f-45ae-be30-6dd4acf4cb85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.e" uuid="bd435536-2fba-452a-bf80-32686ad68426">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d9d4572a-c15a-49f9-be57-045c0e616afd">
+      <statement statement-id="ir-9_stmt.e" uuid="29b7f249-0b28-4634-a204-ac053f80084d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ir-9_stmt.f" uuid="f690e041-e126-4ee1-94f5-305d1b41c8ed">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b1e11a91-0645-4ade-8f15-8d341d3778a3">
+      <statement statement-id="ir-9_stmt.f" uuid="2dfbee00-5db5-43dd-99c7-131a27804956">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4275,10 +4275,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="adbcdbe0-685c-4624-b84e-817c169abdc9" control-id="ir-9.1">
+    <implemented-requirement uuid="c7fd67e1-7589-4a5d-a698-95740328359b" control-id="ir-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.1_stmt" uuid="30d7ee02-5e16-4cd8-9da1-fdfe8ce7e301">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4da6e1cd-3157-467d-a9f6-ff8b686e3290">
+      <statement statement-id="ir-9.1_stmt" uuid="a959e5cf-3777-4cac-b73d-e4d375119041">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4286,10 +4286,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1082e3bb-2901-4b66-8890-3b11d27e1086" control-id="ir-9.2">
+    <implemented-requirement uuid="d655dd6c-5107-41ac-b8ba-6fc4a2bd7230" control-id="ir-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.2_stmt" uuid="96c01fce-a159-4f96-9c86-f5e2cc963ba0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8e52e418-ac85-4c27-9a0c-f925e04cad31">
+      <statement statement-id="ir-9.2_stmt" uuid="db9488da-2b33-4cfe-be53-bde44aff97ac">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4297,10 +4297,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0ab0131c-935f-4c02-9442-28471534fe0e" control-id="ir-9.3">
+    <implemented-requirement uuid="e66be561-ec5e-402b-be11-89c9cc2d6a03" control-id="ir-9.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.3_stmt" uuid="5e20034a-1f65-4442-b25c-7f51e43ef647">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5edab1ae-1d37-4f17-9f60-31e6e054d575">
+      <statement statement-id="ir-9.3_stmt" uuid="f18c8ce4-99b9-4d25-8255-61fdd485f54f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4308,10 +4308,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4f68212e-8d6d-45fb-88c8-18579f72871c" control-id="ir-9.4">
+    <implemented-requirement uuid="eccff598-379e-45fd-9d5c-65773e649950" control-id="ir-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ir-9.4_stmt" uuid="e2612356-69af-4be4-9d1a-8c9c3d833122">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="30f1af1b-3c3d-481d-a5d8-e5d3792eca11">
+      <statement statement-id="ir-9.4_stmt" uuid="1e2e089e-bdca-4823-b35b-dfd53e798318">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4df9247a-2515-43ec-8bf6-7b86fec2445a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4319,18 +4319,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb3515d0-6911-4caf-aff4-a8645d1d5445" control-id="ma-1">
+    <implemented-requirement uuid="79bbe60d-fb10-4957-8236-c6012202d83a" control-id="ma-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-1_stmt.a" uuid="ce39450a-d476-425f-87a1-0860319a8092">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c01fc694-550f-4ced-898b-0251cd21315a">
+      <statement statement-id="ma-1_stmt.a" uuid="9330d002-55ee-428a-b026-9534632ae9bd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-1_stmt.b" uuid="26044881-2b2f-44a7-8349-8ec3ec617680">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="75a449ef-5eab-4590-8b61-d4715d121a29">
+      <statement statement-id="ma-1_stmt.b" uuid="01d928ae-fba4-4073-bed0-d2b7b996e31c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4338,50 +4338,50 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7c554be0-55e7-4839-a707-9bcae3cc12bd" control-id="ma-2">
+    <implemented-requirement uuid="2c7f66ff-b53e-4cf1-a882-4224dfd66064" control-id="ma-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-2_stmt.a" uuid="5c6e0478-7d7c-42bb-b584-766ff0574efd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="41477cec-15c0-42f8-89f4-43b5ca421ca2">
+      <statement statement-id="ma-2_stmt.a" uuid="4effddb8-e41b-4761-b7f3-1e725cd04b74">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.b" uuid="3a1bd0cb-d63d-460a-836d-338da8c41d47">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="569b7f2d-2c9a-4f9c-98d8-9b802cea172b">
+      <statement statement-id="ma-2_stmt.b" uuid="b62298fa-b158-4c85-88ac-04e00acc41de">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.c" uuid="7b37a702-18db-4afe-8388-e5a23211aabf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b0749f6c-1418-41f4-a213-33173122e086">
+      <statement statement-id="ma-2_stmt.c" uuid="a077c965-9ef7-43eb-a00e-0eecd8465d5e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.d" uuid="f13c508f-c350-45b9-8d01-8e7fcf7563f8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c4765aee-500c-4f0f-bcd2-f285a9b6fd78">
+      <statement statement-id="ma-2_stmt.d" uuid="71605f10-203f-4d37-8a73-60acf1a19490">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.e" uuid="d1adc29a-b7ca-442b-9fdb-c29adb10af86">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2d2add93-8aff-4d37-bde4-b6c229f64329">
+      <statement statement-id="ma-2_stmt.e" uuid="8059b9a5-9327-4fdb-9fb4-1817ef4b8282">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-2_stmt.f" uuid="b590ef7a-4114-4cb0-9a25-2cd79e13c79d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1a582893-690e-4a80-b36a-2a1c01de8719">
+      <statement statement-id="ma-2_stmt.f" uuid="c07f9d07-d835-4f83-ac78-1b754f3787c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4389,10 +4389,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="260727a2-5058-41bd-8e57-53a6cf9de058" control-id="ma-3">
+    <implemented-requirement uuid="51b43dae-6063-4771-840a-2b754cc4de6f" control-id="ma-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3_stmt" uuid="9baabdc6-226e-4b8c-979f-e3150eb551fc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="571ab10f-a95a-458d-b1d0-dab9c10391c9">
+      <statement statement-id="ma-3_stmt" uuid="4e16e51f-09a5-44b7-b8c8-c67a986e4696">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4400,10 +4400,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9f2cbf69-ee3e-4202-a9e6-92aed26e7ce0" control-id="ma-3.1">
+    <implemented-requirement uuid="c6eb59d8-cbe3-4917-8513-d3acfa8615dd" control-id="ma-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.1_stmt" uuid="83fd426b-8f01-49e2-8e9b-33636a2efbdc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9bb82d86-49c1-4571-8827-a0c233e9eefd">
+      <statement statement-id="ma-3.1_stmt" uuid="ff72aece-fe26-4415-b968-def1751b528b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4411,10 +4411,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6af0c889-28c1-419f-ba0c-03af900e6cf9" control-id="ma-3.2">
+    <implemented-requirement uuid="dea1f55a-e6d6-4ea3-8fce-46c277263b97" control-id="ma-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.2_stmt" uuid="aa0714cc-74d1-4694-9007-5a885ca39975">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e41fd48d-9550-45a7-b608-8b197a9f7a89">
+      <statement statement-id="ma-3.2_stmt" uuid="2f5b836d-5e91-4478-9895-7ef7e5f4dd18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e20d23dd-0409-470d-a95e-da34ecaf338b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Checking media containing diagnostic and test programs for
 malicious code before the media are used in the information
@@ -4423,10 +4423,10 @@ system is outside the scope of Red Hat Virtualization Manager (RHVM) configurati
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d46336df-a8dd-42e3-a4fc-e7448ece9885" control-id="ma-3.3">
+    <implemented-requirement uuid="e28a7832-d6cb-4ede-aa99-d3586eb25645" control-id="ma-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-3.3_stmt.a" uuid="abebe055-c704-47b6-8933-6d00fadbaada">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="279683f1-a4c6-453b-834d-ea2b78f6026e">
+      <statement statement-id="ma-3.3_stmt.a" uuid="424133fb-3759-4764-9086-48c72b365945">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="778b0eef-a853-4532-8c1c-5dced7dd12db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by verifying that there is no organizational
@@ -4435,8 +4435,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.b" uuid="20e36bb7-b324-4ced-95ee-6e0944349bbe">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e5f9d8c5-3f3d-402d-9633-686e24e9ded3">
+      <statement statement-id="ma-3.3_stmt.b" uuid="4e7e2816-1ccd-4b18-b8d4-7928146288e3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="fd27ca69-2c2e-4f61-aa4e-04c7f350c60f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by sanitizing or destroying the equipment is
@@ -4444,8 +4444,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.c" uuid="8aa8cd56-cba4-430e-a28b-cbd67eb75dd8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="878a04bc-d76b-40c6-b23e-a9e08332479c">
+      <statement statement-id="ma-3.3_stmt.c" uuid="be47dafc-6633-4cc1-bf6c-dc825ea3d933">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1bde0f7b-2115-4c9b-beb8-f8261ce40a6a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by retaining the equipment within the
@@ -4453,8 +4453,8 @@ facility is outside the scope of Red Hat Virtualization Manager (RHVM) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-3.3_stmt.d" uuid="597eabfd-1429-4323-b62a-eafb924db31e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3bd25ce4-a089-42c7-82d6-c1448f6ec583">
+      <statement statement-id="ma-3.3_stmt.d" uuid="52945e7d-10ed-4ed9-9ab7-4e056d9d14d4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9e558cb-7128-4261-b081-988aa504f75e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Preventing the unauthorized removal of maintenance equipment containing
 organizational information by obtaining an exception from
@@ -4465,10 +4465,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2d2a4f56-d273-4152-9e44-e741348d7e02" control-id="ma-4">
+    <implemented-requirement uuid="712c9223-7d41-4954-abfc-9ddcc8bd2a96" control-id="ma-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ma-4_stmt.a" uuid="b7de3539-481d-478a-b380-c59d16ebad5a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="03f37878-720c-4b3c-bb82-59700ed1374c">
+      <statement statement-id="ma-4_stmt.a" uuid="2bf356a4-b2a4-4067-929b-74401aef9739">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1256c0a7-6fc1-4515-82e3-6c020b38bbff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), all
 maintenance and diagnostic activities are monitored regardless
@@ -4477,16 +4477,16 @@ access mechanism.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.b" uuid="2c39fe71-8f36-402b-8a57-bc6d19ca4c26">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9d7e21cd-753a-43f5-8b8e-74fba7c46199">
+      <statement statement-id="ma-4_stmt.b" uuid="33c06d7b-42ca-43a2-bf2d-b9452b3aa380">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.c" uuid="e33e8979-ef4d-4bcb-b11c-2a0c9933a4f4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9cf6772c-6a9f-43f8-bb5c-fe256a94fccc">
+      <statement statement-id="ma-4_stmt.c" uuid="4072929c-605c-4829-ae5c-1c42f91a53e5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5ce23348-7b55-4f0d-9945-d882f911512c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), both
 local and nonlocal maintenance and diagnostic sessions will require
@@ -4498,8 +4498,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.d" uuid="99287033-b0f5-45e1-9547-51a8b8c3f86c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="160313db-3aad-4c9a-adaa-958457244924">
+      <statement statement-id="ma-4_stmt.d" uuid="6219f076-9f22-4aad-947e-62fb9fe64cde">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="66a7388b-468d-427f-a923-6ab2d04bc6ec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>From the perspective of Red Hat Virtualization Manager (RHVM), session
 and network connections terminate in the same manner (e.g. once user logs out)
@@ -4511,8 +4511,8 @@ https://projects.engineering.redhat.com/browse/RHV-21013
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-4_stmt.e" uuid="f0e11bd5-16c1-4b3a-ae5a-992acc90f0bb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5074a41b-1eb3-452d-9349-3c5a1adf678f">
+      <statement statement-id="ma-4_stmt.e" uuid="067f6cff-06a4-420f-a32f-1ed70c8acb40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4ba51597-ad11-49f4-b37b-eeb4ab2a1b86">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4521,10 +4521,10 @@ https://projects.engineering.redhat.com/browse/RHV-21013
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ad9d60bc-b3ff-4c18-b430-0c22bce4cb56" control-id="ma-4.2">
+    <implemented-requirement uuid="5da754c6-bbb9-41ed-acf2-bc9cb898d2e9" control-id="ma-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-4.2_stmt" uuid="2dbd72ad-c8a4-4849-a7ac-6baa0394387b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cec3438c-4822-4bd2-ab18-4f1382375339">
+      <statement statement-id="ma-4.2_stmt" uuid="25fce7ee-55f0-440e-a747-1ef7cbedaeda">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e5c40590-7ad3-4049-8b16-b6bda19d56d5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4533,10 +4533,10 @@ https://projects.engineering.redhat.com/browse/RHV-21014
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ee670ec0-e443-4c29-afe1-cd70b826e4a2" control-id="ma-5">
+    <implemented-requirement uuid="c6f2454f-6039-4a5c-b3b2-3a12d261e62e" control-id="ma-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5_stmt.a" uuid="ee252e59-2609-4475-951c-1d475cb6d40e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cad553e3-e757-42f5-b2f2-904d0c7a7ef7">
+      <statement statement-id="ma-5_stmt.a" uuid="0d5aa9e5-9153-4af3-a61f-86b82fefe5cf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37184d7c-fae7-4679-a963-845c88234b15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Establishing a process for maintenance personnel authorization and
 maintaining a list of authorized maintenance organizations or personnel
@@ -4544,8 +4544,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.b" uuid="8828a099-e30c-4d12-97bd-cc5d8da4d518">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="729d8cbb-fa9b-427a-b8b6-f3a7a160cec3">
+      <statement statement-id="ma-5_stmt.b" uuid="13062598-98ec-4b3d-b796-e16c64663d7c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c08b5ecc-06df-45aa-925d-de541e2bb933">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Ensuring that non-escorted personnel performing maintenance on
 the information system have required access authorizations is
@@ -4553,8 +4553,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5_stmt.c" uuid="4f061452-cd1c-4eb3-82bc-3950d99d0a97">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3335f200-00aa-44ae-83fd-847b8b6da618">
+      <statement statement-id="ma-5_stmt.c" uuid="287bd11d-ca0a-4758-9af5-1063bcf335fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6551219-a954-46c0-bceb-0316c766710b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Designating organizational personnel with required access
 authorizations and technical competence to supervise the
@@ -4565,10 +4565,10 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="65f16e95-bb8a-433a-9f98-917cb23e7451" control-id="ma-5.1">
+    <implemented-requirement uuid="54d68432-8279-4882-8396-98f6484351af" control-id="ma-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-5.1_stmt.a" uuid="920bd24a-062c-4875-9d56-9718d16cec76">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fa5f4cce-169a-45c2-9e07-bf1c21449c71">
+      <statement statement-id="ma-5.1_stmt.a" uuid="2ffff01d-6c01-422a-b447-78bf8d19cb44">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a0586d5f-7b13-4bc6-a605-4f8274aa5b8a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Implementing organizational procedures for the use of maintenance
 personnel that lack appropriate security clearances or are not U.S.
@@ -4576,8 +4576,8 @@ citizens is outside the scope of Red Hat Virtualization Manager (RHVM) configura
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ma-5.1_stmt.b" uuid="e46e23a6-269d-4f7f-bb9e-3ddf2bdabd91">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="84012f8b-1e4b-432a-8086-f52d6a7a4dbf">
+      <statement statement-id="ma-5.1_stmt.b" uuid="6b778f93-2407-4137-86c5-fc1f6f936d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="34e1fc1e-da41-4f7c-be05-bec4e101c33c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development and implementation of alternate security safeguards
 in the event an information system component cannot be sanitized,
@@ -4587,10 +4587,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8fd4947d-fbe6-4a18-b020-def37964c313" control-id="ma-6">
+    <implemented-requirement uuid="32b69454-b03e-4bc4-ace8-f327d63813fc" control-id="ma-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ma-6_stmt" uuid="4f9819bf-0434-4c69-848b-4d032cd0ce7f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2c260e4f-3764-45a8-92e2-bb9e04b04358">
+      <statement statement-id="ma-6_stmt" uuid="5a8fc70f-bcfc-4f12-b02d-011a5a8d8ec1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="023e6e11-475c-46e2-86cc-7498a60ded11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering progress can be tracked via:
 
@@ -4599,18 +4599,18 @@ https://projects.engineering.redhat.com/browse/RHV-21052
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d144d6f6-1341-4861-9be4-a68a923f10b9" control-id="mp-1">
+    <implemented-requirement uuid="21e2fece-6fb6-4dc4-a165-885ee0319bb6" control-id="mp-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-1_stmt.a" uuid="451fbb1b-d3df-4fad-b53e-9fc4815598bb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2f35de92-378a-479a-b71e-d484708cd147">
+      <statement statement-id="mp-1_stmt.a" uuid="54245217-533b-4796-9349-d7b78db1cb9c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-1_stmt.b" uuid="63dd96e7-639f-4779-9042-450100bf575a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="901ec5ab-dcef-4806-a031-58d1aa6daa32">
+      <statement statement-id="mp-1_stmt.b" uuid="1fa9aa7d-9754-40d5-b9bf-7b514bc8bba5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4618,10 +4618,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d59c2cc4-de16-493d-8c65-ad5ea1e76819" control-id="mp-2">
+    <implemented-requirement uuid="1d719265-c6e1-4e22-87c0-32f73d10445d" control-id="mp-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-2_stmt" uuid="4c5503ba-1322-47b3-91a8-e0370f86e333">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5ac1fd3b-8a89-45d5-9df4-d7e31ae11bb5">
+      <statement statement-id="mp-2_stmt" uuid="52d17426-e19c-44f2-bb00-4aa3fcf18940">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7d85cc4a-8009-4713-824a-590d8f9db555">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -4630,18 +4630,18 @@ https://projects.engineering.redhat.com/browse/RHV-21053</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="19d96e6a-8640-4707-9053-e4aa0a0cdcab" control-id="mp-3">
+    <implemented-requirement uuid="b6cbdb0b-c964-4d16-a682-016aac800494" control-id="mp-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-3_stmt.a" uuid="6eb51056-3d87-47e8-b157-a34bcbf88870">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cdfc91a2-88ab-4f29-89b3-f165d2031472">
+      <statement statement-id="mp-3_stmt.a" uuid="06c5e5a7-3c34-48f3-8ccc-9bfebb9962f1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-3_stmt.b" uuid="5455432d-764c-4851-9dfe-f96242266065">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b9aa2f28-bd3a-497b-95e7-56b78447ebaa">
+      <statement statement-id="mp-3_stmt.b" uuid="8404a05e-f27b-41dc-ae48-e935ce7cffa1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4649,10 +4649,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="54f12fee-17dc-42c8-87fb-3cfb281e62fc" control-id="mp-4">
+    <implemented-requirement uuid="0ae07f16-fcd6-4ca1-af12-5484c7228ed1" control-id="mp-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="mp-4_stmt.a" uuid="d77a5d44-e73c-45b6-aeca-392abefa0c8c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="07ed6e74-b941-4f50-b97f-7eb069fb2c69">
+      <statement statement-id="mp-4_stmt.a" uuid="b2c9bfab-6447-4a76-8556-1f3cf56f77b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -4661,8 +4661,8 @@ https://projects.engineering.redhat.com/browse/RHV-21054
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-4_stmt.b" uuid="0ef0d6b3-e55c-45bd-b523-0022bc241c10">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="14fbd0f6-7b61-489f-ade2-27eb8e18b1dc">
+      <statement statement-id="mp-4_stmt.b" uuid="152c6172-3805-4382-af5e-3493779568ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="77dc9461-6015-46b9-9b2c-a4500344688f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Engineering
 progress can be tracked via:
@@ -4672,34 +4672,34 @@ https://projects.engineering.redhat.com/browse/RHV-21054
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="97521b03-281d-4a5d-ac9a-c389b113ee94" control-id="mp-5">
+    <implemented-requirement uuid="36916837-73ba-485f-8cbc-b952b06b4623" control-id="mp-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5_stmt.a" uuid="c0b1e1d6-5e71-4067-9302-77b388e09097">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b765bec6-fb5a-4cee-90f5-e4f8f1b0c929">
+      <statement statement-id="mp-5_stmt.a" uuid="e0906ff3-f31b-4c8d-8aa0-0c4e4fa3a8a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.b" uuid="14b1c4ad-6e04-4b61-9630-d0575810834b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="19526375-feea-4052-9614-42d9edd6fc9e">
+      <statement statement-id="mp-5_stmt.b" uuid="edc5e494-f272-4d10-9df1-5871af42bb73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.c" uuid="ee9c9f9a-ef23-455f-829f-ffad0e0264a7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5e4675b6-8aea-47bf-8452-e0a1bcb53f20">
+      <statement statement-id="mp-5_stmt.c" uuid="a84b3aba-abb5-4393-9995-84ea457e87ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-5_stmt.d" uuid="2a909e89-101c-4a40-a2b3-4fa03d5daf21">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8ff67565-c344-407e-a2c2-da7c1360b42b">
+      <statement statement-id="mp-5_stmt.d" uuid="a8df34aa-1c68-48fd-81a4-ae42dd813773">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -4707,28 +4707,28 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1af1a4f6-09d7-4bfd-8d3d-bd3c951b150f" control-id="mp-5.4">
+    <implemented-requirement uuid="43ab6425-7575-480a-bb35-97797d8dea5f" control-id="mp-5.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-5.4_stmt" uuid="832d355c-2059-4962-9157-ac9a05b0af4e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2d9487a4-5ed2-44ab-b5dc-9123f3e07df7">
+      <statement statement-id="mp-5.4_stmt" uuid="cab7bc15-ef7d-40e5-9002-6298a3e922b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a2412655-1c13-4084-8d0c-f2c54eb6104b" control-id="mp-6">
+    <implemented-requirement uuid="206115a1-32bb-45fe-b7bd-958b681716ef" control-id="mp-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6_stmt.a" uuid="a40f3098-41cd-421f-a3ab-ceb094cebeb3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bc137071-185e-4a2d-acd7-e90351d74836">
+      <statement statement-id="mp-6_stmt.a" uuid="11e0e048-562f-4a5a-8100-1d226ba054b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="mp-6_stmt.b" uuid="59c5aabd-2fca-4e0c-b449-71dc86a8761c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0dcadd9c-a35b-45c8-900e-2ff1d455fcbe">
+      <statement statement-id="mp-6_stmt.b" uuid="bfe2ce74-209a-475f-8f81-b20fcb291d83">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -4736,20 +4736,20 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="60189034-4e34-4447-80f0-c6e751a95864" control-id="mp-6.2">
+    <implemented-requirement uuid="0c5845cc-d95b-4184-bd4c-c6ed9526bb46" control-id="mp-6.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-6.2_stmt" uuid="9bc99138-1239-4c06-b9bc-badd6aa6e5bd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2ac4c99b-5b3a-4bc6-8547-26ae13314c0c">
+      <statement statement-id="mp-6.2_stmt" uuid="bee4acfb-7955-4781-8eb6-0516c31204bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a14e799-3763-4bde-afd4-60702e5ab4d4" control-id="mp-7">
+    <implemented-requirement uuid="beb2bb67-563e-4523-964e-e3f3311f8298" control-id="mp-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="complete"></annotation>
-      <statement statement-id="mp-7_stmt" uuid="6990b7bb-592c-46b6-a8ec-98fe501b10c0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f4630458-b8c8-4aea-a0eb-1d577e4a4b70">
+      <statement statement-id="mp-7_stmt" uuid="c569f073-ff56-4283-85df-edd9ea04a4bb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ef5e981-f45c-4e6c-afee-b8b076d7f993">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>To prohibit the use of USB storage devices on Red Hat Virtualization
 Manager (RHVM) nodes, the following configuration check must be enabled:
@@ -4770,20 +4770,20 @@ https://projects.engineering.redhat.com/browse/RHV-21055</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dc115532-5e5b-4b9d-82d0-6980bd29a634" control-id="mp-7.1">
+    <implemented-requirement uuid="c753c7a9-1b2b-4d46-84ce-900c8502562d" control-id="mp-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="mp-7.1_stmt" uuid="a83a4eaa-7c80-4695-a92f-df90224c59db">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="74c0ea53-98ed-4cee-a8c6-87e1e8b8262b">
+      <statement statement-id="mp-7.1_stmt" uuid="2cea307a-9461-4ffe-86a3-aed7978ea58b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="001fc4f2-84ef-4b79-a388-8fba3b4639cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.</p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5ab3ea91-6d3b-4ff1-b762-1c8acc8023a9" control-id="pe-1">
+    <implemented-requirement uuid="42a8e6e7-ba47-4673-aa26-921fc065444d" control-id="pe-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-1_stmt.a" uuid="43b73736-7dd5-4c27-a014-103e08350aa9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7792244b-ebfb-4493-a7d3-9ad565ddc1a5">
+      <statement statement-id="pe-1_stmt.a" uuid="c83f6fe7-f379-4d26-b467-b6d8eee9b69d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9ec3101-88dd-4b31-8554-cb58a661cf37">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, documentation, and dissemination of a physical
 and environmental protection policy reflects organizational
@@ -4792,8 +4792,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-1_stmt.b" uuid="6f536a0a-b927-4cf5-a344-49442a554e28">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="02a9373a-5116-49d1-99a2-b2054453e707">
+      <statement statement-id="pe-1_stmt.b" uuid="da7d9481-1921-47cd-a889-16afb00309d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e2f86c0a-2a8a-4fb1-bba7-bcb67201d575">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the physical and
 environmental protection policy reflects organizational
@@ -4803,10 +4803,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d1c0bffc-5af6-47d3-8bc0-7ab6f9ae815e" control-id="pe-2">
+    <implemented-requirement uuid="7ec32282-917b-4e33-9f1b-1cc83c5f2126" control-id="pe-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-2_stmt.a" uuid="462140ed-9ed6-446e-98d5-fd66f7058d8d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cf99c632-0fe3-4dc0-b8f9-662fc46234ed">
+      <statement statement-id="pe-2_stmt.a" uuid="b5066467-2113-4017-8031-35011f19a450">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="038e04b3-3dbe-4b39-92c2-c785877f4bcd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Development, approval, and maintenance of a list
 of individuals with authorized access to the facility
@@ -4816,8 +4816,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.b" uuid="e0b10610-fdd5-4004-a7b7-bfe4727dc5ad">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="400006e1-a117-4ee2-9866-0d6807e23d64">
+      <statement statement-id="pe-2_stmt.b" uuid="392ae166-9512-48e9-aa07-42183889708c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="669f2834-4e92-4717-871b-ae33fdaeaaa1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Issuing authorization credentials for facility access
 reflects organizational procedure/policy and is not
@@ -4825,8 +4825,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.c" uuid="a94cb3b5-cfd8-49b3-95d0-d9fc0c007d62">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bc56a475-313b-4bb8-b435-4ae0933bbdda">
+      <statement statement-id="pe-2_stmt.c" uuid="d5469cdc-724a-4322-9129-d5934c105c10">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bfb7d2d8-d63a-49c4-b3fb-7ca6924e9d98">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing the access list detailing authorized facility
 access by individuals at an organization-defined frequency
@@ -4835,8 +4835,8 @@ applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-2_stmt.d" uuid="be4f21cb-9b88-480a-8486-85db34823435">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c5b450ff-b775-4018-8344-c8814311ba5b">
+      <statement statement-id="pe-2_stmt.d" uuid="a967db64-9e28-4b4e-b8c7-3f44a166c394">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="859bce49-462e-42c3-a22c-f485a8e44724">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Removal of individuals from the facility access list when access
 is no longer required reflects organizational procedure/policy
@@ -4845,10 +4845,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb8df215-246b-41b5-8175-49c4f5a95674" control-id="pe-3">
+    <implemented-requirement uuid="042703fc-da12-4f5b-9c7a-6d0137e53335" control-id="pe-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-3_stmt.a" uuid="be6d5cba-dc74-4925-90d1-04e6ed738940">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c2b0dde7-2e74-4f4f-bd4a-2a824fd659b9">
+      <statement statement-id="pe-3_stmt.a" uuid="5441c93a-ece5-4408-89a4-3016425351ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d32678f5-5c72-4ec3-81f0-9d87d5406f5a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Enforcing physical access authorizations at organization-defined
 entry/exit points to the facility where the information system resides
@@ -4857,8 +4857,8 @@ component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.b" uuid="19046d0a-1fbb-41a2-a762-55b676951232">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="643608c3-8b00-4f67-98b7-e0a3061bcb19">
+      <statement statement-id="pe-3_stmt.b" uuid="ff052ff3-128f-4899-bd0b-2ab818502631">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6fa063ec-7fbd-43c2-b09c-7d1a0f27e663">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Maintaining physical access audit logs for organization-defined
 entry/exit points reflects organizational procedure/policy and
@@ -4866,8 +4866,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.c" uuid="41be9800-bb9c-42d6-a3a1-c0cb33b809c0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="19ddb17b-0ffc-4db0-a4c7-036e2d643701">
+      <statement statement-id="pe-3_stmt.c" uuid="6d431649-93fd-40ed-82a5-a10123b36d13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ab51d315-44ab-420d-a34a-fe28a1bb5d8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Providing organization-defined security safeguards to control access
 to areas within the facility officially designated as publicly
@@ -4876,8 +4876,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.d" uuid="18d5a47e-9bfb-4aea-af47-65b630dfb0f2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ec60a901-5bd8-4ba3-872d-39562ed80370">
+      <statement statement-id="pe-3_stmt.d" uuid="73ada1b1-2cb7-4e33-92b5-d49db0460f18">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="89f5db7a-50c1-41a4-bd2f-b0515b74cd9d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Escorting visitors and monitoring visitor activity during
 organization-defined circumstances requiring visitor escorts
@@ -4886,8 +4886,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.e" uuid="77546150-7fbf-4c7f-85cc-0da557569ed5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="48eced5b-d1ed-4262-8dc1-2c46a7637d3d">
+      <statement statement-id="pe-3_stmt.e" uuid="cf7ec606-b6be-4f32-87a2-b69aacb9c9b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49afbd68-3163-4721-b4a1-6da04653789f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Securing keys, combinations, and other physical access devices
 reflects organizational procedure/policy and
@@ -4895,8 +4895,8 @@ is not applicable to component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.f" uuid="c9a9b7e9-f36e-4eee-8270-24e4793ce62e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9f861ec5-f888-4e46-a325-fc47a2c958fa">
+      <statement statement-id="pe-3_stmt.f" uuid="ac8fc9a1-95dd-4d7c-b1c2-7e8aba4d5be6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0938121d-1df5-4128-b99d-0c772958da88">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Inventory of organization-defined physical access devices
 at an organization-defined frequency reflects organizational
@@ -4905,8 +4905,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-3_stmt.g" uuid="e1f4eb82-0569-45a2-b74e-3572bba3517f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6d0b56de-dad3-4a24-b4e1-3252fe281686">
+      <statement statement-id="pe-3_stmt.g" uuid="38201073-f9fa-470b-be12-c08647c86ac2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="12ae89c8-84dd-48ee-a198-3e89b569638f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Changing combinations and keys at an organization-defined frequency
 and/or when keys are lost, combinations are compromised, or individuals
@@ -4916,10 +4916,10 @@ and is not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e7fd8dc7-b6f6-4271-a58d-b4b0981c2c80" control-id="pe-4">
+    <implemented-requirement uuid="46abf4f3-4472-4c77-bbd9-74c3eae01ff9" control-id="pe-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-4_stmt" uuid="b1fe673a-3a91-43ff-8c30-3d68e2cedfd6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="496ad56a-b0e2-4f25-b123-34e692d6a608">
+      <statement statement-id="pe-4_stmt" uuid="3f1d80f0-7748-44bb-b239-72401a8a3c9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20a97f0a-87de-472b-9dab-1f3e696ffd79">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to organization-defined information
 system distribution and transmission lines within organizational
@@ -4930,10 +4930,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="21360ac9-8485-4fda-95f5-be0990d5b9ed" control-id="pe-5">
+    <implemented-requirement uuid="3cf500e1-b3c3-403e-bbf2-3379450bbcd6" control-id="pe-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-5_stmt" uuid="5ef6b2a7-2688-4b64-8eb0-78b19cd6b2e6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="34589d38-5153-4fb4-a9bf-110b440efc3b">
+      <statement statement-id="pe-5_stmt" uuid="095a9727-ee06-43af-bffc-967482a0e923">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9939d4ca-f972-4a8d-b331-68d3d9967242">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Controlling physical access to information system output devices to
 prevent unauthorized individuals from obtaining the output reflects
@@ -4943,10 +4943,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="43ddf461-22dc-43fd-a12f-4d2c72f09c84" control-id="pe-6">
+    <implemented-requirement uuid="dc8a7092-0aab-4dd5-a47a-e857656e5f0b" control-id="pe-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6_stmt.a" uuid="6d517ab6-e77e-486a-97f2-8b72def1b6c5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="57dfbf32-4053-4b36-b4b2-ac171b746fae">
+      <statement statement-id="pe-6_stmt.a" uuid="33cd6b74-63d4-460b-823f-b5f28b85efcd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d819c998-1e4d-48ac-b59d-ad2866825484">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical access to the facility where the information
 system resides to detect and respond to physical security incidents
@@ -4955,8 +4955,8 @@ of component-level configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.b" uuid="d6fd76fb-3c5c-42eb-9717-0c722e0d74c6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c4d7577b-c99a-4725-ab4d-a790fe66f4f7">
+      <statement statement-id="pe-6_stmt.b" uuid="f3362c58-4214-4a7c-80a0-b105d2e1c71b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ce190ad7-f714-44fa-bfc0-8945d32c13e1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Reviewing physical access logs at an organization-defined
 frequency and upon occurence of organization-defined events
@@ -4966,8 +4966,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-6_stmt.c" uuid="24dddf35-5a67-491e-bc78-4c34811837be">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2d8ac6eb-8d51-44f1-bce7-e3e484186b75">
+      <statement statement-id="pe-6_stmt.c" uuid="b92908ce-4745-4711-bcb3-6a5960563a2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="84fe10a0-60dc-47d9-90ba-d0f6f61bca15">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Coordinating results of reviews and investigations with
 the organizational incident response capability reflects
@@ -4977,10 +4977,10 @@ component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="032f19ae-1c84-4870-b488-d09ebb620a3b" control-id="pe-6.1">
+    <implemented-requirement uuid="9eb8c9df-6a43-4ca1-be5e-af5b64bc1e07" control-id="pe-6.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-6.1_stmt" uuid="a7ca01d3-1afe-40c5-a820-94b52f032dbd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1701377e-b8fe-44fa-a2dd-f293dc792138">
+      <statement statement-id="pe-6.1_stmt" uuid="a52a9d06-93d7-4a3c-87f0-fcedc317b627">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8bef794c-7b7e-4074-8e91-b173fa4abe84">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Monitoring physical intrusion alarms and surveillance
 equipment reflects organizational procedure/policy and is
@@ -4989,182 +4989,182 @@ not applicable to component-level configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c9a1aeb0-f124-4612-8467-1d3f6411664f" control-id="pe-8">
+    <implemented-requirement uuid="8320c2c9-7961-4f3c-a38e-e9264bf352e0" control-id="pe-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-8_stmt.a" uuid="bf505116-d1d4-433c-a007-590bf523d23c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="80d9b9a1-97d7-4389-88a7-09b09000c80e">
+      <statement statement-id="pe-8_stmt.a" uuid="a118fbde-88f3-42fe-98bb-1251e82a149f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-8_stmt.b" uuid="3850dcf4-f168-4f98-98ad-ed3fb1a83896">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="71b4b427-0f0d-4cdb-952a-b05034122102">
+      <statement statement-id="pe-8_stmt.b" uuid="3ac78417-d2a1-4a9b-b566-644a13808b22">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6156c619-b92d-415e-b392-61d3495a9199" control-id="pe-9">
+    <implemented-requirement uuid="419aa702-528f-4137-9417-f8aee5b3e5c6" control-id="pe-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-9_stmt" uuid="f65304f0-a6cd-447e-b8f7-f2bf38ef5d20">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5fac8621-e0e4-4ab7-aec0-f88deb4d6ffb">
+      <statement statement-id="pe-9_stmt" uuid="cbf78a0b-dde9-4922-b7ff-ed6274573a85">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="78ab7275-add6-4dac-8a7a-fd17598c44a9" control-id="pe-10">
+    <implemented-requirement uuid="8ee0cc89-73e3-4aaf-816c-8b1717094049" control-id="pe-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-10_stmt.a" uuid="efd702a2-ef2e-475e-89ee-b10c98cb6ca5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6216d8e5-d12a-4688-94c0-dd0e1321af21">
+      <statement statement-id="pe-10_stmt.a" uuid="7c71b36e-3993-47ea-8e8d-bbd65a5df201">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.b" uuid="6805b478-2f71-4ab8-b861-f4b464e5552d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2ca0eab6-0e42-4fd8-b56c-0bd59eafa7b0">
+      <statement statement-id="pe-10_stmt.b" uuid="48927301-9960-4664-acdb-dbf483363a92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-10_stmt.c" uuid="ae8b9e13-93ec-411c-88af-09188c409827">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="28745dee-5e3a-459b-a248-e0fec6c34cfb">
+      <statement statement-id="pe-10_stmt.c" uuid="a8b7f3c6-6a8e-40b1-87f8-f72b43c24f6f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="79464532-a122-4279-916c-2ed6b8fad854" control-id="pe-11">
+    <implemented-requirement uuid="e66a774c-4e9d-4925-a354-98ca4da35b13" control-id="pe-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-11_stmt" uuid="435720db-6e02-4582-af0e-f6df559db45f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fdbf480e-6bb3-44df-89c2-38fe0586cc51">
+      <statement statement-id="pe-11_stmt" uuid="9c38de5a-67d3-4a00-bb17-d9517cae8d9e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="682eb59b-239b-408e-8f52-6f0694726ce9" control-id="pe-12">
+    <implemented-requirement uuid="6838a18a-fb90-4c6e-a008-a476bb0c63a5" control-id="pe-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-12_stmt" uuid="d81555de-7b93-4b57-a426-a0a1a6afeb35">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b8a3f4e1-848e-45a8-8271-aaa2f60bd632">
+      <statement statement-id="pe-12_stmt" uuid="e6a116ec-fda4-49a6-ad02-e5fe48020d81">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6d52baac-1139-4e93-8d2d-c5e5a7279320" control-id="pe-13">
+    <implemented-requirement uuid="a6a6cfed-f002-4a29-861e-3dec20ca9722" control-id="pe-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13_stmt" uuid="cecdc568-6753-4af4-9e91-38e668c46a65">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="05f3e8ff-6f0f-43ab-a8f6-7ecfdb63b438">
+      <statement statement-id="pe-13_stmt" uuid="46ea2a14-ef47-42d4-a128-07e8622f9a69">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73ef06be-16ac-409d-aa39-08869e733270" control-id="pe-13.2">
+    <implemented-requirement uuid="8bbf2198-c5dd-40c0-bd96-7457df4ebfa9" control-id="pe-13.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.2_stmt" uuid="6eb2606a-0a83-489b-9f77-be7e805628ec">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cbd8df1a-a697-4331-bd34-28ff67ba522d">
+      <statement statement-id="pe-13.2_stmt" uuid="38156d05-4b08-4fcb-95e8-691bf5ff626c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="9923ebd9-bfb6-463a-891c-6607c515df73" control-id="pe-13.3">
+    <implemented-requirement uuid="ca388a07-6d5c-4dd5-9a4a-e245cf2cbeef" control-id="pe-13.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-13.3_stmt" uuid="4e7ac591-f558-4fe5-b823-8f6513a73822">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="088eee42-c57c-4327-9d5c-8d136c64268d">
+      <statement statement-id="pe-13.3_stmt" uuid="f76fdb08-e44f-4c10-9254-52cf5e322a20">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a495e80e-2009-436b-abbb-158ce4112ffe" control-id="pe-14">
+    <implemented-requirement uuid="9b806d64-c3c8-45ed-aea1-dbccae65b275" control-id="pe-14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14_stmt.a" uuid="5dc81488-85c9-415c-9a4f-7382063e750c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="60df84f4-0059-4cb6-9232-2703749a39f6">
+      <statement statement-id="pe-14_stmt.a" uuid="51e93fff-5147-4e45-a169-fed84fd1f4a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-14_stmt.b" uuid="c693187b-25a8-4ee1-8150-2bcf4ae2661f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="27d8df5a-0fce-470f-8e71-f137d27edaf5">
+      <statement statement-id="pe-14_stmt.b" uuid="9492c294-a053-476d-83b7-481034179948">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e93dca3a-a392-45d9-b850-8e4ff7134571" control-id="pe-14.2">
+    <implemented-requirement uuid="99aad80b-2691-4d17-a6ea-cf4e33cff9f3" control-id="pe-14.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-14.2_stmt" uuid="05304c56-20f2-4cbc-87f1-097960976aa7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2520bf64-c668-493d-872b-4c32f719c6a0">
+      <statement statement-id="pe-14.2_stmt" uuid="5cd207cd-e7c5-439d-a60d-74e3624bc9ca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="251791a0-270a-4ba3-bb8f-829ef37353cb" control-id="pe-15">
+    <implemented-requirement uuid="2bff9725-cc40-4d0d-8a46-3e0ff4392ca3" control-id="pe-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-15_stmt" uuid="b33887a9-f3e9-4f6f-bdd7-b0da1042d087">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="15ff19b7-f830-46ab-82a2-11b5f175e3c1">
+      <statement statement-id="pe-15_stmt" uuid="2fedfbd9-eb4d-4b1d-a5a5-956dc3113cd5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="fb88a295-d9c6-4274-ae81-e369990ccc8f" control-id="pe-16">
+    <implemented-requirement uuid="e595f42c-de11-4e82-9d18-fabb75f17145" control-id="pe-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-16_stmt" uuid="69be6c4e-d48a-42c7-963b-fa4a9dbb646d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="23a5c3ab-be66-441f-bff8-abb7b94b0951">
+      <statement statement-id="pe-16_stmt" uuid="7f5a2ee2-6937-4a86-aef6-151e852bee1b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="323b2eb8-7087-4440-b9e7-3fb5abf1c4c4" control-id="pe-17">
+    <implemented-requirement uuid="edef40ea-174c-4d4f-b75c-c0e7a27f27e2" control-id="pe-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pe-17_stmt.a" uuid="0c784003-f097-4154-9d96-48d6a9aeb056">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9d437840-05f2-4f80-b2b7-c2c59ba174aa">
+      <statement statement-id="pe-17_stmt.a" uuid="dd42e137-c83b-4196-b228-f6b6b1952434">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.b" uuid="90853998-7907-4037-ba2a-925b2fc1fd6d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b10f7137-24c0-4d4d-b3cf-a08a5f6f0471">
+      <statement statement-id="pe-17_stmt.b" uuid="781d06d5-96a6-4df4-9a00-455fb8158814">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="pe-17_stmt.c" uuid="c34683db-950a-4293-b0b7-d420f9390224">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a5b00a8e-ecc1-4181-982d-0b76c041c441">
+      <statement statement-id="pe-17_stmt.c" uuid="f494a87c-5024-40d0-837f-f324d8436ad8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6dd1dac0-7e43-4f37-9f6e-efd428603796">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3e6ad3f-cc64-4305-81bd-de9e7eee3530" control-id="pl-1">
+    <implemented-requirement uuid="bf894a0a-38ea-4ffd-8e0b-157daa75e9ad" control-id="pl-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-1_stmt" uuid="7078e0d3-4991-467c-a7ea-6139ae5eb709">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e173e99f-c27c-468f-a8fd-03ade2523499">
+      <statement statement-id="pl-1_stmt" uuid="f47cbca5-b457-47fd-80c2-d7e534170f55">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5172,10 +5172,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ceb9e40-b359-4217-b141-ea3fb313ce63" control-id="pl-2">
+    <implemented-requirement uuid="e68bf66e-6d82-4160-822b-c16a428bd2b3" control-id="pl-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2_stmt" uuid="a1ac3758-2257-46e4-8933-93756f33d8e8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="44e67c89-8420-4d68-ad37-10a558bd8df2">
+      <statement statement-id="pl-2_stmt" uuid="47810737-bc47-4c79-9b16-cb59643cc3d0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5183,10 +5183,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d660d7cc-a8bf-4511-98a1-35a3fcb29be4" control-id="pl-2.3">
+    <implemented-requirement uuid="02bd141f-4046-4dab-a5a2-1e73ad27d410" control-id="pl-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-2.3_stmt" uuid="841e3219-70b9-4efd-97c7-d653e28fd0c2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="05bc1c96-ecd4-49a2-97b8-c6d9db1f63e9">
+      <statement statement-id="pl-2.3_stmt" uuid="abf06d43-30b7-4719-a5c0-75a71380ad9a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5194,10 +5194,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="27174258-ecd7-4580-9258-10d6cc432781" control-id="pl-4">
+    <implemented-requirement uuid="d3548faa-50e7-4418-91fc-978c587b6932" control-id="pl-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4_stmt" uuid="9b648002-efb7-4acc-91cb-610f2b24d33c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0e487c30-79a8-4916-9439-b03e89e8d318">
+      <statement statement-id="pl-4_stmt" uuid="6b6e1b4c-c83a-49b4-969d-c730878f1634">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5205,10 +5205,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cae1b4cd-1a97-4266-b4cb-e860ca4bd03a" control-id="pl-4.1">
+    <implemented-requirement uuid="4e0d5f8f-689b-4300-a6d2-7aed358c6478" control-id="pl-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-4.1_stmt" uuid="7fed3b8f-363e-41d6-8908-7ce3e127e098">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ffd5ceb2-31fd-4e67-ae7a-193e7aebf618">
+      <statement statement-id="pl-4.1_stmt" uuid="adc1efe8-e303-45d1-9c53-82c123991f53">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5216,10 +5216,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3154139d-44bb-4d47-aaa4-b98012567b26" control-id="pl-8">
+    <implemented-requirement uuid="91d71fbd-1d7d-467a-8933-7c337074e189" control-id="pl-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="pl-8_stmt" uuid="071b7a83-db64-478f-a517-5921ae5cdfe4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b136504c-c371-4d58-95df-88496f5536f2">
+      <statement statement-id="pl-8_stmt" uuid="54514b9f-7a5a-4296-a5ff-9a141802c5d5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0e2f9176-593a-472d-89f4-1e3cdc8e609f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>'This control reflects organizational procedure/policy and is not
 applicable to component-level configuration.'
@@ -5227,10 +5227,10 @@ applicable to component-level configuration.'
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="40c5d871-1238-44a1-9007-37a5b0d7fba0" control-id="ps-1">
+    <implemented-requirement uuid="93d1e507-8951-45a8-96c5-57a2597e1852" control-id="ps-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-1_stmt.a" uuid="d12b0973-8a56-452a-a481-75830b080c02">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b971c959-c793-4fd5-a447-5894fc09e97b">
+      <statement statement-id="ps-1_stmt.a" uuid="9a1d5fe5-b6b6-436a-bdc2-97245e2cf2af">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5238,8 +5238,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.1" uuid="1e75be8d-52eb-493e-9af8-64155bef27f3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="eddb1a83-08e2-4123-9071-6dbcd8f58bb8">
+      <statement statement-id="ps-1_stmt.a.1" uuid="8bd33eb5-670c-4421-810e-3788087e21ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5247,8 +5247,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.a.2" uuid="023e1ebb-4eb2-4918-931b-543926de4f6c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6fc9a366-5076-4c75-a1f0-5c6a8c62eda4">
+      <statement statement-id="ps-1_stmt.a.2" uuid="b381e8bc-dd72-4f30-9c01-80de40b9fd09">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5256,8 +5256,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b" uuid="49eec601-e9b7-4a96-a0b7-9bdd7681f761">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6acce0e5-da2e-4de8-865a-3ddaf72a2f48">
+      <statement statement-id="ps-1_stmt.b" uuid="d5793809-eac8-4e6a-85e9-846e5c09d8a3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c65f605a-8f0f-4eb4-8633-fc65d9734d42">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the personnel security policy
 and personnel security procedures at an organization-defined frequency
@@ -5265,8 +5265,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.1" uuid="03c34f2a-6653-4263-b689-4063b95042f9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="214d3e8a-e840-4ffe-a075-ec1c49bc0912">
+      <statement statement-id="ps-1_stmt.b.1" uuid="6ec7797b-8ba2-4407-95da-bde11a63c8be">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5274,8 +5274,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-1_stmt.b.2" uuid="28d75eea-7604-442d-95f5-04d5f82c4ec6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0fb67111-d638-4f3d-b73d-561a630a2e74">
+      <statement statement-id="ps-1_stmt.b.2" uuid="fa7b6a20-02e8-461a-9d2a-45340c6a5448">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f0f60f33-7580-4634-979a-4b232ff5a0e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination of
 a personnel security policy to organization-defined personnel
@@ -5284,18 +5284,18 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c6b5fc0-d7dd-46c8-bc04-82776fdbe199" control-id="ps-2">
+    <implemented-requirement uuid="02a20a00-7ff3-4211-b43b-c104cc3b6a9d" control-id="ps-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-2_stmt.a" uuid="583e2a31-ab7f-4ec8-823a-123607cc9e14">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="11ebdd0e-fcd1-46c0-9dff-7a295410d897">
+      <statement statement-id="ps-2_stmt.a" uuid="6cfc9b43-511f-465c-9044-654e5fe87f77">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad506da8-c0ec-48ba-97b5-16f6fef72a89">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational assignment of a risk designation to all organizational
 positions is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.b" uuid="94482ce0-4328-4a57-8fb7-b18a5d90ad25">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="de65f0ad-af6d-4311-8c3b-d0bb701e85b4">
+      <statement statement-id="ps-2_stmt.b" uuid="4ccf8cb8-eeb1-4eb3-8d98-043269082fa5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a604cd65-e085-46ae-9208-9ab9455e1b97">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational establishment of screening criteria for individuals
 filling those positions is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -5303,8 +5303,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-2_stmt.c" uuid="bf276992-be98-494f-8785-334c6cce37a4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7baf4cbb-4c43-40b4-9bae-1cbbb9e6bf64">
+      <statement statement-id="ps-2_stmt.c" uuid="49f819b8-0769-467f-a8c1-148162cf7870">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e09fcf4c-ceb0-4c42-8b6b-a2d20ecf7aee">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updating of position risk
 designations at an organization-defined frequency is outside the scope
@@ -5313,10 +5313,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c79df722-b2a3-43f9-a048-649c68f2f9a5" control-id="ps-3">
+    <implemented-requirement uuid="97381a61-dfe9-4a8f-a784-2a54978b29df" control-id="ps-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3_stmt.a" uuid="2c7e4de1-25d7-43ab-8e34-f6813d3b6187">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b59fbe8a-f106-4a63-977e-ee8e49661b73">
+      <statement statement-id="ps-3_stmt.a" uuid="729af710-a601-4b8d-9073-286a85ec0661">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff1de7d3-05c5-4397-a184-9cef0d215851">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational screening of individuals prior to authorizing access
 to the information system is outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -5324,8 +5324,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3_stmt.b" uuid="95b9e5e0-e665-4174-9eb9-0017e735dad8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="126ec08d-696e-4922-b751-a1d7a0390ac6">
+      <statement statement-id="ps-3_stmt.b" uuid="e81d4485-4e21-47af-bd94-3c3d8b7cdd40">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="78b3be79-a4bd-4282-8372-aad211307d45">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to rescreen individuals according to
 organization-defined conditions requiring rescreening and,
@@ -5336,10 +5336,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d4f0c3c2-a12b-4137-921f-9dcfbf47b0f5" control-id="ps-3.3">
+    <implemented-requirement uuid="253cc88f-8e1a-41d5-a94e-01a1af3560b2" control-id="ps-3.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-3.3_stmt.a" uuid="10927f21-69be-41d0-83d4-3acfbaccb68f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="256cefc7-b2e2-4a18-86d1-0cf8d53db1c8">
+      <statement statement-id="ps-3.3_stmt.a" uuid="2b3959e6-65b0-423d-a942-789f1fc5b925">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e8585c7d-7133-4f97-a317-3993801395af">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5349,8 +5349,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-3.3_stmt.b" uuid="21c9175d-01ff-4b4b-9f35-81d43e68ef3c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ace61c0b-aec3-4b3e-8280-8d6f67d1902b">
+      <statement statement-id="ps-3.3_stmt.b" uuid="27f42c8b-ed97-4d17-9bb6-e0fec70366f4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3c7cb230-6c65-4cdd-8dcb-04b43e7f58c0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that individuals accessing an
 information system processing, storing, or transmitting information
@@ -5361,10 +5361,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b938c43e-cda3-4b17-9e93-1c1f0e96fe1b" control-id="ps-4">
+    <implemented-requirement uuid="0e6a90ed-195c-4088-8519-f26013c7405c" control-id="ps-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-4_stmt.a" uuid="8ef8eab3-1b01-456b-8c4b-5b74646a8269">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b0d2b72e-1943-40a1-b4f6-b5ceb71de280">
+      <statement statement-id="ps-4_stmt.a" uuid="a8023110-58db-44db-91fe-d97f1798ef8b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1404eeb-e2cc-4490-99b2-c19e8deca439">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, information system access is disabled within an
@@ -5373,8 +5373,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.b" uuid="1d5735d7-3a40-4c9f-ad33-7cccb343daa5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a033c45c-f1e8-4bda-af36-479f4edf50cf">
+      <statement statement-id="ps-4_stmt.b" uuid="565c4b29-d531-4981-88a0-45547dc4e097">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="28910026-6a47-467a-af9b-6f0ec47e6374">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, any authenticators/credentials associated with the individual
@@ -5383,8 +5383,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.c" uuid="f9eb658a-4f1b-4dfa-a0de-6d2e6fcb551f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d0a27aff-7bf3-4887-a395-4247e88d645f">
+      <statement statement-id="ps-4_stmt.c" uuid="72aec3d3-80d8-45f6-8d03-cf9b201fa8a1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b37e5a2e-159b-40f2-af13-28248cc0aa75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, exit interviews are conducted that include a discussion of
@@ -5393,8 +5393,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.d" uuid="6bef1a9e-656d-4c78-a341-91eeb9b51be6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="20cca461-18d8-4466-b547-947d5472a7ec">
+      <statement statement-id="ps-4_stmt.d" uuid="8088243a-2a94-4ee1-800f-3369881614b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a79f6048-6ca4-4ec7-8f9d-e64fdbaac1f5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, all security-related organizational information
@@ -5403,8 +5403,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.e" uuid="e3d9f035-55b9-4bbd-a18e-d542ce6023fd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e0d36f99-c448-4a37-9c9e-eed42d975227">
+      <statement statement-id="ps-4_stmt.e" uuid="f544df03-7464-47ed-9841-2e9062150d73">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f59ecd01-7b04-44c2-a2ac-707c570e59f8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization retains access to organizational
@@ -5413,8 +5413,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-4_stmt.f" uuid="37956f6d-8dbb-459a-b7d5-d45fe94e385f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="80681025-4ae6-480e-a251-b5cda3044e2d">
+      <statement statement-id="ps-4_stmt.f" uuid="ac32121f-0381-469c-9caf-d4460bd7ced8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dbbf7554-60f3-4b0f-8315-63a9bd26c505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes ensuring that, upon termination of individual
 employment, the organization notifies organization-defined personnel
@@ -5424,10 +5424,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0dc775f-3d20-461d-92ea-99daf818d5a2" control-id="ps-5">
+    <implemented-requirement uuid="cd598627-3439-41df-b571-4a11593cc881" control-id="ps-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-5_stmt.a" uuid="2bcf4e23-f900-4a4d-b2d1-55481b0b59b0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ac24996f-154d-44f5-8e05-e3801af25d92">
+      <statement statement-id="ps-5_stmt.a" uuid="18d71eb9-934a-44af-895c-c2297d4f5a0e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7de8444-be5d-489a-bfa9-65b247e63be7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review and confirm ongoing operational
 need for current logical and physical access authorizations to
@@ -5437,8 +5437,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.b" uuid="d8783361-f911-4661-8a36-878a80102be4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="da97e601-7bb5-49e5-8e56-8e2964b31017">
+      <statement statement-id="ps-5_stmt.b" uuid="a0511f2d-f25a-423b-9de3-f72ddc023dd9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d979dc27-c785-4757-a867-f69edf4c49e8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to initiate organization-defined transfer
 or reassignment actions within organization-defined time period
@@ -5447,8 +5447,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.c" uuid="14fa6d69-65dd-49f3-8355-3c4e536bb55a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c5c6b870-5545-4665-a622-a7ec17be0fed">
+      <statement statement-id="ps-5_stmt.c" uuid="79299773-1e94-45ca-818a-6b44ff49f8c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d7f89e6b-7ad4-479e-bf98-8d2ccd964ce3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to modify access authorizations as needed to
 correspond with any changes in oeprational need due to reassignment
@@ -5456,8 +5456,8 @@ or transfer are outside the scope of Red Hat Virtualization Manager (RHVM) confi
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-5_stmt.d" uuid="ef4ab96b-33cd-4d66-91f3-02c7719e9dea">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="45ffaf90-60cf-44c4-84be-d8ee03c34cde">
+      <statement statement-id="ps-5_stmt.d" uuid="a7ed6648-787e-4ab7-ae5b-93de192eac06">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8cbb3c05-982e-466e-9515-d9abb34b357b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notifications of organization-defined personnel
 or roles within an organization-defined time period are outside
@@ -5466,10 +5466,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5416aaa-d440-4b8c-9250-d6dcf507699a" control-id="ps-6">
+    <implemented-requirement uuid="d90e7ad8-3c29-46e4-bb5b-bef781918e51" control-id="ps-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-6_stmt.a" uuid="64e092a8-9200-4365-8688-16463178f189">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a6a65deb-eaaa-4e0e-97dc-567c216ec4f6">
+      <statement statement-id="ps-6_stmt.a" uuid="2d8b2dcb-5489-4e51-a83a-db6a26f5a4c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c7347cdf-4d1f-40c1-8cb5-bd6ef4a60ffb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational process to develop and document access agreements for
 organizational information systems are outside the scope of
@@ -5477,8 +5477,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.b" uuid="007d3570-1249-48fe-98f3-cdc93b75fc5c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c39c0d1c-227b-41d6-8882-dc8077b4e335">
+      <statement statement-id="ps-6_stmt.b" uuid="f6f7ae39-b871-40b9-8d44-5a5bcf51350d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09056f23-47fc-43c4-a899-244bf39ca814">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational reviews and updates to the access agreements at an
 organization-defined frequency are outside the scope of
@@ -5486,8 +5486,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c" uuid="d6a81298-6840-4fc1-815b-feb42eaeaa48">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0f55f759-4670-42b0-b151-ee3073cdf994">
+      <statement statement-id="ps-6_stmt.c" uuid="6e392695-59f0-4dc5-a9c0-80e340eb569d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5495,8 +5495,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.1" uuid="38238eb3-5495-4bfa-87a1-cbd3a82f429b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="53db9522-c55a-4702-bf7f-c1becf7c7159">
+      <statement statement-id="ps-6_stmt.c.1" uuid="2ad016a9-cfec-47f5-bcf4-9f54605827bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5504,8 +5504,8 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-6_stmt.c.2" uuid="7fa4e975-c3f9-4825-a13c-f33af57983ec">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a55ddb16-52ea-47c1-9360-e8d9c9524c75">
+      <statement statement-id="ps-6_stmt.c.2" uuid="2c0af91a-c347-43e4-bd2f-7ff47b39258e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9cf25bb2-c8bb-42a8-8b56-15c94a9cdb0b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes that ensure individuals requiring access to
 organizational information and information systems sign and re-sign
@@ -5514,10 +5514,10 @@ access agreements are outside the scope of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="551951dc-9219-4ab2-bbd1-5d7f2aadee17" control-id="ps-7">
+    <implemented-requirement uuid="e90d5213-ee27-4a47-9929-4f4851a4c13e" control-id="ps-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-7_stmt.a" uuid="b8e5c596-bc7f-42cc-a69a-2dd5d243fa11">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3bbe79d4-fb70-4a83-89d5-3b9d97948e86">
+      <statement statement-id="ps-7_stmt.a" uuid="6b876f4c-4d44-499a-91d0-6d66ad5d851d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="13710e7a-11a5-49df-9cf1-5620861dea20">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish security requirements including
 security roles and responsibilities for third-party providers are
@@ -5525,8 +5525,8 @@ outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.b" uuid="5627987a-c47b-40af-8b40-e75d96ddad6f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="68464c8c-a364-4f0f-b1a0-94f683023dbb">
+      <statement statement-id="ps-7_stmt.b" uuid="95bda73f-2c03-4b3f-ac60-bf47f0a89426">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="11f7bf5f-4f0a-4273-bdc9-b664d512d429">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes requiring third-party providers to comply
 with personnel security polocies and procedures established by
@@ -5534,16 +5534,16 @@ the organization are outside the scope of Red Hat Virtualization Manager (RHVM) 
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.c" uuid="11473cb1-0eac-4ff7-a245-12bd2da68de5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8eb87deb-a52f-4ee8-b1d8-d8f5aaf98285">
+      <statement statement-id="ps-7_stmt.c" uuid="10765576-a41a-4bd1-9ec6-f62f07947d54">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ef7d9a4d-5ee3-414b-bfe3-7287c70cde54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document presonnel security requirements
 are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.d" uuid="a1b9f3d2-e1b3-4283-97ea-7515b30f2df2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c93a96b2-c56e-43c5-a311-d0f13c8e3b12">
+      <statement statement-id="ps-7_stmt.d" uuid="ee923c84-ceb4-4fcc-b017-9575e996ef24">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="278ad774-501b-42d7-8c90-3af58cc2c049">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to require third-party providers to notify
 organization-defined personnel or roles of any personnel transfers or
@@ -5554,8 +5554,8 @@ scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-7_stmt.e" uuid="d2b4afc0-1f70-4afc-b96a-37c22f7960e5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5b23b662-b593-4095-81cf-085e9c664b15">
+      <statement statement-id="ps-7_stmt.e" uuid="100e63ef-5092-48be-84d9-4c1d180176dd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3b90694c-5c80-4865-acbe-b25f0a92c0dc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational monitoring of provider compliance is outside
 the scope of Red Hat Virtualization Manager (RHVM) configuration.
@@ -5563,10 +5563,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8423b324-b9c6-4544-8386-124df7a85148" control-id="ps-8">
+    <implemented-requirement uuid="9000ddd2-1f58-451e-ac22-112f1e24834a" control-id="ps-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ps-8_stmt.a" uuid="c052cc3e-a950-4f77-b0ed-51be71c475c4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0997a540-b396-4350-b777-43a3c4a37ae4">
+      <statement statement-id="ps-8_stmt.a" uuid="a2da16b7-9efb-4ba7-adcb-660fab49c818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e4380d5a-0e4d-4519-9ff7-d45b76504135">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational employment of a formal sanctions process for individuals
 failing to comply with established information security policies
@@ -5574,8 +5574,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ps-8_stmt.b" uuid="78f23812-bc42-46cd-8a2b-c641c129d603">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="97f3f278-ec0b-44cd-bf57-d79b55d4bb71">
+      <statement statement-id="ps-8_stmt.b" uuid="65d1d313-0f08-45cb-a619-0c2f61acfa0b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a62645f-0cd3-49e8-9156-210ee0518aac">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational notification of organization-defined personnel
 or roles within an organization-defined time period when a formal
@@ -5585,10 +5585,10 @@ sanctioned and the reason for the sanction.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c5791695-2778-4f2b-ac7d-65051ac80f0d" control-id="ra-1">
+    <implemented-requirement uuid="44d5151b-7cd9-4df7-9782-2f19636ef16f" control-id="ra-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-1_stmt.a" uuid="885988a8-b7c5-41e8-9822-ad3559e09162">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e1cd7751-49a6-4518-a39e-d2657e73a83a">
+      <statement statement-id="ra-1_stmt.a" uuid="611a8157-0211-45cb-9cb5-3a41191b55cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5596,8 +5596,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.1" uuid="09180c6e-0d07-4da6-9090-b573a0a652c2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bf381e3d-8cbd-4d65-addf-d8f476527701">
+      <statement statement-id="ra-1_stmt.a.1" uuid="c2c644cf-bf5f-45f7-9426-8ffd1e58bd2d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5605,8 +5605,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.a.2" uuid="d0ef0584-9c61-4be6-bf1a-7d87ddfe94ad">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ff20bf97-1632-491a-89bb-f894e90ebb87">
+      <statement statement-id="ra-1_stmt.a.2" uuid="43048ae8-d506-42f9-8e29-c262f83261a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="39c4e769-a72f-4e50-94cf-c50da2ea949f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational development, documentation, and dissemination to
 organization-defined personnel or roles a risk assessment policy
@@ -5614,8 +5614,8 @@ and procedures is outside the scope of Red Hat Virtualization Manager (RHVM) con
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b" uuid="40a58c68-89b0-4321-9c0f-c4fbe85bf290">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8b2d3f6f-62ba-4cbf-947e-a907cf5101b3">
+      <statement statement-id="ra-1_stmt.b" uuid="e9b70516-72ab-4477-8bd6-bcd12e4051a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5623,8 +5623,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.1" uuid="a74eb65c-23e7-4715-84bd-a675e8d3eea2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bf53e263-b6c1-4e7b-bde2-0888ba25eb41">
+      <statement statement-id="ra-1_stmt.b.1" uuid="2a36cb87-f7c0-43be-8aed-76456ce1a6b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5632,8 +5632,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-1_stmt.b.2" uuid="7160d8e9-817e-4cb1-92b5-3fb85037491b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cc7efc0f-ef24-4781-8387-5816ba957765">
+      <statement statement-id="ra-1_stmt.b.2" uuid="b15c9576-2e76-4357-8d59-32758d67061d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="775d9a4b-2ddc-4566-84e6-d69f878a39f4">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the risk assessment policy
 and risk assessment procedures is outside the scope of
@@ -5642,10 +5642,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2b76c574-8c75-4f50-a4ef-224703332086" control-id="ra-2">
+    <implemented-requirement uuid="0ab6a230-1abd-4c7b-a7ce-4d231dea47e8" control-id="ra-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-2_stmt.a" uuid="0174dcd6-1d80-446f-a084-f9ab3e1a411b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="de69d7c7-a59e-406f-a472-ad66eb20f04e">
+      <statement statement-id="ra-2_stmt.a" uuid="f4541f8c-b79c-4ef9-ae8a-0d030bd01480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ca47edfd-09f3-49c4-8365-53ec0d9f9e7f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to categorize information and information
 systems in accordance with applicable federal laws, Executive
@@ -5654,8 +5654,8 @@ guidance, are outside the scope of Red Hat Virtualization Manager (RHVM) configu
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.b" uuid="a7dd3aef-3bad-437a-955e-398789242282">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="57a3bc43-d16c-4b1b-b842-638e594d48b6">
+      <statement statement-id="ra-2_stmt.b" uuid="b7676df9-5836-4d3b-a0cd-a2db0e8c37fd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae86df2b-e64b-45ad-9165-1168e2f87afc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document the security categorization
 results (including supporting rationale) in the security plan for
@@ -5664,8 +5664,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-2_stmt.c" uuid="efddc754-a826-4253-8beb-2696126c74d7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b1724ef2-ef0c-4be1-aa9c-8f60a96d57f3">
+      <statement statement-id="ra-2_stmt.c" uuid="65212924-f089-4cc7-b8af-53fd6a111ed9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="91dd3cf9-5a59-4a54-b6fa-67ffc7f6e780">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to ensure that the authorizing official
 or authorizing official designated representative reviews and
@@ -5675,10 +5675,10 @@ the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e640c7c-421a-4b75-89cf-48d18fc8222e" control-id="ra-3">
+    <implemented-requirement uuid="15f5dd33-0cdd-4e59-a1cd-3c84dad5b12e" control-id="ra-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-3_stmt.a" uuid="6632c06a-316c-4d03-8cdf-ce10971a1e0b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="62270ff0-3f56-4241-ac71-69d165aea8f8">
+      <statement statement-id="ra-3_stmt.a" uuid="7f26caeb-eb87-4f26-950f-6a4b133440d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="825effd2-1fd5-4147-bca9-7282d6fbc19a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to conduct an assessment of risk,
 including the likelihood and magnitude of harm, from the unauthorized
@@ -5688,8 +5688,8 @@ transmits, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.b" uuid="85a39eb9-e7e7-4ded-8a28-712220fd02b9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0bc769c1-222d-4ceb-bf5f-f24062d55828">
+      <statement statement-id="ra-3_stmt.b" uuid="f79083ff-317a-449e-97f4-310242546dad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0692007f-e7a4-467f-ae1d-64c3e2d8cb40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to document risk assessment results in
 security plans, risk assessment reports, or organization-defined
@@ -5697,8 +5697,8 @@ documents, are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.c" uuid="e41b3032-dcf8-49c9-97fc-97e661f49007">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="25e169c9-0f1b-4f2b-8ac6-9176e1b3ab7b">
+      <statement statement-id="ra-3_stmt.c" uuid="0dcd2f27-33d9-42aa-9329-472f8fa07cd4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="de13535d-336a-4db5-8cfb-af7e369f09a8">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to review risk assessment results at
 an organization-defined frequency are outside the scope
@@ -5706,8 +5706,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.d" uuid="8f24fcae-f8a0-4f76-a6d6-475d0613cade">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="074f5d94-21bc-4944-a422-769b716481a5">
+      <statement statement-id="ra-3_stmt.d" uuid="4c6ea21f-9eaf-470e-a2fc-4d4dfb06a46a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3cf43908-7074-438a-89e7-2f60335176cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to disseminate risk assessment results to
 organization-defined personnel or roles are outside the scope
@@ -5715,8 +5715,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-3_stmt.e" uuid="c9256a14-d9f5-49c6-9dca-038c51b2b0a7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f6018a36-6d54-43a7-922e-dc7c9212b914">
+      <statement statement-id="ra-3_stmt.e" uuid="5b44cac1-93ec-418c-b42b-b7f26bb0794c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a1d934df-406d-4e87-8e96-3d48fcac2aff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to update the risk assessment at an
 organization-defined frequency or whenever there are significant
@@ -5728,10 +5728,10 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fbab334-45fb-49d2-8f24-b6e97bbe42e8" control-id="ra-5">
+    <implemented-requirement uuid="796d19ec-7ee2-48f7-8a58-46c76a50db80" control-id="ra-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5_stmt.a" uuid="3603f481-c679-4538-9e1f-b5c90a38833f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b362f776-f3e2-41c5-8fd5-f2c556570a82">
+      <statement statement-id="ra-5_stmt.a" uuid="4e384a7a-c1e1-4c24-a6f5-64d0da121b33">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5739,8 +5739,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.b" uuid="36b7d642-d93f-482d-9b77-563d150c5cf7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="50648b7b-783b-409e-a9d0-34d8c81cdcf4">
+      <statement statement-id="ra-5_stmt.b" uuid="4c1282b0-3a22-4059-8ea0-ff3a59c40b12">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5748,16 +5748,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.c" uuid="8fa90ce1-0daa-4a6c-b250-d245bc4f2ccf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="90324ba9-3221-4df2-acd9-078319b769a2">
+      <statement statement-id="ra-5_stmt.c" uuid="2b015f3a-d332-481f-87df-0362eb31b0ce">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.d" uuid="fe5d9a1d-2bdd-47c8-8623-d75a02940484">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="47157f31-63c6-43f4-a0e3-db5322a4d3ea">
+      <statement statement-id="ra-5_stmt.d" uuid="f5a48b9a-901b-4c56-8f0a-28cb6d37c72a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5765,8 +5765,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="ra-5_stmt.e" uuid="d83151c6-099c-4fc0-89b5-efc34ef137e6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ed88b4a0-f3e2-45a6-a080-04e509db5d29">
+      <statement statement-id="ra-5_stmt.e" uuid="431ed74f-8371-44cb-8d48-682acd1bfe3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6c1cf1b-136f-4647-86a3-b6055003ca11">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to share information obtained from the
 vulnerability scanning process and security control assessments
@@ -5778,10 +5778,10 @@ of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="14f36dc4-256d-4871-8083-574636d533f6" control-id="ra-5.1">
+    <implemented-requirement uuid="25e0e198-6272-4100-aacc-c751b1d866e6" control-id="ra-5.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.1_stmt" uuid="b0045ffc-5526-4f40-aea0-0943034afbcc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cd986088-5891-42ef-8f5b-3c705279a001">
+      <statement statement-id="ra-5.1_stmt" uuid="d8e4be41-53d9-4ebc-bbfa-1f575d095b3c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5790,10 +5790,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac5944d7-ce73-4329-8c64-00b04783a9c4" control-id="ra-5.2">
+    <implemented-requirement uuid="7971b674-5e94-4b48-be7b-78418fd916d5" control-id="ra-5.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.2_stmt" uuid="fcba7123-ea98-4e1d-8c5d-0d6bb64cfc36">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="89ba06d1-5bfa-47a2-b1e1-79ea16f0b495">
+      <statement statement-id="ra-5.2_stmt" uuid="d82e932a-e687-45e5-911c-e662880898c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5801,10 +5801,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f6db0dc9-69be-4d16-909c-ecb73bc5acf6" control-id="ra-5.3">
+    <implemented-requirement uuid="1a4f081d-c680-46c6-9666-6c1296f9181c" control-id="ra-5.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.3_stmt" uuid="b6ee1719-5d48-4bd2-8f86-5f3e50a89860">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="028c77e3-9a1d-4114-b817-c1e3993a84ed">
+      <statement statement-id="ra-5.3_stmt" uuid="8068b1af-dc82-4d4a-a1e2-ca7e8a23dd97">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -5812,10 +5812,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="238c03ad-cf97-4334-a3c7-5af36dd015a0" control-id="ra-5.5">
+    <implemented-requirement uuid="85d3387b-07ff-4c11-9afe-62dde7b4b20b" control-id="ra-5.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="ra-5.5_stmt" uuid="f8f1829a-35b7-400e-8a73-abcf8f835dc1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7d2ccbc7-405f-4d1b-87fd-e09c95d8ee7d">
+      <statement statement-id="ra-5.5_stmt" uuid="56153afb-5fff-4d83-a274-c80dbe05c2e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5824,10 +5824,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="393a7ca0-5ee8-4b66-a5bf-4b8ccb9d0928" control-id="ra-5.6">
+    <implemented-requirement uuid="631f32a6-79e9-4c7e-bce5-dce1e05fb448" control-id="ra-5.6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial"></annotation>
-      <statement statement-id="ra-5.6_stmt" uuid="f6fbfeca-bf54-4c02-89cc-a284cf4a1d06">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ada007f0-3e65-4819-81ac-08644351805a">
+      <statement statement-id="ra-5.6_stmt" uuid="ce8738be-55d6-4014-8ce0-9fa3e2e06d1a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="80928606-58d6-4c1e-9ba9-cd5adb657e94">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response is planned. Progress can be tracked via:
 
@@ -5836,10 +5836,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="917d979e-b15d-47c2-8f65-bb46606f8115" control-id="ra-5.8">
+    <implemented-requirement uuid="5acc9cfd-8e4d-44ae-a5a6-78f1b605c1f0" control-id="ra-5.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="ra-5.8_stmt" uuid="fffaccf1-8cd2-4fee-8572-0b7599860af4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="59595958-09fc-4639-86b9-65a6b7323e97">
+      <statement statement-id="ra-5.8_stmt" uuid="6545d6a7-1e4b-4881-b6e0-6fe581dee0ba">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8ed3dcc9-7caa-4944-9765-7e5c864991bf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review of historic audit logs to determine if a
 vulnerability identified in the information system has been
@@ -5849,10 +5849,10 @@ Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="87ca3d0e-e040-45b0-8745-9cb24c789cb5" control-id="sa-1">
+    <implemented-requirement uuid="a172707c-e357-4978-be84-30e20d476ab0" control-id="sa-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-1_stmt.a" uuid="eafe792c-b500-4ae0-88d7-74e307cc19a8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1cb66be4-0bb9-476a-83ca-9aca766cd8ea">
+      <statement statement-id="sa-1_stmt.a" uuid="a571b48a-fca2-459a-916a-d6a6f24deb5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5861,8 +5861,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.1" uuid="2408c814-adf4-486b-b125-f6736b00b1ae">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="26c0b542-71ad-4c96-a467-d51f1c423a39">
+      <statement statement-id="sa-1_stmt.a.1" uuid="c7e3108a-d39a-4501-9232-187d48111480">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5871,8 +5871,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.a.2" uuid="79b4b1d8-8c1a-48e5-89bf-1dc48053a34a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9be95338-bcd1-4925-b6f4-03a75b7420d4">
+      <statement statement-id="sa-1_stmt.a.2" uuid="13f8840c-c38c-4e70-8635-8cb5419abf98">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e200a6ff-4a7f-4b05-86d3-0dabc6908486">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to develop, document, and disseminate to
 organization-defined personnel or roles a system and services
@@ -5881,8 +5881,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b" uuid="e46c4fa2-f7c2-4721-a94c-f143be4ae92a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6c28cfc8-3333-48ea-a498-ca3eb9d45632">
+      <statement statement-id="sa-1_stmt.b" uuid="f2bf354e-951d-4b99-8101-871827b86f6b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5890,8 +5890,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.1" uuid="a5745a18-c8d4-423d-8097-cc84a94364e0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b64a64f8-b79c-4719-a107-cf54fbcd7f82">
+      <statement statement-id="sa-1_stmt.b.1" uuid="d3bed5b6-3a90-43a6-a31c-2110bb93ae49">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5899,8 +5899,8 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-1_stmt.b.2" uuid="e37a0e83-5d82-405c-b26f-fe9e2cf03031">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b614b609-1ac4-44e1-aad0-f2b65e206c40">
+      <statement statement-id="sa-1_stmt.b.2" uuid="cb76ce98-b4b7-443b-b678-5d3295c84fc0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c27a0d08-45c3-48dd-837a-9bf6be747133">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational review and updates to the current system and services
 acquisition policy and procedures at an organization-defined frequency
@@ -5909,10 +5909,10 @@ is outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4a5a3733-46d6-49ee-b3a0-79eba35333ce" control-id="sa-2">
+    <implemented-requirement uuid="050a21c8-b6c1-4fb9-9500-c8fe7e4e80cb" control-id="sa-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-2_stmt.a" uuid="8bcaf342-ee01-4ea2-a4b3-de0a95f99869">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="88106d70-e37a-41a6-817c-375c922cb981">
+      <statement statement-id="sa-2_stmt.a" uuid="9a617d20-93f0-4558-9782-16e8b1cf2fb4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="68d0d4b0-c0d2-4acd-b8d5-b7737dd46b7c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine information security requirements
 for the information system or information system service in
@@ -5921,8 +5921,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.b" uuid="b1fdfd18-1d1f-4eda-8d80-e1e79bbd2197">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c2d5e639-9bbe-4db2-a912-fd8adc8c3777">
+      <statement statement-id="sa-2_stmt.b" uuid="4e0e53ca-f38d-4c22-8cad-26bfa4c4dbd8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ae257788-6a44-42b5-9e86-ce24b5d7dfb5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to determine, document, and allocate the
 resources required to protect the information system or information
@@ -5932,8 +5932,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-2_stmt.c" uuid="e3a50b34-8158-4f7d-9aa4-60fcdd31d383">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bb858f57-e291-4c34-b1f8-9a911dd27e46">
+      <statement statement-id="sa-2_stmt.c" uuid="483cd77e-9463-42bb-b620-df78fa0c5603">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e33619df-53cf-4942-b14b-df386101333b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to establish a discrete line item for
 information security in organizational programming and budgeting
@@ -5942,10 +5942,10 @@ documentation are outside the scope of Red Hat Virtualization Manager (RHVM) con
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d386a897-3663-4446-8621-4f65d7b29f45" control-id="sa-3">
+    <implemented-requirement uuid="2defe23d-c379-4286-8dd2-f9cc601d209d" control-id="sa-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-3_stmt.a" uuid="3ee472cd-b9c6-4e79-8618-59f245c94601">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c7edf2d4-47c2-49c9-8f48-4f99b2f162d7">
+      <statement statement-id="sa-3_stmt.a" uuid="b107e4ab-86ec-4e37-a993-1653c35c3d46">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f73b71c4-22a7-4d0d-b09e-1ed07d64c174">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to manage the information system using
 organization-defined system development life cycle that incorporates
@@ -5954,8 +5954,8 @@ of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.b" uuid="74283f83-c001-474c-937a-f6e6fce2567d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1deaff3b-e840-4d2e-97b0-418aa6b49c95">
+      <statement statement-id="sa-3_stmt.b" uuid="5ed40cbc-20ea-4b20-8fa8-cbcfe6f4f38a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="70f49197-05e3-4b11-ae79-720d5aaa677b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to define and document information security
 roles and responsibilities throughout the system development
@@ -5963,8 +5963,8 @@ life cycle are outside the scope of Red Hat Virtualization Manager (RHVM) config
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.c" uuid="adefaef2-374e-4470-b777-8219c09060ed">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a21c5b0e-b34a-4afb-a52c-e995068996d0">
+      <statement statement-id="sa-3_stmt.c" uuid="607967a3-21b9-458f-b9eb-f5785b8974b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017043aa-c72c-4e96-9ed2-6ec39b5742ef">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to identify individuals having information
 security roles and responsibilities are outside the scope of
@@ -5972,8 +5972,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-3_stmt.d" uuid="75d18196-3157-42ca-ab82-d9cb7c66615e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3236d74a-3d8c-43c8-b871-f7a189468e98">
+      <statement statement-id="sa-3_stmt.d" uuid="928cbd83-6d80-4906-9edf-bbf9d55d98ad">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="426bc4b6-9812-4098-9cc3-b5dbf7d359d6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to integrate the organizational information
 security risk management process into system development life cycle
@@ -5982,10 +5982,10 @@ activities are outside the scope of Red Hat Virtualization Manager (RHVM) config
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2c85617a-325d-416b-bd47-53e3eaa46e20" control-id="sa-4">
+    <implemented-requirement uuid="bf3098f0-03d4-40c7-9745-d2235ee228c0" control-id="sa-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4_stmt.a" uuid="ee1a8c8d-c136-4953-985f-b9e01aa34ec7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a98dae49-a839-4af6-800e-3a922dcc6165">
+      <statement statement-id="sa-4_stmt.a" uuid="d8407af8-acd4-4428-840c-efefa414e336">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1552cce1-10a9-4a28-acff-0819cd1d5552">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security functional requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -5993,8 +5993,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.b" uuid="4ed1f272-8a1a-47d1-a655-5c9e47ea1497">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f9b3713e-021e-49b0-8095-fa99464d984a">
+      <statement statement-id="sa-4_stmt.b" uuid="516ec171-7079-4c0c-b931-01cfa87d9f39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54666440-ddf1-495a-b24b-de93c187adfc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security strength requirements
 in acquisition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6002,8 +6002,8 @@ configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.c" uuid="1ad83221-2ffd-49d0-92ef-997a801cbe88">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a31f76bf-fbe4-4ee8-b2e5-e212a527441d">
+      <statement statement-id="sa-4_stmt.c" uuid="19367cff-d60e-42dc-aff7-5a3263f206c5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7a4549b6-b8fd-4d3b-a303-c815c6b65618">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security assurance requirements
 in acquisition contracts are outside the scope of
@@ -6011,8 +6011,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.d" uuid="411e753e-914a-444f-a871-1aec10845b39">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="279d6fdf-65f9-4100-9f25-31b39fec7f6e">
+      <statement statement-id="sa-4_stmt.d" uuid="9e656b9a-3b82-47e1-82ad-85a95b2f3224">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c4fdfc14-17e4-4910-82d8-60ad518cffb6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include security-related documentation
 requirements in acquisition contracts are outside the scope of
@@ -6020,8 +6020,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.e" uuid="d2a0fbdb-e390-4e42-a562-195a3a5d0aa0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="abb15a63-f91d-425e-9d30-e684c72a237f">
+      <statement statement-id="sa-4_stmt.e" uuid="ba757458-3c0c-4974-8eb6-04500d23ccc2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="661ec3a0-e738-42f9-a92f-02d313d8e900">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include requirements for protecting
 security-related documentation in acquisition contracts
@@ -6029,8 +6029,8 @@ are outside the scope of Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.f" uuid="7f6970c0-913e-4572-b2f3-69ed917349fe">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fbba83fc-3b63-4a8c-92cd-57714d0c6fae">
+      <statement statement-id="sa-4_stmt.f" uuid="04fa1d51-9152-46b4-b4ae-dc50924ba75e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="45200b4a-85fd-4567-9c82-613516999bd1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include a description of the information
 system development environment and environment in which the system is
@@ -6039,8 +6039,8 @@ Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-4_stmt.g" uuid="74c8d0be-1e3f-4e40-92f9-de741d5a2244">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="110bf9b0-8496-4365-aaac-a039a9c875ea">
+      <statement statement-id="sa-4_stmt.g" uuid="965605ae-2f59-4939-b51f-99c648774e29">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="dd3b9e75-24f0-4011-8062-0dd44081dbe0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Organizational processes to include acceptance criteria in
 acqusition contracts are outside the scope of Red Hat Virtualization Manager (RHVM)
@@ -6049,10 +6049,10 @@ configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a6e172f4-fba5-4fc3-b9b3-e8ae0243fa2b" control-id="sa-4.1">
+    <implemented-requirement uuid="c852b8ed-46e8-49a4-942e-02ad98e2145f" control-id="sa-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.1_stmt" uuid="0079aba7-8791-4766-8921-0700122bc659">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="759db4c5-3d14-4562-b477-bc921529466e">
+      <statement statement-id="sa-4.1_stmt" uuid="5f744a19-86b6-458e-ae5b-9391fdaaf2a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1d0b45d5-3df5-4226-a89d-858eb0881fbd">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (1) is planned. Progress
 can be tracked at:
@@ -6062,10 +6062,10 @@ https://projects.engineering.redhat.com/browse/RHV-22638
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7fe9a53f-cbed-4e1e-855a-4328279fddf9" control-id="sa-4.2">
+    <implemented-requirement uuid="494cce61-f250-443b-86bf-6428be908965" control-id="sa-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.2_stmt" uuid="f57738de-0bcb-45f5-a013-9a1342fff4a8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="624b2295-03ee-45e4-adda-9195fd5a8e38">
+      <statement statement-id="sa-4.2_stmt" uuid="fe19e678-d406-486d-a68b-a93da729dcef">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2a090f9c-dcc8-4565-95ba-9da0c5baa527">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4 (2) is planned. Progress
 can be tracked at:
@@ -6075,10 +6075,10 @@ https://projects.engineering.redhat.com/browse/RHV-22639
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="24e6babc-27d0-481e-adad-097176950e1a" control-id="sa-4.8">
+    <implemented-requirement uuid="f576d7f5-7768-4335-8d9a-6a92332f08f0" control-id="sa-4.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.8_stmt" uuid="c4e3468e-69b7-428c-a152-7beaa654aad1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bd311582-5007-4806-af5f-f7e99256924a">
+      <statement statement-id="sa-4.8_stmt" uuid="3d81371f-0030-4269-8918-c09b32dabcc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9d4765e6-3e2e-4e4b-afbb-5fb77763e42d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(8) is planned. Progress
 can be tracked at:
@@ -6088,10 +6088,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5c9d458c-6adb-4a30-a6c8-f4b0382fe2b7" control-id="sa-4.9">
+    <implemented-requirement uuid="183aecf0-bdf4-413f-8de9-fcbde8bda9b2" control-id="sa-4.9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-4.9_stmt" uuid="5729ea3f-1ac4-42e9-a3f0-a81a3d41040e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e8bdd335-1c55-4cd8-a481-06da7ac6ded2">
+      <statement statement-id="sa-4.9_stmt" uuid="57789a83-af12-481f-8fee-d2420e3b5e3d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="61c674b5-dda5-46f5-96ca-871e9452030f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-4(9) is planned. Progress
 can be tracked at:
@@ -6101,10 +6101,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cf1756f-a3da-4372-9192-f0ab62ceb8b1" control-id="sa-4.10">
+    <implemented-requirement uuid="31e4296d-6361-496e-8531-b092d9a30955" control-id="sa-4.10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-4.10_stmt" uuid="b5819030-135f-4e18-98d0-e7997a25bea2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="06e76dc3-369d-4829-b93b-2c2dc6bf2ca4">
+      <statement statement-id="sa-4.10_stmt" uuid="c7984646-15a2-4a31-983a-8209181d8242">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6112,90 +6112,90 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42a7456c-a192-42ef-952e-e6f84f080d6c" control-id="sa-5">
+    <implemented-requirement uuid="c927e6eb-cd03-4cfc-8370-e65bc1d08e8b" control-id="sa-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-5_stmt.a" uuid="7c2f3779-ace7-455f-b122-f6faefb8263b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c2ca9457-3177-41b8-9cc7-e9b2da068385">
+      <statement statement-id="sa-5_stmt.a" uuid="4faea3e4-73a8-43e7-80fd-d83650013818">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.1" uuid="9989b13b-2e64-4836-acab-ad33e99f98f5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6151f913-bbe4-433a-8422-0d12c9479197">
+      <statement statement-id="sa-5_stmt.a.1" uuid="ae559028-e1e5-4605-8783-025c00f9a8a8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.2" uuid="5bd1f383-82a7-4745-ba90-9e69886fcaf9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="26b94788-a447-436a-9b5a-582acdf3113d">
+      <statement statement-id="sa-5_stmt.a.2" uuid="397a73bf-b7a0-4aaa-bf9d-ede4ecf3685f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.a.3" uuid="d34f15b4-8dde-402c-bd26-20f529d827a6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f54d0d8f-77ac-441a-b618-6b873d0b6de6">
+      <statement statement-id="sa-5_stmt.a.3" uuid="c9ced858-df8e-469c-afbe-1e88080e4ae6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b" uuid="9d4fdb56-8a65-435c-81b7-d5fe8f7a60b1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f821d39b-b977-4196-987c-e60fad5bc678">
+      <statement statement-id="sa-5_stmt.b" uuid="c1639c11-0075-422e-a3bd-a02e115d7a80">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.1" uuid="55169ab3-2c52-4d52-8cb8-809dd77b7a82">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="24d19d36-86a7-4c6b-9f52-a02534097f24">
+      <statement statement-id="sa-5_stmt.b.1" uuid="a9909ce0-0b06-4bf4-83df-c013a2fdd5c4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.2" uuid="41855ecc-7caa-413c-9f19-df8a55455261">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8829693e-2dd4-43b7-b56e-76e3d48207d9">
+      <statement statement-id="sa-5_stmt.b.2" uuid="10ef634b-6c51-40fe-a25c-4ad6ebba34d3">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.b.3" uuid="d3c4222d-8f83-48fc-9c0c-8060282b71ad">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="63535c13-620f-4e07-bb8e-6defcaf71e70">
+      <statement statement-id="sa-5_stmt.b.3" uuid="da0b3f67-4def-4323-b907-0a8237c874c9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.c" uuid="61cd6094-c4c7-4829-821b-0058c6a7c9e9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="99cf7f05-5ed4-430e-9606-4bd0dca43a8b">
+      <statement statement-id="sa-5_stmt.c" uuid="7517ad19-1345-4b26-9f37-c21dc9721b39">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.d" uuid="54722971-2516-48fe-b20f-633324ab3d0c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e264c598-082d-47dc-8619-36531b025bab">
+      <statement statement-id="sa-5_stmt.d" uuid="44d3949f-6897-4950-ad77-aec1c2b4daa6">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-5_stmt.e" uuid="78d9af52-d4ca-41ea-b19f-78265c790514">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d69f0e57-c9cd-4ea2-800c-e96166646f1e">
+      <statement statement-id="sa-5_stmt.e" uuid="38a8ddba-5efc-4f18-91bb-a8fec5728d35">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6203,10 +6203,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3ee183f-4581-47d4-9ab2-366bee400a8a" control-id="sa-8">
+    <implemented-requirement uuid="ceafc844-4178-4e7f-ac35-695b6b6023ef" control-id="sa-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-8_stmt" uuid="70e25d87-add7-4fcc-ab67-39fade8c3bd2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="26a3a3c4-9406-42dc-8096-0e27602860db">
+      <statement statement-id="sa-8_stmt" uuid="769f36da-b419-480f-934c-4f46d8487423">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6214,26 +6214,26 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="53cb8dfc-913e-4218-951f-f1410df2b4c3" control-id="sa-9">
+    <implemented-requirement uuid="0e348750-2071-4c59-a38c-68082ef7a9fd" control-id="sa-9">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9_stmt.a" uuid="95912481-088e-4dcf-8090-52529e85b8b9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ed164bb4-fb72-4779-b68c-135feb0f8a71">
+      <statement statement-id="sa-9_stmt.a" uuid="26cf006d-8120-4aa3-b93e-2c88997ab89e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.b" uuid="59e58e02-6e49-4b13-8ca6-e8d0db923060">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b15ece6b-8309-4149-a650-0b2e8b40b5de">
+      <statement statement-id="sa-9_stmt.b" uuid="2830bcbf-b8eb-409c-b878-25d755268c11">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9_stmt.c" uuid="7172d6e0-eb68-43ed-a5dd-0e5a5ef145a0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="824183ed-bab9-4c60-8bf2-a03beb5893c5">
+      <statement statement-id="sa-9_stmt.c" uuid="c356c752-c622-4e5e-ab13-8f1b11206e48">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6241,18 +6241,18 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="75ac28ed-bed0-433c-a49d-a7e8a6dc77d8" control-id="sa-9.1">
+    <implemented-requirement uuid="d7b28993-7eb6-4b88-95eb-f43087fbc281" control-id="sa-9.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.1_stmt.a" uuid="5e18d51b-fcdb-4a04-944a-ed84d93078b0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ad804eb7-ba61-43de-ab32-3c5fbc81d319">
+      <statement statement-id="sa-9.1_stmt.a" uuid="e96ba58c-314d-4bb3-9847-04c8248c51b9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-9.1_stmt.b" uuid="03594a78-ac8f-405d-942f-c326f53e34c3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="41bf1d5b-ec0e-452d-bb83-e9b2d9b1a261">
+      <statement statement-id="sa-9.1_stmt.b" uuid="d8b9bad4-3f53-4af6-81ef-ff09d46e41e7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6260,10 +6260,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="c663e898-8d94-4279-821e-082d5352afa5" control-id="sa-9.2">
+    <implemented-requirement uuid="dc2401ea-3658-43d4-bb17-583affb252b4" control-id="sa-9.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.2_stmt" uuid="56416056-6b79-4154-a9f4-8c5b6e2af282">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3e893b48-bacb-48b7-8b6f-5dc21fd92495">
+      <statement statement-id="sa-9.2_stmt" uuid="afa3ae26-8993-457f-95af-c4525ff4dd8e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6271,10 +6271,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ca938872-fea7-4bb6-a00e-2a671af2b7be" control-id="sa-9.4">
+    <implemented-requirement uuid="390f46be-3165-4585-a4e7-1dfd25aed746" control-id="sa-9.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sa-9.4_stmt" uuid="e1a71c34-b8f9-4a25-8dce-b660b5a9f515">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="64e10526-ce84-4c77-a5e2-fc01124cd968">
+      <statement statement-id="sa-9.4_stmt" uuid="efb69b66-26dc-408b-92d9-5ae526255984">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cbe91913-6b8c-4b8b-a308-8f1ef9f4d1bc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedure/policy and is not
 applicable to Red Hat Virtualization Manager (RHVM) configuration.
@@ -6282,10 +6282,10 @@ applicable to Red Hat Virtualization Manager (RHVM) configuration.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f4400764-9664-4796-a82d-72d57ec5d973" control-id="sa-9.5">
+    <implemented-requirement uuid="b2aa9d6f-61bf-40d3-aeba-0ec7732ee2c6" control-id="sa-9.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-9.5_stmt" uuid="6be52279-6f4f-410f-b8bf-3cb9845a079b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8723cddb-23ba-4683-b70c-dcda9ecd1862">
+      <statement statement-id="sa-9.5_stmt" uuid="16533dfd-f21e-4ec2-8dd0-9542839ac740">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="54792531-8522-4bb0-8ed0-a3e463c7ab36">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-9(5) is planned. Progress
 can be tracked at:
@@ -6295,10 +6295,10 @@ https://issues.redhat.com/browse/CMP-368
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="3b24c701-d8a6-46ea-b0d3-6fb90c49c4e9" control-id="sa-10">
+    <implemented-requirement uuid="293f268f-39a8-47da-85fb-b1aa98f204be" control-id="sa-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10_stmt.a" uuid="7ec9d437-bac0-43ef-8693-16c61926461c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fb15a718-abd9-4eae-8147-6be520c061a1">
+      <statement statement-id="sa-10_stmt.a" uuid="148daf57-78dd-44f4-9034-2a5a5bf501c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c007989f-6207-43a4-8a0e-c4bbfbcbcfc6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(a) is planned. Progress
 can be tracked at:
@@ -6307,8 +6307,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.b" uuid="1f696fc2-857f-4581-9b5a-2c005aeb65d0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="24ff98de-4dc0-4011-97d3-6877465ef012">
+      <statement statement-id="sa-10_stmt.b" uuid="5c2cc993-ddab-465b-9f1d-e46d3e024e3a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="cfb7401e-c900-4ced-9a20-2bee25790497">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(b) is planned. Progress
 can be tracked at:
@@ -6317,8 +6317,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.c" uuid="494add93-9ebf-4674-b2b7-8e767db49c5c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7db796cb-3b80-4cc0-888e-7e69596ac0dc">
+      <statement statement-id="sa-10_stmt.c" uuid="f1413046-1128-4cb3-8268-177393cfdaf5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b14ad649-026f-462d-849a-0cf4e092d2f3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(c) is planned. Progress
 can be tracked at:
@@ -6327,8 +6327,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.d" uuid="72e0be35-58d4-4e9c-8dfa-f48815216f0b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="999065aa-0618-47eb-97ac-40b9f92ab2d5">
+      <statement statement-id="sa-10_stmt.d" uuid="9d632fcd-3f58-441e-8adb-cc1c3dfa0bca">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="49544cdb-c4a6-4185-80bd-2b5ecb724ab7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(d) is planned. Progress
 can be tracked at:
@@ -6337,8 +6337,8 @@ https://projects.engineering.redhat.com/browse/RHV-21061
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-10_stmt.e" uuid="31c46a10-66f8-4677-8fc2-202959b4ff3b">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c5cfe435-bdd5-40f4-8b0f-6b985139776d">
+      <statement statement-id="sa-10_stmt.e" uuid="2f1236ef-8afa-4b2f-899a-156aa02be068">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2706133d-eb66-4fff-939a-950056d0e299">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(e) is planned. Progress
 can be tracked at:
@@ -6348,10 +6348,10 @@ https://projects.engineering.redhat.com/browse/RHV-21061
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0cca61f5-97f5-4637-b063-36761e497c8a" control-id="sa-10.1">
+    <implemented-requirement uuid="adc8007e-d183-4e3f-aadc-c49f3d8d4132" control-id="sa-10.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-10.1_stmt" uuid="b5115127-69de-4171-9103-65381bf0eab2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="782eba34-6fc6-45e0-a71f-8043918810e9">
+      <statement statement-id="sa-10.1_stmt" uuid="22ec1ae1-100e-4b20-9cc2-3402cdeaef57">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ec1c56ee-d6ab-4f33-9e0d-279b141d27a0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-10(1) is planned. Progress
 can be tracked at:
@@ -6361,10 +6361,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bfb1048c-1d18-4417-9e1c-c3f40d50ca1b" control-id="sa-11">
+    <implemented-requirement uuid="3793a082-b793-4415-a3e2-a5617d4a09c6" control-id="sa-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11_stmt.a" uuid="8d091bdb-01bc-4af9-bf98-6081e5390b6c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b252c4b3-6b09-4479-960e-53bd09b24411">
+      <statement statement-id="sa-11_stmt.a" uuid="cf46ba78-5a5c-475c-be80-c5b57ef96281">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="36a99276-5f2d-428f-9816-f2e4786351d9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(a) is planned. Progress
 can be tracked at:
@@ -6373,8 +6373,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.b" uuid="a5aa3cfe-aca5-4eb0-9128-2f7575bdf019">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="425cf44a-627a-4d02-8b35-716534d778ac">
+      <statement statement-id="sa-11_stmt.b" uuid="061e3634-d640-4dab-be4b-e30bfe16c61e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1937705b-ad55-4470-85df-afd21c29d99f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(b) is planned. Progress
 can be tracked at:
@@ -6383,8 +6383,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.c" uuid="8445cbb6-abfa-4370-8eef-bd29966d39f9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="978d9423-4b97-4b47-8438-45d08bdd50f2">
+      <statement statement-id="sa-11_stmt.c" uuid="b76445b3-6271-4033-bc41-0f358e6badbb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4863aa6f-1480-476e-b863-25faf09c8469">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(c) is planned. Progress
 can be tracked at:
@@ -6393,8 +6393,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.d" uuid="e08c2e9a-522d-4443-b748-7ae953894307">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0ce09cee-7ace-4a00-8cd9-a1a3f027dc40">
+      <statement statement-id="sa-11_stmt.d" uuid="0a2f3d54-2762-41d6-8713-c22e8832c84b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="681bd9b0-f378-4bfe-a3b4-14cc0fc1c799">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(d) is planned. Progress
 can be tracked at:
@@ -6403,8 +6403,8 @@ https://projects.engineering.redhat.com/browse/RHV-21062
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sa-11_stmt.e" uuid="a30a8ef7-b371-4488-8e66-ee89a5b3e3bf">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b1188265-4fe5-4973-89de-45942ea7054a">
+      <statement statement-id="sa-11_stmt.e" uuid="713f2000-3e7c-40d5-a3c9-b40edd933abd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4d9b31e1-662d-4c73-8b23-53ee3a1234e5">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(e) is planned. Progress
 can be tracked at:
@@ -6414,10 +6414,10 @@ https://projects.engineering.redhat.com/browse/RHV-21062
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f2916c6a-068c-4009-9022-4d0a41305ce6" control-id="sa-11.1">
+    <implemented-requirement uuid="f4654e5b-5c8c-4556-acff-4a55e2d7a462" control-id="sa-11.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.1_stmt" uuid="fef9ed62-efe7-4a49-b41c-2789a906075d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="77e5f9a9-ebaa-4c1a-b812-deff92253310">
+      <statement statement-id="sa-11.1_stmt" uuid="499fdb69-b5bd-40ba-addd-0e0c310ba5dc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6a5e446a-ffc4-4b73-b1ee-fd52746fdc16">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(1) is planned. Progress
 can be tracked at:
@@ -6427,10 +6427,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="143b4bb3-2ffe-4724-800b-3127aea369fe" control-id="sa-11.2">
+    <implemented-requirement uuid="ddb2c3a3-ecc2-4a77-99fd-6f779f776f71" control-id="sa-11.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.2_stmt" uuid="a8f71200-1d1a-45ef-82f3-fe541cf50bf5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="54f3ce18-13e6-4c73-b77b-6ba4c76b5f3e">
+      <statement statement-id="sa-11.2_stmt" uuid="dbc9c3c0-0d9a-4da6-b616-af78319989cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="888ad617-e394-456e-a020-63a4f9bcf251">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response to SA-11(2) is planned. Progress
 can be tracked at:
@@ -6440,10 +6440,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="045ac3c3-e456-48c3-99f5-5937be0bc304" control-id="sa-11.8">
+    <implemented-requirement uuid="431a7e86-4fa6-41b0-a14e-8a7b40f965f8" control-id="sa-11.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sa-11.8_stmt" uuid="2db997a7-9c68-4bd4-91eb-e46f211dc038">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7d120f9e-2361-459b-a6ae-8ab8b0491de2">
+      <statement statement-id="sa-11.8_stmt" uuid="c329c78b-2ad2-4474-9716-37bad9f62df1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="20dadd46-daee-4ac0-a03d-61a01669d400">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress
 can be tracked at:
@@ -6453,18 +6453,18 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2f90db88-3a21-49a3-bb27-be0d720f4542" control-id="sc-1">
+    <implemented-requirement uuid="b86cee4d-ce61-45cd-9e34-afdbef6abb73" control-id="sc-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-1_stmt.a" uuid="533db2e9-eb5d-41ab-800b-26a3afd8a650">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2a3d4c01-56e4-4949-a7ca-ee08bd46793a">
+      <statement statement-id="sc-1_stmt.a" uuid="c470702a-260b-496d-9061-de3685081609">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-1_stmt.b" uuid="b7f16db1-e73d-4810-af2f-a5bb801b2c69">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8b5c0389-4eec-463a-a2f7-6a8b87ab3ccb">
+      <statement statement-id="sc-1_stmt.b" uuid="ee59ae69-664f-40fa-b0ec-b0c276e6781e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -6472,10 +6472,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="693b2d00-1aa1-4337-9947-4a3911ebe26c" control-id="sc-2">
+    <implemented-requirement uuid="70da8442-3398-457e-b7c3-f7fc3dae5909" control-id="sc-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-2_stmt" uuid="298ce090-56ed-444d-866c-f21ae9658fa8">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b3907eef-2bcf-489f-91cd-3095b1f4a9b8">
+      <statement statement-id="sc-2_stmt" uuid="44acc704-1e60-4fd5-abe2-024d5664d1aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ee4d9884-03fa-441f-b60e-dcc41011bfec">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for separating user functionality
 including user interface services) from information system management
@@ -6490,10 +6490,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e0ac3cf-c3aa-483c-85e6-8298058e911a" control-id="sc-4">
+    <implemented-requirement uuid="5682e79c-2a44-4798-a0b2-f3380e749850" control-id="sc-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-4_stmt" uuid="11567db9-68cc-4cca-ac6b-260468f3ade7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="384a4867-2b64-4a2f-a538-9de7ca875747">
+      <statement statement-id="sc-4_stmt" uuid="59fce0b6-f3c2-477f-8f72-105d101d9c08">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="6f71cd20-c3ff-4a42-bebf-207b35e29b8f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for preventing unauthorized and
 unintended information transfer via shared system resources. A
@@ -6507,10 +6507,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2500cd5-b861-4bea-982f-1206689f42a5" control-id="sc-5">
+    <implemented-requirement uuid="4d5e1ef8-ad17-4872-8379-031372f0365a" control-id="sc-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-5_stmt" uuid="aff33eaf-2ecf-416e-bd73-3353d1129e07">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="000481b8-6026-47c0-a990-77d4055c34f2">
+      <statement statement-id="sc-5_stmt" uuid="4c889bf3-cdc9-43ba-a467-2c49db0681ec">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6520,10 +6520,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="42b1d79c-43ed-46dd-bf5a-629a25adba9b" control-id="sc-6">
+    <implemented-requirement uuid="82bbbda7-2397-43ce-8a91-45ebe78b28d2" control-id="sc-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-6_stmt" uuid="ba6375f9-7d62-436b-9798-0880ef913550">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="21679585-1d52-46d8-bb7b-08029db831c4">
+      <statement statement-id="sc-6_stmt" uuid="b13d5767-f2bd-4b7f-abb7-098b2d703125">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9b1aa9cb-3e60-45d5-a0cf-18dfeb9a218c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for the protection and availability of
 resources by allocating processor and memory resources by process
@@ -6538,10 +6538,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e3d20766-0371-47aa-b904-d7d2a5a1bec6" control-id="sc-7">
+    <implemented-requirement uuid="5284738c-50c6-4ac6-baa6-f89664275d32" control-id="sc-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7_stmt.a" uuid="81229107-fc58-4492-8c1f-527bfde99849">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b5db5b87-0c18-49e3-852c-138d6eee18a9">
+      <statement statement-id="sc-7_stmt.a" uuid="03be8972-f7f0-461c-90a3-a129c53266d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6550,8 +6550,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.b" uuid="dfc31558-c76e-464a-9f32-56b36fa80c26">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8eeeb702-c097-46f0-bc01-617d90b62dcc">
+      <statement statement-id="sc-7_stmt.b" uuid="246af9e6-fdc5-413b-9fd0-34b2195356bc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6560,8 +6560,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7_stmt.c" uuid="3daf00ad-2f78-4bf5-a9d5-5b9073ac3823">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5c9527d4-8269-4649-9f55-1f8b066546d7">
+      <statement statement-id="sc-7_stmt.c" uuid="9e10874b-71c3-4c5c-a8c8-402054bfb228">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6571,10 +6571,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="8d50ebf8-98b8-4fc1-8a60-9a0f14407107" control-id="sc-7.3">
+    <implemented-requirement uuid="bd054bfa-4fc7-4624-91e4-6bf2052ee2da" control-id="sc-7.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.3_stmt" uuid="ae418b4d-ad98-4409-bd39-ac0da1222e7d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b31b57f1-9081-4152-b5c5-e2f6a7708862">
+      <statement statement-id="sc-7.3_stmt" uuid="bd50dd22-917d-43af-be8e-58c4da6d8e02">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="755d6cf9-a601-470e-95e6-6a9d439390c2">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for limiting the number of external
 network connetions to the information system. A successful control
@@ -6589,42 +6589,42 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5e4c27bc-91f1-4d79-9633-8f677cdbec16" control-id="sc-7.4">
+    <implemented-requirement uuid="d7c75c63-231c-4096-b614-fb94a7e697bc" control-id="sc-7.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.4_stmt.a" uuid="1e3dcbe3-4fd2-47ab-b3e6-3e911751fc3e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="82c84873-aa72-4afc-8372-6f033120c8c1">
+      <statement statement-id="sc-7.4_stmt.a" uuid="32e6ca84-d7c2-43a0-bbb5-1eace8e1ad07">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.b" uuid="9800be9f-b55e-43e6-b4c9-949d534bcfa1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5da4f6cb-a6bb-4184-ad4d-4a0b8d6aa6ab">
+      <statement statement-id="sc-7.4_stmt.b" uuid="bcd5c039-1219-4ec3-b329-e45d99c4d340">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.c" uuid="719a9aa2-0f93-4f8b-97c8-8565ae98164e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2c6e13d9-faa4-4e64-af3b-4b9b951148fc">
+      <statement statement-id="sc-7.4_stmt.c" uuid="069d86ca-da6a-4077-854c-868ee5e9ecc9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.d" uuid="9d9ea11c-3e57-4f64-b9d8-c8e9a75e6979">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="126336ec-5ca6-4f6c-99d4-656a005f6ecf">
+      <statement statement-id="sc-7.4_stmt.d" uuid="8f227e9c-9dfe-4054-b121-4d8a1d4695cd">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-7.4_stmt.e" uuid="e9d5ee9a-9b06-4a99-8e36-ab4db399dfb7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="94bbf6f3-d38d-4ee5-a5e2-1388ff146926">
+      <statement statement-id="sc-7.4_stmt.e" uuid="a3fb9713-8f46-4fbe-9950-20c1f82b14d7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -6632,10 +6632,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="47eff622-ba63-4647-8128-0558daad9cb2" control-id="sc-7.5">
+    <implemented-requirement uuid="6352f83a-1990-4f77-b7d4-20477ea193fc" control-id="sc-7.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.5_stmt" uuid="258e47a0-4dc9-466f-b404-8269e25b469f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1e592bde-b262-4fc5-b042-d82d315373bb">
+      <statement statement-id="sc-7.5_stmt" uuid="77c7eed5-e937-431d-9ecf-06142441cead">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="017bbc7a-e859-49ef-99f5-32b45c249480">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring managed interfaces deny
 network traffic by default and allow network communications traffic
@@ -6649,10 +6649,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f284728e-9f84-49a4-a03a-932df9889124" control-id="sc-7.7">
+    <implemented-requirement uuid="9ce1fd85-8385-434c-9f52-5f83ca6b94f8" control-id="sc-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.7_stmt" uuid="576d87ee-9898-47cf-9e17-9dd2fac2c992">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3d10f1d1-484b-4243-a899-630cc2614753">
+      <statement statement-id="sc-7.7_stmt" uuid="8fe6423b-55dd-492f-98bc-ea63fe10afbc">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8058ef3c-62cb-49af-8163-2a203fc25a6f">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing mechanisms to
 ensure Red Hat Virtualization Manager (RHVM) nodes do not act as proxy or relay servers between
@@ -6661,10 +6661,10 @@ internal and external networks.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="cb2639d6-4fd1-48e6-88b0-53a0ea2a314d" control-id="sc-7.8">
+    <implemented-requirement uuid="c27f649c-058c-46d1-af09-2651e9668239" control-id="sc-7.8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-7.8_stmt" uuid="5d02f64a-f8c1-4912-9071-0f4454e84999">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="955ce72e-4dd8-4392-9e8d-e87f424a32dd">
+      <statement statement-id="sc-7.8_stmt" uuid="d2cb6062-09d9-4314-9a79-1a3b3bb55fc1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6674,10 +6674,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="653ef5d3-7811-499e-bd18-51ee72b7584a" control-id="sc-7.12">
+    <implemented-requirement uuid="88cc2cd2-e8b8-474c-a3f7-e1da1d36e3c6" control-id="sc-7.12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.12_stmt" uuid="448e6384-0123-42a9-8c82-4a2233401e03">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="36a843bb-66be-4106-92c4-9eab354e8a91">
+      <statement statement-id="sc-7.12_stmt" uuid="47ea0ad6-5d46-4f24-a661-403095ebf876">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8c52e724-9ba0-4f88-bf6d-10dc91dee8d3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for implementing host-based
 boundary protection mechanisms. This is often through configuration of
@@ -6691,10 +6691,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="771af36e-5d80-4129-b561-4fb24e98182d" control-id="sc-7.13">
+    <implemented-requirement uuid="87adc99e-fff5-4af4-ba83-1b6b82b0ee89" control-id="sc-7.13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.13_stmt" uuid="99113528-b5c0-4587-a2a9-092b8c661747">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bda1a53b-27f4-4332-a323-ef934b1fb19a">
+      <statement statement-id="sc-7.13_stmt" uuid="999496f6-49b0-434a-a22f-8718c88aba4d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d58896a-07f9-449a-837d-c1bef5a36c8d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for ensuring that Red Hat Virtualization Manager (RHVM) is
 isolated from other internal information system components by
@@ -6711,10 +6711,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a9f4ea0-3ce9-4330-8ce6-9fa7046955fa" control-id="sc-7.18">
+    <implemented-requirement uuid="005ffd60-e29b-4bb5-a964-7ef65783f3d6" control-id="sc-7.18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-7.18_stmt" uuid="ac1f40e5-b8af-4ba7-ac04-90635204b220">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="734e8647-d9f9-44b2-b048-c212e490f06b">
+      <statement statement-id="sc-7.18_stmt" uuid="00c478bf-252c-4c48-91df-18734f3c248d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6724,10 +6724,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d2aaa4ec-3377-4b93-9ca9-f16eb93dab9b" control-id="sc-8">
+    <implemented-requirement uuid="6ebf81ff-2d9d-48c9-bc42-2cf9637471d8" control-id="sc-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8_stmt" uuid="76b0a49f-0ad1-4bbc-9815-432bd20783b2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="adfb4df1-1e5d-4358-a0e1-7f54f89ed999">
+      <statement statement-id="sc-8_stmt" uuid="49e34fad-76b9-4853-9a6a-5d5de9b11158">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6737,10 +6737,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a0f4c637-91d5-4b68-9137-d33aa584fc29" control-id="sc-8.1">
+    <implemented-requirement uuid="1263ce60-fead-4fe3-91c1-2c246a05e045" control-id="sc-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-8.1_stmt" uuid="ac5db102-4f50-430e-80ed-9bf3d8bb6a76">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cc365c9f-5471-4643-8ec4-bf09d4a1bdb2">
+      <statement statement-id="sc-8.1_stmt" uuid="e8d6016b-24d2-4229-94ae-3de7956621a9">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6750,10 +6750,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="b0ad52c0-e97b-4884-b8b9-ddd3fe9746a9" control-id="sc-10">
+    <implemented-requirement uuid="e5a2c493-ec0e-491d-86e3-7b162bdb4ef3" control-id="sc-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-10_stmt" uuid="3096b852-112d-41f9-b1b5-dde1235be320">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dab68881-625e-40e2-8d84-9db7a45f66ce">
+      <statement statement-id="sc-10_stmt" uuid="ee7681ec-31ee-4c11-8ab4-7777139adc68">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="bc326e1e-9b29-46ee-8e79-35af828fc76e">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for terminating network connections
 at the end of the session or after no longer than 30 minutes of
@@ -6768,10 +6768,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="594131f1-4308-4b16-a3cf-b1dbb66fcd15" control-id="sc-12">
+    <implemented-requirement uuid="a6c2e22d-2e4c-4524-a9b4-40e7699e2590" control-id="sc-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12_stmt" uuid="de06e756-23d8-4020-ad3d-e133c488e3fb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2328c93c-2874-4355-87ea-2f7e62317de8">
+      <statement statement-id="sc-12_stmt" uuid="146275cc-6a6b-41fa-adbd-aa394c6964da">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="22c1a45b-7ea9-4b3c-ac60-2c0e6a977cf1">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) utilizes FIPS 140 evaluated
 OpenSSL libraries for the generation of cryptographic keys. This
@@ -6790,10 +6790,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7045b367-9f09-4a7b-aa54-fec459bfd64f" control-id="sc-12.2">
+    <implemented-requirement uuid="4d4f5d27-f723-4222-939b-a20a7b8f0b43" control-id="sc-12.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.2_stmt" uuid="7d55ec54-df92-4ee9-917f-cadb53b1aa6e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1d4ce255-d73c-447b-ad99-23a85a9ecefc">
+      <statement statement-id="sc-12.2_stmt" uuid="a5a12b62-f938-4920-bb4a-79a0fe345369">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6803,10 +6803,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1937ceeb-f788-4bbb-9ce4-833ad09a41c5" control-id="sc-12.3">
+    <implemented-requirement uuid="08160e29-14fc-4dd7-b5b6-fba597db4b6e" control-id="sc-12.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-12.3_stmt" uuid="bae2e7d4-c93f-4f31-9934-dbd20e62646f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a7e615ce-6ac7-482f-85d9-8f7202e05356">
+      <statement statement-id="sc-12.3_stmt" uuid="84f2cc66-d583-4e4f-abea-1ec72a4c573b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6816,10 +6816,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="368ad2cc-56b4-4ada-88f8-e0b972b861ed" control-id="sc-13">
+    <implemented-requirement uuid="17cc2bbf-50a8-46dc-b8cc-81ec9436957e" control-id="sc-13">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-13_stmt" uuid="1b83851a-9082-41bc-b12f-47780f25a557">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a5828e31-5f6d-49fc-9dd5-a8b58fb1c6f1">
+      <statement statement-id="sc-13_stmt" uuid="c9215f59-79d7-4038-850b-46d60f6d2416">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="95afdfd4-0996-40f2-9c0c-f68fbadbe2cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The Federal Information Security Management
 Act (FISMA) requires the use of FIPS 140 evaluated cryptography.
@@ -6834,10 +6834,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="ac8cfbe4-db5f-48e0-8054-5f2f27c33553" control-id="sc-15">
+    <implemented-requirement uuid="20f5a259-b494-4a5d-890d-10bf65c16c05" control-id="sc-15">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-15_stmt.a" uuid="a33bb7b4-0523-4aec-aa92-ebc6fbd2b315">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="97928ffe-6edb-4201-a440-0ff1dfefc85a">
+      <statement statement-id="sc-15_stmt.a" uuid="45e9cdd5-9166-40b2-bb0c-31a61d7c90c1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -6846,8 +6846,8 @@ a collaborative computing device.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-15_stmt.b" uuid="6505e459-96cb-45ba-a576-032f50d7aef3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7e6a073a-1dee-4b4f-9bd8-3245ea573ce2">
+      <statement statement-id="sc-15_stmt.b" uuid="60a11b00-60e7-4cb4-af05-3f2e19e96459">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="09150558-0f97-465b-9e99-cc274cf219ff">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Examples of collaborative computing devices include networked white
 boards, TV conference cameras, and remote video systems. This control
@@ -6857,10 +6857,10 @@ a collaborative computing device.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5dcf35d0-b4d4-4014-b5fe-1d287aa940d1" control-id="sc-17">
+    <implemented-requirement uuid="9c076857-d661-4be2-95d3-920782a6606d" control-id="sc-17">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-17_stmt" uuid="7895595c-3a2b-4466-8251-0db1b0368026">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d275fc5f-459f-4322-a9b2-de2c95b565ed">
+      <statement statement-id="sc-17_stmt" uuid="1287771e-ed58-4c87-87ba-d0cc3a5a201d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="f6c49247-3dbc-4eba-a1d7-c293a52eef9a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -6870,18 +6870,18 @@ https://issues.redhat.com/browse/CMP-419
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="91ce0ba5-40a3-4dfb-a17f-849f4d690f29" control-id="sc-18">
+    <implemented-requirement uuid="5d3f05bc-c7c8-470c-914d-ec87c04ee392" control-id="sc-18">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-18_stmt.a" uuid="d1664a7b-a33b-4b0a-b466-2d637767abda">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9a5d55a7-8933-4b17-b9d5-ff847061f7f5">
+      <statement statement-id="sc-18_stmt.a" uuid="288c4934-cfa1-43b0-80b6-2c17d0c59fb5">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="b9bbcb63-8565-4eae-b386-70f3337b4970">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for defining acceptable and
 unacceptable mobile code and mobile code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.b" uuid="6fb222f5-6898-4a8a-8605-1f8ce235c69c">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ffc05aa6-1eec-463c-829a-14826ed21b4c">
+      <statement statement-id="sc-18_stmt.b" uuid="f2075982-e716-4d6f-b59f-fb353c22add2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="300a4a3e-4553-45b6-9fa6-64fb56470ffa">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for establishing usage restrictions
 and implementation guidance for acceptable mobile code and mobile
@@ -6889,8 +6889,8 @@ code technologies.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-18_stmt.c" uuid="4313598a-e9e3-4821-9e7f-236c23e51b42">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="879744dd-82f2-4262-9b0b-9f72035d08c6">
+      <statement statement-id="sc-18_stmt.c" uuid="2f974c25-54e8-4af3-af44-160b66b2f0bf">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="8d0eed06-b541-4ff7-a7d7-90c4dde3a139">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of mobile code within the system in accordance
@@ -6899,18 +6899,18 @@ with organizational policies defined in SC-18(a) and SC-18(b).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="135f7c58-7637-464b-ac55-d1310077a9e3" control-id="sc-19">
+    <implemented-requirement uuid="f72216e1-b23a-4af4-b730-3073eac610e3" control-id="sc-19">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-19_stmt.a" uuid="d023e159-de4c-4fbf-bc7d-622e322ee5a3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2f039373-8edc-4ea1-b819-0f46ab4f9eac">
+      <statement statement-id="sc-19_stmt.a" uuid="7ee93e00-bbb1-4e9e-b761-a49b76fce2ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-19_stmt.b" uuid="88366947-ce85-45a9-8b93-74206fac3b70">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0650b690-f84e-41ef-9c6f-66f8b88d4bec">
+      <statement statement-id="sc-19_stmt.b" uuid="992aef3c-4eb9-4a40-a0d6-5eba74b1990b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9a61a484-9036-4b36-a33c-746889aac4f7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for authorizing, monitoring, and
 controlling the use of VoIP within the system in accordance with
@@ -6919,10 +6919,10 @@ organizational policies defined in SC-19(a).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dacfeda3-6e18-4e37-8257-5c992541c19d" control-id="sc-20">
+    <implemented-requirement uuid="aac327f7-334f-4136-ba0d-a69495a4228f" control-id="sc-20">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-20_stmt.a" uuid="2a7a2553-05c2-46d7-a6b8-f7d3dbb3e775">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="fd4cbb82-1d71-40d1-b8dc-ea33abef9590">
+      <statement statement-id="sc-20_stmt.a" uuid="67b81ea6-2bf3-46bc-9722-e0dff2d50c87">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="934926ee-05e0-47e6-8f1e-13a8858e54f6">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for providing
 origin authentication and integrity verification artifacts along
@@ -6937,8 +6937,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="sc-20_stmt.b" uuid="26f31733-5e7d-43b9-a631-58c8f4b3e629">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="53b52246-21c8-4048-a40c-867dd7e124e0">
+      <statement statement-id="sc-20_stmt.b" uuid="a871ad06-8c3e-4f76-b4c5-a7de3dd9040a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="5279d66f-e6dc-4f01-a4f8-207873b40bd0">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Red Hat Virtualization Manager (RHVM) administrators are responsible for
 providing means to indicate the security status of child zones and
@@ -6954,10 +6954,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4d1ee8e9-d75a-4927-81ef-253ab6935bff" control-id="sc-21">
+    <implemented-requirement uuid="b7ca6468-ad17-4f00-b5f0-8d0408ee26e0" control-id="sc-21">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-21_stmt" uuid="bf04f926-94df-47a5-8cf7-0054a78ec432">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2f386e26-bd86-4e3a-bca1-44b8a8c1299c">
+      <statement statement-id="sc-21_stmt" uuid="ead80409-da32-40bb-aea8-811f569cf14e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e1b3c881-8d1d-48c5-8ecf-c4719ee59ca9">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>Documentation to configure DNSSEC is provided in the Red Hat
 Security Guide:
@@ -6972,10 +6972,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a3a0d953-3f98-4b29-b0cf-51558d0f9bc0" control-id="sc-22">
+    <implemented-requirement uuid="f6d227e0-4670-42e1-b7ee-caa42a9deadd" control-id="sc-22">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="sc-22_stmt" uuid="8fb519ac-ddec-47e6-8b45-793417e41259">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dc85096e-2060-4545-926f-6d2dda9c44f2">
+      <statement statement-id="sc-22_stmt" uuid="9dd70fd2-1b7c-45cc-a6d7-b7c7c414a703">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7907baf5-a82f-4ad6-b991-bf9cf4e6d622">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The organization is responsible for ensuring that the information systems
 that function as nameservers are fault-tolerant and implement internal/external role
@@ -6984,10 +6984,10 @@ separation.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="db2f74e0-3c9a-42b5-a26e-734d63543f64" control-id="sc-23">
+    <implemented-requirement uuid="8d358d47-5981-4e35-b156-3f59ebcb9375" control-id="sc-23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-23_stmt" uuid="0b73ef1d-eb99-4df3-adc2-ef13b07e5d08">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a99ca589-95a7-4d88-844e-512903cc3270">
+      <statement statement-id="sc-23_stmt" uuid="af621af7-8e88-404f-8733-4ec9d3319a92">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="e411f9a4-503d-41df-8bb6-75236999ea40">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for guarding against, for
 example, man in the middle or session hijacking attacks for
@@ -7007,10 +7007,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6902bdf9-6971-4bd2-bcf9-06e2878d1c42" control-id="sc-28">
+    <implemented-requirement uuid="5369e7e4-4f63-47a4-a269-858e0d726ed2" control-id="sc-28">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28_stmt" uuid="a64749b4-96de-45d4-9dec-f90de11596ed">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="846610e8-6d4d-4d74-9b88-1569fbfb2774">
+      <statement statement-id="sc-28_stmt" uuid="3c623361-fd52-46c2-b652-86f40cfbf05c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7020,10 +7020,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="f5ffd302-3157-45b5-9b36-5ff9954e9689" control-id="sc-28.1">
+    <implemented-requirement uuid="ead5d9b7-8685-4ec5-98e3-be95239a7ac1" control-id="sc-28.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-28.1_stmt" uuid="de400283-bbcd-4041-860a-b6405e6614ad">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d7a484ab-e57e-4b26-a1f2-ad8bbefe241f">
+      <statement statement-id="sc-28.1_stmt" uuid="85579a64-91f8-4875-ba31-3a301c7c2da7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ff1eb1f-b2c6-42e0-a5a3-df44f4885a46">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for implementing cryptographic
 mechanisms to prevent unauthorzed disclosure and modification of
@@ -7044,10 +7044,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d41b4f15-3abd-470b-b3f6-6aae42526a6c" control-id="sc-39">
+    <implemented-requirement uuid="18492d24-fcdb-4b37-bca3-45866ef75858" control-id="sc-39">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="sc-39_stmt" uuid="5e6c03f3-d32e-4f36-a59b-cfabb544de89">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e14ded52-8bee-4dfd-8d66-0cbe3ee54ef1">
+      <statement statement-id="sc-39_stmt" uuid="3d537e80-1058-4a08-90ba-7914b55b29b1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="37595941-cf79-46ab-abb1-b35dc61a57cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A complete control response is planned. Engineering progress can be
 tracked via:
@@ -7057,50 +7057,50 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d604cd0a-994a-4e49-b283-cd9516c21f12" control-id="si-1">
+    <implemented-requirement uuid="69d4323a-60d7-433f-8def-834118e54ec3" control-id="si-1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-1_stmt.a" uuid="f28ed65a-79b7-4da9-8280-7cfedd7c2ebc">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="eadc1a0d-75b7-41fb-a567-af5f3fd24a34">
+      <statement statement-id="si-1_stmt.a" uuid="94b8cd57-db6c-45cb-9083-c68f55d824ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.1" uuid="45d5bdc9-8f81-4562-a441-e05e2d7f8dc9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="220ff727-b6c3-4cf5-ac16-cae38ed46c3d">
+      <statement statement-id="si-1_stmt.a.1" uuid="5445db05-a229-4dc8-8db5-aac44c81e11b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.a.2" uuid="b1f14365-5831-4101-ad94-081a143ac929">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="48ae5453-08ea-4aad-820e-3535eb3daed4">
+      <statement statement-id="si-1_stmt.a.2" uuid="f701cd56-8a46-46f9-a67b-f933907d3366">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b" uuid="5a2a8ff0-ac0b-4e35-a0f7-1576a2bcf073">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="783df561-e635-4bea-8a47-a36da1167ffd">
+      <statement statement-id="si-1_stmt.b" uuid="43752a7d-deb8-4a5b-95e6-24d6559073a0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.1" uuid="e4ff20aa-2f90-4e1b-b01d-3a351001037a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="62325e5f-32f9-4119-8be0-b63dcbb7d337">
+      <statement statement-id="si-1_stmt.b.1" uuid="f51c8e38-661f-4dc2-8b95-d9a6a581256c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-1_stmt.b.2" uuid="7776d776-4146-458b-9e26-fd5d50b00004">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6e33e0d4-ac92-4579-84cd-b2b4f348fd23">
+      <statement statement-id="si-1_stmt.b.2" uuid="8a613969-37bd-44a4-b52f-347ed9730db4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7108,10 +7108,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dbd5b8db-5128-45ca-a959-e7939e411a84" control-id="si-2">
+    <implemented-requirement uuid="7cedbd5c-1b1d-4006-8b67-4a7737372576" control-id="si-2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2_stmt.a" uuid="0a0f7fdd-c578-4fb2-8505-929868b328fa">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9630b637-b21c-46fc-977f-77f1ae2a85c8">
+      <statement statement-id="si-2_stmt.a" uuid="96489f3b-4bf5-4c8f-861d-51c61891be1d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="3ed4991a-e585-4e65-8fcd-7dc03286246b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for analyzing their Red Hat Virtualization Manager (RHVM) deployment for
 flaws, reporting on those flaws, and correcting them. A successful
@@ -7121,8 +7121,8 @@ assist in detection and remediation.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.b" uuid="6890e06e-4bec-441d-bef7-96599cef2005">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="45b4d968-356e-42b5-ba7a-8f8dff2f564e">
+      <statement statement-id="si-2_stmt.b" uuid="086eebad-1e6b-4123-baff-e5d987e41741">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="29cfb255-66c1-40de-b090-cf3d790e6c1c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for testing Red Hat Virtualization Manager (RHVM) updates
 related to flaw remediation prior to installation. A successful
@@ -7132,16 +7132,16 @@ the tools in testing, etc.).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.c" uuid="4e4422ce-5b75-453c-b61c-2a5272605ce0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6d67c818-d704-4a9b-b554-8c86f46f3d5c">
+      <statement statement-id="si-2_stmt.c" uuid="0a0349f9-7247-4d4f-9252-6510fb5c3964">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2_stmt.d" uuid="6c310445-3fed-440f-8598-8078d0393b0a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c4c27f3d-feb2-46a7-bf7a-7500e506a6bf">
+      <statement statement-id="si-2_stmt.d" uuid="40f6fe99-bbfa-4675-9b65-946ed3fcddf0">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7149,10 +7149,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="824e4744-07a8-4b03-bc5e-b572052befc7" control-id="si-2.2">
+    <implemented-requirement uuid="f39f62f5-798d-48f5-8703-27d537979525" control-id="si-2.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-2.2_stmt" uuid="4fd5ad8d-20b5-4216-b822-d2e5db16905e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="8a0f5699-c26a-4abe-aa24-13780daf0e35">
+      <statement statement-id="si-2.2_stmt" uuid="2fcbc796-5a33-4953-b75d-ed3bbf6cd579">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d37014f-dd7c-410f-8ccd-f0873ee726fe">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be required to employ automated mechanisms on a
 monthly basis to determine the state of information system components
@@ -7170,10 +7170,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0a95ac9a-9a74-4878-b8d2-92fc9749a1ea" control-id="si-2.3">
+    <implemented-requirement uuid="d38d4178-a27f-4336-8b18-b771c6fa51a2" control-id="si-2.3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-2.3_stmt.a" uuid="672bc042-21b1-404f-b460-cdafdcd89cfb">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="12e1506b-4891-4cc6-8a82-2b31fd400c41">
+      <statement statement-id="si-2.3_stmt.a" uuid="317b7580-7849-4b11-a98b-c0688f66bb36">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94fd875b-e9bc-4031-a6d1-5e97de9e3abb">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for scanning for flaws in their
 information systems and for measuring the time between flaw
@@ -7184,8 +7184,8 @@ difference.
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-2.3_stmt.b" uuid="a9a60e3f-5026-42e0-9fed-9722ee4f4d82">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a7a8715a-c6bb-45e7-9a96-504f9b225517">
+      <statement statement-id="si-2.3_stmt.b" uuid="f4581556-4d4d-44c8-b3e7-51cda1e2d642">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="1c229540-247c-4453-8c66-d276fc9bf466">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for scanning for flaws in their
 information systems and for establishing benchmarks for taking
@@ -7197,10 +7197,10 @@ customer defined period after a flaws discovery.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="2ab2d21c-45a7-48ca-9030-b53e83c36c18" control-id="si-3">
+    <implemented-requirement uuid="8fb0583e-6c93-479a-831b-d10e080b9a60" control-id="si-3">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3_stmt.a" uuid="a87b7939-e848-453a-ad20-024025af0656">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="2183866e-64e2-4cd3-b891-0e88106cc82b">
+      <statement statement-id="si-3_stmt.a" uuid="96c9f924-a2fd-4c4e-bc94-628b0f1ef963">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="94905c61-6bce-4dc2-9253-c9f199fb293a">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they employ malicious
 code protection at information system entry, and exit points to detect
@@ -7216,8 +7216,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.b" uuid="4f12d42c-5aeb-437b-92ab-c289c6265a3a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="4688fecf-3323-4006-b654-b3528424a9b2">
+      <statement statement-id="si-3_stmt.b" uuid="42f7abe3-c9eb-49cb-94cb-6f9c17b5f0f2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7226,8 +7226,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c" uuid="4111d9e2-dde7-47a9-9c2e-e2ddc42eca7d">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="d9294ae3-e49e-49c5-975c-184c11f00472">
+      <statement statement-id="si-3_stmt.c" uuid="7c6fe192-3bf9-4f69-b0f9-ff7e7422a091">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7236,8 +7236,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.1" uuid="506bee76-bb83-4b7c-a722-d07ae74339be">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ab52453a-0e43-481c-97f4-be93cb59b3ab">
+      <statement statement-id="si-3_stmt.c.1" uuid="74524043-5114-456a-91e8-0aeba087bf50">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7246,8 +7246,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.c.2" uuid="0cd6e0c4-767f-4479-afc8-521af7fc6f16">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="35cc1be3-bb68-4272-b638-3e293637b19a">
+      <statement statement-id="si-3_stmt.c.2" uuid="4e47ed17-cd83-4ed7-976a-e20121178f72">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7256,8 +7256,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-3_stmt.d" uuid="680dc5ce-ffd3-4d01-b3af-6f9952a8cf87">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6909bd5a-507d-45a1-bee0-4826296ccb56">
+      <statement statement-id="si-3_stmt.d" uuid="d97e7a7b-bd3b-4757-bbbb-f3b38665bb3e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="43cc9d15-3663-42d1-96f7-b782858d7505">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-3 is planned. Engineering progress can be
 tracked via:
@@ -7267,10 +7267,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="082d4df9-e577-48ca-b178-76f77bf09216" control-id="si-3.1">
+    <implemented-requirement uuid="3ebea031-233c-464a-998d-c0c3d922b851" control-id="si-3.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.1_stmt" uuid="a04ee37c-c6c1-4cad-8227-4b9e6022ea29">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="961166e8-7484-4c24-94bb-08dad6f463d0">
+      <statement statement-id="si-3.1_stmt" uuid="9e989886-07e9-4d4a-98ed-be98fb1368ea">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c58ac54f-22ef-4855-adb1-33eee390792b">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that their malicious code
 protection mechanisms are centrally managed. A successful control
@@ -7286,10 +7286,10 @@ tracked via:
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="a62d615f-5845-4206-8138-bcc2965e8789" control-id="si-3.2">
+    <implemented-requirement uuid="67609e78-72bc-40fd-b9f8-0728765cfc5a" control-id="si-3.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-3.2_stmt" uuid="76fd688a-8775-40b0-9b8e-8029e1208584">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f4d89fa6-eeab-4274-ae9b-57a3767da0a6">
+      <statement statement-id="si-3.2_stmt" uuid="b0ad1bcb-2da0-409a-bce2-8c8dce7b4539">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071bdb1c-8691-40b5-b1e8-17d54c02caa3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they update their
 malicious code protection mechanisms automatically when new versions/
@@ -7305,10 +7305,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d95fce38-63b2-4095-980e-f890d39aabc6" control-id="si-3.7">
+    <implemented-requirement uuid="e0f1ca33-2212-4e02-bea8-2b2961431e00" control-id="si-3.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-3.7_stmt" uuid="fd6f7c50-e05e-4ff2-82cc-83278e72c2cd">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7d264f90-99cb-4ffb-b300-2f7cb63a44c3">
+      <statement statement-id="si-3.7_stmt" uuid="c197c739-ab67-4d4a-89bd-78bc67721465">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="98787694-bec5-4c19-a079-27ca4960a28c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer is responsible for ensuring that they implement a
 nonsignature-based malicious code detection mechanism on their
@@ -7323,90 +7323,90 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7706ccfc-68b3-41f1-b25b-d48bdeb65941" control-id="si-4">
+    <implemented-requirement uuid="42da28da-22d3-48d2-9596-ee182934124c" control-id="si-4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4_stmt.a" uuid="81fdb976-5363-48a0-bc55-af0d50dbf6a6">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c90045da-5c46-463d-bb91-727f5490e2a6">
+      <statement statement-id="si-4_stmt.a" uuid="ad5f1c2c-5d90-4441-a995-674a523c202c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.1" uuid="3c818e94-8678-49df-a1f0-2cc57764e502">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="1f7e92a4-a280-4613-91ee-1b269f0220ca">
+      <statement statement-id="si-4_stmt.a.1" uuid="f607b60e-d90e-4e43-98dc-3a7a9636fc7d">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.a.2" uuid="4a1f2c95-51e9-46a5-a6f8-b3b26252a639">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="75ae00ec-ed62-427f-8a98-2ded601f5d75">
+      <statement statement-id="si-4_stmt.a.2" uuid="a10661b3-77ee-4238-a310-7a54cfbbe381">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.b" uuid="b5b82aba-5e84-4c0e-989c-5d9dee5d7753">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dd0a4dbb-9590-4d02-bb72-d2d779b2f337">
+      <statement statement-id="si-4_stmt.b" uuid="93b8c509-885e-418d-a16d-2e774aeafb13">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c" uuid="1604014a-9d61-4c1f-9014-dcd790612034">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="deb7b842-cbd7-403a-bacd-79f821523194">
+      <statement statement-id="si-4_stmt.c" uuid="c35fb893-5523-4f34-925d-1434f16a0e91">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.1" uuid="4fa12d77-f6aa-4a7f-b7a1-0ac53063c68a">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f1d61550-3193-4f4f-963f-bdac404d4630">
+      <statement statement-id="si-4_stmt.c.1" uuid="5551c8bd-d3f0-48a4-89fd-fcff3254c583">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.c.2" uuid="ea824a83-3c1c-4cb1-95e4-50ae13cf1464">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0390fa07-c35e-4e5a-9800-1c008c2fca15">
+      <statement statement-id="si-4_stmt.c.2" uuid="d541badd-ea98-4830-b51f-44e2b827e474">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.d" uuid="c4906836-3a35-41f9-a24c-2e9865a78b03">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="ee8f7a31-23c9-4f2c-8693-ad9e52d76942">
+      <statement statement-id="si-4_stmt.d" uuid="eab74f27-bef7-4c94-9448-5664bc339713">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.e" uuid="43363eab-0e7a-4cdb-a125-ad42a3d17714">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="eebb2cd8-154e-4485-8ea2-074ae3784e69">
+      <statement statement-id="si-4_stmt.e" uuid="c67c8bcb-a07d-4eb1-8ecc-033bc9a800aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.f" uuid="2c09de21-4184-4fe1-98cd-fb00862fa365">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="128253f0-a2f1-40c7-b061-249c733b5f79">
+      <statement statement-id="si-4_stmt.f" uuid="97dc93ed-5f81-4453-b322-45bdea8dd72f">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-4_stmt.g" uuid="536e5fb9-ca39-4191-a9f9-67fb514facb1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a59c84e2-4d40-417c-807c-30c05cbba0c8">
+      <statement statement-id="si-4_stmt.g" uuid="83c23958-58eb-45ae-b5d9-57211186fd65">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7414,10 +7414,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="dda93111-2a13-4e24-a9fc-03681c2d0596" control-id="si-4.1">
+    <implemented-requirement uuid="9fb8d001-a07c-48bc-a75f-a742ff6757b0" control-id="si-4.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.1_stmt" uuid="61cbc619-5a44-4516-9530-d7b0a4c72a3e">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3248f6ea-7c10-45b2-b2c7-636377699fbc">
+      <statement statement-id="si-4.1_stmt" uuid="1f43e40b-e9c7-43d4-a4f5-7521084f3bae">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="4a0cc4d0-2529-46e1-8af9-82ad56c02239">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for integrating intrusion detection
 tools into the Red Hat Virtualization Manager (RHVM) environment, and documenting how this
@@ -7434,10 +7434,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="852ed7b5-62e3-4579-8baf-966990cd1d02" control-id="si-4.2">
+    <implemented-requirement uuid="283ad864-6082-4571-848c-9fd3accadf1c" control-id="si-4.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.2_stmt" uuid="fe0702e7-9701-4244-9526-a6eee1b433f4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="dd48ef20-feec-4141-b07c-f3bd97fb7b47">
+      <statement statement-id="si-4.2_stmt" uuid="80a356fd-653d-432a-bfa8-eaaca3b3cee8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="818bf351-1106-49a6-9dda-1dda289ea4db">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for deploying automated tools to
 support near real-time analysis of events in their infrastructure.
@@ -7456,10 +7456,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ef20430-8cdd-468e-b532-b01824d13ac5" control-id="si-4.4">
+    <implemented-requirement uuid="16783170-544f-41c7-9a13-99abdbbd9c36" control-id="si-4.4">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.4_stmt" uuid="8b2cad0f-4b92-4141-9651-a3760f058078">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="049f9ea2-7509-43b0-9540-3d2b3413f553">
+      <statement statement-id="si-4.4_stmt" uuid="c2cf100d-6819-43c6-be66-ea9fb2012e61">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0d2ca56b-bd9b-411b-bb38-3e205fc8d841">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for identifying how and where
 network traffic is continuously monitored.
@@ -7472,10 +7472,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="7ce8789b-6e96-4513-98d5-b71fc6e3ba94" control-id="si-4.5">
+    <implemented-requirement uuid="5396bcbd-5df3-468b-a6fc-70f008a8c1b5" control-id="si-4.5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.5_stmt" uuid="3401d654-2bd2-4f80-848b-4a868222bb37">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6fc461ee-016d-4cb8-90fc-5cbdb8765296">
+      <statement statement-id="si-4.5_stmt" uuid="7d4e1aa3-8989-4b97-8cb1-1b607440335b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d9c63bf7-e4b8-499d-8db7-bf313c017b75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for automatic notification of
 appropriate staff when indicators of compromise are detected.
@@ -7492,20 +7492,20 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="e6c1b360-e218-40e0-b1a7-4746ace5f089" control-id="si-4.14">
+    <implemented-requirement uuid="7fddf4bf-1684-4e2d-8d95-0e8ca745a37d" control-id="si-4.14">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-4.14_stmt" uuid="c6f26b3b-ad6a-4a5a-b5cb-cfc8febc12b1">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7ec5c669-21e4-4ef3-967d-dd48c19e7dd0">
+      <statement statement-id="si-4.14_stmt" uuid="b41ffecc-9d23-4e18-a5ae-e37101e9f3a2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="d6e4f3a9-00ac-48a1-a8be-7f607b8f5761">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>An Red Hat Virtualization Manager (RHVM) infrastructure does not have wireless capabilities.
 </p></remarks>
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="64bf479e-923a-4576-bf62-11571e89bea4" control-id="si-4.16">
+    <implemented-requirement uuid="253bf33a-ac68-4dd3-b870-7700ee285f87" control-id="si-4.16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.16_stmt" uuid="b7266a48-dc97-4438-93e0-779ec1a188f2">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3212e381-5ca5-4163-adb3-98f08504aab0">
+      <statement statement-id="si-4.16_stmt" uuid="a152da88-93f8-4db0-81c4-cb866db6b80a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="7452c87a-d7b0-43c2-8a16-d7f459271774">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for aggregating and correlating
 information from monitoring tools, for multiple system components.
@@ -7520,10 +7520,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="983076e9-f8b6-47f6-8749-68cb5d39a639" control-id="si-4.23">
+    <implemented-requirement uuid="017b99af-4904-448c-9750-472ca8910e0c" control-id="si-4.23">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-4.23_stmt" uuid="713ba5d6-b6fd-4bcc-9d2a-a602ac92b393">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="48e28d29-8d3c-4629-88bd-c5d3f4a53712">
+      <statement statement-id="si-4.23_stmt" uuid="41aff24c-6253-4372-adda-a2c33d49d2cb">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c2c33bcf-6d25-4521-ad34-a59873c6219c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for installing host-based monitoring
 mechanisms. A successful control response will need to discuss how
@@ -7537,10 +7537,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="1fba67af-9d11-4de0-b466-e2cf30f15e54" control-id="si-5">
+    <implemented-requirement uuid="e294f724-c931-45f0-be8e-18f53f1e1de1" control-id="si-5">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-5_stmt.a" uuid="819298a1-cba5-41fc-8beb-745eaf0c4164">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="28bae787-4c0f-4e71-8a94-441d64eb9bcb">
+      <statement statement-id="si-5_stmt.a" uuid="17f36d0b-dec0-43b3-aab1-f0b51418fef7">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="93b82632-4cd4-44ce-b402-76972a2854e7">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(a) is planned. Engineering progress can be
 tracked via:
@@ -7549,16 +7549,16 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.b" uuid="aaae046f-2e52-4b5b-aa46-03581d991af0">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="a186d8da-746d-4fce-ae0d-6ba3f2f7e6fe">
+      <statement statement-id="si-5_stmt.b" uuid="cb7122e4-08c8-438d-ba3d-66beb38366d2">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.c" uuid="85cea985-b9bb-4f7c-8274-f5d0b867da3f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="9bf7390d-3a60-45b7-b519-baf01783c2b9">
+      <statement statement-id="si-5_stmt.c" uuid="f0a013c1-d056-43e7-a56d-54d0866803aa">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="0754290e-5fcd-4d6f-9e69-e81b32d2f167">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-5(c) is planned. Engineering progress can be
 tracked via:
@@ -7567,8 +7567,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-5_stmt.d" uuid="738a51ac-d19b-4d99-bfb0-d9208c899614">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="107a9dad-0218-4339-be75-215007eb47c4">
+      <statement statement-id="si-5_stmt.d" uuid="cd44fe4d-fa2d-40d4-8f5b-e52b09880005">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="53456cfa-38f8-4a58-97a7-90db01cd6140">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies, and is not
 applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7576,10 +7576,10 @@ applicable to the configuration of Red Hat Virtualization Manager (RHVM).
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="408d44ad-40e2-43dc-aae0-6f16f9cef6a3" control-id="si-6">
+    <implemented-requirement uuid="38b01b39-5943-49c8-b108-044a6e4bacd8" control-id="si-6">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-6_stmt.a" uuid="53773eaf-f500-4c90-8406-1e4d151e75a3">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="cc925303-6abe-49ff-943c-20583cb28d75">
+      <statement statement-id="si-6_stmt.a" uuid="d64f2de2-7f02-4e63-aaff-02696686cb5b">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="30a447dc-056f-47a6-933c-b570d8213b54">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for verifying the correct operation
 of security functions within customer-controlled operating systems and
@@ -7594,8 +7594,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.b" uuid="96153aa6-582a-48b5-a7f8-f84af4d0704f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="69e0f1bb-acb3-4823-bfcd-1c8433b117c1">
+      <statement statement-id="si-6_stmt.b" uuid="d22f4f0c-240f-4b13-bdc9-47cce702cc94">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -7604,8 +7604,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.c" uuid="2bd16113-a871-4621-a781-79b86ce2f14f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="c472e987-a079-4b1f-85eb-9695d0db3301">
+      <statement statement-id="si-6_stmt.c" uuid="4bb561ed-8a3d-4fe3-9ca6-00b7213dc2c8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -7614,8 +7614,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-6_stmt.d" uuid="625fa53c-ed97-4576-97ff-de629d52abde">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="05af0f2e-76a1-4b84-a165-6cd0cf643d27">
+      <statement statement-id="si-6_stmt.d" uuid="2d6bd4eb-8197-41d5-9e13-023435276675">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="17503162-d1b0-4fa8-a9e4-2deeef31831c">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-6 is planned. Engineering progress can be
 tracked via:
@@ -7625,10 +7625,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="5a4c991b-9137-4245-a147-b8c84423db39" control-id="si-7">
+    <implemented-requirement uuid="fd45ca54-ac27-4043-9523-cb122d75ef7b" control-id="si-7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7_stmt" uuid="db27fe9d-a266-4c4e-8b2e-7990feea10d9">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="07f21f7f-0023-4013-94ee-0e238900733f">
+      <statement statement-id="si-7_stmt" uuid="2d2570a5-feaf-4efa-9783-099aa818c505">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ff0de457-49b4-4344-8372-7c7e6a4164cf">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for employing integrity verification
 tools for customer-controlled operating systems and software. A
@@ -7643,10 +7643,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="d3f9243b-71ff-497a-b1d8-108220c04744" control-id="si-7.1">
+    <implemented-requirement uuid="3c62e9a0-e77d-4915-b5bd-d8e7c7cebf56" control-id="si-7.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-7.1_stmt" uuid="3f659981-10d3-4134-9b20-d2719a8c9916">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="7b5f2881-9dad-4d48-84e0-0385912e8481">
+      <statement statement-id="si-7.1_stmt" uuid="a3e8de9b-0300-45f9-a7b7-2d965e7a83ed">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="db598211-5d2e-4a86-b372-f2d6a2f5c9de">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for performing integrity checks at
 customer-specific frequencies and under customer-specified
@@ -7662,10 +7662,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="73af2cfe-2bcc-453d-9f58-879aced98cb1" control-id="si-7.7">
+    <implemented-requirement uuid="238745f8-f792-4744-a556-4d37fb719e92" control-id="si-7.7">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-7.7_stmt" uuid="a41122a9-56fd-4664-baa6-c123f7a196a4">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="0a65ce35-16dd-4faa-a8ee-a89a10529e34">
+      <statement statement-id="si-7.7_stmt" uuid="f803d629-a5f1-49e6-9c48-f8817f6513e4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="9f731fc9-6a66-4606-aac9-e5e632291a57">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for incorporating the detection of
 customer-defined security-relevant changes into the customers incident
@@ -7677,18 +7677,18 @@ capability is invoked when needed.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="6f25fedf-4e7b-4a33-b0e3-f28095494330" control-id="si-8">
+    <implemented-requirement uuid="c22c0270-72c1-4c9d-a808-23c4af992f0f" control-id="si-8">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8_stmt.a" uuid="770949d1-57a5-4b0c-ad73-e22a052e94a5">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="e6044226-b2b9-4d8f-9586-9417bdfb9bae">
+      <statement statement-id="si-8_stmt.a" uuid="03fe5bcf-c4c4-4996-970f-516793b29758">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-8_stmt.b" uuid="7a705d5e-e5c9-4188-9fe1-d761752e491f">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="bbe4e802-d95b-47d5-9ab7-b42fc6e10cf1">
+      <statement statement-id="si-8_stmt.b" uuid="2de94f56-26bb-4b4c-b442-0ba0071ed8b4">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7696,10 +7696,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="4be2dddd-ac59-460c-8cfe-72a86b8e634e" control-id="si-8.1">
+    <implemented-requirement uuid="c970cc21-906f-4f2c-968e-501975d83dd6" control-id="si-8.1">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.1_stmt" uuid="3b013a0e-36c6-4ec0-b88b-49a09ce76559">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="f979dcc2-948f-444e-9d78-18e1a92f70de">
+      <statement statement-id="si-8.1_stmt" uuid="2d1fea47-0b97-470c-b2a4-0129938f179a">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7707,10 +7707,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="bb8b7e55-212a-4fd7-8617-8f0f37a3d6b7" control-id="si-8.2">
+    <implemented-requirement uuid="fcba003b-aee3-4093-a092-c2a3dbc5bf7d" control-id="si-8.2">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-8.2_stmt" uuid="c19231e3-d56d-49da-99a7-c6e893ae6495">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="5b52b205-ffb4-4440-9f63-9e3b926f0d86">
+      <statement statement-id="si-8.2_stmt" uuid="aa0c719b-2499-486f-aa1f-aeadd9b07cc8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="2bccecae-4ab7-4cbd-b684-3d2960a19a66">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>This control reflects organizational procedures/policies that
 are not applicable to the configuration of Red Hat Virtualization Manager (RHVM).
@@ -7718,10 +7718,10 @@ are not applicable to the configuration of Red Hat Virtualization Manager (RHVM)
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="358e1822-1b33-41f8-85cd-186e60da5b01" control-id="si-10">
+    <implemented-requirement uuid="a692ad57-9df9-46f8-9f6b-9cfdc5eb8331" control-id="si-10">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-10_stmt" uuid="f1569eba-4e23-44bf-b9b3-d21b792af131">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="3b7f1f09-7ea2-4b41-8917-d05a2a4add6a">
+      <statement statement-id="si-10_stmt" uuid="5653a342-a850-4ce4-86c7-ee90659a39b8">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="c8f5633d-efbc-49d5-9e55-9124a516abe3">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for checking the validity of
 information inputs to customer-controlled operating systems and
@@ -7738,10 +7738,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0f8c6f6e-ce9a-4480-a34d-c069a037efee" control-id="si-11">
+    <implemented-requirement uuid="b3a5c29e-0faa-469d-b445-999334811b7d" control-id="si-11">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-11_stmt.a" uuid="39f36289-2364-44f4-a128-ae39be4a2544">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="51090c70-244f-4410-83b0-de1d88f5843d">
+      <statement statement-id="si-11_stmt.a" uuid="96e25551-2aaf-4632-aede-caced5280e5c">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="336b8f57-a23a-47a8-b9d6-99b085addd75">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for generating error messages in
 cusomer-controlled operating systems and software that provide
@@ -7757,8 +7757,8 @@ https://projects.engineering.redhat.com/browse/RHV-
 </p></remarks>
         </by-component>
       </statement>
-      <statement statement-id="si-11_stmt.b" uuid="fdb207cc-0cdd-463e-9fbb-3b7c3f4722ce">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="124cbcd7-2c3f-484c-8018-1d3ece941ca5">
+      <statement statement-id="si-11_stmt.b" uuid="865efc56-48e7-464c-9d66-8d1fd50b47ab">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="ad9a4e66-e871-4618-ba62-7d464c99668d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for revealing error messages only to
 authorized personnel. A successful control response will need to
@@ -7773,10 +7773,10 @@ https://projects.engineering.redhat.com/browse/RHV-
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="17586381-63c8-45e4-88bb-a2301127fa8d" control-id="si-12">
+    <implemented-requirement uuid="073e59b6-334f-4554-8dcb-e8adb4bfa03a" control-id="si-12">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned"></annotation>
-      <statement statement-id="si-12_stmt" uuid="eddc021e-bf6c-4db5-ad14-dff879795349">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="6aba4d78-a437-432a-a2b2-3860e7dc32e7">
+      <statement statement-id="si-12_stmt" uuid="c54da56a-94d6-48d2-a137-0577ddfb83e1">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="071845fd-4fb7-4382-9736-531d35f08a6d">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>The customer will be responsible for handling and retaining
 information within, or hosted by, Red Hat Virtualization Manager (RHVM) in
@@ -7790,10 +7790,10 @@ are met.
         </by-component>
       </statement>
     </implemented-requirement>
-    <implemented-requirement uuid="0db474bd-121b-4db4-a91d-cd39997fd849" control-id="si-16">
+    <implemented-requirement uuid="64d17c5f-6fbd-45c2-acbb-b8f9cee20597" control-id="si-16">
       <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="not-applicable"></annotation>
-      <statement statement-id="si-16_stmt" uuid="72a097a9-2f5e-4c86-9d92-2f7f9437c6c7">
-        <by-component component-uuid="bd0824f3-f709-4e40-87bb-6b21e30a7d17" uuid="b61bf410-a052-4a18-95df-5164636931f3">
+      <statement statement-id="si-16_stmt" uuid="f623eba6-d85d-42d2-aee3-24b81072373e">
+        <by-component component-uuid="bdba9d56-2be4-498d-8d31-b43cab6a44bd" uuid="a08df08e-d420-44b1-93af-bc8317bf14cc">
           <description><p>Describe how is the software component satisfying the control.</p></description>
           <remarks><p>A control response for SI-16 is planned. Engineering progress can be
 tracked via:


### PR DESCRIPTION
From now on, UUID of an OSCAL element will change only when its content
changes.

Learn more about stable UUIDs at https://github.com/GoComply/fedramp/commit/bddbbb8d6d3f69425c4f211464e904677e193327